### PR TITLE
Alternative fix for issue #31

### DIFF
--- a/src/algorithms/acquisition/gnuradio_blocks/galileo_e5a_noncoherent_iq_acquisition_caf_cc.cc
+++ b/src/algorithms/acquisition/gnuradio_blocks/galileo_e5a_noncoherent_iq_acquisition_caf_cc.cc
@@ -424,19 +424,11 @@ int galileo_e5a_noncoherentIQ_acquisition_caf_cc::general_work(int noutput_items
 
             // initialize acquisition algorithm
             int doppler;
-#if VOLK_GT_122
-            uint16_t indext = 0;
-            uint16_t indext_IA = 0;
-            uint16_t indext_IB = 0;
-            uint16_t indext_QA = 0;
-            uint16_t indext_QB = 0;
-#else
-            unsigned int indext = 0;
-            unsigned int indext_IA = 0;
-            unsigned int indext_IB = 0;
-            unsigned int indext_QA = 0;
-            unsigned int indext_QB = 0;
-#endif
+            uint32_t indext = 0;
+            uint32_t indext_IA = 0;
+            uint32_t indext_IB = 0;
+            uint32_t indext_QA = 0;
+            uint32_t indext_QB = 0;
             float magt = 0.0;
             float magt_IA = 0.0;
             float magt_IB = 0.0;
@@ -483,7 +475,7 @@ int galileo_e5a_noncoherentIQ_acquisition_caf_cc::general_work(int noutput_items
 
                     // Search maximum
                     volk_32fc_magnitude_squared_32f(d_magnitudeIA, d_ifft->get_outbuf(), d_fft_size);
-                    volk_32f_index_max_16u(&indext_IA, d_magnitudeIA, d_fft_size);
+                    volk_32f_index_max_32u(&indext_IA, d_magnitudeIA, d_fft_size);
                     // Normalize the maximum value to correct the scale factor introduced by FFTW
                     magt_IA = d_magnitudeIA[indext_IA] / (fft_normalization_factor * fft_normalization_factor);
 
@@ -494,7 +486,7 @@ int galileo_e5a_noncoherentIQ_acquisition_caf_cc::general_work(int noutput_items
                                     d_fft_if->get_outbuf(), d_fft_code_Q_A, d_fft_size);
                             d_ifft->execute();
                             volk_32fc_magnitude_squared_32f(d_magnitudeQA, d_ifft->get_outbuf(), d_fft_size);
-                            volk_32f_index_max_16u(&indext_QA, d_magnitudeQA, d_fft_size);
+                            volk_32f_index_max_32u(&indext_QA, d_magnitudeQA, d_fft_size);
                             magt_QA = d_magnitudeQA[indext_QA] / (fft_normalization_factor * fft_normalization_factor);
                         }
                     if (d_sampled_ms > 1) // If Integration time > 1 code
@@ -504,7 +496,7 @@ int galileo_e5a_noncoherentIQ_acquisition_caf_cc::general_work(int noutput_items
                                     d_fft_if->get_outbuf(), d_fft_code_I_B, d_fft_size);
                             d_ifft->execute();
                             volk_32fc_magnitude_squared_32f(d_magnitudeIB, d_ifft->get_outbuf(), d_fft_size);
-                            volk_32f_index_max_16u(&indext_IB, d_magnitudeIB, d_fft_size);
+                            volk_32f_index_max_32u(&indext_IB, d_magnitudeIB, d_fft_size);
                             magt_IB = d_magnitudeIB[indext_IB] / (fft_normalization_factor * fft_normalization_factor);
 
                             if (d_both_signal_components == true)
@@ -514,7 +506,7 @@ int galileo_e5a_noncoherentIQ_acquisition_caf_cc::general_work(int noutput_items
                                             d_fft_if->get_outbuf(), d_fft_code_Q_B, d_fft_size);
                                     d_ifft->execute();
                                     volk_32fc_magnitude_squared_32f(d_magnitudeQB, d_ifft->get_outbuf(), d_fft_size);
-                                    volk_32f_index_max_16u(&indext_QB, d_magnitudeQB, d_fft_size);
+                                    volk_32f_index_max_32u(&indext_QB, d_magnitudeQB, d_fft_size);
                                     magt_QB = d_magnitudeIB[indext_QB] / (fft_normalization_factor * fft_normalization_factor);
                                 }
                         }
