### PR TITLE
Cross-compilation fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,7 +21,7 @@
 # Project setup
 ########################################################################
 if(${CMAKE_SOURCE_DIR} STREQUAL ${CMAKE_BINARY_DIR})
-    message(FATAL_ERROR "Prevented in-tree build. This is bad practice. Try 'cd build && cmake ../' ")
+    message(WARNING "In-tree build is bad practice. Try 'cd build && cmake ../' ")
 endif(${CMAKE_SOURCE_DIR} STREQUAL ${CMAKE_BINARY_DIR})
 cmake_minimum_required(VERSION 2.8)
 project(gnss-sdr CXX C)
@@ -398,11 +398,15 @@ if(OS_IS_MACOSX)
     endif(CMAKE_GENERATOR STREQUAL Xcode)
 endif(OS_IS_MACOSX)
 if(NOT VOLK_GNSSSDR_FOUND)
+    set(VOLK_GNSSSDR_CMAKE_ARGS -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER} -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER} -DCMAKE_INSTALL_PREFIX=${CMAKE_CURRENT_BINARY_DIR}/volk_gnsssdr_module/install -DENABLE_STATIC_LIBS=ON ${STRIP_VOLK_GNSSSDR_PROFILE} ${USE_MACPORTS_PYTHON})
+    if(CMAKE_TOOLCHAIN_FILE)
+      set(VOLK_GNSSSDR_CMAKE_ARGS ${VOLK_GNSSSDR_CMAKE_ARGS} -DCMAKE_TOOLCHAIN_FILE ${CMAKE_TOOLCHAIN_FILE})
+    endif(CMAKE_TOOLCHAIN_FILE)
     ExternalProject_Add(volk_gnsssdr_module
          PREFIX ${CMAKE_CURRENT_BINARY_DIR}/volk_gnsssdr_module
          SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/src/algorithms/libs/volk_gnsssdr_module/volk_gnsssdr
          BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR}/volk_gnsssdr_module/build   
-         CMAKE_ARGS -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER} -DCMAKE_INSTALL_PREFIX=${CMAKE_CURRENT_BINARY_DIR}/volk_gnsssdr_module/install -DENABLE_STATIC_LIBS=ON ${STRIP_VOLK_GNSSSDR_PROFILE} ${USE_MACPORTS_PYTHON}
+         CMAKE_ARGS ${VOLK_GNSSSDR_CMAKE_ARGS}
          DOWNLOAD_COMMAND ""
          UPDATE_COMMAND ""
          PATCH_COMMAND ""
@@ -724,7 +728,7 @@ if(OS_IS_LINUX)
         else(${LINUX_DISTRIBUTION} MATCHES "Fedora" OR ${LINUX_DISTRIBUTION} MATCHES "Red Hat")
             message(" sudo apt-get install gfortran") 
         endif(${LINUX_DISTRIBUTION} MATCHES "Fedora" OR ${LINUX_DISTRIBUTION} MATCHES "Red Hat")
-        message(FATAL_ERROR "gfortran is required to build gnss-sdr")
+        #message(FATAL_ERROR "gfortran is required to build gnss-sdr")
     endif(NOT GFORTRAN)
 endif(OS_IS_LINUX)
 
@@ -1080,5 +1084,3 @@ add_subdirectory(src)
 if(ENABLE_PACKAGING)
     include(GnssSdrPackaging)
 endif(ENABLE_PACKAGING)
-
-

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,9 +51,9 @@ endif(ENABLE_PACKAGING)
 
 
 ###############################
-# GNSS-SDR version information 
+# GNSS-SDR version information
 ###############################
