### PR TITLE
New funcionality for pcps_acquisition. A second grid with a narrower grid is performed

### DIFF
--- a/src/algorithms/acquisition/adapters/galileo_e5a_pcps_acquisition.cc
+++ b/src/algorithms/acquisition/adapters/galileo_e5a_pcps_acquisition.cc
@@ -44,6 +44,7 @@ using google::LogMessage;
 GalileoE5aPcpsAcquisition::GalileoE5aPcpsAcquisition(ConfigurationInterface* configuration,
     std::string role, unsigned int in_streams, unsigned int out_streams) : role_(role), in_streams_(in_streams), out_streams_(out_streams)
 {
+    pcpsconf_t acq_parameters;
     configuration_ = configuration;
     std::string default_item_type = "gr_complex";
     std::string default_dump_filename = "../data/acquisition.dat";
@@ -54,6 +55,8 @@ GalileoE5aPcpsAcquisition::GalileoE5aPcpsAcquisition(ConfigurationInterface* con
 
     long fs_in_deprecated = configuration_->property("GNSS-SDR.internal_fs_hz", 32000000);
     fs_in_ = configuration_->property("GNSS-SDR.internal_fs_sps", fs_in_deprecated);
+    acq_parameters.fs_in = fs_in_;
+    acq_parameters.freq = 0;
     acq_pilot_ = configuration_->property(role + ".acquire_pilot", false);
     acq_iq_ = configuration_->property(role + ".acquire_iq", false);
     if (acq_iq_)
@@ -61,17 +64,23 @@ GalileoE5aPcpsAcquisition::GalileoE5aPcpsAcquisition(ConfigurationInterface* con
             acq_pilot_ = false;
         }
     dump_ = configuration_->property(role + ".dump", false);
+    acq_parameters.dump = dump_;
     doppler_max_ = configuration_->property(role + ".doppler_max", 5000);
     if (FLAGS_doppler_max != 0) doppler_max_ = FLAGS_doppler_max;
-    sampled_ms_ = configuration_->property(role + ".coherent_integration_time_ms", 1);
+    acq_parameters.doppler_max = doppler_max_;
+    sampled_ms_ = 1;
     max_dwells_ = configuration_->property(role + ".max_dwells", 1);
+    acq_parameters.max_dwells = max_dwells_;
     dump_filename_ = configuration_->property(role + ".dump_filename", default_dump_filename);
+    acq_parameters.dump_filename = dump_filename_;
     bit_transition_flag_ = configuration_->property(role + ".bit_transition_flag", false);
+    acq_parameters.bit_transition_flag = bit_transition_flag_;
     use_CFAR_ = configuration_->property(role + ".use_CFAR_algorithm", false);
+    acq_parameters.use_CFAR_algorithm_flag = use_CFAR_;
     blocking_ = configuration_->property(role + ".blocking", true);
-
+    acq_parameters.blocking = blocking_;
     //--- Find number of samples per spreading code (1ms)-------------------------
-    code_length_ = round(static_cast<double>(fs_in_) / Galileo_E5a_CODE_CHIP_RATE_HZ * static_cast<double>(Galileo_E5a_CODE_LENGTH_CHIPS));
+    code_length_ = static_cast<unsigned int>(std::round(static_cast<double>(fs_in_) / Galileo_E5a_CODE_CHIP_RATE_HZ * static_cast<double>(Galileo_E5a_CODE_LENGTH_CHIPS)));
     vector_length_ = code_length_ * sampled_ms_;
 
     code_ = new gr_complex[vector_length_];
@@ -89,10 +98,14 @@ GalileoE5aPcpsAcquisition::GalileoE5aPcpsAcquisition(ConfigurationInterface* con
             item_size_ = sizeof(gr_complex);
             LOG(WARNING) << item_type_ << " unknown acquisition item type";
         }
-
-    acquisition_ = pcps_make_acquisition(sampled_ms_, max_dwells_, doppler_max_, 0, fs_in_,
-        code_length_, code_length_, bit_transition_flag_, use_CFAR_, dump_, blocking_,
-        dump_filename_, item_size_);
+    acq_parameters.it_size = item_size_;
+    acq_parameters.samples_per_code = code_length_;
+    acq_parameters.samples_per_ms = code_length_;
+    acq_parameters.sampled_ms = sampled_ms_;
+    acq_parameters.num_doppler_bins_step2 = configuration_->property(role + ".second_nbins", 4);
+    acq_parameters.doppler_step2 = configuration_->property(role + ".second_doppler_step", 125.0);
+    acq_parameters.make_2_steps = configuration_->property(role + ".make_two_steps", false);
+    acquisition_ = pcps_make_acquisition(acq_parameters);
 
     stream_to_vector_ = gr::blocks::stream_to_vector::make(item_size_, vector_length_);
     channel_ = 0;

--- a/src/algorithms/acquisition/adapters/glonass_l1_ca_pcps_acquisition.cc
+++ b/src/algorithms/acquisition/adapters/glonass_l1_ca_pcps_acquisition.cc
@@ -46,6 +46,7 @@ GlonassL1CaPcpsAcquisition::GlonassL1CaPcpsAcquisition(
     ConfigurationInterface* configuration, std::string role,
     unsigned int in_streams, unsigned int out_streams) : role_(role), in_streams_(in_streams), out_streams_(out_streams)
 {
+    pcpsconf_t acq_parameters;
     configuration_ = configuration;
     std::string default_item_type = "gr_complex";
     std::string default_dump_filename = "./data/acquisition.dat";
@@ -56,22 +57,28 @@ GlonassL1CaPcpsAcquisition::GlonassL1CaPcpsAcquisition(
 
     long fs_in_deprecated = configuration_->property("GNSS-SDR.internal_fs_hz", 2048000);
     fs_in_ = configuration_->property("GNSS-SDR.internal_fs_sps", fs_in_deprecated);
+    acq_parameters.fs_in = fs_in_;
     if_ = configuration_->property(role + ".if", 0);
+    acq_parameters.freq = if_;
     dump_ = configuration_->property(role + ".dump", false);
+    acq_parameters.dump = dump_;
     blocking_ = configuration_->property(role + ".blocking", true);
+    acq_parameters.blocking = blocking_;
     doppler_max_ = configuration_->property(role + ".doppler_max", 5000);
     if (FLAGS_doppler_max != 0) doppler_max_ = FLAGS_doppler_max;
+    acq_parameters.doppler_max = doppler_max_;
     sampled_ms_ = configuration_->property(role + ".coherent_integration_time_ms", 1);
-
+    acq_parameters.sampled_ms = sampled_ms_;
     bit_transition_flag_ = configuration_->property(role + ".bit_transition_flag", false);
+    acq_parameters.bit_transition_flag = bit_transition_flag_;
     use_CFAR_algorithm_flag_ = configuration_->property(role + ".use_CFAR_algorithm", true);  //will be false in future versions
-
+    acq_parameters.use_CFAR_algorithm_flag = use_CFAR_algorithm_flag_;
     max_dwells_ = configuration_->property(role + ".max_dwells", 1);
-
+    acq_parameters.max_dwells = max_dwells_;
     dump_filename_ = configuration_->property(role + ".dump_filename", default_dump_filename);
-
+    acq_parameters.dump_filename = dump_filename_;
     //--- Find number of samples per spreading code -------------------------
-    code_length_ = round(fs_in_ / (GLONASS_L1_CA_CODE_RATE_HZ / GLONASS_L1_CA_CODE_LENGTH_CHIPS));
+    code_length_ = static_cast<unsigned int>(std::round(static_cast<double>(fs_in_) / (GLONASS_L1_CA_CODE_RATE_HZ / GLONASS_L1_CA_CODE_LENGTH_CHIPS)));
 
     vector_length_ = code_length_ * sampled_ms_;
 
@@ -90,9 +97,14 @@ GlonassL1CaPcpsAcquisition::GlonassL1CaPcpsAcquisition(
         {
             item_size_ = sizeof(gr_complex);
         }
-    acquisition_ = pcps_make_acquisition(sampled_ms_, max_dwells_,
-        doppler_max_, if_, fs_in_, code_length_, code_length_,
-        bit_transition_flag_, use_CFAR_algorithm_flag_, dump_, blocking_, dump_filename_, item_size_);
+    acq_parameters.it_size = item_size_;
+    acq_parameters.sampled_ms = sampled_ms_;
+    acq_parameters.samples_per_ms = code_length_;
+    acq_parameters.samples_per_code = code_length_;
+    acq_parameters.num_doppler_bins_step2 = configuration_->property(role + ".second_nbins", 4);
+    acq_parameters.doppler_step2 = configuration_->property(role + ".second_doppler_step", 125.0);
+    acq_parameters.make_2_steps = configuration_->property(role + ".make_two_steps", false);
+    acquisition_ = pcps_make_acquisition(acq_parameters);
     DLOG(INFO) << "acquisition(" << acquisition_->unique_id() << ")";
 
     stream_to_vector_ = gr::blocks::stream_to_vector::make(item_size_, vector_length_);

--- a/src/algorithms/acquisition/adapters/glonass_l2_ca_pcps_acquisition.cc
+++ b/src/algorithms/acquisition/adapters/glonass_l2_ca_pcps_acquisition.cc
@@ -45,6 +45,7 @@ GlonassL2CaPcpsAcquisition::GlonassL2CaPcpsAcquisition(
     ConfigurationInterface* configuration, std::string role,
     unsigned int in_streams, unsigned int out_streams) : role_(role), in_streams_(in_streams), out_streams_(out_streams)
 {
+    pcpsconf_t acq_parameters;
     configuration_ = configuration;
     std::string default_item_type = "gr_complex";
     std::string default_dump_filename = "./data/acquisition.dat";
@@ -55,22 +56,27 @@ GlonassL2CaPcpsAcquisition::GlonassL2CaPcpsAcquisition(
 
     long fs_in_deprecated = configuration_->property("GNSS-SDR.internal_fs_hz", 2048000);
     fs_in_ = configuration_->property("GNSS-SDR.internal_fs_sps", fs_in_deprecated);
+    acq_parameters.fs_in = fs_in_;
     if_ = configuration_->property(role + ".if", 0);
+    acq_parameters.freq = if_;
     dump_ = configuration_->property(role + ".dump", false);
+    acq_parameters.dump = dump_;
     blocking_ = configuration_->property(role + ".blocking", true);
+    acq_parameters.blocking = blocking_;
     doppler_max_ = configuration_->property(role + ".doppler_max", 5000);
     if (FLAGS_doppler_max != 0) doppler_max_ = FLAGS_doppler_max;
+    acq_parameters.doppler_max = doppler_max_;
     sampled_ms_ = configuration_->property(role + ".coherent_integration_time_ms", 1);
-
     bit_transition_flag_ = configuration_->property(role + ".bit_transition_flag", false);
+    acq_parameters.bit_transition_flag = bit_transition_flag_;
     use_CFAR_algorithm_flag_ = configuration_->property(role + ".use_CFAR_algorithm", true);  //will be false in future versions
-
+    acq_parameters.use_CFAR_algorithm_flag = use_CFAR_algorithm_flag_;
     max_dwells_ = configuration_->property(role + ".max_dwells", 1);
 
     dump_filename_ = configuration_->property(role + ".dump_filename", default_dump_filename);
-
+    acq_parameters.dump_filename = dump_filename_;
     //--- Find number of samples per spreading code -------------------------
-    code_length_ = round(fs_in_ / (GLONASS_L2_CA_CODE_RATE_HZ / GLONASS_L2_CA_CODE_LENGTH_CHIPS));
+    code_length_ = static_cast<unsigned int>(std::round(static_cast<double>(fs_in_) / (GLONASS_L2_CA_CODE_RATE_HZ / GLONASS_L2_CA_CODE_LENGTH_CHIPS)));
 
     vector_length_ = code_length_ * sampled_ms_;
 
@@ -89,9 +95,14 @@ GlonassL2CaPcpsAcquisition::GlonassL2CaPcpsAcquisition(
         {
             item_size_ = sizeof(gr_complex);
         }
-    acquisition_ = pcps_make_acquisition(sampled_ms_, max_dwells_,
-        doppler_max_, if_, fs_in_, code_length_, code_length_,
-        bit_transition_flag_, use_CFAR_algorithm_flag_, dump_, blocking_, dump_filename_, item_size_);
+    acq_parameters.it_size = item_size_;
+    acq_parameters.sampled_ms = sampled_ms_;
+    acq_parameters.samples_per_ms = code_length_;
+    acq_parameters.samples_per_code = code_length_;
+    acq_parameters.num_doppler_bins_step2 = configuration_->property(role + ".second_nbins", 4);
+    acq_parameters.doppler_step2 = configuration_->property(role + ".second_doppler_step", 125.0);
+    acq_parameters.make_2_steps = configuration_->property(role + ".make_two_steps", false);
+    acquisition_ = pcps_make_acquisition(acq_parameters);
     DLOG(INFO) << "acquisition(" << acquisition_->unique_id() << ")";
 
     stream_to_vector_ = gr::blocks::stream_to_vector::make(item_size_, vector_length_);

--- a/src/algorithms/acquisition/adapters/gps_l1_ca_pcps_acquisition.cc
+++ b/src/algorithms/acquisition/adapters/gps_l1_ca_pcps_acquisition.cc
@@ -48,6 +48,7 @@ GpsL1CaPcpsAcquisition::GpsL1CaPcpsAcquisition(
     ConfigurationInterface* configuration, std::string role,
     unsigned int in_streams, unsigned int out_streams) : role_(role), in_streams_(in_streams), out_streams_(out_streams)
 {
+    pcpsconf_t acq_parameters;
     configuration_ = configuration;
     std::string default_item_type = "gr_complex";
     std::string default_dump_filename = "./data/acquisition.dat";
@@ -57,22 +58,31 @@ GpsL1CaPcpsAcquisition::GpsL1CaPcpsAcquisition(
     item_type_ = configuration_->property(role + ".item_type", default_item_type);
     long fs_in_deprecated = configuration_->property("GNSS-SDR.internal_fs_hz", 2048000);
     fs_in_ = configuration_->property("GNSS-SDR.internal_fs_sps", fs_in_deprecated);
+    acq_parameters.fs_in = fs_in_;
     if_ = configuration_->property(role + ".if", 0);
+    acq_parameters.freq = if_;
     dump_ = configuration_->property(role + ".dump", false);
+    acq_parameters.dump = dump_;
     blocking_ = configuration_->property(role + ".blocking", true);
+    acq_parameters.blocking = blocking_;
     doppler_max_ = configuration_->property(role + ".doppler_max", 5000);
     if (FLAGS_doppler_max != 0) doppler_max_ = FLAGS_doppler_max;
+    acq_parameters.doppler_max = doppler_max_;
     sampled_ms_ = configuration_->property(role + ".coherent_integration_time_ms", 1);
-
+    acq_parameters.sampled_ms = sampled_ms_;
     bit_transition_flag_ = configuration_->property(role + ".bit_transition_flag", false);
+    acq_parameters.bit_transition_flag = bit_transition_flag_;
     use_CFAR_algorithm_flag_ = configuration_->property(role + ".use_CFAR_algorithm", true);  //will be false in future versions
-
+    acq_parameters.use_CFAR_algorithm_flag = use_CFAR_algorithm_flag_;
     max_dwells_ = configuration_->property(role + ".max_dwells", 1);
-
+    acq_parameters.max_dwells = max_dwells_;
     dump_filename_ = configuration_->property(role + ".dump_filename", default_dump_filename);
-
+    acq_parameters.dump_filename = dump_filename_;
+    acq_parameters.num_doppler_bins_step2 = configuration_->property(role + ".second_nbins", 4);
+    acq_parameters.doppler_step2 = configuration_->property(role + ".second_doppler_step", 125.0);
+    acq_parameters.make_2_steps = configuration_->property(role + ".make_two_steps", false);
     //--- Find number of samples per spreading code -------------------------
-    code_length_ = round(fs_in_ / (GPS_L1_CA_CODE_RATE_HZ / GPS_L1_CA_CODE_LENGTH_CHIPS));
+    code_length_ = static_cast<unsigned int>(std::round(static_cast<double>(fs_in_) / (GPS_L1_CA_CODE_RATE_HZ / GPS_L1_CA_CODE_LENGTH_CHIPS)));
 
     vector_length_ = code_length_ * sampled_ms_;
 
@@ -91,9 +101,10 @@ GpsL1CaPcpsAcquisition::GpsL1CaPcpsAcquisition(
         {
             item_size_ = sizeof(gr_complex);
         }
-    acquisition_ = pcps_make_acquisition(sampled_ms_, max_dwells_,
-        doppler_max_, if_, fs_in_, code_length_, code_length_,
-        bit_transition_flag_, use_CFAR_algorithm_flag_, dump_, blocking_, dump_filename_, item_size_);
+    acq_parameters.samples_per_ms = code_length_;
+    acq_parameters.samples_per_code = code_length_;
+    acq_parameters.it_size = item_size_;
+    acquisition_ = pcps_make_acquisition(acq_parameters);
     DLOG(INFO) << "acquisition(" << acquisition_->unique_id() << ")";
 
     stream_to_vector_ = gr::blocks::stream_to_vector::make(item_size_, vector_length_);

--- a/src/algorithms/acquisition/adapters/gps_l5i_pcps_acquisition.cc
+++ b/src/algorithms/acquisition/adapters/gps_l5i_pcps_acquisition.cc
@@ -46,6 +46,7 @@ GpsL5iPcpsAcquisition::GpsL5iPcpsAcquisition(
     ConfigurationInterface* configuration, std::string role,
     unsigned int in_streams, unsigned int out_streams) : role_(role), in_streams_(in_streams), out_streams_(out_streams)
 {
+    pcpsconf_t acq_parameters;
     configuration_ = configuration;
     std::string default_item_type = "gr_complex";
     std::string default_dump_filename = "./data/acquisition.dat";
@@ -56,21 +57,26 @@ GpsL5iPcpsAcquisition::GpsL5iPcpsAcquisition(
 
     long fs_in_deprecated = configuration_->property("GNSS-SDR.internal_fs_hz", 2048000);
     fs_in_ = configuration_->property("GNSS-SDR.internal_fs_sps", fs_in_deprecated);
+    acq_parameters.fs_in = fs_in_;
     if_ = configuration_->property(role + ".if", 0);
+    acq_parameters.freq = if_;
     dump_ = configuration_->property(role + ".dump", false);
+    acq_parameters.dump = dump_;
     blocking_ = configuration_->property(role + ".blocking", true);
+    acq_parameters.blocking = blocking_;
     doppler_max_ = configuration->property(role + ".doppler_max", 5000);
     if (FLAGS_doppler_max != 0) doppler_max_ = FLAGS_doppler_max;
-
+    acq_parameters.doppler_max = doppler_max_;
     bit_transition_flag_ = configuration_->property(role + ".bit_transition_flag", false);
+    acq_parameters.bit_transition_flag = bit_transition_flag_;
     use_CFAR_algorithm_flag_ = configuration_->property(role + ".use_CFAR_algorithm", true);  //will be false in future versions
-
+    acq_parameters.use_CFAR_algorithm_flag = use_CFAR_algorithm_flag_;
     max_dwells_ = configuration_->property(role + ".max_dwells", 1);
-
+    acq_parameters.max_dwells = max_dwells_;
     dump_filename_ = configuration_->property(role + ".dump_filename", default_dump_filename);
-
+    acq_parameters.dump_filename = dump_filename_;
     //--- Find number of samples per spreading code -------------------------
-    code_length_ = round(static_cast<double>(fs_in_) / (GPS_L5i_CODE_RATE_HZ / static_cast<double>(GPS_L5i_CODE_LENGTH_CHIPS)));
+    code_length_ = static_cast<unsigned int>(std::round(static_cast<double>(fs_in_) / (GPS_L5i_CODE_RATE_HZ / static_cast<double>(GPS_L5i_CODE_LENGTH_CHIPS))));
 
     vector_length_ = code_length_;
 
@@ -89,10 +95,14 @@ GpsL5iPcpsAcquisition::GpsL5iPcpsAcquisition(
         {
             item_size_ = sizeof(gr_complex);
         }
-    acquisition_ = pcps_make_acquisition(1, max_dwells_,
-        doppler_max_, if_, fs_in_, code_length_, code_length_,
-        bit_transition_flag_, use_CFAR_algorithm_flag_, dump_, blocking_,
-        dump_filename_, item_size_);
+    acq_parameters.samples_per_code = code_length_;
+    acq_parameters.samples_per_ms = code_length_;
+    acq_parameters.it_size = item_size_;
+    acq_parameters.sampled_ms = 1;
+    acq_parameters.num_doppler_bins_step2 = configuration_->property(role + ".second_nbins", 4);
+    acq_parameters.doppler_step2 = configuration_->property(role + ".second_doppler_step", 125.0);
+    acq_parameters.make_2_steps = configuration_->property(role + ".make_two_steps", false);
+    acquisition_ = pcps_make_acquisition(acq_parameters);
     DLOG(INFO) << "acquisition(" << acquisition_->unique_id() << ")";
 
     stream_to_vector_ = gr::blocks::stream_to_vector::make(item_size_, vector_length_);

--- a/src/algorithms/acquisition/gnuradio_blocks/pcps_acquisition.cc
+++ b/src/algorithms/acquisition/gnuradio_blocks/pcps_acquisition.cc
@@ -45,59 +45,34 @@
 
 using google::LogMessage;
 
-pcps_acquisition_sptr pcps_make_acquisition(
-    unsigned int sampled_ms, unsigned int max_dwells,
-    unsigned int doppler_max, long freq, long fs_in,
-    int samples_per_ms, int samples_per_code,
-    bool bit_transition_flag, bool use_CFAR_algorithm_flag,
-    bool dump, bool blocking,
-    std::string dump_filename, size_t it_size)
+pcps_acquisition_sptr pcps_make_acquisition(pcpsconf_t conf_)
 {
-    return pcps_acquisition_sptr(
-        new pcps_acquisition(sampled_ms, max_dwells, doppler_max, freq, fs_in, samples_per_ms,
-            samples_per_code, bit_transition_flag, use_CFAR_algorithm_flag, dump, blocking, dump_filename, it_size));
+    return pcps_acquisition_sptr(new pcps_acquisition(conf_));
 }
 
 
-pcps_acquisition::pcps_acquisition(
-    unsigned int sampled_ms, unsigned int max_dwells,
-    unsigned int doppler_max, long freq, long fs_in,
-    int samples_per_ms, int samples_per_code,
-    bool bit_transition_flag, bool use_CFAR_algorithm_flag,
-    bool dump, bool blocking,
-    std::string dump_filename,
-    size_t it_size) : gr::block("pcps_acquisition",
-                          gr::io_signature::make(1, 1, it_size * sampled_ms * samples_per_ms * (bit_transition_flag ? 2 : 1)),
-                          gr::io_signature::make(0, 0, it_size * sampled_ms * samples_per_ms * (bit_transition_flag ? 2 : 1)))
+pcps_acquisition::pcps_acquisition(pcpsconf_t conf_) : gr::block("pcps_acquisition",
+                                                           gr::io_signature::make(1, 1, conf_.it_size * conf_.sampled_ms * conf_.samples_per_ms * (conf_.bit_transition_flag ? 2 : 1)),
+                                                           gr::io_signature::make(0, 0, conf_.it_size * conf_.sampled_ms * conf_.samples_per_ms * (conf_.bit_transition_flag ? 2 : 1)))
 {
     this->message_port_register_out(pmt::mp("events"));
 
+    acq_parameters = conf_;
     d_sample_counter = 0;  // SAMPLE COUNTER
     d_active = false;
     d_state = 0;
-    d_freq = freq;
-    d_old_freq = freq;
-    d_fs_in = fs_in;
-    d_samples_per_ms = samples_per_ms;
-    d_samples_per_code = samples_per_code;
-    d_sampled_ms = sampled_ms;
-    d_max_dwells = max_dwells;
+    d_old_freq = conf_.freq;
     d_well_count = 0;
-    d_doppler_max = doppler_max;
-    d_fft_size = d_sampled_ms * d_samples_per_ms;
+    d_fft_size = acq_parameters.sampled_ms * acq_parameters.samples_per_ms;
     d_mag = 0;
     d_input_power = 0.0;
     d_num_doppler_bins = 0;
-    d_num_doppler_bins_step_two = 4;
-    d_bit_transition_flag = bit_transition_flag;
-    d_use_CFAR_algorithm_flag = use_CFAR_algorithm_flag;
     d_threshold = 0.0;
     d_doppler_step = 0;
-    d_doppler_step_two = 0.0;
     d_doppler_center_step_two = 0.0;
     d_test_statistics = 0.0;
     d_channel = 0;
-    if (it_size == sizeof(gr_complex))
+    if (conf_.it_size == sizeof(gr_complex))
         {
             d_cshort = false;
         }
@@ -116,10 +91,10 @@ pcps_acquisition::pcps_acquisition(
     //
     // We can avoid this by doing linear correlation, effectively doubling the
     // size of the input buffer and padding the code with zeros.
-    if (d_bit_transition_flag)
+    if (acq_parameters.bit_transition_flag)
         {
             d_fft_size *= 2;
-            d_max_dwells = 1;  //Activation of d_bit_transition_flag invalidates the value of d_max_dwells
+            acq_parameters.max_dwells = 1;  //Activation of acq_parameters.bit_transition_flag invalidates the value of acq_parameters.max_dwells
         }
 
     d_fft_codes = static_cast<gr_complex*>(volk_gnsssdr_malloc(d_fft_size * sizeof(gr_complex), volk_gnsssdr_get_alignment()));
@@ -131,13 +106,9 @@ pcps_acquisition::pcps_acquisition(
     // Inverse FFT
     d_ifft = new gr::fft::fft_complex(d_fft_size, false);
 
-    // For dumping samples into a file
-    d_dump = dump;
-    d_dump_filename = dump_filename;
     d_gnss_synchro = 0;
     d_grid_doppler_wipeoffs = nullptr;
     d_grid_doppler_wipeoffs_step_two = nullptr;
-    d_blocking = blocking;
     d_worker_active = false;
     d_data_buffer = static_cast<gr_complex*>(volk_gnsssdr_malloc(d_fft_size * sizeof(gr_complex), volk_gnsssdr_get_alignment()));
     if (d_cshort)
@@ -163,9 +134,9 @@ pcps_acquisition::~pcps_acquisition()
                 }
             delete[] d_grid_doppler_wipeoffs;
         }
-    if (d_num_doppler_bins_step_two > 0)
+    if (acq_parameters.make_2_steps)
         {
-            for (unsigned int i = 0; i < d_num_doppler_bins_step_two; i++)
+            for (unsigned int i = 0; i < acq_parameters.num_doppler_bins_step2; i++)
                 {
                     volk_gnsssdr_free(d_grid_doppler_wipeoffs_step_two[i]);
                 }
@@ -186,7 +157,7 @@ pcps_acquisition::~pcps_acquisition()
 void pcps_acquisition::set_local_code(std::complex<float>* code)
 {
     // reset the intermediate frequency
-    d_freq = d_old_freq;
+    acq_parameters.freq = d_old_freq;
     // This will check if it's fdma, if yes will update the intermediate frequency and the doppler grid
     if (is_fdma())
         {
@@ -197,7 +168,7 @@ void pcps_acquisition::set_local_code(std::complex<float>* code)
     // [ 0 0 0 ... 0 c_0 c_1 ... c_L]
     // where c_i is the local code and there are L zeros and L chips
     gr::thread::scoped_lock lock(d_setlock);  // require mutex with work function called by the scheduler
-    if (d_bit_transition_flag)
+    if (acq_parameters.bit_transition_flag)
         {
             int offset = d_fft_size / 2;
             std::fill_n(d_fft_if->get_inbuf(), offset, gr_complex(0.0, 0.0));
@@ -218,14 +189,14 @@ bool pcps_acquisition::is_fdma()
     // Dealing with FDMA system
     if (strcmp(d_gnss_synchro->Signal, "1G") == 0)
         {
-            d_freq += DFRQ1_GLO * GLONASS_PRN.at(d_gnss_synchro->PRN);
-            LOG(INFO) << "Trying to acquire SV PRN " << d_gnss_synchro->PRN << " with freq " << d_freq << " in Glonass Channel " << GLONASS_PRN.at(d_gnss_synchro->PRN) << std::endl;
+            acq_parameters.freq += DFRQ1_GLO * GLONASS_PRN.at(d_gnss_synchro->PRN);
+            LOG(INFO) << "Trying to acquire SV PRN " << d_gnss_synchro->PRN << " with freq " << acq_parameters.freq << " in Glonass Channel " << GLONASS_PRN.at(d_gnss_synchro->PRN) << std::endl;
             return true;
         }
     else if (strcmp(d_gnss_synchro->Signal, "2G") == 0)
         {
-            d_freq += DFRQ2_GLO * GLONASS_PRN.at(d_gnss_synchro->PRN);
-            LOG(INFO) << "Trying to acquire SV PRN " << d_gnss_synchro->PRN << " with freq " << d_freq << " in Glonass Channel " << GLONASS_PRN.at(d_gnss_synchro->PRN) << std::endl;
+            acq_parameters.freq += DFRQ2_GLO * GLONASS_PRN.at(d_gnss_synchro->PRN);
+            LOG(INFO) << "Trying to acquire SV PRN " << d_gnss_synchro->PRN << " with freq " << acq_parameters.freq << " in Glonass Channel " << GLONASS_PRN.at(d_gnss_synchro->PRN) << std::endl;
             return true;
         }
     else
@@ -237,7 +208,7 @@ bool pcps_acquisition::is_fdma()
 
 void pcps_acquisition::update_local_carrier(gr_complex* carrier_vector, int correlator_length_samples, float freq)
 {
-    float phase_step_rad = GPS_TWO_PI * freq / static_cast<float>(d_fs_in);
+    float phase_step_rad = GPS_TWO_PI * freq / static_cast<float>(acq_parameters.fs_in);
     float _phase[1];
     _phase[0] = 0;
     volk_gnsssdr_s32f_sincos_32fc(carrier_vector, -phase_step_rad, _phase, correlator_length_samples);
@@ -257,27 +228,29 @@ void pcps_acquisition::init()
     d_mag = 0.0;
     d_input_power = 0.0;
 
-    d_num_doppler_bins = static_cast<unsigned int>(std::ceil(static_cast<double>(static_cast<int>(d_doppler_max) - static_cast<int>(-d_doppler_max)) / static_cast<double>(d_doppler_step)));
+    d_num_doppler_bins = static_cast<unsigned int>(std::ceil(static_cast<double>(static_cast<int>(acq_parameters.doppler_max) - static_cast<int>(-acq_parameters.doppler_max)) / static_cast<double>(d_doppler_step)));
 
     // Create the carrier Doppler wipeoff signals
     d_grid_doppler_wipeoffs = new gr_complex*[d_num_doppler_bins];
-    d_grid_doppler_wipeoffs_step_two = new gr_complex*[d_num_doppler_bins_step_two];
+    if (acq_parameters.make_2_steps)
+        {
+            d_grid_doppler_wipeoffs_step_two = new gr_complex*[acq_parameters.num_doppler_bins_step2];
+            for (unsigned int doppler_index = 0; doppler_index < acq_parameters.num_doppler_bins_step2; doppler_index++)
+                {
+                    d_grid_doppler_wipeoffs_step_two[doppler_index] = static_cast<gr_complex*>(volk_gnsssdr_malloc(d_fft_size * sizeof(gr_complex), volk_gnsssdr_get_alignment()));
+                }
+        }
     for (unsigned int doppler_index = 0; doppler_index < d_num_doppler_bins; doppler_index++)
         {
             d_grid_doppler_wipeoffs[doppler_index] = static_cast<gr_complex*>(volk_gnsssdr_malloc(d_fft_size * sizeof(gr_complex), volk_gnsssdr_get_alignment()));
-            int doppler = -static_cast<int>(d_doppler_max) + d_doppler_step * doppler_index;
-            update_local_carrier(d_grid_doppler_wipeoffs[doppler_index], d_fft_size, d_freq + doppler);
+            int doppler = -static_cast<int>(acq_parameters.doppler_max) + d_doppler_step * doppler_index;
+            update_local_carrier(d_grid_doppler_wipeoffs[doppler_index], d_fft_size, acq_parameters.freq + doppler);
         }
-    for (unsigned int doppler_index = 0; doppler_index < d_num_doppler_bins_step_two; doppler_index++)
-        {
-            d_grid_doppler_wipeoffs_step_two[doppler_index] = static_cast<gr_complex*>(volk_gnsssdr_malloc(d_fft_size * sizeof(gr_complex), volk_gnsssdr_get_alignment()));
-        }
-
     d_worker_active = false;
 
-    if (d_dump)
+    if (acq_parameters.dump)
         {
-            unsigned int effective_fft_size = (d_bit_transition_flag ? (d_fft_size / 2) : d_fft_size);
+            unsigned int effective_fft_size = (acq_parameters.bit_transition_flag ? (d_fft_size / 2) : d_fft_size);
             grid_ = arma::fmat(effective_fft_size, d_num_doppler_bins, arma::fill::zeros);
         }
 }
@@ -287,18 +260,16 @@ void pcps_acquisition::update_grid_doppler_wipeoffs()
 {
     for (unsigned int doppler_index = 0; doppler_index < d_num_doppler_bins; doppler_index++)
         {
-            //CHECK IF CALLING MALLOC IS NEEDED!!!
-            //d_grid_doppler_wipeoffs[doppler_index] = static_cast<gr_complex*>(volk_gnsssdr_malloc(d_fft_size * sizeof(gr_complex), volk_gnsssdr_get_alignment()));
-            int doppler = -static_cast<int>(d_doppler_max) + d_doppler_step * doppler_index;
-            update_local_carrier(d_grid_doppler_wipeoffs[doppler_index], d_fft_size, d_freq + doppler);
+            int doppler = -static_cast<int>(acq_parameters.doppler_max) + d_doppler_step * doppler_index;
+            update_local_carrier(d_grid_doppler_wipeoffs[doppler_index], d_fft_size, acq_parameters.freq + doppler);
         }
 }
 
 void pcps_acquisition::update_grid_doppler_wipeoffs_step2()
 {
-    for (unsigned int doppler_index = 0; doppler_index < d_num_doppler_bins_step_two; doppler_index++)
+    for (unsigned int doppler_index = 0; doppler_index < acq_parameters.num_doppler_bins_step2; doppler_index++)
         {
-            float doppler = (static_cast<float>(doppler_index) - static_cast<float>(d_num_doppler_bins_step_two) / 2.0) * d_doppler_step_two;
+            float doppler = (static_cast<float>(doppler_index) - static_cast<float>(acq_parameters.num_doppler_bins_step2) / 2.0) * acq_parameters.doppler_step2;
             update_local_carrier(d_grid_doppler_wipeoffs_step_two[doppler_index], d_fft_size, d_doppler_center_step_two + doppler);
         }
 }
@@ -423,7 +394,7 @@ int pcps_acquisition::general_work(int noutput_items __attribute__((unused)),
                     {
                         memcpy(d_data_buffer, input_items[0], d_fft_size * sizeof(gr_complex));
                     }
-                if (d_blocking)
+                if (acq_parameters.blocking)
                     {
                         lk.unlock();
                         acquisition_core(d_sample_counter);
@@ -450,7 +421,7 @@ void pcps_acquisition::acquisition_core(unsigned long int samp_count)
     uint32_t indext = 0;
     float magt = 0.0;
     const gr_complex* in = d_data_buffer;  //Get the input samples pointer
-    int effective_fft_size = (d_bit_transition_flag ? d_fft_size / 2 : d_fft_size);
+    int effective_fft_size = (acq_parameters.bit_transition_flag ? d_fft_size / 2 : d_fft_size);
     if (d_cshort)
         {
             volk_gnsssdr_16ic_convert_32fc(d_data_buffer, d_data_buffer_sc, d_fft_size);
@@ -464,12 +435,12 @@ void pcps_acquisition::acquisition_core(unsigned long int samp_count)
     DLOG(INFO) << "Channel: " << d_channel
                << " , doing acquisition of satellite: " << d_gnss_synchro->System << " " << d_gnss_synchro->PRN
                << " ,sample stamp: " << samp_count << ", threshold: "
-               << d_threshold << ", doppler_max: " << d_doppler_max
+               << d_threshold << ", doppler_max: " << acq_parameters.doppler_max
                << ", doppler_step: " << d_doppler_step
-               << ", use_CFAR_algorithm_flag: " << (d_use_CFAR_algorithm_flag ? "true" : "false");
+               << ", use_CFAR_algorithm_flag: " << (acq_parameters.use_CFAR_algorithm_flag ? "true" : "false");
 
     lk.unlock();
-    if (d_use_CFAR_algorithm_flag)
+    if (acq_parameters.use_CFAR_algorithm_flag)
         {
             // 1- (optional) Compute the input signal power estimation
             volk_32fc_magnitude_squared_32f(d_magnitude, in, d_fft_size);
@@ -482,7 +453,7 @@ void pcps_acquisition::acquisition_core(unsigned long int samp_count)
             for (unsigned int doppler_index = 0; doppler_index < d_num_doppler_bins; doppler_index++)
                 {
                     // doppler search steps
-                    int doppler = -static_cast<int>(d_doppler_max) + d_doppler_step * doppler_index;
+                    int doppler = -static_cast<int>(acq_parameters.doppler_max) + d_doppler_step * doppler_index;
 
                     volk_32fc_x2_multiply_32fc(d_fft_if->get_inbuf(), in, d_grid_doppler_wipeoffs[doppler_index], d_fft_size);
 
@@ -498,12 +469,12 @@ void pcps_acquisition::acquisition_core(unsigned long int samp_count)
                     d_ifft->execute();
 
                     // Search maximum
-                    size_t offset = (d_bit_transition_flag ? effective_fft_size : 0);
+                    size_t offset = (acq_parameters.bit_transition_flag ? effective_fft_size : 0);
                     volk_32fc_magnitude_squared_32f(d_magnitude, d_ifft->get_outbuf() + offset, effective_fft_size);
                     volk_gnsssdr_32f_index_max_32u(&indext, d_magnitude, effective_fft_size);
                     magt = d_magnitude[indext];
 
-                    if (d_use_CFAR_algorithm_flag)
+                    if (acq_parameters.use_CFAR_algorithm_flag)
                         {
                             // Normalize the maximum value to correct the scale factor introduced by FFTW
                             magt = d_magnitude[indext] / (fft_normalization_factor * fft_normalization_factor);
@@ -513,14 +484,14 @@ void pcps_acquisition::acquisition_core(unsigned long int samp_count)
                         {
                             d_mag = magt;
 
-                            if (!d_use_CFAR_algorithm_flag)
+                            if (!acq_parameters.use_CFAR_algorithm_flag)
                                 {
                                     // Search grid noise floor approximation for this doppler line
                                     volk_32f_accumulator_s32f(&d_input_power, d_magnitude, effective_fft_size);
                                     d_input_power = (d_input_power - d_mag) / (effective_fft_size - 1);
                                 }
 
-                            // In case that d_bit_transition_flag = true, we compare the potentially
+                            // In case that acq_parameters.bit_transition_flag = true, we compare the potentially
                             // new maximum test statistics (d_mag/d_input_power) with the value in
                             // d_test_statistics. When the second dwell is being processed, the value
                             // of d_mag/d_input_power could be lower than d_test_statistics (i.e,
@@ -528,9 +499,9 @@ void pcps_acquisition::acquisition_core(unsigned long int samp_count)
                             // current d_mag/d_input_power). Note that d_test_statistics is not
                             // restarted between consecutive dwells in multidwell operation.
 
-                            if (d_test_statistics < (d_mag / d_input_power) or !d_bit_transition_flag)
+                            if (d_test_statistics < (d_mag / d_input_power) or !acq_parameters.bit_transition_flag)
                                 {
-                                    d_gnss_synchro->Acq_delay_samples = static_cast<double>(indext % d_samples_per_code);
+                                    d_gnss_synchro->Acq_delay_samples = static_cast<double>(indext % acq_parameters.samples_per_code);
                                     d_gnss_synchro->Acq_doppler_hz = static_cast<double>(doppler);
                                     d_gnss_synchro->Acq_samplestamp_samples = samp_count;
 
@@ -540,12 +511,12 @@ void pcps_acquisition::acquisition_core(unsigned long int samp_count)
                                 }
                         }
                     // Record results to file if required
-                    if (d_dump)
+                    if (acq_parameters.dump)
                         {
                             memcpy(grid_.colptr(doppler_index), d_magnitude, sizeof(float) * effective_fft_size);
                             if (doppler_index == (d_num_doppler_bins - 1))
                                 {
-                                    std::string filename = d_dump_filename;
+                                    std::string filename = acq_parameters.dump_filename;
                                     filename.append("_");
                                     filename.append(1, d_gnss_synchro->System);
                                     filename.append("_");
@@ -558,7 +529,7 @@ void pcps_acquisition::acquisition_core(unsigned long int samp_count)
                                     if (matfp == NULL)
                                         {
                                             std::cout << "Unable to create or open Acquisition dump file" << std::endl;
-                                            d_dump = false;
+                                            acq_parameters.dump = false;
                                         }
                                     else
                                         {
@@ -569,7 +540,7 @@ void pcps_acquisition::acquisition_core(unsigned long int samp_count)
 
                                             dims[0] = static_cast<size_t>(1);
                                             dims[1] = static_cast<size_t>(1);
-                                            matvar = Mat_VarCreate("doppler_max", MAT_C_SINGLE, MAT_T_UINT32, 1, dims, &d_doppler_max, 0);
+                                            matvar = Mat_VarCreate("doppler_max", MAT_C_SINGLE, MAT_T_UINT32, 1, dims, &acq_parameters.doppler_max, 0);
                                             Mat_VarWrite(matfp, matvar, MAT_COMPRESSION_ZLIB);  // or MAT_COMPRESSION_NONE
                                             Mat_VarFree(matvar);
 
@@ -585,10 +556,10 @@ void pcps_acquisition::acquisition_core(unsigned long int samp_count)
         }
     else
         {
-            for (unsigned int doppler_index = 0; doppler_index < d_num_doppler_bins_step_two; doppler_index++)
+            for (unsigned int doppler_index = 0; doppler_index < acq_parameters.num_doppler_bins_step2; doppler_index++)
                 {
                     // doppler search steps
-                    float doppler = d_doppler_center_step_two + (static_cast<float>(doppler_index) - static_cast<float>(d_num_doppler_bins_step_two) / 2.0) * d_doppler_step_two;
+                    float doppler = d_doppler_center_step_two + (static_cast<float>(doppler_index) - static_cast<float>(acq_parameters.num_doppler_bins_step2) / 2.0) * acq_parameters.doppler_step2;
 
                     volk_32fc_x2_multiply_32fc(d_fft_if->get_inbuf(), in, d_grid_doppler_wipeoffs_step_two[doppler_index], d_fft_size);
 
@@ -604,12 +575,12 @@ void pcps_acquisition::acquisition_core(unsigned long int samp_count)
                     d_ifft->execute();
 
                     // Search maximum
-                    size_t offset = (d_bit_transition_flag ? effective_fft_size : 0);
+                    size_t offset = (acq_parameters.bit_transition_flag ? effective_fft_size : 0);
                     volk_32fc_magnitude_squared_32f(d_magnitude, d_ifft->get_outbuf() + offset, effective_fft_size);
                     volk_gnsssdr_32f_index_max_32u(&indext, d_magnitude, effective_fft_size);
                     magt = d_magnitude[indext];
 
-                    if (d_use_CFAR_algorithm_flag)
+                    if (acq_parameters.use_CFAR_algorithm_flag)
                         {
                             // Normalize the maximum value to correct the scale factor introduced by FFTW
                             magt = d_magnitude[indext] / (fft_normalization_factor * fft_normalization_factor);
@@ -619,14 +590,14 @@ void pcps_acquisition::acquisition_core(unsigned long int samp_count)
                         {
                             d_mag = magt;
 
-                            if (!d_use_CFAR_algorithm_flag)
+                            if (!acq_parameters.use_CFAR_algorithm_flag)
                                 {
                                     // Search grid noise floor approximation for this doppler line
                                     volk_32f_accumulator_s32f(&d_input_power, d_magnitude, effective_fft_size);
                                     d_input_power = (d_input_power - d_mag) / (effective_fft_size - 1);
                                 }
 
-                            // In case that d_bit_transition_flag = true, we compare the potentially
+                            // In case that acq_parameters.bit_transition_flag = true, we compare the potentially
                             // new maximum test statistics (d_mag/d_input_power) with the value in
                             // d_test_statistics. When the second dwell is being processed, the value
                             // of d_mag/d_input_power could be lower than d_test_statistics (i.e,
@@ -634,9 +605,9 @@ void pcps_acquisition::acquisition_core(unsigned long int samp_count)
                             // current d_mag/d_input_power). Note that d_test_statistics is not
                             // restarted between consecutive dwells in multidwell operation.
 
-                            if (d_test_statistics < (d_mag / d_input_power) or !d_bit_transition_flag)
+                            if (d_test_statistics < (d_mag / d_input_power) or !acq_parameters.bit_transition_flag)
                                 {
-                                    d_gnss_synchro->Acq_delay_samples = static_cast<double>(indext % d_samples_per_code);
+                                    d_gnss_synchro->Acq_delay_samples = static_cast<double>(indext % acq_parameters.samples_per_code);
                                     d_gnss_synchro->Acq_doppler_hz = static_cast<double>(doppler);
                                     d_gnss_synchro->Acq_samplestamp_samples = samp_count;
 
@@ -648,37 +619,12 @@ void pcps_acquisition::acquisition_core(unsigned long int samp_count)
                 }
         }
     lk.lock();
-    if (!d_bit_transition_flag)
+    if (!acq_parameters.bit_transition_flag)
         {
             if (d_test_statistics > d_threshold)
                 {
                     d_active = false;
-                    if (d_step_two)
-                        {
-                            send_positive_acquisition();
-                            d_step_two = false;
-                            d_state = 0;  // Positive acquisition
-                        }
-                    else
-                        {
-                            d_step_two = true;  // Clear input buffer and make small grid acquisition
-                            d_state = 0;
-                        }
-                }
-            else if (d_well_count == d_max_dwells)
-                {
-                    d_state = 0;
-                    d_active = false;
-                    d_step_two = false;
-                    send_negative_acquisition();
-                }
-        }
-    else
-        {
-            if (d_well_count == d_max_dwells)  // d_max_dwells = 2
-                {
-                    d_active = false;
-                    if (d_test_statistics > d_threshold)
+                    if (acq_parameters.make_2_steps)
                         {
                             if (d_step_two)
                                 {
@@ -694,10 +640,48 @@ void pcps_acquisition::acquisition_core(unsigned long int samp_count)
                         }
                     else
                         {
-                            d_state = 0;  // Negative acquisition
-                            d_step_two = false;
-                            send_negative_acquisition();
+                            send_positive_acquisition();
+                            d_state = 0;  // Positive acquisition
                         }
+                }
+            else if (d_well_count == acq_parameters.max_dwells)
+                {
+                    d_state = 0;
+                    d_active = false;
+                    d_step_two = false;
+                    send_negative_acquisition();
+                }
+        }
+    else
+        {
+            d_active = false;
+            if (d_test_statistics > d_threshold)
+                {
+                    if (acq_parameters.make_2_steps)
+                        {
+                            if (d_step_two)
+                                {
+                                    send_positive_acquisition();
+                                    d_step_two = false;
+                                    d_state = 0;  // Positive acquisition
+                                }
+                            else
+                                {
+                                    d_step_two = true;  // Clear input buffer and make small grid acquisition
+                                    d_state = 0;
+                                }
+                        }
+                    else
+                        {
+                            send_positive_acquisition();
+                            d_state = 0;  // Positive acquisition
+                        }
+                }
+            else
+                {
+                    d_state = 0;  // Negative acquisition
+                    d_step_two = false;
+                    send_negative_acquisition();
                 }
         }
     d_worker_active = false;

--- a/src/algorithms/acquisition/gnuradio_blocks/pcps_acquisition.h
+++ b/src/algorithms/acquisition/gnuradio_blocks/pcps_acquisition.h
@@ -59,18 +59,33 @@
 #include <volk_gnsssdr/volk_gnsssdr.h>
 #include <string>
 
+typedef struct
+{
+    /* pcps acquisition configuration */
+    unsigned int sampled_ms;
+    unsigned int max_dwells;
+    unsigned int doppler_max;
+    unsigned int num_doppler_bins_step2;
+    float doppler_step2;
+    long freq;
+    long fs_in;
+    int samples_per_ms;
+    int samples_per_code;
+    bool bit_transition_flag;
+    bool use_CFAR_algorithm_flag;
+    bool dump;
+    bool blocking;
+    bool make_2_steps;
+    std::string dump_filename;
+    size_t it_size;
+} pcpsconf_t;
 
 class pcps_acquisition;
 
 typedef boost::shared_ptr<pcps_acquisition> pcps_acquisition_sptr;
 
 pcps_acquisition_sptr
-pcps_make_acquisition(unsigned int sampled_ms, unsigned int max_dwells,
-    unsigned int doppler_max, long freq, long fs_in,
-    int samples_per_ms, int samples_per_code,
-    bool bit_transition_flag, bool use_CFAR_algorithm_flag,
-    bool dump, bool blocking,
-    std::string dump_filename, size_t it_size);
+pcps_make_acquisition(pcpsconf_t conf_);
 
 /*!
  * \brief This class implements a Parallel Code Phase Search Acquisition.
@@ -82,19 +97,9 @@ class pcps_acquisition : public gr::block
 {
 private:
     friend pcps_acquisition_sptr
-    pcps_make_acquisition(unsigned int sampled_ms, unsigned int max_dwells,
-        unsigned int doppler_max, long freq, long fs_in,
-        int samples_per_ms, int samples_per_code,
-        bool bit_transition_flag, bool use_CFAR_algorithm_flag,
-        bool dump, bool blocking,
-        std::string dump_filename, size_t it_size);
+    pcps_make_acquisition(pcpsconf_t conf_);
 
-    pcps_acquisition(unsigned int sampled_ms, unsigned int max_dwells,
-        unsigned int doppler_max, long freq, long fs_in,
-        int samples_per_ms, int samples_per_code,
-        bool bit_transition_flag, bool use_CFAR_algorithm_flag,
-        bool dump, bool blocking,
-        std::string dump_filename, size_t it_size);
+    pcps_acquisition(pcpsconf_t conf_);
 
     void update_local_carrier(gr_complex* carrier_vector, int correlator_length_samples, float freq);
     void update_grid_doppler_wipeoffs();
@@ -107,12 +112,9 @@ private:
 
     void send_positive_acquisition();
 
-    bool d_bit_transition_flag;
-    bool d_use_CFAR_algorithm_flag;
+    pcpsconf_t acq_parameters;
     bool d_active;
-    bool d_dump;
     bool d_worker_active;
-    bool d_blocking;
     bool d_cshort;
     bool d_step_two;
     float d_threshold;
@@ -120,23 +122,14 @@ private:
     float d_input_power;
     float d_test_statistics;
     float* d_magnitude;
-    long d_fs_in;
-    long d_freq;
     long d_old_freq;
-    int d_samples_per_ms;
-    int d_samples_per_code;
     int d_state;
     unsigned int d_channel;
-    unsigned int d_doppler_max;
     unsigned int d_doppler_step;
-    float d_doppler_step_two;
     float d_doppler_center_step_two;
-    unsigned int d_sampled_ms;
-    unsigned int d_max_dwells;
     unsigned int d_well_count;
     unsigned int d_fft_size;
     unsigned int d_num_doppler_bins;
-    unsigned int d_num_doppler_bins_step_two;
     unsigned long int d_sample_counter;
     gr_complex** d_grid_doppler_wipeoffs;
     gr_complex** d_grid_doppler_wipeoffs_step_two;
@@ -146,7 +139,6 @@ private:
     gr::fft::fft_complex* d_fft_if;
     gr::fft::fft_complex* d_ifft;
     Gnss_Synchro* d_gnss_synchro;
-    std::string d_dump_filename;
     arma::fmat grid_;
 
 public:
@@ -228,7 +220,7 @@ public:
     inline void set_doppler_max(unsigned int doppler_max)
     {
         gr::thread::scoped_lock lock(d_setlock);  // require mutex with work function called by the scheduler
-        d_doppler_max = doppler_max;
+        acq_parameters.doppler_max = doppler_max;
     }
 
     /*!
@@ -239,7 +231,6 @@ public:
     {
         gr::thread::scoped_lock lock(d_setlock);  // require mutex with work function called by the scheduler
         d_doppler_step = doppler_step;
-        d_doppler_step_two = static_cast<float>(d_doppler_step) / 2.0;
     }
 
     /*!

--- a/src/algorithms/acquisition/gnuradio_blocks/pcps_acquisition.h
+++ b/src/algorithms/acquisition/gnuradio_blocks/pcps_acquisition.h
@@ -98,6 +98,7 @@ private:
 
     void update_local_carrier(gr_complex* carrier_vector, int correlator_length_samples, float freq);
     void update_grid_doppler_wipeoffs();
+    void update_grid_doppler_wipeoffs_step2();
     bool is_fdma();
 
     void acquisition_core(unsigned long int samp_count);
@@ -113,6 +114,7 @@ private:
     bool d_worker_active;
     bool d_blocking;
     bool d_cshort;
+    bool d_step_two;
     float d_threshold;
     float d_mag;
     float d_input_power;
@@ -127,14 +129,17 @@ private:
     unsigned int d_channel;
     unsigned int d_doppler_max;
     unsigned int d_doppler_step;
+    float d_doppler_step_two;
+    float d_doppler_center_step_two;
     unsigned int d_sampled_ms;
     unsigned int d_max_dwells;
     unsigned int d_well_count;
     unsigned int d_fft_size;
     unsigned int d_num_doppler_bins;
-    unsigned int d_code_phase;
+    unsigned int d_num_doppler_bins_step_two;
     unsigned long int d_sample_counter;
     gr_complex** d_grid_doppler_wipeoffs;
+    gr_complex** d_grid_doppler_wipeoffs_step_two;
     gr_complex* d_fft_codes;
     gr_complex* d_data_buffer;
     lv_16sc_t* d_data_buffer_sc;
@@ -234,6 +239,7 @@ public:
     {
         gr::thread::scoped_lock lock(d_setlock);  // require mutex with work function called by the scheduler
         d_doppler_step = doppler_step;
+        d_doppler_step_two = static_cast<float>(d_doppler_step) / 2.0;
     }
 
     /*!

--- a/src/algorithms/tracking/gnuradio_blocks/dll_pll_veml_tracking.cc
+++ b/src/algorithms/tracking/gnuradio_blocks/dll_pll_veml_tracking.cc
@@ -430,6 +430,7 @@ void dll_pll_veml_tracking::start_tracking()
 
     long int acq_trk_diff_samples = static_cast<long int>(d_sample_counter) - static_cast<long int>(d_acq_sample_stamp);
     double acq_trk_diff_seconds = static_cast<double>(acq_trk_diff_samples) / d_fs_in;
+    std::cout << "ACQ to TRK diff seconds = " << acq_trk_diff_seconds << std::endl;
     DLOG(INFO) << "Number of samples between Acquisition and Tracking = " << acq_trk_diff_samples;
     DLOG(INFO) << "Number of seconds between Acquisition and Tracking = " << acq_trk_diff_seconds;
     // Doppler effect Fd = (C / (C + Vr)) * F

--- a/src/algorithms/tracking/gnuradio_blocks/dll_pll_veml_tracking.cc
+++ b/src/algorithms/tracking/gnuradio_blocks/dll_pll_veml_tracking.cc
@@ -430,7 +430,6 @@ void dll_pll_veml_tracking::start_tracking()
 
     long int acq_trk_diff_samples = static_cast<long int>(d_sample_counter) - static_cast<long int>(d_acq_sample_stamp);
     double acq_trk_diff_seconds = static_cast<double>(acq_trk_diff_samples) / d_fs_in;
-    std::cout << "ACQ to TRK diff seconds = " << acq_trk_diff_seconds << std::endl;
     DLOG(INFO) << "Number of samples between Acquisition and Tracking = " << acq_trk_diff_samples;
     DLOG(INFO) << "Number of seconds between Acquisition and Tracking = " << acq_trk_diff_seconds;
     // Doppler effect Fd = (C / (C + Vr)) * F

--- a/src/tests/unit-tests/signal-processing-blocks/acquisition/gps_l2_m_pcps_acquisition_test.cc
+++ b/src/tests/unit-tests/signal-processing-blocks/acquisition/gps_l2_m_pcps_acquisition_test.cc
@@ -168,6 +168,7 @@ void GpsL2MPcpsAcquisitionTest::init()
     config->set_property("Acquisition_2S.doppler_max", std::to_string(doppler_max));
     config->set_property("Acquisition_2S.doppler_step", std::to_string(doppler_step));
     config->set_property("Acquisition_2S.repeat_satellite", "false");
+    config->set_property("Acquisition_2S.make_two_steps", "false");
 }
 
 


### PR DESCRIPTION
This funcionality aims to decrease the sample delay between the acquisition block and the tracking block which is produced due to the processing time of the FFT.
The acquisition algorithm makes a full grid search and, then, consumes all the samples of the input buffer in order to catch up the tracking block.
Finally, a smaller grid search (less doppler frequency bins) centered at the doppler frequency obtained in the first step is performed again.

Also, a new data structure has been created in order to facilitate the instantiation of the pcps_acquisition block.