### PR TITLE
OsmoSdr Flags

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -444,7 +444,7 @@ if (NOT GFlags_FOUND)
      ExternalProject_Add(
           gflags-${gflags_RELEASE}
           PREFIX ${CMAKE_CURRENT_BINARY_DIR}/gflags-${gflags_RELEASE}
-          GIT_REPOSITORY https://github.com/gflags/gflags
+          GIT_REPOSITORY git://github.com/gflags/gflags.git
           GIT_TAG v${gflags_RELEASE}
           DOWNLOAD_DIR ${CMAKE_CURRENT_BINARY_DIR}/download/gflags-${gflags_RELEASE}
           SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/thirdparty/gflags/gflags-${gflags_RELEASE}

--- a/conf/gnss-sdr_GPS_L1_rtl_tcp_realtime.conf
+++ b/conf/gnss-sdr_GPS_L1_rtl_tcp_realtime.conf
@@ -1,0 +1,308 @@
+; Default configuration file
+; You can define your own receiver and invoke it by doing
+; gnss-sdr --config_file=my_GNSS_SDR_configuration.conf
+;
+
+[GNSS-SDR]
+
+;######### GLOBAL OPTIONS ##################
+;internal_fs_hz: Internal signal sampling frequency after the signal conditioning stage [Hz].
+;FOR USE GNSS-SDR WITH RTLSDR DONGLES USER MUST SET THE CALIBRATED SAMPLE RATE HERE
+; i.e. using front-end-cal as reported here:http://www.cttc.es/publication/turning-a-television-into-a-gnss-receiver/
+GNSS-SDR.internal_fs_hz=1999898
+
+;######### CONTROL_THREAD CONFIG ############
+ControlThread.wait_for_flowgraph=false
+
+;######### SUPL RRLP GPS assistance configuration #####
+GNSS-SDR.SUPL_gps_enabled=false
+GNSS-SDR.SUPL_read_gps_assistance_xml=false
+GNSS-SDR.SUPL_gps_ephemeris_server=supl.nokia.com
+GNSS-SDR.SUPL_gps_ephemeris_port=7275
+GNSS-SDR.SUPL_gps_acquisition_server=supl.google.com
+GNSS-SDR.SUPL_gps_acquisition_port=7275
+GNSS-SDR.SUPL_MCC=244
+GNSS-SDR.SUPL_MNS=5
+GNSS-SDR.SUPL_LAC=0x59e2
+GNSS-SDR.SUPL_CI=0x31b0
+
+;######### SIGNAL_SOURCE CONFIG ############
+;#implementation: Use [File_Signal_Source] or [UHD_Signal_Source] or [GN3S_Signal_Source] [Osmosdr_Signal_Source]
+SignalSource.implementation=Osmosdr_Signal_Source
+
+;#filename: path to file with the captured GNSS signal samples to be processed
+SignalSource.filename=/media/DATALOGGER_/signals/RTL-SDR/geo/pmt4.dat
+
+;#item_type: Type and resolution for each of the signal samples. Use only gr_complex in this version.
+SignalSource.item_type=gr_complex
+
+;#sampling_frequency: Original Signal sampling frequency in [Hz]
+;FOR USE GNSS-SDR WITH RTLSDR DONGLES USER MUST SET THE CALIBRATED SAMPLE RATE HERE
+; i.e. using front-end-cal as reported here:http://www.cttc.es/publication/turning-a-television-into-a-gnss-receiver/
+SignalSource.sampling_frequency=2000000
+
+;#freq: RF front-end center frequency in [Hz]
+SignalSource.freq=1575420000
+
+;#gain: Front-end overall gain Gain in [dB]
+SignalSource.gain=40
+
+;#rf_gain: Front-end RF stage gain in [dB]
+SignalSource.rf_gain=40
+
+;#rf_gain: Front-end IF stage gain in [dB]
+SignalSource.if_gain=30
+
+;#AGC_enabled: Front-end AGC enabled or disabled
+SignalSource.AGC_enabled = false
+
+;#samples: Number of samples to be processed. Notice that 0 indicates the entire file.
+SignalSource.samples=0
+
+;#repeat: Repeat the processing file. Disable this option in this version
+SignalSource.repeat=false
+
+;#dump: Dump the Signal source data to a file. Disable this option in this version
+SignalSource.dump=false
+
+SignalSource.dump_filename=../data/signal_source.dat
+
+
+;#enable_throttle_control: Enabling this option tells the signal source to keep the delay between samples in post processing.
+; it helps to not overload the CPU, but the processing time will be longer.
+SignalSource.enable_throttle_control=false
+
+;#Send optional arguments to the OsmoSdr Gnuradio block
+;#Arguments are comma-delimited. See http://sdr.osmocom.org/trac/wiki/GrOsmoSDR for documentation.
+SignalSource.osmosdr_args=rtl_tcp,offset_tune=1
+
+;######### SIGNAL_CONDITIONER CONFIG ############
+;## It holds blocks to change data type, filter and resample input data.
+
+;#implementation: Use [Pass_Through] or [Signal_Conditioner]
+;#[Pass_Through] disables this block and the [DataTypeAdapter], [InputFilter] and [Resampler] blocks
+;#[Signal_Conditioner] enables this block. Then you have to configure [DataTypeAdapter], [InputFilter] and [Resampler] blocks
+SignalConditioner.implementation=Signal_Conditioner
+
+;######### DATA_TYPE_ADAPTER CONFIG ############
+;## Changes the type of input data. Please disable it in this version.
+;#implementation: [Pass_Through] disables this block
+DataTypeAdapter.implementation=Pass_Through
+
+;######### INPUT_FILTER CONFIG ############
+;## Filter the input data. Can be combined with frequency translation for IF signals
+
+;#implementation: Use [Pass_Through] or [Fir_Filter] or [Freq_Xlating_Fir_Filter]
+;#[Pass_Through] disables this block
+;#[Fir_Filter] enables a FIR Filter
+;#[Freq_Xlating_Fir_Filter] enables FIR filter and a composite frequency translation that shifts IF down to zero Hz.
+
+InputFilter.implementation=Freq_Xlating_Fir_Filter
+
+;#dump: Dump the filtered data to a file.
+InputFilter.dump=false
+
+;#dump_filename: Log path and filename.
+InputFilter.dump_filename=../data/input_filter.dat
+
+;#The following options are used in the filter design of Fir_Filter and Freq_Xlating_Fir_Filter implementation.
+;#These options are based on parameters of gnuradio's function: gr_remez.
+;#These function calculates the optimal (in the Chebyshev/minimax sense) FIR filter inpulse reponse given a set of band edges, the desired reponse on those bands, and the weight given to the error in those bands.
+
+;#input_item_type: Type and resolution for input signal samples. Use only gr_complex in this version.
+InputFilter.input_item_type=gr_complex
+
+;#outut_item_type: Type and resolution for output filtered signal samples. Use only gr_complex in this version.
+InputFilter.output_item_type=gr_complex
+
+;#taps_item_type: Type and resolution for the taps of the filter. Use only float in this version.
+InputFilter.taps_item_type=float
+
+;#number_of_taps: Number of taps in the filter. Increasing this parameter increases the processing time
+InputFilter.number_of_taps=5
+
+;#number_of _bands: Number of frequency bands in the filter.
+InputFilter.number_of_bands=2
+
+;#bands: frequency at the band edges [ b1 e1 b2 e2 b3 e3 ...].
+;#Frequency is in the range [0, 1], with 1 being the Nyquist frequency (Fs/2)
+;#The number of band_begin and band_end elements must match the number of bands
+
+InputFilter.band1_begin=0.0
+InputFilter.band1_end=0.45
+InputFilter.band2_begin=0.55
+InputFilter.band2_end=1.0
+
+;#ampl: desired amplitude at the band edges [ a(b1) a(e1) a(b2) a(e2) ...].
+;#The number of ampl_begin and ampl_end elements must match the number of bands
+
+InputFilter.ampl1_begin=1.0
+InputFilter.ampl1_end=1.0
+InputFilter.ampl2_begin=0.0
+InputFilter.ampl2_end=0.0
+
+;#band_error: weighting applied to each band (usually 1).
+;#The number of band_error elements must match the number of bands
+InputFilter.band1_error=1.0
+InputFilter.band2_error=1.0
+
+;#filter_type: one of "bandpass", "hilbert" or "differentiator"
+InputFilter.filter_type=bandpass
+
+;#grid_density: determines how accurately the filter will be constructed.
+;The minimum value is 16; higher values are slower to compute the filter.
+InputFilter.grid_density=16
+
+;#The following options are used only in Freq_Xlating_Fir_Filter implementation.
+;#InputFilter.IF is the intermediate frequency (in Hz) shifted down to zero Hz
+;FOR USE GNSS-SDR WITH RTLSDR DONGLES USER MUST SET THE CALIBRATED SAMPLE RATE HERE
+; i.e. using front-end-cal as reported here:http://www.cttc.es/publication/turning-a-television-into-a-gnss-receiver/
+InputFilter.sampling_frequency=1999898
+;# IF deviation due to front-end LO inaccuracies [HZ]
+InputFilter.IF=80558
+
+;######### RESAMPLER CONFIG ############
+;## Resamples the input data.
+;# DISABLED IN THE RTL-SDR REALTIME
+;#implementation: Use [Pass_Through] or [Direct_Resampler]
+;#[Pass_Through] disables this block
+Resampler.implementation=Pass_Through
+
+;######### CHANNELS GLOBAL CONFIG ############
+;#count: Number of available GPS satellite channels.
+Channels_GPS.count=4
+;#count: Number of available Galileo satellite channels.
+Channels_Galileo.count=0
+;#in_acquisition: Number of channels simultaneously acquiring for the whole receiver
+Channels.in_acquisition=1
+;#system: GPS, GLONASS, GALILEO, SBAS or COMPASS
+;#if the option is disabled by default is assigned GPS
+Channel.system=GPS
+
+;#signal:
+;#if the option is disabled by default is assigned "1C" GPS L1 C/A
+Channel.signal=1C
+Channel0.signal=1C
+
+
+;######### ACQUISITION GLOBAL CONFIG ############
+
+;#dump: Enable or disable the acquisition internal data file logging [true] or [false]
+Acquisition_GPS.dump=false
+;#filename: Log path and filename
+Acquisition_GPS.dump_filename=./acq_dump.dat
+;#item_type: Type and resolution for each of the signal samples. Use only gr_complex in this version.
+Acquisition_GPS.item_type=gr_complex
+;#if: Signal intermediate frequency in [Hz]
+Acquisition_GPS.if=0
+;#sampled_ms: Signal block duration for the acquisition signal detection [ms]
+Acquisition_GPS.sampled_ms=1
+;#implementation: Acquisition algorithm selection for this channel: [GPS_L1_CA_PCPS_Acquisition] or [Galileo_E1_PCPS_Ambiguous_Acquisition]
+Acquisition_GPS.implementation=GPS_L1_CA_PCPS_Acquisition_Fine_Doppler
+;#threshold: Acquisition threshold
+Acquisition_GPS.threshold=0.015
+;#pfa: Acquisition false alarm probability. This option overrides the threshold option. Only use with implementations: [GPS_L1_CA_PCPS_Acquisition] or [Galileo_E1_PCPS_Ambiguous_Acquisition]
+;Acquisition_GPS.pfa=0.0001
+;#doppler_max: Maximum expected Doppler shift [Hz]
+Acquisition_GPS.doppler_max=10000
+;#doppler_max: Maximum expected Doppler shift [Hz]
+Acquisition_GPS.doppler_min=-10000
+;#doppler_step Doppler step in the grid search [Hz]
+Acquisition_GPS.doppler_step=500
+;#maximum dwells
+Acquisition_GPS.max_dwells=15
+
+;######### ACQUISITION CHANNELS CONFIG ######
+;#The following options are specific to each channel and overwrite the generic options
+
+;#repeat_satellite: Use only jointly with the satellite PRN ID option. The default value is false
+;Acquisition0.repeat_satellite = false
+
+;######### TRACKING GLOBAL CONFIG ############
+
+;#implementation: Selected tracking algorithm: [GPS_L1_CA_DLL_PLL_Tracking] or [GPS_L1_CA_DLL_FLL_PLL_Tracking] [GPS_L1_CA_DLL_PLL_Optim_Tracking]
+Tracking_GPS.implementation=GPS_L1_CA_DLL_PLL_Optim_Tracking
+;#item_type: Type and resolution for each of the signal samples. Use only [gr_complex] in this version.
+Tracking_GPS.item_type=gr_complex
+
+;#sampling_frequency: Signal Intermediate Frequency in [Hz]
+Tracking_GPS.if=0
+
+;#dump: Enable or disable the Tracking internal binary data file logging [true] or [false]
+Tracking_GPS.dump=false
+
+;#dump_filename: Log path and filename. Notice that the tracking channel will add "x.dat" where x is the channel number.
+Tracking_GPS.dump_filename=./tracking_ch_
+
+;#pll_bw_hz: PLL loop filter bandwidth [Hz]
+Tracking_GPS.pll_bw_hz=40.0;
+
+;#dll_bw_hz: DLL loop filter bandwidth [Hz]
+Tracking_GPS.dll_bw_hz=2.0;
+
+;#fll_bw_hz: FLL loop filter bandwidth [Hz]
+Tracking_GPS.fll_bw_hz=10.0;
+
+;#order: PLL/DLL loop filter order [2] or [3]
+Tracking_GPS.order=3;
+
+;#early_late_space_chips: correlator early-late space [chips]. Use [0.5]
+Tracking_GPS.early_late_space_chips=0.5;
+
+;######### TELEMETRY DECODER GPS CONFIG ############
+;#implementation: Use [GPS_L1_CA_Telemetry_Decoder] for GPS L1 C/A
+TelemetryDecoder_GPS.implementation=GPS_L1_CA_Telemetry_Decoder
+TelemetryDecoder_GPS.dump=false
+;#decimation factor
+TelemetryDecoder_GPS.decimation_factor=1;
+
+;######### OBSERVABLES CONFIG ############
+;#implementation: Use [GPS_L1_CA_Observables] for GPS L1 C/A.
+Observables.implementation=GPS_L1_CA_Observables
+
+;#dump: Enable or disable the Observables internal binary data file logging [true] or [false]
+Observables.dump=false
+
+;#dump_filename: Log path and filename.
+Observables.dump_filename=./observables.dat
+
+
+;######### PVT CONFIG ############
+;#implementation: Position Velocity and Time (PVT) implementation algorithm: Use [GPS_L1_CA_PVT] in this version.
+PVT.implementation=GPS_L1_CA_PVT
+
+;#averaging_depth: Number of PVT observations in the moving average algorithm
+PVT.averaging_depth=10
+
+;#flag_average: Enables the PVT averaging between output intervals (arithmetic mean) [true] or [false]
+PVT.flag_averaging=true
+
+;#output_rate_ms: Period between two PVT outputs. Notice that the minimum period is equal to the tracking integration time (for GPS CA L1 is 1ms) [ms]
+PVT.output_rate_ms=100
+
+;#display_rate_ms: Position console print (std::out) interval [ms]. Notice that output_rate_ms<=display_rate_ms.
+PVT.display_rate_ms=500
+
+;# RINEX, KML, and NMEA output configuration
+
+;#dump_filename: Log path and filename without extension. Notice that PVT will add ".dat" to the binary dump and ".kml" to GoogleEarth dump.
+PVT.dump_filename=./PVT
+
+;#nmea_dump_filename: NMEA log path and filename
+PVT.nmea_dump_filename=./gnss_sdr_pvt.nmea;
+
+;#flag_nmea_tty_port: Enable or disable the NMEA log to a serial TTY port (Can be used with real hardware or virtual one)
+PVT.flag_nmea_tty_port=false;
+
+;#nmea_dump_devname: serial device descriptor for NMEA logging
+PVT.nmea_dump_devname=/dev/pts/4
+
+
+;#dump: Enable or disable the PVT internal binary data file logging [true] or [false]
+PVT.dump=true
+
+;######### OUTPUT_FILTER CONFIG ############
+;# Receiver output filter: Leave this block disabled in this version
+OutputFilter.implementation=Null_Sink_Output_Filter
+OutputFilter.filename=data/gnss-sdr.dat
+OutputFilter.item_type=gr_complex

--- a/src/algorithms/signal_source/adapters/osmosdr_signal_source.cc
+++ b/src/algorithms/signal_source/adapters/osmosdr_signal_source.cc
@@ -65,6 +65,7 @@ OsmosdrSignalSource::OsmosdrSignalSource(ConfigurationInterface* configuration,
     if_gain_ = configuration->property(role + ".if_gain", (double)40.0);
     sample_rate_ = configuration->property(role + ".sampling_frequency", (double)2.0e6);
     item_type_ = configuration->property(role + ".item_type", default_item_type);
+    osmosdr_args_ = configuration->property(role + ".osmosdr_args", std::string( ));
 
     if (item_type_.compare("short") == 0)
         {
@@ -76,7 +77,7 @@ OsmosdrSignalSource::OsmosdrSignalSource(ConfigurationInterface* configuration,
             // 1. Make the driver instance
             try
             {
-                    osmosdr_source_ = osmosdr::source::make();
+                    osmosdr_source_ = osmosdr::source::make(osmosdr_args_);
             }
             catch( boost::exception & e )
             {

--- a/src/algorithms/signal_source/adapters/osmosdr_signal_source.cc
+++ b/src/algorithms/signal_source/adapters/osmosdr_signal_source.cc
@@ -77,6 +77,11 @@ OsmosdrSignalSource::OsmosdrSignalSource(ConfigurationInterface* configuration,
             // 1. Make the driver instance
             try
             {
+                    if (!osmosdr_args_.empty())
+                        {
+                        std::cout << "OsmoSdr arguments: " << osmosdr_args_ << std::endl;
+                        LOG(INFO) << "OsmoSdr arguments: " << osmosdr_args_;
+                        }
                     osmosdr_source_ = osmosdr::source::make(osmosdr_args_);
             }
             catch( boost::exception & e )

--- a/src/algorithms/signal_source/adapters/osmosdr_signal_source.h
+++ b/src/algorithms/signal_source/adapters/osmosdr_signal_source.h
@@ -100,6 +100,7 @@ private:
     std::string dump_filename_;
 
     osmosdr::source::sptr osmosdr_source_;
+    std::string osmosdr_args_;
 
     boost::shared_ptr<gr::block> valve_;
     gr::blocks::file_sink::sptr file_sink_;


### PR DESCRIPTION
This is a change to introduce a new SignalSource config string known as `SignalSource.osmosdr_args`. These arguments will be sent to the GrOsmoSdr library when building the `osmosdr::source` object of the `osmosdr_signal_source` adapter. 

Sending arguments to this constructor allows greater control over the library, including specifying which device to use (in case you have more than one plugged in) and other fun stuff such as connecting to an `rtl_tcp` host over a network.

See http://sdr.osmocom.org/trac/wiki/GrOsmoSDR for details.

The default value for this config string is just an empty string, which is the default argument for the `osmosdr::source` constructor. So old behaviour won't be affected.

I performed a test by running `rtl_tcp -a <network address> -f 1575420000 -g 0 -s 2000000` on one computer  attached to a LAN and with an RTL dongle attached. I then ran GNSS-SDR on a separate computer attached to the same LAN with the configuration value set to `SignalSource.osmosdr_args=rtl_tcp=<address of remote computer>`. GrOsmoSdr connected just fine, and started reading I/Q data of the LAN.