### PR TITLE
Add bladeRF support

### DIFF
--- a/conf/gnss-sdr_GPS_L1_bladeRF.conf
+++ b/conf/gnss-sdr_GPS_L1_bladeRF.conf
@@ -1,0 +1,110 @@
+[GNSS-SDR]
+
+;######### GLOBAL OPTIONS ##################
+GNSS-SDR.internal_fs_sps=2000000
+
+;######### SIGNAL_SOURCE CONFIG ############
+SignalSource.implementation=Osmosdr_Signal_Source
+SignalSource.item_type=gr_complex
+SignalSource.sampling_frequency=2000000
+SignalSource.freq=1575420000
+;# RF Gain: LNA Gain {0, 3, 6}
+SignalSource.gain=6
+;# IF Gain: N/A
+SignalSource.rf_gain=40
+;# BB Gain: RX VGA1 + VGA2 [5, 60]
+SignalSource.if_gain=48
+SignalSource.AGC_enabled=false
+SignalSource.samples=0
+SignalSource.repeat=false
+;# Next line enables the bladeRF
+SignalSource.osmosdr_args=bladerf=0
+SignalSource.enable_throttle_control=false
+SignalSource.dump=false
+SignalSource.dump_filename=./signal_source.dat
+
+;######### SIGNAL_CONDITIONER CONFIG ############
+SignalConditioner.implementation=Signal_Conditioner
+
+;######### DATA_TYPE_ADAPTER CONFIG ############
+DataTypeAdapter.implementation=Pass_Through
+
+;######### INPUT_FILTER CONFIG ############
+InputFilter.implementation=Freq_Xlating_Fir_Filter
+InputFilter.decimation_factor=1
+InputFilter.input_item_type=gr_complex
+InputFilter.output_item_type=gr_complex
+InputFilter.taps_item_type=float
+InputFilter.number_of_taps=5
+InputFilter.number_of_bands=2
+InputFilter.band1_begin=0.0
+InputFilter.band1_end=0.85
+InputFilter.band2_begin=0.9
+InputFilter.band2_end=1.0
+InputFilter.ampl1_begin=1.0
+InputFilter.ampl1_end=1.0
+InputFilter.ampl2_begin=0.0
+InputFilter.ampl2_end=0.0
+InputFilter.band1_error=1.0
+InputFilter.band2_error=1.0
+InputFilter.filter_type=bandpass
+InputFilter.grid_density=16
+InputFilter.dump=false
+InputFilter.dump_filename=../data/input_filter.dat
+
+;######### RESAMPLER CONFIG ############
+Resampler.implementation=Pass_Through
+
+;######### CHANNELS GLOBAL CONFIG ############
+Channels_1C.count=8
+Channels.in_acquisition=1
+Channel.signal=1C
+
+;######### ACQUISITION GLOBAL CONFIG ############
+Acquisition_1C.implementation=GPS_L1_CA_PCPS_Acquisition_Fine_Doppler
+Acquisition_1C.item_type=gr_complex
+Acquisition_1C.if=0
+Acquisition_1C.sampled_ms=1
+Acquisition_1C.threshold=0.015
+Acquisition_1C.doppler_max=10000
+Acquisition_1C.doppler_min=-10000
+Acquisition_1C.doppler_step=500
+Acquisition_1C.max_dwells=15
+Acquisition_1C.dump=false
+Acquisition_1C.dump_filename=./acq_dump.dat
+
+;######### TRACKING GLOBAL CONFIG ############
+Tracking_1C.implementation=GPS_L1_CA_DLL_PLL_Tracking
+Tracking_1C.item_type=gr_complex
+Tracking_1C.if=0
+Tracking_1C.pll_bw_hz=40.0;
+Tracking_1C.dll_bw_hz=2.0;
+Tracking_1C.order=3;
+Tracking_1C.early_late_space_chips=0.5;
+Tracking_1C.dump=false
+Tracking_1C.dump_filename=./tracking_ch_
+
+;######### TELEMETRY DECODER GPS CONFIG ############
+TelemetryDecoder_1C.implementation=GPS_L1_CA_Telemetry_Decoder
+TelemetryDecoder_1C.dump=false
+
+;######### OBSERVABLES CONFIG ############
+#Observables.implementation=GPS_L1_CA_Observables
+Observables.implementation=Hybrid_Observables
+Observables.dump=false
+Observables.dump_filename=./observables.dat
+
+;######### PVT CONFIG ############
+;PVT.implementation=RTKLIB_PVT
+PVT.positioning_mode=Single
+PVT.output_rate_ms=100
+PVT.display_rate_ms=500
+PVT.iono_model=Broadcast
+PVT.trop_model=Saastamoinen
+PVT.flag_rtcm_server=false
+PVT.flag_rtcm_tty_port=false
+PVT.rtcm_dump_devname=/dev/pts/1
+PVT.rtcm_tcp_port=2101
+PVT.rtcm_MT1019_rate_ms=5000
+PVT.rtcm_MT1077_rate_ms=1000
+PVT.rinex_version=2

