### PR TITLE
avx2: Adds support for AVX2 intrinsic to some kernels

### DIFF
--- a/src/algorithms/libs/volk_gnsssdr_module/volk_gnsssdr/kernels/volk_gnsssdr/volk_gnsssdr_32fc_resamplerxnpuppet_32fc.h
+++ b/src/algorithms/libs/volk_gnsssdr_module/volk_gnsssdr/kernels/volk_gnsssdr/volk_gnsssdr_32fc_resamplerxnpuppet_32fc.h
@@ -71,7 +71,7 @@ static inline void volk_gnsssdr_32fc_resamplerxnpuppet_32fc_generic(lv_32fc_t* r
 }
 
 #endif /* LV_HAVE_GENERIC */
- 
+
 
 #ifdef LV_HAVE_SSE3
 static inline void volk_gnsssdr_32fc_resamplerxnpuppet_32fc_a_sse3(lv_32fc_t* result, const lv_32fc_t* local_code, unsigned int num_points)
@@ -236,6 +236,64 @@ static inline void volk_gnsssdr_32fc_resamplerxnpuppet_32fc_u_avx(lv_32fc_t* res
     }
 
     volk_gnsssdr_32fc_xn_resampler_32fc_xn_u_avx(result_aux, local_code, rem_code_phase_chips, code_phase_step_chips, shifts_chips, code_length_chips, num_out_vectors, num_points);
