### PR TITLE
Fix RTCM server

### DIFF
--- a/src/core/system_parameters/rtcm.h
+++ b/src/core/system_parameters/rtcm.h
@@ -50,6 +50,7 @@
 #include <thread>
 #include <utility>
 #include <vector>
+#include <glog/logging.h>
 
 
 /*!
@@ -641,7 +642,6 @@ private:
     {
     public:
         Rtcm_Session(boost::asio::ip::tcp::socket socket, Rtcm_Listener_Room& room) : socket_(std::move(socket)), room_(room) {}
-
         inline void start()
         {
             room_.join(shared_from_this());
@@ -665,11 +665,11 @@ private:
             boost::asio::async_read(socket_,
                 boost::asio::buffer(read_msg_.data(), Rtcm_Message::header_length),
                 [this, self](boost::system::error_code ec, std::size_t /*length*/) {
-                    if (!ec && read_msg_.decode_header())
+                    if (!ec and read_msg_.decode_header())
                         {
                             do_read_message_body();
                         }
-                    else if (!ec && !read_msg_.decode_header())
+                    else if (!ec and !read_msg_.decode_header())
                         {
                             client_says += read_msg_.data();
                             bool first = true;
@@ -687,7 +687,7 @@ private:
                         }
                     else
                         {
-                            std::cout << "Closing connection with client from " << socket_.remote_endpoint().address() << std::endl;
+                            std::cout << "Closing connection with RTCM client" << std::endl;
                             room_.leave(shared_from_this());
                         }
                 });
@@ -709,7 +709,7 @@ private:
                         }
                     else
                         {
-                            std::cout << "Closing connection with client from " << socket_.remote_endpoint().address() << std::endl;
+                            std::cout << "Closing connection with RTCM client" << std::endl;
                             room_.leave(shared_from_this());
                         }
                 });
@@ -719,8 +719,7 @@ private:
         {
             auto self(shared_from_this());
             boost::asio::async_write(socket_,
-                boost::asio::buffer(write_msgs_.front().body(),
-                    write_msgs_.front().body_length()),
+                boost::asio::buffer(write_msgs_.front().body(), write_msgs_.front().body_length()),
                 [this, self](boost::system::error_code ec, std::size_t /*length*/) {
                     if (!ec)
                         {
@@ -732,7 +731,7 @@ private:
                         }
                     else
                         {
-                            std::cout << "Closing connection with client from " << socket_.remote_endpoint().address() << std::endl;
+                            std::cout << "Closing connection with RTCM client" << std::endl;
                             room_.leave(shared_from_this());
                         }
                 });
@@ -903,6 +902,7 @@ private:
                             {
                                 std::cout << "Starting RTCM TCP server session..." << std::endl;
                                 std::cout << "Serving client from " << socket_.remote_endpoint().address() << std::endl;
+                                LOG(INFO) << "Serving client from " << socket_.remote_endpoint().address();
                             }
                         std::make_shared<Rtcm_Session>(std::move(socket_), room_)->start();
                     }


### PR DESCRIPTION
An exception was thrown when trying to print the IP address of a client that was already disconnected