--- a/src/algorithms/signal_source/adapters/osmosdr_signal_source.cc
+++ b/src/algorithms/signal_source/adapters/osmosdr_signal_source.cc
@@ -78,13 +78,13 @@ OsmosdrSignalSource::OsmosdrSignalSource(ConfigurationInterface* configuration,
             // 1. Make the driver instance
             OsmosdrSignalSource::driver_instance();
 
-			// For LimeSDR: Set RX antenna
-			if (!antenna_.empty())
-				{
-					osmosdr_source_->set_antenna(antenna_, 0);
-					std::cout << boost::format("Set RX Antenna : %s") % (osmosdr_source_->get_antenna(0)) << std::endl ;
-					LOG(INFO) << boost::format("Set RX Antenna : %s") % (osmosdr_source_->get_antenna(0));
-				}
+            // For LimeSDR: Set RX antenna
+            if (!antenna_.empty())
+                {
+                    osmosdr_source_->set_antenna(antenna_, 0);
+                    std::cout << boost::format("Set RX Antenna : %s") % (osmosdr_source_->get_antenna(0)) << std::endl ;
+                    LOG(INFO) << boost::format("Set RX Antenna : %s") % (osmosdr_source_->get_antenna(0));
+                }
 
             // 2 set sampling rate
             osmosdr_source_->set_sample_rate(sample_rate_);
@@ -97,7 +97,7 @@ OsmosdrSignalSource::OsmosdrSignalSource(ConfigurationInterface* configuration,
             LOG(INFO) << boost::format("Actual RX Freq: %f [Hz]...") % (osmosdr_source_->get_center_freq());
 
             // TODO: Assign the remnant IF from the PLL tune error
-            std::cout << boost::format("PLL Frequency tune error %f [Hz]...") % (osmosdr_source_->get_center_freq() - freq_) ;
+            std::cout << boost::format("PLL Frequency tune error %f [Hz]...") % (osmosdr_source_->get_center_freq() - freq_) << std::endl;
             LOG(INFO) <<  boost::format("PLL Frequency tune error %f [Hz]...") % (osmosdr_source_->get_center_freq() - freq_) ;
 
             // 4. set rx gain
@@ -113,9 +113,22 @@ OsmosdrSignalSource::OsmosdrSignalSource(ConfigurationInterface* configuration,
                     osmosdr_source_->set_gain(gain_, 0);
                     osmosdr_source_->set_if_gain(rf_gain_, 0);
                     osmosdr_source_->set_bb_gain(if_gain_, 0);
-                    std::cout << boost::format("Actual RX Gain: %f dB...") % osmosdr_source_->get_gain() << std::endl;
-                    LOG(INFO) << boost::format("Actual RX Gain: %f dB...") % osmosdr_source_->get_gain();
+                    if (!osmosdr_args_.empty() && (osmosdr_args_.find("bladerf") != std::string::npos))
+                        {
+                            std::cout << boost::format("Actual LNA Gain: %f dB...") % osmosdr_source_->get_gain("LNA",0) << std::endl;
+                            std::cout << boost::format("Actual VGA1 Gain: %f dB...") % osmosdr_source_->get_gain("VGA1",0) << std::endl;
+                            std::cout << boost::format("Actual VGA2 Gain: %f dB...") % osmosdr_source_->get_gain("VGA2",0) << std::endl;
+    
+                        }
+                    else
+                        {
+                            std::cout << boost::format("Actual RX Gain: %f dB...") % osmosdr_source_->get_gain() << std::endl;
+                            LOG(INFO) << boost::format("Actual RX Gain: %f dB...") % osmosdr_source_->get_gain();
+                        }
                 }
+            
+            // Get actual bandwidth
+            std::cout << boost::format("Actual Bandwidth: %f [Hz]...") % osmosdr_source_->get_bandwidth(0) << std::endl;
         }
     else
         {


### PR DESCRIPTION
The get_gain() function in gr-osmosdr/lib/bladerf/bladerf_source_c.cc does not return the overall RX gain but provides only the LNA gain value. If bladeRF is set for the signal source, all the RX gain values including VGA1 and VGA2 are displayed.
