### PR TITLE
Two bit packed file source

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 *~
+.*.swp
 docs/doxygen/Doxyfile
 docs/html
 docs/latex

--- a/conf/gnss-sdr_GPS_L1_nsr_twobit_packed.conf
+++ b/conf/gnss-sdr_GPS_L1_nsr_twobit_packed.conf
@@ -1,0 +1,152 @@
+; Sample configuration file for IFEN SX-NSR software receiver front-end
+; http://www.ifen.com/products/sx-scientific-gnss-solutions/nsr-software-receiver.html
+; This sample configuration is able to process directly .sream binary files
+; You can define your own receiver and invoke it by doing
+; gnss-sdr --config_file=my_GNSS_SDR_configuration.conf
+;
+
+[GNSS-SDR]
+
+;######### GLOBAL OPTIONS ##################
+;internal_fs_hz: Internal signal sampling frequency after the signal conditioning stage [Hz].
+GNSS-SDR.internal_fs_hz=2560000
+
+;######### CONTROL_THREAD CONFIG ############
+ControlThread.wait_for_flowgraph=false
+
+;######### SUPL RRLP GPS assistance configuration #####
+GNSS-SDR.SUPL_gps_enabled=false
+GNSS-SDR.SUPL_read_gps_assistance_xml=false
+GNSS-SDR.SUPL_gps_ephemeris_server=supl.nokia.com
+GNSS-SDR.SUPL_gps_ephemeris_port=7275
+GNSS-SDR.SUPL_gps_acquisition_server=supl.google.com
+GNSS-SDR.SUPL_gps_acquisition_port=7275
+GNSS-SDR.SUPL_MCC=244
+GNSS-SDR.SUPL_MNS=5
+GNSS-SDR.SUPL_LAC=0x59e2
+GNSS-SDR.SUPL_CI=0x31b0
+
+;######### SIGNAL_SOURCE CONFIG ############
+SignalSource.implementation=Two_Bit_Packed_File_Signal_Source
+SignalSource.filename=/datalogger/signals/ifen/E1L1_FE0_Band0.stream
+SignalSource.item_type=byte
+; big_endian_items : not needed for byte inputs
+; If the input were 'short' then this can either be big endian or little
+; endian. If it is big endian then the second byte should be output
+; first in each short.
+; SignalSource.big_endian_items=false
+; big_endian_bytes: true if the most signficiant two bits in the byte
+; are the first two to be output.
+SignalSource.big_endian_bytes=false
+; sample_type: one of 'real' 'iq' or 'qi'
+; Data is either real or complex.
+; if the data is complex there are two conventions for sample ordering:
+; 1) Real first : 'iq'
+; 2) Imaginary first: 'qi'
+; This setting specifies which of the three cases holds for this data file
+SignalSource.sample_type=real
+SignalSource.sampling_frequency=20480000
+SignalSource.freq=1575420000
+SignalSource.samples=0
+SignalSource.repeat=false
+SignalSource.dump=false
+SignalSource.dump_filename=../data/signal_source.dat
+SignalSource.enable_throttle_control=false
+
+
+;######### SIGNAL_CONDITIONER CONFIG ############
+SignalConditioner.implementation=Signal_Conditioner
+
+;######### DATA_TYPE_ADAPTER CONFIG ############
+DataTypeAdapter.implementation=Pass_Through
+DataTypeAdapter.item_type=float
+
+;######### INPUT_FILTER CONFIG ############
+InputFilter.implementation=Freq_Xlating_Fir_Filter
+InputFilter.dump=false
+InputFilter.dump_filename=../data/input_filter.dat
+InputFilter.input_item_type=float
+InputFilter.output_item_type=gr_complex
+InputFilter.taps_item_type=float
+InputFilter.number_of_taps=5
+InputFilter.number_of_bands=2
+InputFilter.band1_begin=0.0
+InputFilter.band1_end=0.45
+InputFilter.band2_begin=0.55
+InputFilter.band2_end=1.0
+InputFilter.ampl1_begin=1.0
+InputFilter.ampl1_end=1.0
+InputFilter.ampl2_begin=0.0
+InputFilter.ampl2_end=0.0
+InputFilter.band1_error=1.0
+InputFilter.band2_error=1.0
+InputFilter.filter_type=bandpass
+InputFilter.grid_density=16
+InputFilter.sampling_frequency=20480000
+InputFilter.IF=5499998.47412109
+InputFilter.decimation_factor=8
+
+
+;######### RESAMPLER CONFIG ############
+Resampler.implementation=Pass_Through
+Resampler.dump=false
+Resampler.dump_filename=../data/resampler.dat
+Resampler.item_type=gr_complex
+
+
+;######### CHANNELS GLOBAL CONFIG ############
+;#count: Number of available GPS satellite channels.
+Channels_1C.count=8
+Channels.in_acquisition=1
+Channel.signal=1C
+
+
+;######### GPS ACQUISITION CONFIG ############
+Acquisition_1C.dump=false
+Acquisition_1C.dump_filename=./acq_dump.dat
+Acquisition_1C.item_type=gr_complex
+Acquisition_1C.if=0
+Acquisition_1C.sampled_ms=1
+Acquisition_1C.implementation=GPS_L1_CA_PCPS_Acquisition
+Acquisition_1C.threshold=0.0075
+;Acquisition_1C.pfa=0.01
+Acquisition_1C.doppler_max=10000
+Acquisition_1C.doppler_step=500
+
+
+;######### TRACKING GPS CONFIG ############
+Tracking_1C.implementation=GPS_L1_CA_DLL_PLL_Tracking
+Tracking_1C.item_type=gr_complex
+Tracking_1C.if=0
+Tracking_1C.dump=false
+Tracking_1C.dump_filename=../data/epl_tracking_ch_
+Tracking_1C.pll_bw_hz=45.0;
+Tracking_1C.dll_bw_hz=2.0;
+Tracking_1C.order=3;
+
+;######### TELEMETRY DECODER GPS CONFIG ############
+TelemetryDecoder_1C.implementation=GPS_L1_CA_Telemetry_Decoder
+TelemetryDecoder_1C.dump=false
+TelemetryDecoder_1C.decimation_factor=1;
+
+;######### OBSERVABLES CONFIG ############
+Observables.implementation=GPS_L1_CA_Observables
+Observables.dump=false
+Observables.dump_filename=./observables.dat
+
+
+;######### PVT CONFIG ############
+PVT.implementation=GPS_L1_CA_PVT
+PVT.averaging_depth=100
+PVT.flag_averaging=false
+PVT.output_rate_ms=10
+PVT.display_rate_ms=500
+PVT.dump_filename=./PVT
+PVT.nmea_dump_filename=./gnss_sdr_pvt.nmea;
+PVT.flag_nmea_tty_port=false;
+PVT.nmea_dump_devname=/dev/pts/4
+PVT.dump=true
+
+;######### OUTPUT_FILTER CONFIG ############
+OutputFilter.implementation=Null_Sink_Output_Filter
+OutputFilter.item_type=gr_complex

