### PR TITLE
Remove dead commented code in tracking_FLL_PLL_filter.cc

### DIFF
--- a/src/algorithms/tracking/libs/tracking_FLL_PLL_filter.cc
+++ b/src/algorithms/tracking/libs/tracking_FLL_PLL_filter.cc
@@ -104,11 +104,6 @@ float Tracking_FLL_PLL_filter::get_carrier_error(float FLL_discriminator, float 
             pll_w_new = d_pll_w + PLL_discriminator * d_pll_w0p2 * correlation_time_s + FLL_discriminator * d_pll_w0f * correlation_time_s;
             carrier_error_hz = 0.5 * (pll_w_new + d_pll_w) + d_pll_a2 * d_pll_w0p * PLL_discriminator;
             d_pll_w = pll_w_new;
-            /*std::cout<<" d_pll_w = "<<carrier_error_hz<<
-               ", pll_w_new = "<<pll_w_new
-               <<", PLL_discriminator=" <<PLL_discriminator
-               <<" FLL_discriminator ="<<FLL_discriminator
-               <<" correlation_time_s = "<<correlation_time_s<<"\r\n";*/
         }
 
     return carrier_error_hz;


### PR DESCRIPTION
Removed dead code left commented out in tracking_FLL_PLL_filter.cc.

This also serves as an initial test pull request for the Community Bonding period of GSoC 2018, in preparation for future contributions as part of the program under the mentorship of _Carles Fernandez-Prades_ and _Jordi Vilà-Valls_.