+
+    memcpy((lv_32fc_t*)result, (lv_32fc_t*)result_aux[0], sizeof(lv_32fc_t) * num_points);
+
+    for(n = 0; n < num_out_vectors; n++)
+    {
+        volk_gnsssdr_free(result_aux[n]);
+    }
+    volk_gnsssdr_free(result_aux);
+}
+#endif
+
+
+#ifdef LV_HAVE_AVX2
+static inline void volk_gnsssdr_32fc_resamplerxnpuppet_32fc_a_avx2(lv_32fc_t* result, const lv_32fc_t* local_code, unsigned int num_points)
+{
+    float code_phase_step_chips = -0.6;
+    int code_length_chips = 1023;
+    int num_out_vectors = 3;
+    float rem_code_phase_chips = -0.234;
+    unsigned int n;
+    float shifts_chips[3] = { -0.1, 0.0, 0.1 };
+
+    lv_32fc_t** result_aux =  (lv_32fc_t**)volk_gnsssdr_malloc(sizeof(lv_32fc_t*) * num_out_vectors, volk_gnsssdr_get_alignment());
+    for(n = 0; n < num_out_vectors; n++)
+    {
+       result_aux[n] = (lv_32fc_t*)volk_gnsssdr_malloc(sizeof(lv_32fc_t) * num_points, volk_gnsssdr_get_alignment());
+    }
+
+    volk_gnsssdr_32fc_xn_resampler_32fc_xn_a_avx2(result_aux, local_code, rem_code_phase_chips, code_phase_step_chips, shifts_chips, code_length_chips, num_out_vectors, num_points);
+
+    memcpy((lv_32fc_t*)result, (lv_32fc_t*)result_aux[0], sizeof(lv_32fc_t) * num_points);
+
+    for(n = 0; n < num_out_vectors; n++)
+    {
+        volk_gnsssdr_free(result_aux[n]);
+    }
+    volk_gnsssdr_free(result_aux);
+}
+#endif
+
+
+#ifdef LV_HAVE_AVX2
+static inline void volk_gnsssdr_32fc_resamplerxnpuppet_32fc_u_avx2(lv_32fc_t* result, const lv_32fc_t* local_code, unsigned int num_points)
+{
+    float code_phase_step_chips = -0.6;
+    int code_length_chips = 1023;
+    int num_out_vectors = 3;
+    float rem_code_phase_chips = -0.234;
+    unsigned int n;
+    float shifts_chips[3] = { -0.1, 0.0, 0.1 };
+
+    lv_32fc_t** result_aux =  (lv_32fc_t**)volk_gnsssdr_malloc(sizeof(lv_32fc_t*) * num_out_vectors, volk_gnsssdr_get_alignment());
+    for(n = 0; n < num_out_vectors; n++)
+    {
+       result_aux[n] = (lv_32fc_t*)volk_gnsssdr_malloc(sizeof(lv_32fc_t) * num_points, volk_gnsssdr_get_alignment());
+    }
+
+    volk_gnsssdr_32fc_xn_resampler_32fc_xn_u_avx2(result_aux, local_code, rem_code_phase_chips, code_phase_step_chips, shifts_chips, code_length_chips, num_out_vectors, num_points);
 
     memcpy((lv_32fc_t*)result, (lv_32fc_t*)result_aux[0], sizeof(lv_32fc_t) * num_points);
 

--- a/src/algorithms/libs/volk_gnsssdr_module/volk_gnsssdr/kernels/volk_gnsssdr/volk_gnsssdr_8i_accumulator_s8i.h
+++ b/src/algorithms/libs/volk_gnsssdr_module/volk_gnsssdr/kernels/volk_gnsssdr/volk_gnsssdr_8i_accumulator_s8i.h
@@ -152,6 +152,83 @@ static inline void volk_gnsssdr_8i_accumulator_s8i_a_sse3(char* result, const ch
 #endif /* LV_HAVE_SSE3 */
 
 
+#ifdef LV_HAVE_AVX2
+#include <immintrin.h>
+
+static inline void volk_gnsssdr_8i_accumulator_s8i_a_avx2(char* result, const char* inputBuffer, unsigned int num_points)
+{
+    char returnValue = 0;
+    const unsigned int sse_iters = num_points / 32;
+    unsigned int number;
+    unsigned int i;
+
+    const char* aPtr = inputBuffer;
+
+    __VOLK_ATTR_ALIGNED(32) char tempBuffer[32];
+    __m256i accumulator = _mm256_setzero_si256();
+    __m256i aVal = _mm256_setzero_si256();
+
+    for(number = 0; number < sse_iters; number++)
+        {
+            aVal = _mm256_load_si256((__m256i*)aPtr);
+            accumulator = _mm256_add_epi8(accumulator, aVal);
+            aPtr += 32;
+        }
+    _mm256_store_si256((__m256i*)tempBuffer,accumulator);
+
+    for(i = 0; i < 32; ++i)
+        {
+            returnValue += tempBuffer[i];
+        }
+
+    for(i = 0; i < (num_points % 32); ++i)
+        {
+            returnValue += (*aPtr++);
+        }
+
+    *result = returnValue;
+}
+#endif /* LV_HAVE_SSE3 */
+
+
+#ifdef LV_HAVE_AVX2
+#include <pmmintrin.h>
+
+static inline void volk_gnsssdr_8i_accumulator_s8i_u_avx2(char* result, const char* inputBuffer, unsigned int num_points)
+{
+    char returnValue = 0;
+    const unsigned int sse_iters = num_points / 32;
+    unsigned int number;
+    unsigned int i;
+    const char* aPtr = inputBuffer;
+
+    __VOLK_ATTR_ALIGNED(32) char tempBuffer[32];
+    __m256i accumulator = _mm256_setzero_si256();
+    __m256i aVal = _mm256_setzero_si256();
+
+    for(number = 0; number < sse_iters; number++)
+        {
+            aVal = _mm256_lddqu_si256((__m256i*)aPtr);
+            accumulator = _mm256_add_epi8(accumulator, aVal);
+            aPtr += 32;
+        }
+    _mm256_storeu_si256((__m256i*)tempBuffer, accumulator);
+
+    for(i = 0; i < 32; ++i)
+        {
+            returnValue += tempBuffer[i];
+        }
+
+    for(i = 0; i < (num_points % 32); ++i)
+        {
+            returnValue += (*aPtr++);
+        }
+
+    *result = returnValue;
+}
+#endif /* LV_HAVE_SSE3 */
+
+
 #ifdef LV_HAVE_ORC
 
 extern void volk_gnsssdr_8i_accumulator_s8i_a_orc_impl(short* result, const char* inputBuffer, unsigned int num_points);
@@ -169,4 +246,3 @@ static inline void volk_gnsssdr_8i_accumulator_s8i_u_orc(char* result, const cha
 #endif /* LV_HAVE_ORC */
 
 #endif /* INCLUDED_volk_gnsssdr_8i_accumulator_s8i_H */
-

--- a/src/algorithms/libs/volk_gnsssdr_module/volk_gnsssdr/kernels/volk_gnsssdr/volk_gnsssdr_8i_x2_add_8i.h
+++ b/src/algorithms/libs/volk_gnsssdr_module/volk_gnsssdr/kernels/volk_gnsssdr/volk_gnsssdr_8i_x2_add_8i.h
@@ -94,6 +94,42 @@ static inline void volk_gnsssdr_8i_x2_add_8i_u_sse2(char* cVector, const char* a
 #endif /* LV_HAVE_SSE2 */
 
 
+#ifdef LV_HAVE_AVX2
+#include <immintrin.h>
+
+static inline void volk_gnsssdr_8i_x2_add_8i_u_avx2(char* cVector, const char* aVector, const char* bVector, unsigned int num_points)
+{
+    const unsigned int avx_iters = num_points / 32;
+    unsigned int number;
+    unsigned int i;
+    char* cPtr = cVector;
+    const char* aPtr = aVector;
+    const char* bPtr = bVector;
+
+    __m256i aVal, bVal, cVal;
+
+    for(number = 0; number < avx_iters; number++)
+        {
+            aVal = _mm256_loadu_si256((__m256i*)aPtr);
+            bVal = _mm256_loadu_si256((__m256i*)bPtr);
+
+            cVal = _mm256_add_epi8(aVal, bVal);
+
+            _mm256_storeu_si256((__m256i*)cPtr, cVal); // Store the results back into the C container
+
+            aPtr += 32;
+            bPtr += 32;
+            cPtr += 32;
+        }
+
+    for(i = avx_iters * 32; i < num_points; ++i)
+        {
+            *cPtr++ = (*aPtr++) + (*bPtr++);
+        }
+}
+#endif /* LV_HAVE_SSE2 */
+
+
 #ifdef LV_HAVE_GENERIC
 
 static inline void volk_gnsssdr_8i_x2_add_8i_generic(char* cVector, const char* aVector, const char* bVector, unsigned int num_points)
@@ -140,6 +176,42 @@ static inline void volk_gnsssdr_8i_x2_add_8i_a_sse2(char* cVector, const char* a
         }
 
     for(i = sse_iters * 16; i < num_points; ++i)
+        {
+            *cPtr++ = (*aPtr++) + (*bPtr++);
+        }
+}
+#endif /* LV_HAVE_SSE2 */
+
+
+#ifdef LV_HAVE_AVX2
+#include <immintrin.h>
+
+static inline void volk_gnsssdr_8i_x2_add_8i_a_avx2(char* cVector, const char* aVector, const char* bVector, unsigned int num_points)
+{
+    const unsigned int avx_iters = num_points / 32;
+    unsigned int number;
+    unsigned int i;
+    char* cPtr = cVector;
+    const char* aPtr = aVector;
+    const char* bPtr = bVector;
+
+    __m256i aVal, bVal, cVal;
+
+    for(number = 0; number < avx_iters; number++)
+        {
+            aVal = _mm256_load_si256((__m256i*)aPtr);
+            bVal = _mm256_load_si256((__m256i*)bPtr);
+
+            cVal = _mm256_add_epi8(aVal, bVal);
+
+            _mm256_store_si256((__m256i*)cPtr, cVal); // Store the results back into the C container
+
+            aPtr += 32;
+            bPtr += 32;
+            cPtr += 32;
+        }
+
+    for(i = avx_iters * 32; i < num_points; ++i)
         {
             *cPtr++ = (*aPtr++) + (*bPtr++);
         }

--- a/src/algorithms/libs/volk_gnsssdr_module/volk_gnsssdr/kernels/volk_gnsssdr/volk_gnsssdr_8ic_conjugate_8ic.h
+++ b/src/algorithms/libs/volk_gnsssdr_module/volk_gnsssdr/kernels/volk_gnsssdr/volk_gnsssdr_8ic_conjugate_8ic.h
@@ -59,6 +59,37 @@
 
 #include <volk_gnsssdr/volk_gnsssdr_complex.h>
 
+#ifdef LV_HAVE_AVX2
+#include <immintrin.h>
+
+static inline void volk_gnsssdr_8ic_conjugate_8ic_u_avx2(lv_8sc_t* cVector, const lv_8sc_t* aVector, unsigned int num_points)
+{
+    const unsigned int avx2_iters = num_points / 16;
+    unsigned int i;
+    lv_8sc_t* c = cVector;
+    const lv_8sc_t* a = aVector;
+
+    __m256i tmp;
+    __m256i conjugator = _mm256_setr_epi8(1, -1, 1, -1, 1, -1, 1, -1, 1, -1, 1, -1, 1, -1, 1, -1, 1, -1, 1, -1, 1, -1, 1, -1, 1, -1, 1, -1, 1, -1, 1, -1);
+
+    for (i = 0; i < avx2_iters; ++i)
+        {
+            tmp = _mm256_loadu_si256((__m256i*)a);
+            tmp = _mm256_sign_epi8(tmp, conjugator);
+            _mm256_storeu_si256((__m256i*)c, tmp);
+
+            a += 16;
+            c += 16;
+        }
+
+    for (i = avx2_iters * 16; i < num_points; ++i)
+        {
+            *c++ = lv_conj(*a++);
+        }
+}
+#endif /* LV_HAVE_AVX2 */
+
+
 #ifdef LV_HAVE_AVX
 #include <immintrin.h>
 
@@ -215,6 +246,37 @@ static inline void volk_gnsssdr_8ic_conjugate_8ic_a_avx(lv_8sc_t* cVector, const
         }
 }
 #endif /* LV_HAVE_AVX */
+
+
+#ifdef LV_HAVE_AVX2
+#include <immintrin.h>
+
+static inline void volk_gnsssdr_8ic_conjugate_8ic_a_avx2(lv_8sc_t* cVector, const lv_8sc_t* aVector, unsigned int num_points)
+{
+    const unsigned int avx2_iters = num_points / 16;
+    unsigned int i;
+    lv_8sc_t* c = cVector;
+    const lv_8sc_t* a = aVector;
+
+    __m256i tmp;
+    __m256i conjugator = _mm256_setr_epi8(1, -1, 1, -1, 1, -1, 1, -1, 1, -1, 1, -1, 1, -1, 1, -1, 1, -1, 1, -1, 1, -1, 1, -1, 1, -1, 1, -1, 1, -1, 1, -1);
+
+    for (i = 0; i < avx2_iters; ++i)
+        {
+            tmp = _mm256_load_si256((__m256i*)a);
+            tmp = _mm256_sign_epi8(tmp, conjugator);
+            _mm256_store_si256((__m256i*)c, tmp);
+
+            a += 16;
+            c += 16;
+        }
+
+    for (i = avx2_iters * 16; i < num_points; ++i)
+        {
+            *c++ = lv_conj(*a++);
+        }
+}
+#endif /* LV_HAVE_AVX2 */
 
 
 #ifdef LV_HAVE_SSSE3


### PR DESCRIPTION
Adds AVX2 intrinsic to several kernels ranging from multiply and add to
more detailed operations such as convert. New peotokernels also may take
advantage of the fused multiply add (fma). List of modified kernels include

1. volk_gnsssdr_32fc_convert_16ic
2. volk_gnsssdr_32fc_convert_8ic
3. volk_gnsssdr_32fc_xn_resampler_32fc_xn
4. volk_gnsssdr_8i_accumulator_s8i
5. volk_gnsssdr_8i_index_max_16u
6. volk_gnsssdr_8i_max_s8i
7. volk_gnsssdr_8i_x2_add_8i
8. volk_gnsssdr_8ic_conjugate_8i
9. volk_gnsssdr_8u_x2_multiply_8u

See below output of volk_gnsssdr_profile. Notice speed improvement

```
RUN_VOLK_GNSSSDR_TESTS: volk_gnsssdr_32fc_resamplerxnpuppet_32fc(8111,1987)
generic completed in 309.058ms
a_sse3 completed in 118.262ms
u_sse3 completed in 117.087ms
u_sse4_1 completed in 105.24ms
a_sse4_1 completed in 106.465ms
a_avx completed in 96.077ms
u_avx completed in 99.526ms
a_avx2 completed in 91.856ms
u_avx2 completed in 91.297ms
Best aligned arch: u_avx2
Best unaligned arch: u_avx2

RUN_VOLK_GNSSSDR_TESTS: volk_gnsssdr_32fc_convert_8ic(8111,1987)
generic completed in 63.262ms
u_avx2 completed in 2.95ms
a_avx2 completed in 2.912ms
u_sse2 completed in 5.285ms
a_sse2 completed in 5.149ms
Best aligned arch: a_avx2
Best unaligned arch: u_avx2

RUN_VOLK_GNSSSDR_TESTS: volk_gnsssdr_32fc_convert_16ic(8111,100000)
u_sse2 completed in 220.145ms
u_sse completed in 224.889ms
u_avx2 completed in 135.432ms
a_sse2 completed in 221.39ms
a_sse completed in 222.389ms
a_avx2 completed in 139.24ms
generic completed in 3004.3ms
Best aligned arch: u_avx2
Best unaligned arch: u_avx2

RUN_VOLK_GNSSSDR_TESTS: volk_gnsssdr_8i_accumulator_s8i(8111,100000)
u_sse3 completed in 25.218ms
generic completed in 283.954ms
a_sse3 completed in 93.059ms
a_avx2 completed in 13.036ms
u_avx2 completed in 17.635ms
Best aligned arch: a_avx2
Best unaligned arch: u_avx2

RUN_VOLK_GNSSSDR_TESTS: volk_gnsssdr_8i_index_max_16u(8111,100000)
u_avx2 completed in 50.234ms
u_avx completed in 85.26ms
u_sse4_1 completed in 52.306ms
u_sse2 completed in 67.374ms
generic completed in 575.584ms
a_avx2 completed in 41.447ms
a_avx completed in 92.329ms
a_sse4_1 completed in 79.798ms
a_sse2 completed in 53.54ms
Best aligned arch: a_avx2
Best unaligned arch: u_avx2

RUN_VOLK_GNSSSDR_TESTS: volk_gnsssdr_8i_max_s8i(8111,100000)
u_avx2 completed in 10.4ms
u_sse4_1 completed in 42.862ms
u_sse2 completed in 85.851ms
generic completed in 15.222ms
a_sse4_1 completed in 43.452ms
a_avx2 completed in 11.367ms
a_sse2 completed in 79.007ms
Best aligned arch: u_avx2
Best unaligned arch: u_avx2

RUN_VOLK_GNSSSDR_TESTS: volk_gnsssdr_8i_x2_add_8i(8111,100000)
u_sse2 completed in 34.726ms
u_avx2 completed in 16.279ms
generic completed in 26.768ms
a_sse2 completed in 35.206ms
a_avx2 completed in 16.822ms
Best aligned arch: u_avx2
Best unaligned arch: u_avx2

RUN_VOLK_GNSSSDR_TESTS: volk_gnsssdr_8ic_conjugate_8ic(8111,100000)
u_avx2 completed in 28.908ms
u_avx completed in 43.391ms
u_ssse3 completed in 47.187ms
u_sse3 completed in 69.272ms
generic completed in 64.229ms
a_avx completed in 44.509ms
a_avx2 completed in 33.322ms
a_ssse3 completed in 53.952ms
a_sse3 completed in 67.058ms
Best aligned arch: u_avx2
Best unaligned arch: u_avx2

RUN_VOLK_GNSSSDR_TESTS: volk_gnsssdr_8u_x2_multiply_8u(8111,100000)
u_avx2 completed in 37.521ms
u_sse3 completed in 75.603ms
generic completed in 46.593ms
a_sse3 completed in 71.273ms
a_avx2 completed in 41.133ms
Best aligned arch: u_avx2
Best unaligned arch: u_avx2
```