--- a/src/algorithms/signal_source/adapters/CMakeLists.txt
+++ b/src/algorithms/signal_source/adapters/CMakeLists.txt
@@ -140,7 +140,9 @@ set(SIGNAL_SOURCE_ADAPTER_SOURCES file_signal_source.cc
 )
 
 if(PC_GNURADIO_RUNTIME_VERSION VERSION_GREATER 3.7.3)
-     set(SIGNAL_SOURCE_ADAPTER_SOURCES ${SIGNAL_SOURCE_ADAPTER_SOURCES} two_bit_cpx_file_signal_source.cc )
+     set(SIGNAL_SOURCE_ADAPTER_SOURCES ${SIGNAL_SOURCE_ADAPTER_SOURCES}
+         two_bit_cpx_file_signal_source.cc
+         two_bit_packed_file_signal_source.cc )
 endif(PC_GNURADIO_RUNTIME_VERSION VERSION_GREATER 3.7.3)
 
 include_directories(

--- a/src/algorithms/signal_source/adapters/two_bit_packed_file_signal_source.cc
+++ b/src/algorithms/signal_source/adapters/two_bit_packed_file_signal_source.cc
@@ -1,0 +1,331 @@
+/*!
+ * \file two_bit_packed_file_signal_source.cc
+ * \brief Interface of a class that reads signals samples from a file. Each
+ * sample is two bits, which are packed into bytes or shorts.
+ *
+ * \author Cillian O'Driscoll, 2015 cillian.odriscoll (at) gmail.com
+ *
+ * -------------------------------------------------------------------------
+ *
+ * Copyright (C) 2010-2015  (see AUTHORS file for a list of contributors)
+ *
+ * GNSS-SDR is a software defined Global Navigation
+ *          Satellite Systems receiver
+ *
+ * This file is part of GNSS-SDR.
+ *
+ * GNSS-SDR is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * GNSS-SDR is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with GNSS-SDR. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * -------------------------------------------------------------------------
+ */
+
+#include "two_bit_packed_file_signal_source.h"
+#include <cstdlib>
+#include <exception>
+#include <fstream>
+#include <iomanip>
+#include <iostream>
+#include <gflags/gflags.h>
+#include <glog/logging.h>
+#include "gnss_sdr_valve.h"
+#include "configuration_interface.h"
+#include <gnuradio/blocks/char_to_float.h>
+
+
+using google::LogMessage;
+
+//DEFINE_string(two_bit_packed_signal_source, "-",
+//		"If defined, path to the file containing the NSR (byte to 2-bit packed) signal samples (overrides the configuration file)");
+
+
+TwoBitPackedFileSignalSource::TwoBitPackedFileSignalSource(ConfigurationInterface* configuration,
+        std::string role, unsigned int in_streams, unsigned int out_streams,
+        boost::shared_ptr<gr::msg_queue> queue) :
+		                role_(role), in_streams_(in_streams), out_streams_(out_streams), queue_(queue)
+{
+    std::string default_filename = "../data/my_capture.dat";
+    std::string default_item_type = "byte";
+    std::string default_dump_filename = "../data/my_capture_dump.dat";
+    std::string default_sample_type = "real";
+    double default_seconds_to_skip = 0.0;
+
+    samples_ = configuration->property(role + ".samples", 0L);
+    sampling_frequency_ = configuration->property(role + ".sampling_frequency", 0);
+    filename_ = configuration->property(role + ".filename", default_filename);
+
+    // override value with commandline flag, if present
+    //if (FLAGS_nsr_signal_source.compare("-") != 0) filename_= FLAGS_nsr_signal_source;
+
+    item_type_ = configuration->property(role + ".item_type", default_item_type);
+    big_endian_items_ = configuration->property(role + ".big_endian_items", true);
+    big_endian_bytes_ = configuration->property(role + ".big_endian_bytes", false);
+    sample_type_  = configuration->property(role + ".sample_type", default_sample_type ); // options: "real", "iq", "qi"
+    repeat_ = configuration->property(role + ".repeat", false);
+    dump_ = configuration->property(role + ".dump", false);
+    dump_filename_ = configuration->property(role + ".dump_filename", default_dump_filename);
+    enable_throttle_control_ = configuration->property(role + ".enable_throttle_control", false);
+    double seconds_to_skip = configuration->property(role + ".seconds_to_skip", default_seconds_to_skip );
+    long bytes_to_skip = 0;
+
+    if (item_type_.compare("byte") == 0)
+        {
+            item_size_ = sizeof(char);
+        }
+    else if( item_type_.compare("short") == 0)
+        {
+            // If we have shorts stored in little endian format, might as
+            // well read them in as bytes.
+            if( big_endian_items_ )
+            {
+                item_size_ = sizeof(short);
+            }
+            else
+            {
+                item_size_ = sizeof(char);
+            }
+        }
+    else
+        {
+            LOG(WARNING) << item_type_  << " unrecognized item type. Using byte.";
+            item_size_ = sizeof(char);
+        }
+
+
+    if( sample_type_.compare("real") == 0 )
+    {
+        is_complex_ = false;
+    }
+    else if( sample_type_.compare("iq" ) == 0 )
+    {
+        is_complex_ = true;
+        reverse_interleaving_ = false;
+    }
+    else if( sample_type_.compare("qi") == 0 )
+    {
+        is_complex_ = true;
+        reverse_interleaving_ = true;
+    }
+    else
+    {
+        LOG(WARNING) << sample_type_ << " unrecognized sample type. Assuming: "
+            << ( is_complex_ ? ( reverse_interleaving_ ? "qi" : "iq" ) : "real" );
+    }
+    try
+    {
+            file_source_ = gr::blocks::file_source::make(item_size_, filename_.c_str(), repeat_);
+
+            if( seconds_to_skip > 0 )
+            {
+                bytes_to_skip = static_cast< long >(
+                        seconds_to_skip * sampling_frequency_ / 4 );
+                if( is_complex_ )
+                {
+                    bytes_to_skip <<= 1;
+                }
+                file_source_->seek( bytes_to_skip, SEEK_SET );
+            }
+
+            unpack_samples_ = make_unpack_2bit_samples( big_endian_bytes_,
+                    item_size_, big_endian_items_, reverse_interleaving_);
+            if( is_complex_ )
+            {
+                char_to_float_ =
+                    gr::blocks::interleaved_char_to_complex::make(false);
+            }
+            else
+            {
+                char_to_float_ =
+                    gr::blocks::char_to_float::make();
+            }
+
+    }
+    catch (const std::exception &e)
+    {
+            std::cerr
+            << "The receiver was configured to work with a file signal source "
+            << std::endl
+            << "but the specified file is unreachable by GNSS-SDR."
+            << std::endl
+            <<  "Please modify your configuration file"
+            << std::endl
+            <<  "and point SignalSource.filename to a valid raw data file. Then:"
+            << std::endl
+            << "$ gnss-sdr --config_file=/path/to/my_GNSS_SDR_configuration.conf"
+            << std::endl
+            << "Examples of configuration files available at:"
+            << std::endl
+            << GNSSSDR_INSTALL_DIR "/share/gnss-sdr/conf/"
+            << std::endl;
+
+            LOG(WARNING) << "file_signal_source: Unable to open the samples file "
+                         << filename_.c_str() << ", exiting the program.";
+            throw(e);
+    }
+
+    DLOG(INFO) << "file_source(" << file_source_->unique_id() << ")";
+
+    if (samples_ == 0) // read all file
+        {
+            /*!
+             * BUG workaround: The GNU Radio file source does not stop the receiver after reaching the End of File.
+             * A possible solution is to compute the file length in samples using file size, excluding the last 2 milliseconds, and enable always the
+             * valve block
+             */
+            std::ifstream file (filename_.c_str(), std::ios::in | std::ios::binary | std::ios::ate);
+            std::ifstream::pos_type size;
+
+            if (file.is_open())
+                {
+                    size = file.tellg();
+                    samples_ = floor((double)size * ( is_complex_ ? 2.0 : 4.0 ) );
+                    LOG(INFO) << "Total samples in the file= " << samples_; // 4 samples per byte
+                    samples_ -= bytes_to_skip;
+
+                    //Also skip the last two milliseconds:
+                    samples_ -= ceil( 0.002 * sampling_frequency_ / (is_complex_ ? 2.0 : 4.0 ) );
+                }
+            else
+                {
+                    std::cout << "file_signal_source: Unable to open the samples file " << filename_.c_str() << std::endl;
+                    LOG(ERROR) << "file_signal_source: Unable to open the samples file " << filename_.c_str();
+                }
+            std::cout << std::setprecision(16);
+            std::cout << "Processing file " << filename_ << ", which contains " << (double)size << " [bytes]" << std::endl;
+
+        }
+
+    CHECK(samples_ > 0) << "File does not contain enough samples to process.";
+    double signal_duration_s;
+    signal_duration_s = (double)samples_ * ( 1 /(double)sampling_frequency_);
+    LOG(INFO) << "Total number samples to be processed= " << samples_ << " GNSS signal duration= " << signal_duration_s << " [s]";
+    std::cout << "GNSS signal recorded time to be processed: " << signal_duration_s << " [s]" << std::endl;
+
+    valve_ = gnss_sdr_make_valve(sizeof(gr_complex), samples_, queue_);
+    DLOG(INFO) << "valve(" << valve_->unique_id() << ")";
+
+    if (dump_)
+        {
+            //sink_ = gr_make_file_sink(item_size_, dump_filename_.c_str());
+            sink_ = gr::blocks::file_sink::make(sizeof(gr_complex), dump_filename_.c_str());
+            DLOG(INFO) << "file_sink(" << sink_->unique_id() << ")";
+        }
+
+    if (enable_throttle_control_)
+        {
+            throttle_ = gr::blocks::throttle::make(sizeof(gr_complex), sampling_frequency_);
+        }
+    DLOG(INFO) << "File source filename " << filename_;
+    DLOG(INFO) << "Samples " << samples_;
+    DLOG(INFO) << "Sampling frequency " << sampling_frequency_;
+    DLOG(INFO) << "Item type " << item_type_;
+    DLOG(INFO) << "Item size " << item_size_;
+    DLOG(INFO) << "Repeat " << repeat_;
+    DLOG(INFO) << "Dump " << dump_;
+    DLOG(INFO) << "Dump filename " << dump_filename_;
+}
+
+
+
+
+TwoBitPackedFileSignalSource::~TwoBitPackedFileSignalSource()
+{}
+
+
+
+
+void TwoBitPackedFileSignalSource::connect(gr::top_block_sptr top_block)
+{
+    gr::basic_block_sptr left_block = file_source_;
+    gr::basic_block_sptr right_block = unpack_samples_;
+
+    top_block->connect(file_source_, 0, unpack_samples_, 0);
+    left_block = right_block;
+
+    DLOG(INFO) << "connected file source to unpack samples";
+    right_block = char_to_float_;
+    top_block->connect( left_block, 0, right_block, 0 );
+    left_block = right_block;
+    DLOG(INFO) << "connected unpack samples to char to float";
+
+    if( enable_throttle_control_ )
+    {
+        right_block = throttle_;
+        top_block->connect( left_block, 0, right_block, 0 );
+        left_block = right_block;
+        DLOG(INFO) << " connected to throttle";
+    }
+
+    top_block->connect(left_block, 0, valve_, 0);
+    DLOG(INFO) << "connected to valve";
+    if (dump_)
+    {
+        top_block->connect(valve_, 0, sink_, 0);
+        DLOG(INFO) << "connected valve to file sink";
+    }
+}
+
+
+
+
+
+
+void TwoBitPackedFileSignalSource::disconnect(gr::top_block_sptr top_block)
+{
+    gr::basic_block_sptr left_block = file_source_;
+    gr::basic_block_sptr right_block = unpack_samples_;
+
+    top_block->disconnect(file_source_, 0, unpack_samples_, 0);
+    left_block = right_block;
+
+
+    DLOG(INFO) << "disconnected file source to unpack samples";
+    right_block = char_to_float_;
+    top_block->disconnect( left_block, 0, right_block, 0 );
+    left_block = right_block;
+    DLOG(INFO) << "disconnected unpack samples to char to float";
+
+    if( enable_throttle_control_ )
+    {
+        right_block = throttle_;
+        top_block->disconnect( left_block, 0, right_block, 0 );
+        left_block = right_block;
+        DLOG(INFO) << " disconnected to throttle";
+    }
+
+    top_block->disconnect(left_block, 0, valve_, 0);
+    DLOG(INFO) << "disconnected to valve";
+    if (dump_)
+    {
+        top_block->disconnect(valve_, 0, sink_, 0);
+        DLOG(INFO) << "disconnected valve to file sink";
+    }
+}
+
+
+gr::basic_block_sptr TwoBitPackedFileSignalSource::get_left_block()
+{
+    LOG(WARNING) << "Left block of a signal source should not be retrieved";
+    //return gr_block_sptr();
+    return gr::blocks::file_source::sptr();
+}
+
+
+
+
+
+gr::basic_block_sptr TwoBitPackedFileSignalSource::get_right_block()
+{
+    return valve_;
+}
+

--- a/src/algorithms/signal_source/adapters/two_bit_packed_file_signal_source.h
+++ b/src/algorithms/signal_source/adapters/two_bit_packed_file_signal_source.h
@@ -1,0 +1,150 @@
+/*!
+ * \file two_bit_packed_file_signal_source.h
+ * \brief Interface of a class that reads signals samples from a file. Each
+ * sample is two bits, which are packed into bytes or shorts.
+ *
+ * \author Cillian O'Driscoll, 2015 cillian.odriscoll (at) gmail.com
+ *
+ * This class represents a file signal source.
+ *
+ * -------------------------------------------------------------------------
+ *
+ * Copyright (C) 2010-2015  (see AUTHORS file for a list of contributors)
+ *
+ * GNSS-SDR is a software defined Global Navigation
+ *          Satellite Systems receiver
+ *
+ * This file is part of GNSS-SDR.
+ *
+ * GNSS-SDR is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * GNSS-SDR is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with GNSS-SDR. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * -------------------------------------------------------------------------
+ */
+
+#ifndef GNSS_SDR_TWO_BIT_PACKED_FILE_SIGNAL_SOURCE_H_
+#define GNSS_SDR_TWO_BIT_PACKED_FILE_SIGNAL_SOURCE_H_
+
+#include <string>
+#include <gnuradio/blocks/file_source.h>
+#include <gnuradio/blocks/file_sink.h>
+#include <gnuradio/blocks/throttle.h>
+#include <gnuradio/hier_block2.h>
+#include <gnuradio/msg_queue.h>
+#include <gnuradio/blocks/interleaved_char_to_complex.h>
+#include "gnss_block_interface.h"
+#include "unpack_2bit_samples.h"
+
+
+
+class ConfigurationInterface;
+
+/*!
+ * \brief Class that reads signals samples from a file
+ * and adapts it to a SignalSourceInterface
+ */
+class TwoBitPackedFileSignalSource: public GNSSBlockInterface
+{
+public:
+    TwoBitPackedFileSignalSource(ConfigurationInterface* configuration, std::string role,
+            unsigned int in_streams, unsigned int out_streams,
+            boost::shared_ptr<gr::msg_queue> queue);
+
+    virtual ~TwoBitPackedFileSignalSource();
+    std::string role()
+    {
+        return role_;
+    }
+
+    /*!
+     * \brief Returns "Two_Bit_Packed_File_Signal_Source".
+     */
+    std::string implementation()
+    {
+        return "Two_Bit_Packed_File_Signal_Source";
+    }
+    size_t item_size()
+    {
+        return item_size_;
+    }
+    void connect(gr::top_block_sptr top_block);
+    void disconnect(gr::top_block_sptr top_block);
+    gr::basic_block_sptr get_left_block();
+    gr::basic_block_sptr get_right_block();
+    std::string filename()
+    {
+        return filename_;
+    }
+    std::string item_type()
+    {
+        return item_type_;
+    }
+    bool repeat()
+    {
+        return repeat_;
+    }
+    long sampling_frequency()
+    {
+        return sampling_frequency_;
+    }
+    long samples()
+    {
+        return samples_;
+    }
+    bool big_endian_items()
+    {
+        return big_endian_items_;
+    }
+    bool big_endian_bytes()
+    {
+        return big_endian_bytes_;
+    }
+    bool is_complex()
+    {
+        return is_complex_;
+    }
+    bool reverse_interleaving()
+    {
+        return reverse_interleaving_;
+    }
+
+private:
+    unsigned long long samples_;
+    long sampling_frequency_;
+    std::string filename_;
+    std::string item_type_;
+    bool repeat_;
+    bool dump_;
+    std::string dump_filename_;
+    std::string role_;
+    unsigned int in_streams_;
+    unsigned int out_streams_;
+    gr::blocks::file_source::sptr file_source_;
+    unpack_2bit_samples_sptr unpack_samples_;
+    gr::basic_block_sptr char_to_float_;
+    boost::shared_ptr<gr::block> valve_;
+    gr::blocks::file_sink::sptr sink_;
+    gr::blocks::throttle::sptr  throttle_;
+    boost::shared_ptr<gr::msg_queue> queue_;
+    size_t item_size_;
+    bool big_endian_items_;
+    bool big_endian_bytes_;
+    bool is_complex_;
+    bool reverse_interleaving_;
+    std::string sample_type_;
+    // Throttle control
+    bool enable_throttle_control_;
+};
+
+#endif /*GNSS_SDR_TWO_BIT_CPX_FILE_SIGNAL_SOURCE_H_*/
+

--- a/src/algorithms/signal_source/gnuradio_blocks/CMakeLists.txt
+++ b/src/algorithms/signal_source/gnuradio_blocks/CMakeLists.txt
@@ -22,6 +22,7 @@ set(SIGNAL_SOURCE_GR_BLOCKS_SOURCES
      unpack_byte_2bit_cpx_samples.cc
      unpack_intspir_1bit_samples.cc
      rtl_tcp_signal_source_c.cc
+     unpack_2bit_samples.cc
 )
 
 include_directories(

--- a/src/algorithms/signal_source/gnuradio_blocks/unpack_2bit_samples.cc
+++ b/src/algorithms/signal_source/gnuradio_blocks/unpack_2bit_samples.cc
@@ -71,12 +71,14 @@ void swapEndianness( int8_t const *in, std::vector< int8_t > &out, size_t item_s
     unsigned int i;
     unsigned int j = 0;
     int k = 0;
+    int l = 0;
     size_t skip = item_size - 1;
 
     for( i = 0; i < ninput_items; ++i )
     {
         k = j + skip;
-        while( k >= 0 )
+        l = j;
+        while( k >= l )
         {
             out[j++] = in[k--];
         }

--- a/src/algorithms/signal_source/gnuradio_blocks/unpack_2bit_samples.cc
+++ b/src/algorithms/signal_source/gnuradio_blocks/unpack_2bit_samples.cc
@@ -1,0 +1,184 @@
+/*!
+ * \file unpack_2bit_samples.cc
+ *
+ * \brief Unpacks 2 bit samples that have been packed into bytes or shorts
+ * \author Cillian O'Driscoll cillian.odriscoll (at) gmail.com
+ * -------------------------------------------------------------------------
+ *
+ * Copyright (C) 2010-2015  (see AUTHORS file for a list of contributors)
+ *
+ * GNSS-SDR is a software defined Global Navigation
+ *          Satellite Systems receiver
+ *
+ * This file is part of GNSS-SDR.
+ *
+ * GNSS-SDR is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * GNSS-SDR is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with GNSS-SDR. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * -------------------------------------------------------------------------
+ */
+
+
+#include "unpack_2bit_samples.h"
+#include <iostream>
+#include <gnuradio/io_signature.h>
+
+struct byte_2bit_struct
+{
+  signed sample_0:2;  // <- 2 bits wide only
+  signed sample_1:2;  // <- 2 bits wide only
+  signed sample_2:2;  // <- 2 bits wide only
+  signed sample_3:2;  // <- 2 bits wide only
+};
+
+union byte_and_samples
+{
+    int8_t byte;
+    byte_2bit_struct samples;
+};
+
+bool systemIsBigEndian()
+{
+    union
+    {
+        uint32_t i;
+        char c[4];
+    } test_int = {0x01020304};
+
+    return test_int.c[0] == 1; 
+}
+
+bool systemBytesAreBigEndian()
+{
+    byte_and_samples b;
+    b.byte = static_cast< int8_t>(0x1B);
+
+    return b.samples.sample_0 == 0x3;
+}
+
+void swapEndianness( int8_t const *in, std::vector< int8_t > &out, size_t item_size, unsigned int ninput_items )
+{
+    unsigned int i;
+    unsigned int j = 0;
+    int k = 0;
+    size_t skip = item_size - 1;
+
+    for( i = 0; i < ninput_items; ++i )
+    {
+        k = j + skip;
+        while( k >= 0 )
+        {
+            out[j++] = in[k--];
+        }
+    }
+}
+
+unpack_2bit_samples_sptr make_unpack_2bit_samples( bool big_endian_bytes,
+                                                   size_t item_size,
+                                                   bool big_endian_items )
+{
+    return unpack_2bit_samples_sptr(
+            new unpack_2bit_samples( big_endian_bytes,
+                                     item_size,
+                                     big_endian_items )
+            );
+}
+
+unpack_2bit_samples::unpack_2bit_samples( bool big_endian_bytes,
+                                          size_t item_size,
+                                          bool big_endian_items )
+    : sync_interpolator("unpack_2bit_samples",
+                        gr::io_signature::make(1, 1, item_size),
+                        gr::io_signature::make(1, 1, sizeof(char)),
+            	        4*item_size ), // we make 4 bytes out for every byte in
+      big_endian_bytes_(big_endian_bytes),
+      item_size_(item_size),
+      big_endian_items_(big_endian_items),
+      swap_endian_items_(false)
+{
+
+    bool big_endian_system = systemIsBigEndian();
+
+    // Only swap the item bytes if the item size > 1 byte and the system 
+    // endianess is not the same as the item endianness:
+    swap_endian_items_ = ( item_size_ > 1 ) && 
+                         ( big_endian_system != big_endian_items);
+
+    bool big_endian_bytes_system = systemBytesAreBigEndian();
+
+    swap_endian_bytes_ = ( big_endian_bytes_system != big_endian_bytes_ );
+
+}
+
+unpack_2bit_samples::~unpack_2bit_samples()
+{}
+
+int unpack_2bit_samples::work(int noutput_items,
+                                   gr_vector_const_void_star &input_items,
+                                   gr_vector_void_star &output_items)
+{
+    signed char const *in = (signed char const *)input_items[0];
+    int8_t *out = (int8_t*)output_items[0];
+
+    size_t ninput_bytes = noutput_items/4;
+    size_t ninput_items = ninput_bytes/item_size_;
+    
+    // Handle endian swap if needed
+    if( swap_endian_items_ )
+    {
+        work_buffer_.resize( ninput_bytes );
+        swapEndianness( in, work_buffer_, item_size_, ninput_items );
+
+        in = const_cast< signed char const *> ( &work_buffer_[0] );
+    }
+
+    // Here the in pointer can be interpreted as a stream of bytes to be
+    // converted. But we now have two possibilities:
+    // 1) The samples in a byte are in big endian order
+    // 2) The samples in a byte are in little endian order
+
+    byte_and_samples raw_byte;
+    int n = 0;
+
+    if( swap_endian_bytes_ )
+    {
+        for(int i = 0; i < ninput_bytes; ++i)
+        {
+            // Read packed input sample (1 byte = 4 samples)
+            raw_byte.byte = in[i];
+
+            out[n++] = (int8_t)( 2*raw_byte.samples.sample_3 + 1 );
+            out[n++] = (int8_t)( 2*raw_byte.samples.sample_2 + 1 );
+            out[n++] = (int8_t)( 2*raw_byte.samples.sample_1 + 1 );
+            out[n++] = (int8_t)( 2*raw_byte.samples.sample_0 + 1 );
+
+        }
+    }
+    else
+    {
+        for( int i = 0; i < ninput_bytes; ++i )
+        {
+
+            // Read packed input sample (1 byte = 4 samples)
+            raw_byte.byte = in[i];
+
+            out[n++] = (int8_t)( 2*raw_byte.samples.sample_0 + 1 );
+            out[n++] = (int8_t)( 2*raw_byte.samples.sample_1 + 1 );
+            out[n++] = (int8_t)( 2*raw_byte.samples.sample_2 + 1 );
+            out[n++] = (int8_t)( 2*raw_byte.samples.sample_3 + 1 );
+        }
+    }
+
+    return noutput_items;
+}
+

--- a/src/algorithms/signal_source/gnuradio_blocks/unpack_2bit_samples.h
+++ b/src/algorithms/signal_source/gnuradio_blocks/unpack_2bit_samples.h
@@ -76,7 +76,8 @@ typedef boost::shared_ptr<unpack_2bit_samples> unpack_2bit_samples_sptr;
 
 unpack_2bit_samples_sptr make_unpack_2bit_samples( bool big_endian_bytes, 
                                                    size_t item_size,
-                                                   bool big_endian_items );
+                                                   bool big_endian_items,
+                                                   bool reverse_interleaving = false );
 
 /*!
  * \brief This class takes 2 bit samples that have been packed into bytes or
@@ -89,12 +90,14 @@ private:
     friend unpack_2bit_samples_sptr
            make_unpack_2bit_samples_sptr( bool big_endian_bytes, 
                                           size_t item_size,
-                                          bool big_endian_items );
+                                          bool big_endian_items,
+                                          bool reverse_interleaving);
 
 public:
     unpack_2bit_samples( bool big_endianBytes,
                          size_t item_size,
-                         bool big_endian_items );
+                         bool big_endian_items,
+                         bool reverse_interleaving );
 
     ~unpack_2bit_samples();
 
@@ -108,6 +111,7 @@ private:
     bool big_endian_items_;
     bool swap_endian_items_;
     bool swap_endian_bytes_;
+    bool reverse_interleaving_;
     std::vector< int8_t > work_buffer_;
     
 };

--- a/src/algorithms/signal_source/gnuradio_blocks/unpack_2bit_samples.h
+++ b/src/algorithms/signal_source/gnuradio_blocks/unpack_2bit_samples.h
@@ -1,0 +1,115 @@
+/*!
+ * \file unpack_2bit_samples.h
+ *
+ * \brief Unpacks 2 bit samples
+ *  samples may be packed in any of the following ways:
+ *  1) Into bytes [ item == byte ]
+ *      1a) Big endian ordering within the byte
+ *      1b) Little endian ordering within the byte
+ *  2) Into shorts [ item == short ]
+ *      2a) Big endian ordering of bytes, big endian within the byte
+ *      2b) Big endian ordering of bytes, little endian within the byte
+ *      2c) Little endian ordering of bytes, big endian within the byte
+ *      2d) Little endian ordering of bytes, little endian within the byte
+ *
+ *  Within a byte the two possibilities look like this:
+ *    7       6       5       4       3       2       1       0     : Bit number
+ *  x_n,1   x_n,0  x_n+1,1 x_n+1,0 x_n+2,1 x_n+2,0 x_n+3,1 x_n+3,0  : Little endian
+ * x_n+3,1 x_n+3,0 x_n+2,1 x_n+2,0 x_n+1,0 x_n+1,0  x_n,1   x_n, 0  : Big Endian
+ *
+ *  For a short (uint16_t) the bytes are either transmitted as follows:
+ *
+ *   1       0         : Byte number
+ * Byte_n   Byte_n+1   : Little endian
+ * Byte_n+1 Byte_n     : Bit endian
+ *
+ *  The two bit values are assumed to have the following mapping:
+ *
+ *  x_1  x_0     Value
+ *   0    0       +1
+ *   0    1       +3
+ *   1    0       -3
+ *   1    1       -1
+ *
+ *   Letting x denote the two's complement interpretation of x_1 x_0, then:
+ *
+ *   Value = 2*x + 1
+ *
+ *   We want to output the data in the order:
+ *
+ *   Value_0, Value_1, Value_2, ..., Value_n, Value_n+1, Value_n+2, ...
+ *
+ * \author Cillian O'Driscoll cillian.odriscoll (at) gmail . com 
+ * -------------------------------------------------------------------------
+ *
+ * Copyright (C) 2010-2015  (see AUTHORS file for a list of contributors)
+ *
+ * GNSS-SDR is a software defined Global Navigation
+ *          Satellite Systems receiver
+ *
+ * This file is part of GNSS-SDR.
+ *
+ * GNSS-SDR is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * GNSS-SDR is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with GNSS-SDR. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * -------------------------------------------------------------------------
+ */
+
+#ifndef GNSS_SDR_UNPACK_2BIT_SAMPLES_H
+#define GNSS_SDR_UNPACK_2BIT_SAMPLES_H
+
+#include <gnuradio/sync_interpolator.h>
+
+class unpack_2bit_samples;
+
+typedef boost::shared_ptr<unpack_2bit_samples> unpack_2bit_samples_sptr;
+
+unpack_2bit_samples_sptr make_unpack_2bit_samples( bool big_endian_bytes, 
+                                                   size_t item_size,
+                                                   bool big_endian_items );
+
+/*!
+ * \brief This class takes 2 bit samples that have been packed into bytes or
+ * shorts as input and generates a byte for each sample. It generates eight
+ * times as much data as is input (every two bits become 16 bits)
+ */
+class unpack_2bit_samples: public gr::sync_interpolator
+{
+private:
+    friend unpack_2bit_samples_sptr
+           make_unpack_2bit_samples_sptr( bool big_endian_bytes, 
+                                          size_t item_size,
+                                          bool big_endian_items );
+
+public:
+    unpack_2bit_samples( bool big_endianBytes,
+                         size_t item_size,
+                         bool big_endian_items );
+
+    ~unpack_2bit_samples();
+
+    int work (int noutput_items,
+              gr_vector_const_void_star &input_items,
+              gr_vector_void_star &output_items);
+
+private:
+    bool big_endian_bytes_;
+    size_t item_size_;
+    bool big_endian_items_;
+    bool swap_endian_items_;
+    bool swap_endian_bytes_;
+    std::vector< int8_t > work_buffer_;
+    
+};
+
+#endif

--- a/src/core/receiver/gnss_block_factory.cc
+++ b/src/core/receiver/gnss_block_factory.cc
@@ -48,6 +48,7 @@
 #include "two_bit_cpx_file_signal_source.h"
 #include "spir_file_signal_source.h"
 #include "rtl_tcp_signal_source.h"
+#include "two_bit_packed_file_signal_source.h"
 #include "null_sink_output_filter.h"
 #include "file_output_filter.h"
 #include "channel.h"
@@ -1063,6 +1064,20 @@ std::unique_ptr<GNSSBlockInterface> GNSSBlockFactory::GetBlock(
             {
                     std::cout << "GNSS-SDR program ended." << std::endl;
                     exit(1);
+            }
+        }
+    else if(implementation.compare("Two_Bit_Packed_File_Signal_Source") == 0 )
+        {
+            try
+            {
+                std::unique_ptr<GNSSBlockInterface> block_(new TwoBitPackedFileSignalSource(configuration.get(), role, in_streams,
+                            out_streams, queue));
+                block = std::move(block_);
+            }
+            catch(const std::exception &e)
+            {
+                std::cout << "GNSS-SDR program ended." << std::endl;
+                exit(1);
             }
         }
 #endif

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -119,6 +119,7 @@ include_directories(
      ${CMAKE_SOURCE_DIR}/src/algorithms/telemetry_decoder/gnuradio_blocks
      ${CMAKE_SOURCE_DIR}/src/algorithms/telemetry_decoder/libs
      ${CMAKE_SOURCE_DIR}/src/algorithms/signal_source/adapters
+     ${CMAKE_SOURCE_DIR}/src/algorithms/signal_source/gnuradio_blocks
      ${CMAKE_SOURCE_DIR}/src/algorithms/signal_generator/adapters
      ${CMAKE_SOURCE_DIR}/src/algorithms/signal_generator/gnuradio_blocks
      ${CMAKE_SOURCE_DIR}/src/algorithms/input_filter/adapters
@@ -267,13 +268,45 @@ target_link_libraries(gnss_block_test ${Boost_LIBRARIES}
                                       out_adapters
                                       ${VOLK_GNSSSDR_LIBRARIES} ${ORC_LIBRARIES}
                                       )
-                                      
+
 add_test(gnss_block_test gnss_block_test)
 if(NOT ${GTEST_DIR_LOCAL})
     add_dependencies(gnss_block_test gtest-${gtest_RELEASE})
 else(NOT ${GTEST_DIR_LOCAL})
     add_dependencies(gnss_block_test gtest)
 endif(NOT ${GTEST_DIR_LOCAL}) 
+
+add_executable(gnuradio_block_test
+     ${CMAKE_CURRENT_SOURCE_DIR}/single_test_main.cc
+     ${CMAKE_CURRENT_SOURCE_DIR}/gnuradio_block/unpack_2bit_samples_test.cc
+)
+if(NOT ${ENABLE_PACKAGING})
+     set_property(TARGET gnuradio_block_test PROPERTY EXCLUDE_FROM_ALL TRUE)
+endif(NOT ${ENABLE_PACKAGING})
+
+target_link_libraries(gnuradio_block_test ${Boost_LIBRARIES}
+                                      ${GFLAGS_LIBS}
+                                      ${GLOG_LIBRARIES}
+                                      ${GTEST_LIBRARIES}
+                                      ${GNURADIO_RUNTIME_LIBRARIES}
+                                      ${GNURADIO_BLOCKS_LIBRARIES}
+                                      ${GNURADIO_FILTER_LIBRARIES}
+                                      ${GNURADIO_ANALOG_LIBRARIES}
+                                      gnss_sp_libs
+                                      gnss_rx
+                                      gnss_system_parameters
+                                      # signal_generator_blocks
+                                      out_adapters
+                                      ${VOLK_GNSSSDR_LIBRARIES} ${ORC_LIBRARIES}
+                                      )
+
+add_test(gnuradio_block_test gnuradio_block_test)
+if(NOT ${GTEST_DIR_LOCAL})
+    add_dependencies(gnuradio_block_test gtest-${gtest_RELEASE})
+else(NOT ${GTEST_DIR_LOCAL})
+    add_dependencies(gnuradio_block_test gtest)
+endif(NOT ${GTEST_DIR_LOCAL})
+
 
 # add_executable(acq_test ${EXCLUDE}
 #      ${CMAKE_CURRENT_SOURCE_DIR}/single_test_main.cc 
@@ -328,5 +361,6 @@ else(NOT ${GTEST_DIR_LOCAL})
     add_dependencies(trk_test gtest)
 endif(NOT ${GTEST_DIR_LOCAL}) 
 
-add_dependencies(check control_thread_test flowgraph_test gnss_block_test trk_test)
+add_dependencies(check control_thread_test flowgraph_test gnss_block_test 
+    gnuradio_block_test trk_test)
 

--- a/src/tests/gnuradio_block/unpack_2bit_samples_test.cc
+++ b/src/tests/gnuradio_block/unpack_2bit_samples_test.cc
@@ -1,0 +1,310 @@
+/*!
+ * \file unpack_2bit_samples_test.cc
+ * \brief  This file implements unit tests for the unpack_2bit_samples
+ *      custom block
+ * \author Cillian O'Driscoll, 2015. cillian.odriscoll (at) gmail.com
+ *
+ *
+ * -------------------------------------------------------------------------
+ *
+ * Copyright (C) 2010-2015  (see AUTHORS file for a list of contributors)
+ *
+ * GNSS-SDR is a software defined Global Navigation
+ *          Satellite Systems receiver
+ *
+ * This file is part of GNSS-SDR.
+ *
+ * GNSS-SDR is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * GNSS-SDR is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with GNSS-SDR. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * -------------------------------------------------------------------------
+ */
+
+
+#include <gtest/gtest.h>
+#include <gnuradio/top_block.h>
+#include <gnuradio/blocks/vector_source_b.h>
+#include <gnuradio/blocks/vector_source_s.h>
+#include <gnuradio/blocks/vector_sink_b.h>
+#include <gnuradio/blocks/stream_to_vector.h>
+#include "unpack_2bit_samples.h"
+
+std::vector< uint8_t > packData( std::vector< int8_t > const & raw_data,
+                                 bool big_endian )
+{
+    std::vector< uint8_t > packed_data( raw_data.size()/4 );
+
+    int shift = ( big_endian ? 6 : 0 );
+    unsigned int j = 0;
+
+    for( unsigned int i = 0; i < raw_data.size(); ++i )
+    {
+        unsigned val = static_cast< unsigned >( (raw_data[i] - 1 )/2 & 0x03 );
+
+        packed_data[j] |= val << shift;
+
+        if( big_endian )
+        {
+            shift -= 2;
+            if( shift < 0 )
+            {
+                shift = 6;
+                j++;
+            }
+        }
+        else
+        {
+            shift += 2;
+            if( shift > 6 )
+            {
+                shift = 0;
+                j++;
+            }
+
+        }
+
+    }
+
+    return packed_data;
+
+}
+
+TEST(Unpack_2bit_Samples_Test, CheckBigEndianByte)
+{
+    bool big_endian_bytes = true;
+    size_t item_size = 1;
+    bool big_endian_items = false;
+
+
+    std::vector< int8_t > raw_data = { -1, 3, 1, -1, -3, 1, 3, 1 };
+    std::vector< uint8_t > packed_data = packData( raw_data, big_endian_bytes );
+    std::vector< uint8_t > unpacked_data;
+
+    gr::top_block_sptr top_block = gr::make_top_block("unpack_2bit_samples_test");
+
+    gr::blocks::vector_source_b::sptr source = 
+        gr::blocks::vector_source_b::make( packed_data );
+
+    
+    boost::shared_ptr<gr::block> unpacker = 
+        make_unpack_2bit_samples(big_endian_bytes,
+                                 item_size,
+                                 big_endian_items );
+
+    gr::blocks::stream_to_vector::sptr stov =
+        gr::blocks::stream_to_vector::make( item_size, raw_data.size() );
+
+    gr::blocks::vector_sink_b::sptr sink = 
+        gr::blocks::vector_sink_b::make( raw_data.size() );
+
+
+    top_block->connect(source, 0, unpacker, 0);
+    top_block->connect(unpacker, 0, stov, 0 );
+    top_block->connect(stov, 0, sink, 0);
+
+    top_block->run();
+    top_block->stop();
+
+    unpacked_data = sink->data();
+
+    EXPECT_EQ( raw_data.size(), unpacked_data.size() );
+
+    for( unsigned int i = 0; i < raw_data.size(); ++i )
+    {
+        EXPECT_EQ( raw_data[i], static_cast< int8_t >( unpacked_data[i] ) );
+    }
+
+}
+
+TEST(Unpack_2bit_Samples_Test, CheckLittleEndianByte)
+{
+    bool big_endian_bytes = false;
+    size_t item_size = 1;
+    bool big_endian_items = false;
+
+
+    std::vector< int8_t > raw_data = { -1, 3, 1, -1, -3, 1, 3, 1 };
+    std::vector< uint8_t > packed_data = packData( raw_data, big_endian_bytes );
+    std::vector< uint8_t > unpacked_data;
+
+    gr::top_block_sptr top_block = gr::make_top_block("unpack_2bit_samples_test");
+
+    gr::blocks::vector_source_b::sptr source = 
+        gr::blocks::vector_source_b::make( packed_data );
+
+    
+    boost::shared_ptr<gr::block> unpacker = 
+        make_unpack_2bit_samples(big_endian_bytes,
+                                 item_size,
+                                 big_endian_items );
+
+    gr::blocks::stream_to_vector::sptr stov =
+        gr::blocks::stream_to_vector::make( item_size, raw_data.size() );
+
+    gr::blocks::vector_sink_b::sptr sink = 
+        gr::blocks::vector_sink_b::make( raw_data.size() );
+
+
+    top_block->connect(source, 0, unpacker, 0);
+    top_block->connect(unpacker, 0, stov, 0 );
+    top_block->connect(stov, 0, sink, 0);
+
+    top_block->run();
+    top_block->stop();
+
+    unpacked_data = sink->data();
+
+    EXPECT_EQ( raw_data.size(), unpacked_data.size() );
+
+    for( unsigned int i = 0; i < raw_data.size(); ++i )
+    {
+        EXPECT_EQ( raw_data[i], static_cast< int8_t >( unpacked_data[i] ) );
+    }
+
+}
+
+TEST(Unpack_2bit_Samples_Test, CheckBigEndianShortBigEndianByte)
+{
+    bool big_endian_bytes = true;
+    size_t item_size = 2;
+    bool big_endian_items = true;
+
+
+    std::vector< int8_t > raw_data = { -1, 3, 1, -1, -3, 1, 3, 1 };
+    std::vector< uint8_t > packed_data = packData( raw_data, big_endian_bytes );
+    // change the order of each pair of bytes:
+    for( unsigned int ii = 0; ii < packed_data.size(); ii+=item_size )
+    {
+        unsigned int kk = ii + item_size - 1;
+        unsigned int jj = ii;
+        while( kk > jj )
+        {
+            uint8_t tmp = packed_data[jj];
+            packed_data[jj] = packed_data[kk];
+            packed_data[kk] = tmp;
+            --kk;
+            ++jj;
+        }
+    }
+
+    // Now create a new big endian buffer:
+    std::vector< int16_t > packed_data_short(
+            reinterpret_cast< int16_t *>( &packed_data[0] ), 
+            reinterpret_cast< int16_t * >( &packed_data[0] ) 
+            + packed_data.size()/item_size);
+    
+    std::vector< uint8_t > unpacked_data;
+
+    gr::top_block_sptr top_block = gr::make_top_block("unpack_2bit_samples_test");
+
+    gr::blocks::vector_source_s::sptr source = 
+        gr::blocks::vector_source_s::make( packed_data_short );
+
+    
+    boost::shared_ptr<gr::block> unpacker = 
+        make_unpack_2bit_samples(big_endian_bytes,
+                                 item_size,
+                                 big_endian_items );
+
+    gr::blocks::stream_to_vector::sptr stov =
+        gr::blocks::stream_to_vector::make( 1, raw_data.size() );
+
+    gr::blocks::vector_sink_b::sptr sink = 
+        gr::blocks::vector_sink_b::make( raw_data.size() );
+
+
+    top_block->connect(source, 0, unpacker, 0);
+    top_block->connect(unpacker, 0, stov, 0 );
+    top_block->connect(stov, 0, sink, 0);
+
+    top_block->run();
+    top_block->stop();
+
+    unpacked_data = sink->data();
+
+    EXPECT_EQ( raw_data.size(), unpacked_data.size() );
+
+    for( unsigned int i = 0; i < raw_data.size(); ++i )
+    {
+        EXPECT_EQ( raw_data[i], static_cast< int8_t >( unpacked_data[i] ) );
+    }
+
+}
+
+TEST(Unpack_2bit_Samples_Test, CheckBigEndianShortLittleEndianByte)
+{
+    bool big_endian_bytes = false;
+    size_t item_size = 2;
+    bool big_endian_items = true;
+
+
+    std::vector< int8_t > raw_data = { -1, 3, 1, -1, -3, 1, 3, 1 };
+    std::vector< uint8_t > packed_data = packData( raw_data, big_endian_bytes );
+    // change the order of each pair of bytes:
+    for( unsigned int ii = 0; ii < packed_data.size(); ii+=item_size )
+    {
+        unsigned int kk = ii + item_size - 1;
+        unsigned int jj = ii;
+        while( kk > jj )
+        {
+            uint8_t tmp = packed_data[jj];
+            packed_data[jj] = packed_data[kk];
+            packed_data[kk] = tmp;
+            --kk;
+            ++jj;
+        }
+    }
+
+    // Now create a new big endian buffer:
+    std::vector< int16_t > packed_data_short(
+            reinterpret_cast< int16_t *>( &packed_data[0] ), 
+            reinterpret_cast< int16_t * >( &packed_data[0] ) 
+            + packed_data.size()/item_size);
+    
+    std::vector< uint8_t > unpacked_data;
+
+    gr::top_block_sptr top_block = gr::make_top_block("unpack_2bit_samples_test");
+
+    gr::blocks::vector_source_s::sptr source = 
+        gr::blocks::vector_source_s::make( packed_data_short );
+
+    
+    boost::shared_ptr<gr::block> unpacker = 
+        make_unpack_2bit_samples(big_endian_bytes,
+                                 item_size,
+                                 big_endian_items );
+
+    gr::blocks::stream_to_vector::sptr stov =
+        gr::blocks::stream_to_vector::make( 1, raw_data.size() );
+
+    gr::blocks::vector_sink_b::sptr sink = 
+        gr::blocks::vector_sink_b::make( raw_data.size() );
+
+
+    top_block->connect(source, 0, unpacker, 0);
+    top_block->connect(unpacker, 0, stov, 0 );
+    top_block->connect(stov, 0, sink, 0);
+
+    top_block->run();
+    top_block->stop();
+
+    unpacked_data = sink->data();
+
+    EXPECT_EQ( raw_data.size(), unpacked_data.size() );
+
+    for( unsigned int i = 0; i < raw_data.size(); ++i )
+    {
+        EXPECT_EQ( raw_data[i], static_cast< int8_t >( unpacked_data[i] ) );
+    }
+
+}


### PR DESCRIPTION
This pull request adds a generic two bit packed file source. The data is assumed to be packed as bytes ```item_type=byte``` or shorts ```item_type=short``` so that there are 4 two bit samples in each byte.

The two bit values are assumed to have the following interpretation:

| b_1 | b_0 | Value |
|------ |------|----------|
|   0   |   0  |   +1     |
|   0   |   1  |   +3     |
|   1   |   0  |   -3      |
|   1   |   1  |   -1      |

Within a byte the samples may be packed in big endian ```big_endian_bytes=true``` or little endian ```big_endian_bytes=false``` order. If the order is big endian then the most significant two bits will form the first sample output, otherwise the least significant two bits will be used.

Additionally the samples may be either real ```sample_type=real```, or complex. If the sample type is complex, then the samples are either stored in the order: real, imag, real, imag, ... ```sample_type=iq``` or in the order: imag, real, imag, real, ... ```sample_type=qi```.

Finally, if the data is stored as shorts ```item_type=short```, then it may be stored in either big endian ```big_endian_items=true``` or little endian ```big_endian_items=false```. If the shorts are big endian then the 2nd byte in each short is output first.

The output data type is either ```float``` or ```gr_complex``` depending on whether or not ```sample_type``` is ```real```.

A sample config file is also provided, which simply reproduces the GPS L1 NSR config file using the new (more general) file source. I haven't been able to test this particular configuration as I don't have an NSR, so it would be good if someone could try this out.

This has been tested on a sample source with the following configuration:
```
;######### SIGNAL_SOURCE CONFIG ############
;#implementation: Use [File_Signal_Source] or [UHD_Signal_Source] or [GN3S_Signal_Source] (experimental)
SignalSource.implementation=Two_Bit_Packed_File_Signal_Source

;#filename: path to file with the captured GNSS signal samples to be processed
SignalSource.filename=/data/150924-1450.datz

;#item_type: Type and resolution for each of the signal samples. Use only gr_complex in this version.
SignalSource.item_type=short

;#sampling_frequency: Original Signal sampling frequency in [Hz]
SignalSource.sampling_frequency=60000000 

;#freq: RF front-end center frequency in [Hz]
SignalSource.freq=1575468750 

;#samples: Number of samples to be processed. Notice that 0 indicates the entire file.
SignalSource.samples=6000000000

;#repeat: Repeat the processing file. Disable this option in this version
SignalSource.repeat=false

;#dump: Dump the Signal source data to a file. Disable this option in this version
SignalSource.dump=false

SignalSource.dump_filename=./signal_source.dat


;#enable_throttle_control: Enabling this option tells the signal source to keep the delay between samples in post processing.
; it helps to not overload the CPU, but the processing time will be longer.
SignalSource.enable_throttle_control=false

SignalSource.sample_type=iq
SignalSource.big_endian_items=true
SignalSource.big_endian_bytes=false
```