@@ -551,7 +543,7 @@ int galileo_e5a_noncoherentIQ_acquisition_caf_cc::general_work(int noutput_items
                                                         }
                                                 }
                                         }
-                                    volk_32f_index_max_16u(&indext, d_magnitudeIA, d_fft_size);
+                                    volk_32f_index_max_32u(&indext, d_magnitudeIA, d_fft_size);
                                     magt = d_magnitudeIA[indext] / (fft_normalization_factor * fft_normalization_factor);
                                 }
                             else
@@ -580,7 +572,7 @@ int galileo_e5a_noncoherentIQ_acquisition_caf_cc::general_work(int noutput_items
                                                         }
                                                 }
                                         }
-                                    volk_32f_index_max_16u(&indext, d_magnitudeIB, d_fft_size);
+                                    volk_32f_index_max_32u(&indext, d_magnitudeIB, d_fft_size);
                                     magt = d_magnitudeIB[indext] / (fft_normalization_factor * fft_normalization_factor);
                                 }
                         }
@@ -598,7 +590,7 @@ int galileo_e5a_noncoherentIQ_acquisition_caf_cc::general_work(int noutput_items
                                             d_magnitudeIA[i] += d_magnitudeQA[i];
                                         }
                                 }
-                            volk_32f_index_max_16u(&indext, d_magnitudeIA, d_fft_size);
+                            volk_32f_index_max_32u(&indext, d_magnitudeIA, d_fft_size);
                             magt = d_magnitudeIA[indext] / (fft_normalization_factor * fft_normalization_factor);
                         }
 
@@ -736,7 +728,7 @@ int galileo_e5a_noncoherentIQ_acquisition_caf_cc::general_work(int noutput_items
                         }
 
                     // Recompute the maximum doppler peak
-                    volk_32f_index_max_16u(&indext, d_CAF_vector, d_num_doppler_bins);
+                    volk_32f_index_max_32u(&indext, d_CAF_vector, d_num_doppler_bins);
                     doppler = -static_cast<int>(d_doppler_max) + d_doppler_step * indext;
                     d_gnss_synchro->Acq_doppler_hz = static_cast<double>(doppler);
                     // Dump if required, appended at the end of the file

