### PR TITLE
 Add GPS Exchange Format (GPX) output support

### DIFF
--- a/src/algorithms/PVT/gnuradio_blocks/rtklib_pvt_cc.cc
+++ b/src/algorithms/PVT/gnuradio_blocks/rtklib_pvt_cc.cc
@@ -261,6 +261,12 @@ rtklib_pvt_cc::rtklib_pvt_cc(unsigned int nchannels, bool dump, std::string dump
     d_kml_dump = std::make_shared<Kml_Printer>();
     d_kml_dump->set_headers(kml_dump_filename);
 
+    //initialize gpx_printer
+    std::string gpx_dump_filename;
+    gpx_dump_filename = d_dump_filename;
+    d_gpx_dump = std::make_shared<Gpx_Printer>();
+    d_gpx_dump->set_headers(gpx_dump_filename);
+
     //initialize geojson_printer
     std::string geojson_dump_filename;
     geojson_dump_filename = d_dump_filename;
@@ -678,6 +684,7 @@ int rtklib_pvt_cc::work(int noutput_items, gr_vector_const_void_star& input_item
                                             first_fix = false;
                                         }
                                     d_kml_dump->print_position(d_ls_pvt, false);
+                                    d_gpx_dump->print_position(d_ls_pvt, false);
                                     d_geojson_printer->print_position(d_ls_pvt, false);
                                     d_nmea_printer->Print_Nmea_Line(d_ls_pvt, false);
 

--- a/src/algorithms/PVT/gnuradio_blocks/rtklib_pvt_cc.h
+++ b/src/algorithms/PVT/gnuradio_blocks/rtklib_pvt_cc.h
@@ -34,6 +34,7 @@
 
 #include "nmea_printer.h"
 #include "kml_printer.h"
+#include "gpx_printer.h"
 #include "geojson_printer.h"
 #include "rinex_printer.h"
 #include "rtcm_printer.h"
@@ -120,6 +121,7 @@ private:
 
     std::shared_ptr<Rinex_Printer> rp;
     std::shared_ptr<Kml_Printer> d_kml_dump;
+    std::shared_ptr<Gpx_Printer> d_gpx_dump;
     std::shared_ptr<Nmea_Printer> d_nmea_printer;
     std::shared_ptr<GeoJSON_Printer> d_geojson_printer;
     std::shared_ptr<Rtcm_Printer> d_rtcm_printer;

--- a/src/algorithms/PVT/libs/CMakeLists.txt
+++ b/src/algorithms/PVT/libs/CMakeLists.txt
@@ -23,6 +23,7 @@ set(PVT_LIB_SOURCES
      ls_pvt.cc
      hybrid_ls_pvt.cc
      kml_printer.cc
+     gpx_printer.cc
      rinex_printer.cc
      nmea_printer.cc  
      rtcm_printer.cc

--- a/src/algorithms/PVT/libs/gpx_printer.cc
+++ b/src/algorithms/PVT/libs/gpx_printer.cc
@@ -1,0 +1,176 @@
+/*!
+ * \file gpx_printer.cc
+ * \brief Interface of a class that prints PVT information to a gpx file
+ * \author Álvaro Cebrián Juan, 2018. acebrianjuan(at)gmail.com
+ *
+ *
+ * -------------------------------------------------------------------------
+ *
+ * Copyright (C) 2010-2018  (see AUTHORS file for a list of contributors)
+ *
+ * GNSS-SDR is a software defined Global Navigation
+ *          Satellite Systems receiver
+ *
+ * This file is part of GNSS-SDR.
+ *
+ * GNSS-SDR is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * GNSS-SDR is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with GNSS-SDR. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * -------------------------------------------------------------------------
+ */
+
+
+#include "gpx_printer.h"
+#include <boost/date_time/posix_time/posix_time.hpp>
+#include <glog/logging.h>
+#include <sstream>
+
+using google::LogMessage;
+
+bool Gpx_Printer::set_headers(std::string filename, bool time_tag_name)
+{
+    boost::posix_time::ptime pt = boost::posix_time::second_clock::local_time();
+    tm timeinfo = boost::posix_time::to_tm(pt);
+
+    if (time_tag_name)
+        {
+            std::stringstream strm0;
+            const int year = timeinfo.tm_year - 100;
+            strm0 << year;
+            const int month = timeinfo.tm_mon + 1;
+            if (month < 10)
+                {
+                    strm0 << "0";
+                }
+            strm0 << month;
+            const int day = timeinfo.tm_mday;
+            if (day < 10)
+                {
+                    strm0 << "0";
+                }
+            strm0 << day << "_";
+            const int hour = timeinfo.tm_hour;
+            if (hour < 10)
+                {
+                    strm0 << "0";
+                }
+            strm0 << hour;
+            const int min = timeinfo.tm_min;
+            if (min < 10)
+                {
+                    strm0 << "0";
+                }
+            strm0 << min;
+            const int sec = timeinfo.tm_sec;
+            if (sec < 10)
+                {
+                    strm0 << "0";
+                }
+            strm0 << sec;
+
+            gpx_filename = filename + "_" + strm0.str() + ".gpx";
+        }
+    else
+        {
+            gpx_filename = filename + ".gpx";
+        }
+    gpx_file.open(gpx_filename.c_str());
+
+    if (gpx_file.is_open())
+        {
+            DLOG(INFO) << "GPX printer writing on " << filename.c_str();
+            // Set iostream numeric format and precision
+            gpx_file.setf(gpx_file.fixed, gpx_file.floatfield);
+            gpx_file << std::setprecision(14);
+            gpx_file << "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" << std::endl
+                     << "<gpx version=\"1.1\" creator=\"GNSS-SDR\"" << std::endl
+                     << "xsi:schemaLocation=\"http://www.topografix.com/GPX/1/1 http://www.topografix.com/GPX/1/1/gpx.xsd\"" << std::endl
+                     << "xmlns=\"http://www.topografix.com/GPX/1/1\"" << std::endl
+                     << "xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">" << std::endl
+                     << "<trk>" << std::endl
+                     << "<trkseg>" << std::endl;
+            return true;
+        }
+    else
+        {
+            return false;
+        }
+}
+
+
+bool Gpx_Printer::print_position(const std::shared_ptr<Pvt_Solution>& position, bool print_average_values)
+{
+    double latitude;
+    double longitude;
+    double height;
+
+    positions_printed = true;
+
+    std::shared_ptr<Pvt_Solution> position_ = position;
+
+    if (print_average_values == false)
+        {
+            latitude = position_->get_latitude();
+            longitude = position_->get_longitude();
+            height = position_->get_height();
+        }
+    else
+        {
+            latitude = position_->get_avg_latitude();
+            longitude = position_->get_avg_longitude();
+            height = position_->get_avg_height();
+        }
+
+    if (gpx_file.is_open())
+        {
+            gpx_file << "<trkpt lon=\"" << longitude << "\" lat=\"" << latitude << "\"><ele>" << height << "</ele></trkpt>" << std::endl;
+            return true;
+        }
+    else
+        {
+            return false;
+        }
+}
+
+
+bool Gpx_Printer::close_file()
+{
+    if (gpx_file.is_open())
+        {
+            gpx_file << "</trkseg>" << std::endl
+                     << "</trk>" << std::endl
+                     << "</gpx>";
+            gpx_file.close();
+            return true;
+        }
+    else
+        {
+            return false;
+        }
+}
+
+
+Gpx_Printer::Gpx_Printer()
+{
+    positions_printed = false;
+}
+
+
+Gpx_Printer::~Gpx_Printer()
+{
+    close_file();
+    if (!positions_printed)
+        {
+            if (remove(gpx_filename.c_str()) != 0) LOG(INFO) << "Error deleting temporary GPX file";
+        }
+}

--- a/src/algorithms/PVT/libs/gpx_printer.h
+++ b/src/algorithms/PVT/libs/gpx_printer.h
@@ -1,0 +1,62 @@
+/*!
+ * \file gpx_printer.h
+ * \brief Interface of a class that prints PVT information to a gpx file
+ * \author Álvaro Cebrián Juan, 2018. acebrianjuan(at)gmail.com
+ *
+ *
+ * -------------------------------------------------------------------------
+ *
+ * Copyright (C) 2010-2018  (see AUTHORS file for a list of contributors)
+ *
+ * GNSS-SDR is a software defined Global Navigation
+ *          Satellite Systems receiver
+ *
+ * This file is part of GNSS-SDR.
+ *
+ * GNSS-SDR is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * GNSS-SDR is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with GNSS-SDR. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * -------------------------------------------------------------------------
+ */
+
+
+#ifndef GNSS_SDR_GPX_PRINTER_H_
+#define GNSS_SDR_GPX_PRINTER_H_
+
+#include "pvt_solution.h"
+#include <fstream>
+#include <memory>
+#include <string>
+
+
+/*!
+ * \brief Prints PVT information to GPX format file
+ *
+ * See http://www.topografix.com/gpx.asp
+ */
+class Gpx_Printer
+{
+private:
+    std::ofstream gpx_file;
+    bool positions_printed;
+    std::string gpx_filename;
+
+public:
+    Gpx_Printer();
+    ~Gpx_Printer();
+    bool set_headers(std::string filename, bool time_tag_name = true);
+    bool print_position(const std::shared_ptr<Pvt_Solution>& position, bool print_average_values);
+    bool close_file();
+};
+
+#endif


### PR DESCRIPTION
This PR adds [GPS Exchange Format (GPX)](http://www.topografix.com/gpx.asp) output support for GNSS-SDR as requested in issue #40.

The new functionality has been tested using the [`2013_04_04_GNSS_SIGNAL_at_CTTC_SPAIN.dat`](https://sourceforge.net/projects/gnss-sdr/files/data/2013_04_04_GNSS_SIGNAL_at_CTTC_SPAIN.tar.gz/download) raw signals as the signal source.

The following is a fragment of the printed GPX file after processing the signals:

```
<?xml version="1.0" encoding="UTF-8"?>
<gpx version="1.1" creator="GNSS-SDR"
xsi:schemaLocation="http://www.topografix.com/GPX/1/1 http://www.topografix.com/GPX/1/1/gpx.xsd"
xmlns="http://www.topografix.com/GPX/1/1"
xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
<trk>
<trkseg>
<trkpt lon="1.98757387052301" lat="41.27473239559724"><ele>74.52263314742595</ele></trkpt>
<trkpt lon="1.98758217409283" lat="41.27473304465703"><ele>75.58309511095285</ele></trkpt>
...
<trkpt lon="1.98757418644633" lat="41.27484507692196"><ele>62.04405858553946</ele></trkpt>
</trkseg>
</trk>
</gpx>
```

The current implementation of the GPX printer logs latitude, longitude and elevation. In the future, it can be expanded to log timestamps and other useful parameters.

The file has been validated successfully with the [SAX API](https://en.wikipedia.org/wiki/Simple_API_for_XML) from [Apache Xerces C++](https://xerces.apache.org/xerces-c/).

This is the result after parsing the file `pvt.dat_180505_070459.gpx` with [SAXCount](https://xerces.apache.org/xerces-c/saxcount-3.html):

```
$ SAXCount -v=always -n -s -f pvt.dat_180505_070459.gpx 
pvt.dat_180505_070459.gpx: 1089 ms (14961 elems, 14963 attrs, 7484 spaces, 127154 chars)
```

The position fixes can also be readily plotted by uploading the GPX file to an on-line visualization tool such as [GPS Visualizer](http://www.gpsvisualizer.com/):

![gpx_fixes](https://user-images.githubusercontent.com/34104100/39660353-3eaaf14e-503d-11e8-867f-562d2a23a0f9.png)