-set(THIS_IS_A_RELEASE OFF)   # only related to version name, no further implications. 
+set(THIS_IS_A_RELEASE OFF)   # only related to version name, no further implications.
 if(NOT ${THIS_IS_A_RELEASE})
     # Get the current working branch
     execute_process(
@@ -96,7 +96,7 @@ endif( CMAKE_SIZEOF_VOID_P EQUAL 8 )
 set(OS_IS_MACOSX "")
 set(OS_IS_LINUX "")
 
-# Detect Linux Distribution 
+# Detect Linux Distribution
 if(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
      set(OperatingSystem "Linux")
      set(OS_IS_LINUX TRUE)
@@ -135,7 +135,7 @@ if(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
                              RESULT_VARIABLE LINUX_VER_RESULT
              )
          endif(EXISTS "/etc/linuxmint/info")
-     endif(NOT LINUX_DISTRIBUTION)    
+     endif(NOT LINUX_DISTRIBUTION)
      if(NOT LINUX_DISTRIBUTION)
          if(EXISTS "/etc/os-release")
              execute_process(COMMAND cat /etc/os-release
@@ -158,7 +158,7 @@ if(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
                  set(LINUX_DISTRIBUTION "Debian")
                  file(READ /etc/debian_version LINUX_VER)
              endif(${LINUX_DISTRIBUTION} MATCHES "Debian")
-         endif(EXISTS "/etc/os-release")  
+         endif(EXISTS "/etc/os-release")
      endif(NOT LINUX_DISTRIBUTION)
      if(NOT LINUX_DISTRIBUTION)
          if(EXISTS "/etc/redhat-release")
@@ -175,7 +175,7 @@ if(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
      if(NOT LINUX_DISTRIBUTION)
          set(LINUX_DISTRIBUTION "Generic")
          set(LINUX_VER "Unknown")
-     endif(NOT LINUX_DISTRIBUTION)      
+     endif(NOT LINUX_DISTRIBUTION)
      message(STATUS "Configuring GNSS-SDR v${VERSION} to be built on ${LINUX_DISTRIBUTION} GNU/Linux Release ${LINUX_VER} ${ARCH_}")
 endif(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
 
@@ -218,7 +218,7 @@ if(NOT CMAKE_BUILD_TYPE)
     else(ENABLE_GPERFTOOLS)
         set(CMAKE_BUILD_TYPE "Release")
         message(STATUS "Build type not specified: defaulting to Release.")
-    endif(ENABLE_GPERFTOOLS)   
+    endif(ENABLE_GPERFTOOLS)
 endif(NOT CMAKE_BUILD_TYPE)
 set(CMAKE_BUILD_TYPE ${CMAKE_BUILD_TYPE} CACHE STRING "")
 
@@ -319,7 +319,7 @@ set(Boost_ADDITIONAL_VERSIONS
 )
 set(Boost_USE_MULTITHREAD ON)
 set(Boost_USE_STATIC_LIBS OFF)
-find_package(Boost COMPONENTS date_time system filesystem thread serialization chrono REQUIRED) 
+find_package(Boost COMPONENTS date_time system filesystem thread serialization chrono REQUIRED)
 if(NOT Boost_FOUND)
      message(FATAL_ERROR "Fatal error: Boost (version >=1.45.0) required.")
 endif(NOT Boost_FOUND)
@@ -394,18 +394,18 @@ set(VOLK_GNSSSDR_BUILD_COMMAND "make")
 if(OS_IS_MACOSX)
     set(USE_MACPORTS_PYTHON "-DPYTHON_EXECUTABLE=/opt/local/bin/python")
     if(CMAKE_GENERATOR STREQUAL Xcode)
-        set(VOLK_GNSSSDR_BUILD_COMMAND "xcodebuild" "-configuration" "Debug" "-target")    
+        set(VOLK_GNSSSDR_BUILD_COMMAND "xcodebuild" "-configuration" "Debug" "-target")
     endif(CMAKE_GENERATOR STREQUAL Xcode)
 endif(OS_IS_MACOSX)
 if(NOT VOLK_GNSSSDR_FOUND)
     set(VOLK_GNSSSDR_CMAKE_ARGS -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER} -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER} -DCMAKE_INSTALL_PREFIX=${CMAKE_CURRENT_BINARY_DIR}/volk_gnsssdr_module/install -DENABLE_STATIC_LIBS=ON ${STRIP_VOLK_GNSSSDR_PROFILE} ${USE_MACPORTS_PYTHON})
     if(CMAKE_TOOLCHAIN_FILE)
-      set(VOLK_GNSSSDR_CMAKE_ARGS ${VOLK_GNSSSDR_CMAKE_ARGS} -DCMAKE_TOOLCHAIN_FILE ${CMAKE_TOOLCHAIN_FILE})
+      set(VOLK_GNSSSDR_CMAKE_ARGS ${VOLK_GNSSSDR_CMAKE_ARGS} -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TOOLCHAIN_FILE})
     endif(CMAKE_TOOLCHAIN_FILE)
     ExternalProject_Add(volk_gnsssdr_module
          PREFIX ${CMAKE_CURRENT_BINARY_DIR}/volk_gnsssdr_module
          SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/src/algorithms/libs/volk_gnsssdr_module/volk_gnsssdr
-         BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR}/volk_gnsssdr_module/build   
+         BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR}/volk_gnsssdr_module/build
          CMAKE_ARGS ${VOLK_GNSSSDR_CMAKE_ARGS}
          DOWNLOAD_COMMAND ""
          UPDATE_COMMAND ""
@@ -418,7 +418,7 @@ if(NOT VOLK_GNSSSDR_FOUND)
          set(ORC_LIBRARIES "")
          set(ORC_INCLUDE_DIRS "")
     endif(NOT ORC_FOUND)
-        
+
     add_library(volk_gnsssdr UNKNOWN IMPORTED)
     set_property(TARGET volk_gnsssdr PROPERTY IMPORTED_LOCATION ${CMAKE_CURRENT_BINARY_DIR}/volk_gnsssdr_module/install/lib/libvolk_gnsssdr.a)
     set(VOLK_GNSSSDR_INCLUDE_DIRS "${CMAKE_CURRENT_BINARY_DIR}/volk_gnsssdr_module/build/include/;${CMAKE_CURRENT_SOURCE_DIR}/src/algorithms/libs/volk_gnsssdr_module/volk_gnsssdr/include;${ORC_INCLUDE_DIRS}")
@@ -444,8 +444,8 @@ if (NOT GFlags_FOUND)
      if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
          file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/gflags-${gflags_RELEASE}/tmp/configure_osx
 "#!/bin/sh
-export CXXFLAGS=\"-stdlib=libc++\" 
-export CC=clang 
+export CXXFLAGS=\"-stdlib=libc++\"
+export CC=clang
 export CXX=clang++
 ${CMAKE_CURRENT_SOURCE_DIR}/thirdparty/gflags/gflags-${gflags_RELEASE}/configure")
          file(COPY ${CMAKE_CURRENT_BINARY_DIR}/gflags-${gflags_RELEASE}/tmp/configure_osx
@@ -463,7 +463,7 @@ ${CMAKE_CURRENT_SOURCE_DIR}/thirdparty/gflags/gflags-${gflags_RELEASE}/configure
                  GROUP_EXECUTE WORLD_READ WORLD_EXECUTE)
           set(CONF_SCRIPT ${CMAKE_CURRENT_BINARY_DIR}/gflags-${gflags_RELEASE}/configure_linux)
      endif("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
-     
+
      ExternalProject_Add(
           gflags-${gflags_RELEASE}
           PREFIX ${CMAKE_CURRENT_BINARY_DIR}/gflags-${gflags_RELEASE}
@@ -472,17 +472,17 @@ ${CMAKE_CURRENT_SOURCE_DIR}/thirdparty/gflags/gflags-${gflags_RELEASE}/configure
           URL_MD5 ${gflags_MD5}
           SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/thirdparty/gflags/gflags-${gflags_RELEASE}
           BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR}/gflags-${gflags_RELEASE}
-          CONFIGURE_COMMAND ${CONF_SCRIPT} --prefix=${CMAKE_CURRENT_BINARY_DIR}/gflags-${gflags_RELEASE}  
+          CONFIGURE_COMMAND ${CONF_SCRIPT} --prefix=${CMAKE_CURRENT_BINARY_DIR}/gflags-${gflags_RELEASE}
           BUILD_COMMAND make
           UPDATE_COMMAND ""
           PATCH_COMMAND ""
           INSTALL_COMMAND ""
      )
 
-     set(GFlags_INCLUDE_DIRS 
-          ${CMAKE_CURRENT_BINARY_DIR}/gflags-${gflags_RELEASE}/src CACHE PATH "Local Gflags headers"      
+     set(GFlags_INCLUDE_DIRS
+          ${CMAKE_CURRENT_BINARY_DIR}/gflags-${gflags_RELEASE}/src CACHE PATH "Local Gflags headers"
      )
-     
+
      add_library(gflags UNKNOWN IMPORTED)
      set_property(TARGET gflags PROPERTY IMPORTED_LOCATION ${CMAKE_CURRENT_BINARY_DIR}/gflags-${gflags_RELEASE}/.libs/${CMAKE_FIND_LIBRARY_PREFIXES}gflags.a)
      add_dependencies(gflags gflags-${gflags_RELEASE})
@@ -520,7 +520,7 @@ if (NOT GLOG_FOUND OR ${LOCAL_GFLAGS})
      endif(NOT ${LOCAL_GFLAGS})
      set(glog_RELEASE 0.3.3)
      set(glog_MD5 "a6fd2c22f8996846e34c763422717c18")
-     
+
      if(${LOCAL_GFLAGS})
          set(TARGET_GFLAGS ${gflags})
          if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
@@ -529,8 +529,8 @@ if (NOT GLOG_FOUND OR ${LOCAL_GFLAGS})
 export CPPFLAGS=-I${GFlags_INCLUDE_DIRS}
 export LDFLAGS=-L${CMAKE_CURRENT_BINARY_DIR}/gflags-${gflags_RELEASE}/.libs
 export LIBS=${GFlags_SHARED_LIBS}
-export CXXFLAGS=\"-stdlib=libc++\" 
-export CC=clang 
+export CXXFLAGS=\"-stdlib=libc++\"
+export CC=clang
 export CXX=clang++
 ${CMAKE_CURRENT_SOURCE_DIR}/thirdparty/glog/glog-${glog_RELEASE}/configure")
              file(COPY ${CMAKE_CURRENT_BINARY_DIR}/glog-${glog_RELEASE}/tmp/configure_with_gflags
@@ -548,8 +548,8 @@ ${CMAKE_CURRENT_SOURCE_DIR}/thirdparty/glog/glog-${glog_RELEASE}/configure")
                DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/glog-${glog_RELEASE}
                FILE_PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ
                                 GROUP_EXECUTE WORLD_READ WORLD_EXECUTE)
-         endif("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")                           
-   
+         endif("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
+
      else(${LOCAL_GFLAGS})
          set(TARGET_GFLAGS gflags-${gflags_RELEASE})
          if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
@@ -558,8 +558,8 @@ ${CMAKE_CURRENT_SOURCE_DIR}/thirdparty/glog/glog-${glog_RELEASE}/configure")
 export CPPFLAGS=-I${GFlags_INCLUDE_DIRS}
 export LDFLAGS=-L${GFlags_LIBRARY_DIRS}
 export LIBS=\"${GFlags_LIBS} -lc++\"
-export CXXFLAGS=\"-stdlib=libc++\" 
-export CC=clang 
+export CXXFLAGS=\"-stdlib=libc++\"
+export CC=clang
 export CXX=clang++
 ${CMAKE_CURRENT_SOURCE_DIR}/thirdparty/glog/glog-${glog_RELEASE}/configure")
               file(COPY ${CMAKE_CURRENT_BINARY_DIR}/glog-${glog_RELEASE}/tmp/configure_with_gflags
@@ -577,10 +577,10 @@ ${CMAKE_CURRENT_SOURCE_DIR}/thirdparty/glog/glog-${glog_RELEASE}/configure")
                 DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/glog-${glog_RELEASE}
                 FILE_PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ
                                 GROUP_EXECUTE WORLD_READ WORLD_EXECUTE)
-         endif("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang") 
+         endif("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
      endif(${LOCAL_GFLAGS})
 
-     set(GLOG_CONFIGURE ${CMAKE_CURRENT_BINARY_DIR}/glog-${glog_RELEASE}/configure_with_gflags)   
+     set(GLOG_CONFIGURE ${CMAKE_CURRENT_BINARY_DIR}/glog-${glog_RELEASE}/configure_with_gflags)
      if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
           ExternalProject_Add(
               glog-${glog_RELEASE}
@@ -591,7 +591,7 @@ ${CMAKE_CURRENT_SOURCE_DIR}/thirdparty/glog/glog-${glog_RELEASE}/configure")
               DOWNLOAD_DIR ${CMAKE_CURRENT_BINARY_DIR}/download/glog-${glog_RELEASE}
               SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/thirdparty/glog/glog-${glog_RELEASE}
               BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR}/glog-${glog_RELEASE}
-              CONFIGURE_COMMAND ${GLOG_CONFIGURE} --prefix=<INSTALL_DIR> 
+              CONFIGURE_COMMAND ${GLOG_CONFIGURE} --prefix=<INSTALL_DIR>
               BUILD_COMMAND make
               UPDATE_COMMAND ""
               PATCH_COMMAND ""
@@ -607,7 +607,7 @@ ${CMAKE_CURRENT_SOURCE_DIR}/thirdparty/glog/glog-${glog_RELEASE}/configure")
               URL_MD5 ${glog_MD5}
               SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/thirdparty/glog/glog-${glog_RELEASE}
               BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR}/glog-${glog_RELEASE}
-              CONFIGURE_COMMAND ${GLOG_CONFIGURE} --prefix=<INSTALL_DIR> 
+              CONFIGURE_COMMAND ${GLOG_CONFIGURE} --prefix=<INSTALL_DIR>
               BUILD_COMMAND make
               UPDATE_COMMAND ""
               PATCH_COMMAND ""
@@ -615,15 +615,15 @@ ${CMAKE_CURRENT_SOURCE_DIR}/thirdparty/glog/glog-${glog_RELEASE}/configure")
           )
      endif("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
      # Set up variables
-     set(GLOG_INCLUDE_DIRS 
-          ${CMAKE_CURRENT_SOURCE_DIR}/thirdparty/glog/glog-${glog_RELEASE}/src/ 
+     set(GLOG_INCLUDE_DIRS
+          ${CMAKE_CURRENT_SOURCE_DIR}/thirdparty/glog/glog-${glog_RELEASE}/src/
           ${CMAKE_CURRENT_BINARY_DIR}/glog-${glog_RELEASE}/src
      )
-     set(GLOG_LIBRARIES 
-          ${CMAKE_CURRENT_BINARY_DIR}/glog-${glog_RELEASE}/.libs/${CMAKE_FIND_LIBRARY_PREFIXES}glog.a 
+     set(GLOG_LIBRARIES
+          ${CMAKE_CURRENT_BINARY_DIR}/glog-${glog_RELEASE}/.libs/${CMAKE_FIND_LIBRARY_PREFIXES}glog.a
      )
      set(LOCAL_GLOG true CACHE STRING "Glog downloaded and built automatically" FORCE)
-else(NOT GLOG_FOUND OR ${LOCAL_GFLAGS})    
+else(NOT GLOG_FOUND OR ${LOCAL_GFLAGS})
      add_library(glog-${glog_RELEASE} UNKNOWN IMPORTED)
      set_property(TARGET glog-${glog_RELEASE} PROPERTY IMPORTED_LOCATION "${GLOG_LIBRARIES}")
 endif(NOT GLOG_FOUND OR ${LOCAL_GFLAGS})
@@ -635,7 +635,7 @@ endif(NOT GLOG_FOUND OR ${LOCAL_GFLAGS})
 ################################################################################
 if(OS_IS_LINUX)
     #############################################################################
-    # Check that LAPACK is found in the system 
+    # Check that LAPACK is found in the system
     # LAPACK is required for matrix decompositions (eg. SVD) and matrix inverse.
     #############################################################################
     find_library(LAPACK lapack)
@@ -643,11 +643,11 @@ if(OS_IS_LINUX)
         message(" The LAPACK library has not been found.")
         message(" You can try to install it by typing:")
         if(${LINUX_DISTRIBUTION} MATCHES "Fedora" OR ${LINUX_DISTRIBUTION} MATCHES "Red Hat")
-            message(" sudo yum install lapack-devel") 
+            message(" sudo yum install lapack-devel")
         elseif(${LINUX_DISTRIBUTION} MATCHES "openSUSE")
             message(" sudo zypper install lapack-devel")
         else(${LINUX_DISTRIBUTION} MATCHES "Fedora" OR ${LINUX_DISTRIBUTION} MATCHES "Red Hat")
-            message(" sudo apt-get install liblapack-dev") 
+            message(" sudo apt-get install liblapack-dev")
         endif(${LINUX_DISTRIBUTION} MATCHES "Fedora" OR ${LINUX_DISTRIBUTION} MATCHES "Red Hat")
         message(FATAL_ERROR "LAPACK is required to build gnss-sdr")
     endif(NOT LAPACK)
@@ -661,9 +661,9 @@ if(OS_IS_LINUX)
         message(" The BLAS library has not been found.")
         message(" You can try to install it by typing:")
         if(${LINUX_DISTRIBUTION} MATCHES "Fedora" OR ${LINUX_DISTRIBUTION} MATCHES "Red Hat")
-            message(" sudo yum install blas-devel") 
+            message(" sudo yum install blas-devel")
         else(${LINUX_DISTRIBUTION} MATCHES "Fedora" OR ${LINUX_DISTRIBUTION} MATCHES "Red Hat")
-            message(" sudo apt-get install libopenblas-dev") 
+            message(" sudo apt-get install libopenblas-dev")
         endif(${LINUX_DISTRIBUTION} MATCHES "Fedora" OR ${LINUX_DISTRIBUTION} MATCHES "Red Hat")
         message(FATAL_ERROR "BLAS is required to build gnss-sdr")
     endif(NOT BLAS)
@@ -720,13 +720,13 @@ if(OS_IS_LINUX)
                 )
     if(NOT GFORTRAN)
         message(" The gfortran library has not been found.")
-        message(" You can try to install it by typing:")    
+        message(" You can try to install it by typing:")
         if(${LINUX_DISTRIBUTION} MATCHES "Fedora" OR ${LINUX_DISTRIBUTION} MATCHES "Red Hat")
-            message(" sudo yum install gcc-fortran") 
+            message(" sudo yum install gcc-fortran")
         elseif(${LINUX_DISTRIBUTION} MATCHES "openSUSE")
             message(" sudo zypper install gcc-fortran")
         else(${LINUX_DISTRIBUTION} MATCHES "Fedora" OR ${LINUX_DISTRIBUTION} MATCHES "Red Hat")
-            message(" sudo apt-get install gfortran") 
+            message(" sudo apt-get install gfortran")
         endif(${LINUX_DISTRIBUTION} MATCHES "Fedora" OR ${LINUX_DISTRIBUTION} MATCHES "Red Hat")
         #message(FATAL_ERROR "gfortran is required to build gnss-sdr")
     endif(NOT GFORTRAN)
@@ -737,10 +737,10 @@ if(NOT ARMADILLO_FOUND)
      message (STATUS " Armadillo has not been found.")
      message (STATUS " Armadillo will be downloaded and built automatically ")
      message (STATUS " when doing 'make'. ")
-  
-     set(armadillo_RELEASE 4.600.2)  
-     set(armadillo_MD5 "cfa4962bfa48bf3953d012b2f8fcfa35") 
-     
+
+     set(armadillo_RELEASE 4.600.2)
+     set(armadillo_MD5 "cfa4962bfa48bf3953d012b2f8fcfa35")
+
      ExternalProject_Add(
          armadillo-${armadillo_RELEASE}
          PREFIX ${CMAKE_CURRENT_BINARY_DIR}/armadillo-${armadillo_RELEASE}
@@ -750,13 +750,13 @@ if(NOT ARMADILLO_FOUND)
          CMAKE_ARGS -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER} -DBUILD_SHARED_LIBS=OFF
          BUILD_IN_SOURCE 1
          BUILD_COMMAND make
-         UPDATE_COMMAND "" 
+         UPDATE_COMMAND ""
          INSTALL_COMMAND ""
      )
 
      # Set up variables
      ExternalProject_Get_Property(armadillo-${armadillo_RELEASE} binary_dir)
-     set(ARMADILLO_INCLUDE_DIRS ${binary_dir}/include )     
+     set(ARMADILLO_INCLUDE_DIRS ${binary_dir}/include )
      find_library(LAPACK NAMES lapack HINTS /usr/lib /usr/local/lib /usr/lib64)
      if(OS_IS_MACOSX)
          find_library(BLAS blas)
@@ -772,7 +772,7 @@ if(NOT ARMADILLO_FOUND)
           DESTINATION ${CMAKE_CURRENT_SOURCE_DIR}/thirdparty/armadillo
      )
 else(NOT ARMADILLO_FOUND)
-     set(armadillo_RELEASE ${ARMADILLO_VERSION_STRING})  
+     set(armadillo_RELEASE ${ARMADILLO_VERSION_STRING})
      add_library(armadillo-${armadillo_RELEASE} UNKNOWN IMPORTED)
      set_property(TARGET armadillo-${armadillo_RELEASE} PROPERTY IMPORTED_LOCATION "${ARMADILLO_LIBRARIES}")
 endif(NOT ARMADILLO_FOUND)
@@ -786,13 +786,13 @@ find_package(OpenSSL)
 if(NOT OPENSSL_FOUND)
     message(" The OpenSSL library has not been found.")
     message(" You can try to install it by typing:")
-    if(OS_IS_LINUX)      
+    if(OS_IS_LINUX)
         if(${LINUX_DISTRIBUTION} MATCHES "Fedora" OR ${LINUX_DISTRIBUTION} MATCHES "Red Hat")
-            message(" sudo yum install openssl-devel") 
+            message(" sudo yum install openssl-devel")
         else(${LINUX_DISTRIBUTION} MATCHES "Fedora" OR ${LINUX_DISTRIBUTION} MATCHES "Red Hat")
-            message(" sudo apt-get install libssl-dev") 
+            message(" sudo apt-get install libssl-dev")
         endif(${LINUX_DISTRIBUTION} MATCHES "Fedora" OR ${LINUX_DISTRIBUTION} MATCHES "Red Hat")
-    endif(OS_IS_LINUX) 
+    endif(OS_IS_LINUX)
     if(OS_IS_MACOSX)
         message(" sudo port install openssl")
     endif(OS_IS_MACOSX)
@@ -846,7 +846,7 @@ if(DOXYGEN_FOUND)
           COMMENT "Generating API documentation with Doxygen." VERBATIM
      )
      if(LATEX_COMPILER)
-          message(STATUS "'make pdfmanual' will generate a manual at ${CMAKE_SOURCE_DIR}/docs/GNSS-SDR_manual.pdf")         
+          message(STATUS "'make pdfmanual' will generate a manual at ${CMAKE_SOURCE_DIR}/docs/GNSS-SDR_manual.pdf")
           add_custom_target(pdfmanual
                COMMAND ${CMAKE_MAKE_PROGRAM}
                COMMAND ${CMAKE_COMMAND} -E copy refman.pdf ${CMAKE_SOURCE_DIR}/docs/GNSS-SDR_manual.pdf
@@ -869,9 +869,9 @@ else(DOXYGEN_FOUND)
      message(STATUS " Get it from http://www.stack.nl/~dimitri/doxygen/index.html")
      if(OS_IS_LINUX)
          if(${LINUX_DISTRIBUTION} MATCHES "Fedora" OR ${LINUX_DISTRIBUTION} MATCHES "Red Hat")
-             message(" or simply by doing 'sudo yum install doxygen-latex'.") 
+             message(" or simply by doing 'sudo yum install doxygen-latex'.")
          else(${LINUX_DISTRIBUTION} MATCHES "Fedora" OR ${LINUX_DISTRIBUTION} MATCHES "Red Hat")
-             message(" or simply by doing 'sudo apt-get install doxygen-latex'.") 
+             message(" or simply by doing 'sudo apt-get install doxygen-latex'.")
          endif(${LINUX_DISTRIBUTION} MATCHES "Fedora" OR ${LINUX_DISTRIBUTION} MATCHES "Red Hat")
      endif(OS_IS_LINUX)
      if(OS_IS_MACOSX)
@@ -942,10 +942,10 @@ if(GN3S_DRIVER)
 endif(GN3S_DRIVER)
 if(ENABLE_GN3S)
      message(STATUS "The GN3S driver will be compiled.")
-     message(STATUS "You can disable it with 'cmake -DENABLE_GN3S=OFF ../'" )  
+     message(STATUS "You can disable it with 'cmake -DENABLE_GN3S=OFF ../'" )
 else(ENABLE_GN3S)
      message(STATUS "The (optional and experimental) GN3S driver is not enabled." )
-     message(STATUS "Enable it with 'cmake -DENABLE_GN3S=ON ../' to add support for the GN3S dongle." )  
+     message(STATUS "Enable it with 'cmake -DENABLE_GN3S=ON ../' to add support for the GN3S dongle." )
 endif(ENABLE_GN3S)
 
 
@@ -960,7 +960,7 @@ endif(RAW_ARRAY_DRIVER)
 
 if(ENABLE_ARRAY)
     message(STATUS "CTTC's Antenna Array front-end driver will be compiled." )
-    message(STATUS "You can disable it with 'cmake -DENABLE_ARRAY=OFF ../'" )  
+    message(STATUS "You can disable it with 'cmake -DENABLE_ARRAY=OFF ../'" )
     # copy firmware to install folder
     # Build project gr-dbfcttc
 else(ENABLE_ARRAY)
@@ -975,7 +975,7 @@ endif($ENV{RTLSDR_DRIVER})
 
 if(ENABLE_OSMOSDR)
     message(STATUS "The driver for OsmoSDR and other front-ends (HackRF, bladeRF, Realtek's RTL2832U-based dongles, etc.) will be compiled." )
-    message(STATUS "You can disable it with 'cmake -DENABLE_OSMOSDR=OFF ../'" )  
+    message(STATUS "You can disable it with 'cmake -DENABLE_OSMOSDR=OFF ../'" )
 else(ENABLE_OSMOSDR)
     message(STATUS "The (optional) driver for OsmoSDR and related front-ends is not enabled." )
     message(STATUS "Enable it with 'cmake -DENABLE_OSMOSDR=ON ../' to add support for OsmoSDR and other front-ends (HackRF, bladeRF, Realtek's RTL2832U-based USB dongles, etc.)" )
@@ -992,7 +992,7 @@ endif(FLEXIBAND_DRIVER)
 
 if(ENABLE_FLEXIBAND)
     message(STATUS "CTTC's Antenna Array front-end driver will be compiled." )
-    message(STATUS "You can disable it with 'cmake -DENABLE_FLEXIBAND=OFF ../'" )  
+    message(STATUS "You can disable it with 'cmake -DENABLE_FLEXIBAND=OFF ../'" )
 else(ENABLE_FLEXIBAND)
     message(STATUS "The (optional) Teleorbit Flexiband front-end driver adapter is not enabled." )
     message(STATUS "Enable it with 'cmake -DENABLE_FLEXIBAND=ON ../' to add support for the Teleorbit Flexiband front-end." )
@@ -1008,9 +1008,9 @@ if(CMAKE_COMPILER_IS_GNUCXX AND NOT WIN32)
      set(MY_CXX_FLAGS "${MY_CXX_FLAGS} -std=c++11 -Wall -Wextra")  #Add warning flags: For "-Wall" see http://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html
 endif(CMAKE_COMPILER_IS_GNUCXX AND NOT WIN32)
 if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-    set(MY_CXX_FLAGS "${MY_CXX_FLAGS} -std=c++11 -stdlib=libc++ -Wno-c++11-narrowing") 
+    set(MY_CXX_FLAGS "${MY_CXX_FLAGS} -std=c++11 -stdlib=libc++ -Wno-c++11-narrowing")
     if(CMAKE_BUILD_TYPE MATCHES "Release")
-        set(MY_CXX_FLAGS "${MY_CXX_FLAGS} -Wno-unused-private-field") 
+        set(MY_CXX_FLAGS "${MY_CXX_FLAGS} -Wno-unused-private-field")
     endif(CMAKE_BUILD_TYPE MATCHES "Release")
 endif(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
 
@@ -1048,21 +1048,21 @@ if(ENABLE_GPERFTOOLS)
     # See http://gperftools.googlecode.com/svn/trunk/README
     if(GPERFTOOLS_FOUND)
         if(CMAKE_COMPILER_IS_GNUCXX AND NOT WIN32)
-            set(MY_CXX_FLAGS "${MY_CXX_FLAGS} -fno-builtin-malloc -fno-builtin-calloc -fno-builtin-realloc -fno-builtin-free")       
+            set(MY_CXX_FLAGS "${MY_CXX_FLAGS} -fno-builtin-malloc -fno-builtin-calloc -fno-builtin-realloc -fno-builtin-free")
         endif(CMAKE_COMPILER_IS_GNUCXX AND NOT WIN32)
         if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-            set(MY_CXX_FLAGS "${MY_CXX_FLAGS} -fno-builtin") 
+            set(MY_CXX_FLAGS "${MY_CXX_FLAGS} -fno-builtin")
         endif(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
     endif(GPERFTOOLS_FOUND)
 endif(ENABLE_GPERFTOOLS)
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${MY_CXX_FLAGS}")
 
-if(OS_IS_LINUX)      
+if(OS_IS_LINUX)
     if(${LINUX_DISTRIBUTION} MATCHES "Fedora" OR ${LINUX_DISTRIBUTION} MATCHES "openSUSE")
         link_libraries(pthread)
     endif(${LINUX_DISTRIBUTION} MATCHES "Fedora" OR ${LINUX_DISTRIBUTION} MATCHES "openSUSE")
-endif(OS_IS_LINUX) 
+endif(OS_IS_LINUX)
 
 
 ########################################################################

--- a/cmake/Modules/TestForARM.cmake
+++ b/cmake/Modules/TestForARM.cmake
@@ -26,7 +26,7 @@ set (ARM_VERSION "")
 
 if (CMAKE_COMPILER_IS_GNUCXX)
   execute_process(COMMAND echo "int main(){}"
-                  COMMAND ${CMAKE_CXX_COMPILER} -dM -E -
+                  COMMAND ${CMAKE_CXX_COMPILER} ${CMAKE_CXX_COMPILER_ARG1} -dM -E -
 		  OUTPUT_VARIABLE TEST_FOR_ARM_RESULTS)
 
   string(REGEX MATCH "__arm" ARM_FOUND "${TEST_FOR_ARM_RESULTS}")

--- a/cmake/Modules/TestForSSE.cmake
+++ b/cmake/Modules/TestForSSE.cmake
@@ -8,7 +8,7 @@
 function (test_for_sse h_file result_var name)
   if (NOT DEFINED ${result_var})
     execute_process(COMMAND echo "#include <${h_file}>"
-                    COMMAND ${CMAKE_CXX_COMPILER} -c -x c++ -
+                    COMMAND ${CMAKE_CXX_COMPILER} ${CMAKE_CXX_COMPILER_ARG1} -c -x c++ -
 		    RESULT_VARIABLE COMPILE_RESULT
 		    OUTPUT_QUIET ERROR_QUIET)
     set(detected 0)

--- a/src/algorithms/libs/volk_gnsssdr_module/volk_gnsssdr/CMakeLists.txt
+++ b/src/algorithms/libs/volk_gnsssdr_module/volk_gnsssdr/CMakeLists.txt
@@ -38,6 +38,7 @@ set(CMAKE_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}) #allows this to be a sub-proje
 set(CMAKE_BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR}) #allows this to be a sub-project
 set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake) #location for custom "Modules"
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=c11")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
 
 ########################################################################
 # Environment setup

--- a/src/algorithms/libs/volk_gnsssdr_module/volk_gnsssdr/lib/volk_gnsssdr_malloc.c
+++ b/src/algorithms/libs/volk_gnsssdr_module/volk_gnsssdr/lib/volk_gnsssdr_malloc.c
@@ -20,8 +20,7 @@
 #include "volk_gnsssdr/volk_gnsssdr_malloc.h"
 #include <pthread.h>
 #include <stdio.h>
-
-
+#include <string.h>
 
 /*
  * For #defines used to determine support for allocation functions,
@@ -52,12 +51,20 @@
 //#else // _ISOC11_SOURCE
 
 // Otherwise, test if we are a POSIX or X/Open system
-// This only has a restriction that alignment be a power of 2.
+// This only has a restriction that alignment be a power of 2and a
+// multiple of sizeof(void *).
 #if _POSIX_C_SOURCE >= 200112L || _XOPEN_SOURCE >= 600 || HAVE_POSIX_MEMALIGN
 
 void *volk_gnsssdr_malloc(size_t size, size_t alignment)
 {
     void *ptr;
+
+  // quoting posix_memalign() man page:
+  // "alignment must be a power of two and a multiple of sizeof(void *)"
+  // volk_get_alignment() could return 1 for some machines (e.g. generic_orc)
+  if (alignment == 1)
+    return malloc(size);
+
     int err = posix_memalign(&ptr, alignment, size);
     if(err == 0)
         {
@@ -65,7 +72,9 @@ void *volk_gnsssdr_malloc(size_t size, size_t alignment)
         }
     else
         {
-            fprintf(stderr, "VOLK: Error allocating memory (posix_memalign: %d)\n", err);
+            fprintf(stderr,
+                    "VOLK: Error allocating memory "
+                    "(posix_memalign: error %d: %s)\n", err, strerror(err));
             return NULL;
         }
 }


### PR DESCRIPTION
These are a few changes which were needed in order to get cross-compilation working a little easier. In particular, when trying to compile in a Buildroot environment.

Here are some justifications for all of the changes:

## 1. Reverted In-tree Build to a Warning
Buildroot likes to do its builds in-tree. It's not really worth the effort to work around it, so I think a simple warning would suffice.

## 2. CMake Arguments for the VOLK module
The C compiler argument was missing, which caused CMake to pick the system default; this breaks if you want to use something different. I also added a toolchain file argument when one is being used. The VOLK module should now build under the same environment as GNSS-SDR.

## 3. Not Failing When gfortran is Not Found
As per issue #5, gfortran isn't actually essential. If gfortran is not available, Armadillo will still build just fine. A warning will still be printed, but config/build will still go ahead.

The main issue here is that Fortran support is deprecated in Buildroot.

## 4. New Compilation Tests in TestForARM and TestForSSE.

When using certain compilers, including ccache, the arguments `-dM` and `-c` are not directly supported (i.e. ccache will balk and refuse to continue.) The Buildroot toolchain file specifices `${CMAKE_CXX_COMPILER_ARG1}` which is the actual path to the cross-compiler and the first argument to ccache. The test compilation now works as expected, and doesn't intrude on standard builds either.

## 5. Setting C++ Compiler Flags for VOLK

The new math functions like `std::exp2` and `std::log`, which were introduced in C++11, are used in Armadillo header files. Added `-std=c++11` to allow compilation to continue.


## 6. Patch for volk_gnsssdr_malloc

VOLK's use of `posix_memalign` is broken on some ARM systems. This is due to the alignment on these systems being 1, which is not a multiple of `sizeof(void*)`. A near-identical patch has been applied to the upstream out-of-tree VOLK for gnuradio. 