--- a/src/algorithms/acquisition/gnuradio_blocks/galileo_pcps_8ms_acquisition_cc.cc
+++ b/src/algorithms/acquisition/gnuradio_blocks/galileo_pcps_8ms_acquisition_cc.cc
@@ -242,15 +242,9 @@ int galileo_pcps_8ms_acquisition_cc::general_work(int noutput_items,
         {
             // initialize acquisition algorithm
             int doppler;
-#if VOLK_GT_122
-            uint16_t indext = 0;
-            uint16_t indext_A = 0;
-            uint16_t indext_B = 0;
-#else
-            unsigned int indext = 0;
-            unsigned int indext_A = 0;
-            unsigned int indext_B = 0;
-#endif
+            uint32_t indext = 0;
+            uint32_t indext_A = 0;
+            uint32_t indext_B = 0;
             float magt = 0.0;
             float magt_A = 0.0;
             float magt_B = 0.0;
@@ -299,7 +293,7 @@ int galileo_pcps_8ms_acquisition_cc::general_work(int noutput_items,
 
                     // Search maximum
                     volk_32fc_magnitude_squared_32f(d_magnitude, d_ifft->get_outbuf(), d_fft_size);
-                    volk_32f_index_max_16u(&indext_A, d_magnitude, d_fft_size);
+                    volk_32f_index_max_32u(&indext_A, d_magnitude, d_fft_size);
 
                     // Normalize the maximum value to correct the scale factor introduced by FFTW
                     magt_A = d_magnitude[indext_A] / (fft_normalization_factor * fft_normalization_factor);
@@ -315,7 +309,7 @@ int galileo_pcps_8ms_acquisition_cc::general_work(int noutput_items,
 
                     // Search maximum
                     volk_32fc_magnitude_squared_32f(d_magnitude, d_ifft->get_outbuf(), d_fft_size);
-                    volk_32f_index_max_16u(&indext_B, d_magnitude, d_fft_size);
+                    volk_32f_index_max_32u(&indext_B, d_magnitude, d_fft_size);
 
                     // Normalize the maximum value to correct the scale factor introduced by FFTW
                     magt_B = d_magnitude[indext_B] / (fft_normalization_factor * fft_normalization_factor);

--- a/src/algorithms/acquisition/gnuradio_blocks/pcps_acquisition_cc.cc
+++ b/src/algorithms/acquisition/gnuradio_blocks/pcps_acquisition_cc.cc
@@ -284,11 +284,7 @@ int pcps_acquisition_cc::general_work(int noutput_items,
         {
             // initialize acquisition algorithm
             int doppler;
-#if VOLK_GT_122
-            uint16_t indext = 0;
-#else
-            unsigned int indext = 0;
-#endif
+            uint32_t indext = 0;
             float magt = 0.0;
             const gr_complex *in = (const gr_complex *)input_items[0]; //Get the input samples pointer
 
@@ -340,7 +336,7 @@ int pcps_acquisition_cc::general_work(int noutput_items,
                     // Search maximum
                     size_t offset = ( d_bit_transition_flag ? effective_fft_size : 0 );
                     volk_32fc_magnitude_squared_32f(d_magnitude, d_ifft->get_outbuf() + offset, effective_fft_size);
-                    volk_32f_index_max_16u(&indext, d_magnitude, effective_fft_size);
+                    volk_32f_index_max_32u(&indext, d_magnitude, effective_fft_size);
                     magt = d_magnitude[indext];
 
                     if (d_use_CFAR_algorithm_flag == true)

--- a/src/algorithms/acquisition/gnuradio_blocks/pcps_acquisition_fine_doppler_cc.cc
+++ b/src/algorithms/acquisition/gnuradio_blocks/pcps_acquisition_fine_doppler_cc.cc
@@ -222,17 +222,12 @@ double pcps_acquisition_fine_doppler_cc::search_maximum()
     float magt = 0.0;
     float fft_normalization_factor;
     int index_doppler = 0;
-#if VOLK_GT_122
-    uint16_t tmp_intex_t;
-    uint16_t index_time = 0;
-#else
-    unsigned int tmp_intex_t = 0;
-    unsigned int index_time = 0;
-#endif
+    uint32_t tmp_intex_t = 0;
+    uint32_t index_time = 0;
 
     for (int i=0;i<d_num_doppler_points;i++)
         {
-            volk_32f_index_max_16u(&tmp_intex_t, d_grid_data[i], d_fft_size);
+            volk_32f_index_max_32u(&tmp_intex_t, d_grid_data[i], d_fft_size);
             if (d_grid_data[i][tmp_intex_t] > magt)
                 {
                     magt = d_grid_data[i][tmp_intex_t];
@@ -364,12 +359,8 @@ int pcps_acquisition_fine_doppler_cc::estimate_Doppler(gr_vector_const_void_star
 
     volk_32fc_magnitude_squared_32f(p_tmp_vector, fft_operator->get_outbuf(), fft_size_extended);
 
-#if VOLK_GT_122
-    uint16_t tmp_index_freq = 0;
-#else
-    unsigned int tmp_index_freq = 0;
-#endif
-    volk_32f_index_max_16u(&tmp_index_freq, p_tmp_vector, fft_size_extended);
+    uint32_t tmp_index_freq = 0;
+    volk_32f_index_max_32u(&tmp_index_freq, p_tmp_vector, fft_size_extended);
 
     //case even
     int counter = 0;

--- a/src/algorithms/acquisition/gnuradio_blocks/pcps_acquisition_sc.cc
+++ b/src/algorithms/acquisition/gnuradio_blocks/pcps_acquisition_sc.cc
@@ -281,11 +281,7 @@ int pcps_acquisition_sc::general_work(int noutput_items,
         {
             // initialize acquisition algorithm
             int doppler;
-#if VOLK_GT_122
-            uint16_t indext = 0;
-#else
-            unsigned int indext = 0;
-#endif
+            uint32_t indext = 0;
             float magt = 0.0;
             const lv_16sc_t *in = (const lv_16sc_t *)input_items[0]; //Get the input samples pointer
             int effective_fft_size = ( d_bit_transition_flag ? d_fft_size/2 : d_fft_size );
@@ -338,7 +334,7 @@ int pcps_acquisition_sc::general_work(int noutput_items,
                     // Search maximum
                     size_t offset = ( d_bit_transition_flag ? effective_fft_size : 0 );
                     volk_32fc_magnitude_squared_32f(d_magnitude, d_ifft->get_outbuf() + offset, effective_fft_size);
-                    volk_32f_index_max_16u(&indext, d_magnitude, effective_fft_size);
+                    volk_32f_index_max_32u(&indext, d_magnitude, effective_fft_size);
                     magt = d_magnitude[indext];
 
                     if (d_use_CFAR_algorithm_flag == true)

--- a/src/algorithms/acquisition/gnuradio_blocks/pcps_assisted_acquisition_cc.cc
+++ b/src/algorithms/acquisition/gnuradio_blocks/pcps_assisted_acquisition_cc.cc
@@ -268,17 +268,12 @@ double pcps_assisted_acquisition_cc::search_maximum()
     float magt = 0.0;
     float fft_normalization_factor;
     int index_doppler = 0;
-#if VOLK_GT_122
-    uint16_t tmp_intex_t;
-    uint16_t index_time = 0;
-#else
-    unsigned int tmp_intex_t = 0;
-    unsigned int index_time = 0;
-#endif
+    uint32_t tmp_intex_t = 0;
+    uint32_t index_time = 0;
 
     for (int i=0;i<d_num_doppler_points;i++)
         {
-            volk_32f_index_max_16u_a(&tmp_intex_t,d_grid_data[i],d_fft_size);
+            volk_32f_index_max_32u_a(&tmp_intex_t,d_grid_data[i],d_fft_size);
             if (d_grid_data[i][tmp_intex_t] > magt)
                 {
                     magt = d_grid_data[i][index_time];

--- a/src/algorithms/acquisition/gnuradio_blocks/pcps_cccwsr_acquisition_cc.cc
+++ b/src/algorithms/acquisition/gnuradio_blocks/pcps_cccwsr_acquisition_cc.cc
@@ -254,16 +254,10 @@ int pcps_cccwsr_acquisition_cc::general_work(int noutput_items,
         {
             // initialize acquisition algorithm
             int doppler;
-#if VOLK_GT_122
-            uint16_t indext = 0;
-            uint16_t indext_plus = 0;
-            uint16_t indext_minus = 0;
-#else
 
-            unsigned int indext = 0;
-            unsigned int indext_plus = 0;
-            unsigned int indext_minus = 0;
-#endif
+            uint32_t indext = 0;
+            uint32_t indext_plus = 0;
+            uint32_t indext_minus = 0;
             float magt = 0.0;
             float magt_plus = 0.0;
             float magt_minus = 0.0;
@@ -337,11 +331,11 @@ int pcps_cccwsr_acquisition_cc::general_work(int noutput_items,
                         }
 
                     volk_32fc_magnitude_squared_32f(d_magnitude, d_correlation_plus, d_fft_size);
-                    volk_32f_index_max_16u(&indext_plus, d_magnitude, d_fft_size);
+                    volk_32f_index_max_32u(&indext_plus, d_magnitude, d_fft_size);
                     magt_plus = d_magnitude[indext_plus] / (fft_normalization_factor * fft_normalization_factor);
 
                     volk_32fc_magnitude_squared_32f(d_magnitude, d_correlation_minus, d_fft_size);
-                    volk_32f_index_max_16u(&indext_minus, d_magnitude, d_fft_size);
+                    volk_32f_index_max_32u(&indext_minus, d_magnitude, d_fft_size);
                     magt_minus = d_magnitude[indext_minus] / (fft_normalization_factor * fft_normalization_factor);
 
                     if (magt_plus >= magt_minus)

--- a/src/algorithms/acquisition/gnuradio_blocks/pcps_multithread_acquisition_cc.cc
+++ b/src/algorithms/acquisition/gnuradio_blocks/pcps_multithread_acquisition_cc.cc
@@ -200,11 +200,7 @@ void pcps_multithread_acquisition_cc::acquisition_core()
 {
     // initialize acquisition algorithm
     int doppler;
-#if VOLK_GT_122
-    uint16_t indext = 0;
-#else
-    unsigned int indext = 0;
-#endif
+    uint32_t indext = 0;
     float magt = 0.0;
     float fft_normalization_factor = (float)d_fft_size * (float)d_fft_size;
     gr_complex* in = d_in_buffer[d_well_count];
@@ -250,7 +246,7 @@ void pcps_multithread_acquisition_cc::acquisition_core()
 
             // Search maximum
             volk_32fc_magnitude_squared_32f(d_magnitude, d_ifft->get_outbuf(), d_fft_size);
-            volk_32f_index_max_16u(&indext, d_magnitude, d_fft_size);
+            volk_32f_index_max_32u(&indext, d_magnitude, d_fft_size);
 
             // Normalize the maximum value to correct the scale factor introduced by FFTW
             magt = d_magnitude[indext] / (fft_normalization_factor * fft_normalization_factor);

--- a/src/algorithms/acquisition/gnuradio_blocks/pcps_opencl_acquisition_cc.cc
+++ b/src/algorithms/acquisition/gnuradio_blocks/pcps_opencl_acquisition_cc.cc
@@ -386,11 +386,7 @@ void pcps_opencl_acquisition_cc::acquisition_core_volk()
 {
     // initialize acquisition algorithm
     int doppler;
-#if VOLK_GT_122
-    uint16_t indext = 0;
-#else
-    unsigned int indext = 0;
-#endif
+    uint32_t indext = 0;
     float magt = 0.0;
     float fft_normalization_factor = static_cast<float>(d_fft_size) * static_cast<float>(d_fft_size);
     gr_complex* in = d_in_buffer[d_well_count];
@@ -435,7 +431,7 @@ void pcps_opencl_acquisition_cc::acquisition_core_volk()
 
             // Search maximum
             volk_32fc_magnitude_squared_32f(d_magnitude, d_ifft->get_outbuf(), d_fft_size);
-            volk_32f_index_max_16u(&indext, d_magnitude, d_fft_size);
+            volk_32f_index_max_32u(&indext, d_magnitude, d_fft_size);
 
             // Normalize the maximum value to correct the scale factor introduced by FFTW
             magt = d_magnitude[indext] / (fft_normalization_factor * fft_normalization_factor);
@@ -512,11 +508,7 @@ void pcps_opencl_acquisition_cc::acquisition_core_opencl()
 {
     // initialize acquisition algorithm
     int doppler;
-#if VOLK_GT_122
-    uint16_t indext = 0;
-#else
-    unsigned int indext = 0;
-#endif
+    uint32_t indext = 0;
     float magt = 0.0;
     float fft_normalization_factor = (static_cast<float>(d_fft_size_pow2) * static_cast<float>(d_fft_size)); //This works, but I am not sure why.
     gr_complex* in = d_in_buffer[d_well_count];
@@ -601,7 +593,7 @@ void pcps_opencl_acquisition_cc::acquisition_core_opencl()
 
             // Search maximum
             // @TODO: find an efficient way to search the maximum with OpenCL in the GPU.
-            volk_32f_index_max_16u(&indext, d_magnitude, d_fft_size);
+            volk_32f_index_max_32u(&indext, d_magnitude, d_fft_size);
 
             // Normalize the maximum value to correct the scale factor introduced by FFTW
             magt = d_magnitude[indext] / (fft_normalization_factor * fft_normalization_factor);

--- a/src/algorithms/acquisition/gnuradio_blocks/pcps_quicksync_acquisition_cc.cc
+++ b/src/algorithms/acquisition/gnuradio_blocks/pcps_quicksync_acquisition_cc.cc
@@ -301,11 +301,7 @@ int pcps_quicksync_acquisition_cc::general_work(int noutput_items,
             /* initialize acquisition  implementing the QuickSync algorithm*/
             //DLOG(INFO) << "START CASE 1";
             int doppler;
-#if VOLK_GT_122
-            uint16_t indext = 0;
-#else
-            unsigned int indext = 0;
-#endif
+            uint32_t indext = 0;
             float magt = 0.0;
             const gr_complex *in = (const gr_complex *)input_items[0]; //Get the input samples pointer
 
@@ -405,7 +401,7 @@ int pcps_quicksync_acquisition_cc::general_work(int noutput_items,
                    introduced by FFTW*/
                     //volk_32f_s32f_multiply_32f_a(d_magnitude_folded,d_magnitude_folded,
                     // (1 / (fft_normalization_factor * fft_normalization_factor)), d_fft_size);
-                    volk_32f_index_max_16u(&indext, d_magnitude_folded, d_fft_size);
+                    volk_32f_index_max_32u(&indext, d_magnitude_folded, d_fft_size);
 
                     magt = d_magnitude_folded[indext] / (fft_normalization_factor * fft_normalization_factor);
 
@@ -458,7 +454,7 @@ int pcps_quicksync_acquisition_cc::general_work(int noutput_items,
                                         }
                                     /*Obtain maximun value of correlation given the possible delay selected */
                                     volk_32fc_magnitude_squared_32f(d_corr_output_f, complex_acumulator, d_folding_factor);
-                                    volk_32f_index_max_16u(&indext, d_corr_output_f, d_folding_factor);
+                                    volk_32f_index_max_32u(&indext, d_corr_output_f, d_folding_factor);
 
                                     /*Now save the real code phase in the gnss_syncro block for use in other stages*/
                                     d_gnss_synchro->Acq_delay_samples = static_cast<double>(d_possible_delay[indext]);

--- a/src/algorithms/acquisition/gnuradio_blocks/pcps_tong_acquisition_cc.cc
+++ b/src/algorithms/acquisition/gnuradio_blocks/pcps_tong_acquisition_cc.cc
@@ -279,11 +279,7 @@ int pcps_tong_acquisition_cc::general_work(int noutput_items,
         {
             // initialize acquisition algorithm
             int doppler;
-#if VOLK_GT_122
-            uint16_t indext = 0;
-#else
-            unsigned int indext = 0;
-#endif
+            uint32_t indext = 0;
             float magt = 0.0;
             const gr_complex *in = (const gr_complex *)input_items[0]; //Get the input samples pointer
             float fft_normalization_factor = static_cast<float>(d_fft_size) * static_cast<float>(d_fft_size);
@@ -339,7 +335,7 @@ int pcps_tong_acquisition_cc::general_work(int noutput_items,
                     volk_32f_x2_add_32f(d_grid_data[doppler_index], d_magnitude, d_grid_data[doppler_index], d_fft_size);
 
                     // Search maximum
-                    volk_32f_index_max_16u(&indext, d_grid_data[doppler_index], d_fft_size);
+                    volk_32f_index_max_32u(&indext, d_grid_data[doppler_index], d_fft_size);
 
                     magt = d_grid_data[doppler_index][indext];
 


### PR DESCRIPTION
Rather than changing the index type to uint16_t, I think it would be
better to use the volk_32f_index_max32* functions instead of the 16 bit
counterparts. This ensures backwards compatibility (the index was
previously 32 bit, even if the function name indicated that it was 16
bit) and also, for FFT acquisition we may encounter large FFTs with more
than 65 535 points