### PR TITLE
Change std::deque to boost::circular_buffer

### DIFF
--- a/src/algorithms/telemetry_decoder/gnuradio_blocks/gps_l1_ca_telemetry_decoder_cc.cc
+++ b/src/algorithms/telemetry_decoder/gnuradio_blocks/gps_l1_ca_telemetry_decoder_cc.cc
@@ -105,6 +105,8 @@ gps_l1_ca_telemetry_decoder_cc::gps_l1_ca_telemetry_decoder_cc(
     flag_PLL_180_deg_phase_locked = false;
     d_preamble_time_samples = 0;
     d_TOW_at_current_symbol_ms = 0;
+    d_symbol_history.resize(GPS_CA_PREAMBLE_LENGTH_SYMBOLS + 1);  // Change fixed buffer size
+    d_symbol_history.clear();                                     // Clear all the elements in the buffer
 }
 
 
@@ -395,11 +397,6 @@ int gps_l1_ca_telemetry_decoder_cc::general_work(int noutput_items __attribute__
                 }
         }
 
-    // remove used symbols from history
-    if (d_symbol_history.size() > required_symbols)
-        {
-            d_symbol_history.pop_front();
-        }
     //3. Make the output (copy the object contents to the GNURadio reserved memory)
     *out[0] = current_symbol;
 

--- a/src/algorithms/telemetry_decoder/gnuradio_blocks/gps_l1_ca_telemetry_decoder_cc.h
+++ b/src/algorithms/telemetry_decoder/gnuradio_blocks/gps_l1_ca_telemetry_decoder_cc.h
@@ -36,9 +36,9 @@
 #include "gnss_satellite.h"
 #include "gnss_synchro.h"
 #include <gnuradio/block.h>
-#include <deque>
 #include <fstream>
 #include <string>
+#include <boost/circular_buffer.hpp>
 
 class gps_l1_ca_telemetry_decoder_cc;
 
@@ -79,7 +79,7 @@ private:
     bool d_flag_frame_sync;
 
     // symbols
-    std::deque<Gnss_Synchro> d_symbol_history;
+    boost::circular_buffer<Gnss_Synchro> d_symbol_history;
 
     double d_symbol_accumulator;
     short int d_symbol_accumulator_counter;


### PR DESCRIPTION
The circular buffer (fixed memory) increases the performance of the receiver