### PR TITLE
Add monitor block to send data stream to a remote GUI

### DIFF
--- a/src/algorithms/PVT/libs/gpx_printer.cc
+++ b/src/algorithms/PVT/libs/gpx_printer.cc
@@ -1,6 +1,6 @@
 /*!
  * \file gpx_printer.cc
- * \brief Interface of a class that prints PVT information to a gpx file
+ * \brief Implementation of a class that prints PVT information to a gpx file
  * \author Álvaro Cebrián Juan, 2018. acebrianjuan(at)gmail.com
  *
  *

--- a/src/core/monitor/CMakeLists.txt
+++ b/src/core/monitor/CMakeLists.txt
@@ -16,7 +16,22 @@
 # along with GNSS-SDR. If not, see <https://www.gnu.org/licenses/>.
 #
 
-add_subdirectory(system_parameters)
-add_subdirectory(libs)
-add_subdirectory(receiver)
-add_subdirectory(monitor)
+
+set(CORE_MONITOR_LIBS_SOURCES 
+	gnss_synchro_monitor.cc
+	gnss_synchro_udp_sink.cc
+)
+	
+include_directories(
+    ${CMAKE_CURRENT_SOURCE_DIR}
+    ${CMAKE_SOURCE_DIR}/src/core/system_parameters
+    ${GLOG_INCLUDE_DIRS}
+    ${GFlags_INCLUDE_DIRS}
+    ${Boost_INCLUDE_DIRS}
+)
+
+file(GLOB CORE_MONITOR_LIBS_HEADERS "*.h")
+list(SORT CORE_MONITOR_LIBS_HEADERS)
+add_library(core_monitor_lib ${CORE_MONITOR_LIBS_SOURCES} ${CORE_MONITOR_LIBS_HEADERS})
+source_group(Headers FILES ${CORE_MONITOR_LIBS_HEADERS})
+target_link_libraries(core_monitor_lib ${Boost_LIBRARIES}) 

--- a/src/core/monitor/gnss_synchro_monitor.cc
+++ b/src/core/monitor/gnss_synchro_monitor.cc
@@ -1,0 +1,92 @@
+/*!
+ * \file gnss_synchro_monitor.cc
+ * \brief Interface of a Position Velocity and Time computation block
+ * \author Álvaro Cebrián Juan, 2018. acebrianjuan(at)gmail.com
+ *
+ * -------------------------------------------------------------------------
+ *
+ * Copyright (C) 2010-2018  (see AUTHORS file for a list of contributors)
+ *
+ * GNSS-SDR is a software defined Global Navigation
+ *          Satellite Systems receiver
+ *
+ * This file is part of GNSS-SDR.
+ *
+ * GNSS-SDR is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * GNSS-SDR is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with GNSS-SDR. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * -------------------------------------------------------------------------
+ */
+
+#include "gnss_synchro_monitor.h"
+#include "gnss_synchro.h"
+#include <glog/logging.h>
+#include <algorithm>
+#include <iostream>
+
+
+using google::LogMessage;
+
+
+gnss_synchro_monitor_sptr gnss_synchro_make_monitor(unsigned int n_channels,
+    int output_rate_ms,
+    int udp_port,
+    std::vector<std::string> udp_addresses)
+{
+    return gnss_synchro_monitor_sptr(new gnss_synchro_monitor(n_channels,
+        output_rate_ms,
+        udp_port,
+        udp_addresses));
+}
+
+
+gnss_synchro_monitor::gnss_synchro_monitor(unsigned int n_channels,
+    int output_rate_ms,
+    int udp_port,
+    std::vector<std::string> udp_addresses) : gr::sync_block("gnss_synchro_monitor",
+                                                  gr::io_signature::make(n_channels, n_channels, sizeof(Gnss_Synchro)),
+                                                  gr::io_signature::make(0, 0, 0))
+{
+    d_output_rate_ms = output_rate_ms;
+    d_nchannels = n_channels;
+
+    udp_sink_ptr = std::unique_ptr<Gnss_Synchro_Udp_Sink>(new Gnss_Synchro_Udp_Sink(udp_addresses, udp_port));
+}
+
+
+gnss_synchro_monitor::~gnss_synchro_monitor()
+{
+}
+
+
+int gnss_synchro_monitor::work(int noutput_items, gr_vector_const_void_star& input_items,
+    gr_vector_void_star& output_items __attribute__((unused)))
+{
+    const Gnss_Synchro** in = reinterpret_cast<const Gnss_Synchro**>(&input_items[0]);  // Get the input buffer pointer
+    for (int epoch = 0; epoch < noutput_items; epoch++)
+        {
+            // ############ 1. READ PSEUDORANGES ####
+            for (unsigned int i = 0; i < d_nchannels; i++)
+                {
+                    //if (in[i][epoch].Flag_valid_pseudorange)
+                    //    {
+                    //    }
+                    //todo: send the gnss_synchro objects
+
+                    std::vector<Gnss_Synchro> stocks;
+                    stocks.push_back(in[i][epoch]);
+                    udp_sink_ptr->write_gnss_synchro(stocks);
+                }
+        }
+    return noutput_items;
+}

--- a/src/core/monitor/gnss_synchro_monitor.h
+++ b/src/core/monitor/gnss_synchro_monitor.h
@@ -1,0 +1,81 @@
+/*!
+ * \file gnss_synchro_monitor.h
+ * \brief Interface of a Position Velocity and Time computation block
+ * \author Álvaro Cebrián Juan, 2018. acebrianjuan(at)gmail.com
+ *
+ * -------------------------------------------------------------------------
+ *
+ * Copyright (C) 2010-2018  (see AUTHORS file for a list of contributors)
+ *
+ * GNSS-SDR is a software defined Global Navigation
+ *          Satellite Systems receiver
+ *
+ * This file is part of GNSS-SDR.
+ *
+ * GNSS-SDR is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * GNSS-SDR is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with GNSS-SDR. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * -------------------------------------------------------------------------
+ */
+
+#ifndef GNSS_SDR_GNSS_SYNCHRO_MONITOR_H
+#define GNSS_SDR_GNSS_SYNCHRO_MONITOR_H
+
+
+#include "gnss_synchro_udp_sink.h"
+#include <gnuradio/sync_block.h>
+#include <fstream>
+#include <utility>
+#include <string>
+
+
+class gnss_synchro_monitor;
+
+typedef boost::shared_ptr<gnss_synchro_monitor> gnss_synchro_monitor_sptr;
+
+gnss_synchro_monitor_sptr gnss_synchro_make_monitor(unsigned int n_channels,
+    int output_rate_ms,
+    int udp_port,
+    std::vector<std::string> udp_addresses);
+
+/*!
+ * \brief This class implements a block that computes the PVT solution with Galileo E1 signals
+ */
+class gnss_synchro_monitor : public gr::sync_block
+{
+private:
+    friend gnss_synchro_monitor_sptr gnss_synchro_make_monitor(unsigned int nchannels,
+        int output_rate_ms,
+        int udp_port,
+        std::vector<std::string> udp_addresses);
+
+    unsigned int d_nchannels;
+
+    int d_output_rate_ms;
+
+    std::unique_ptr<Gnss_Synchro_Udp_Sink> udp_sink_ptr;
+
+
+public:
+    gnss_synchro_monitor(unsigned int nchannels,
+        int output_rate_ms,
+        int udp_port,
+        std::vector<std::string> udp_addresses);
+
+    ~gnss_synchro_monitor();  //!< Default destructor
+
+    int work(int noutput_items, gr_vector_const_void_star& input_items,
+        gr_vector_void_star& output_items);
+};
+
+#endif

--- a/src/core/monitor/gnss_synchro_udp_sink.cc
+++ b/src/core/monitor/gnss_synchro_udp_sink.cc
@@ -1,0 +1,69 @@
+/*!
+ * \file gnss_synchro_udp_sink.cc
+ * \brief Implementation of a class that sends serialized Gnss_Synchro
+ * objects over udp to one or multiple endponits
+ * \author Álvaro Cebrián Juan, 2018. acebrianjuan(at)gmail.com
+ *
+ * -------------------------------------------------------------------------
+ *
+ * Copyright (C) 2010-2018  (see AUTHORS file for a list of contributors)
+ *
+ * GNSS-SDR is a software defined Global Navigation
+ *          Satellite Systems receiver
+ *
+ * This file is part of GNSS-SDR.
+ *
+ * GNSS-SDR is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * GNSS-SDR is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with GNSS-SDR. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * -------------------------------------------------------------------------
+ */
+
+#include "gnss_synchro_udp_sink.h"
+#include <boost/archive/binary_oarchive.hpp>
+#include <boost/serialization/vector.hpp>
+#include <sstream>
+#include <iostream>
+
+Gnss_Synchro_Udp_Sink::Gnss_Synchro_Udp_Sink(std::vector<std::string> addresses, const unsigned short& port) : socket{io_service}
+{
+    for (auto address : addresses)
+        {
+            boost::asio::ip::udp::endpoint endpoint(boost::asio::ip::address::from_string(address, error), port);
+            endpoints.push_back(endpoint);
+        }
+}
+
+bool Gnss_Synchro_Udp_Sink::write_gnss_synchro(std::vector<Gnss_Synchro> stocks)
+{
+    std::ostringstream archive_stream;
+    boost::archive::binary_oarchive oa{archive_stream};
+    oa << stocks;
+    std::string outbound_data = archive_stream.str();
+
+    for (auto endpoint : endpoints)
+        {
+            socket.open(endpoint.protocol(), error);
+            socket.connect(endpoint, error);
+
+            try
+                {
+                    socket.send(boost::asio::buffer(outbound_data));
+                }
+            catch (boost::system::system_error const& e)
+                {
+                    return false;
+                }
+        }
+    return true;
+}

--- a/src/core/monitor/gnss_synchro_udp_sink.h
+++ b/src/core/monitor/gnss_synchro_udp_sink.h
@@ -1,0 +1,53 @@
+/*!
+ * \file gnss_synchro_udp_sink.h
+ * \brief Interface of a class that sends serialized Gnss_Synchro objects
+ * over udp to one or multiple endponits
+ * \author Álvaro Cebrián Juan, 2018. acebrianjuan(at)gmail.com
+ *
+ * -------------------------------------------------------------------------
+ *
+ * Copyright (C) 2010-2018  (see AUTHORS file for a list of contributors)
+ *
+ * GNSS-SDR is a software defined Global Navigation
+ *          Satellite Systems receiver
+ *
+ * This file is part of GNSS-SDR.
+ *
+ * GNSS-SDR is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * GNSS-SDR is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with GNSS-SDR. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * -------------------------------------------------------------------------
+ */
+
+#ifndef GNSS_SYNCHRO_UDP_SINK_H_
+#define GNSS_SYNCHRO_UDP_SINK_H_
+
+#include <boost/asio.hpp>
+#include "gnss_synchro.h"
+
+class Gnss_Synchro_Udp_Sink
+{
+public:
+    Gnss_Synchro_Udp_Sink(std::vector<std::string> addresses, const unsigned short &port);
+    bool write_gnss_synchro(std::vector<Gnss_Synchro> stocks);
+
+private:
+    boost::asio::io_service io_service;
+    boost::asio::ip::udp::socket socket;
+    boost::system::error_code error;
+    std::vector<boost::asio::ip::udp::endpoint> endpoints;
+    std::vector<Gnss_Synchro> stocks;
+};
+
+
+#endif /* GNSS_SYNCHRO_UDP_SINK_H_ */

--- a/src/core/receiver/CMakeLists.txt
+++ b/src/core/receiver/CMakeLists.txt
@@ -111,6 +111,7 @@ include_directories(
      ${CMAKE_SOURCE_DIR}/src/core/libs/supl
      ${CMAKE_SOURCE_DIR}/src/core/libs/supl/asn-rrlp
      ${CMAKE_SOURCE_DIR}/src/core/libs/supl/asn-supl
+     ${CMAKE_SOURCE_DIR}/src/core/monitor
      ${CMAKE_SOURCE_DIR}/src/algorithms/libs
      ${CMAKE_SOURCE_DIR}/src/algorithms/signal_source/libs
      ${CMAKE_SOURCE_DIR}/src/algorithms/signal_source/adapters
@@ -178,4 +179,5 @@ target_link_libraries(gnss_rx ${Boost_LIBRARIES}
                               pvt_adapters
                               pvt_lib
                               rx_core_lib
+                              core_monitor_lib
 )

--- a/src/core/receiver/gnss_flowgraph.h
+++ b/src/core/receiver/gnss_flowgraph.h
@@ -4,6 +4,7 @@
  * \author Carlos Aviles, 2010. carlos.avilesr(at)googlemail.com
  *         Luis Esteve, 2011. luis(at)epsilon-formacion.com
  *         Carles Fernandez-Prades, 2014. cfernandez(at)cttc.es
+ *         Álvaro Cebrián Juan, 2018. acebrianjuan(at)gmail.com
  *
  * It contains a signal source,
  * a signal conditioner, a set of channels, an observables block and a pvt.
@@ -39,6 +40,7 @@
 #include "GPS_L1_CA.h"
 #include "gnss_signal.h"
 #include "gnss_sdr_sample_counter.h"
+#include "gnss_synchro_monitor.h"
 #include <gnuradio/top_block.h>
 #include <gnuradio/msg_queue.h>
 #include <gnuradio/blocks/null_source.h>
@@ -185,6 +187,9 @@ private:
 
     std::vector<unsigned int> channels_state_;
     std::mutex signal_list_mutex;
+
+    bool enable_monitor_;
+    gr::basic_block_sptr GnssSynchroMonitor_;
 };
 
 #endif /*GNSS_SDR_GNSS_FLOWGRAPH_H_*/

--- a/src/core/system_parameters/gnss_synchro.h
+++ b/src/core/system_parameters/gnss_synchro.h
@@ -4,6 +4,7 @@
  * \author
  *  Luis Esteve, 2012. luis(at)epsilon-formacion.com
  *  Javier Arribas, 2012. jarribas(at)cttc.es
+ *  Álvaro Cebrián Juan, 2018. acebrianjuan(at)gmail.com
  * -------------------------------------------------------------------------
  *
  * Copyright (C) 2010-2018  (see AUTHORS file for a list of contributors)
@@ -73,6 +74,44 @@ public:
     double RX_time;               //!< Set by Observables processing block
     bool Flag_valid_pseudorange;  //!< Set by Observables processing block
     double interp_TOW_ms;         //!< Set by Observables processing block
+
+
+    /*!
+     * \brief This member function is necessary to serialize and restore
+     * Gnss_Synchro objects from a byte stream.
+     */
+    template <class Archive>
+    void serialize(Archive& ar, const unsigned int version)
+    {
+        // Satellite and signal info
+        ar& System;
+        ar& Signal;
+        ar& PRN;
+        ar& Channel_ID;
+        ar& Acq_delay_samples;
+        ar& Acq_doppler_hz;
+        ar& Acq_samplestamp_samples;
+        ar& Flag_valid_acquisition;
+        //Tracking
+        ar& fs;
+        ar& Prompt_I;
+        ar& Prompt_Q;
+        ar& CN0_dB_hz;
+        ar& Carrier_Doppler_hz;
+        ar& Carrier_phase_rads;
+        ar& Code_phase_samples;
+        ar& Tracking_sample_counter;
+        ar& Flag_valid_symbol_output;
+        ar& correlation_length_ms;
+        //Telemetry Decoder
+        ar& Flag_valid_word;
+        ar& TOW_at_current_symbol_ms;
+        // Observables
+        ar& Pseudorange_m;
+        ar& RX_time;
+        ar& Flag_valid_pseudorange;
+        ar& interp_TOW_ms;
+    }
 };
 
 #endif

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -307,6 +307,7 @@ set(LIST_INCLUDE_DIRS
      ${CMAKE_SOURCE_DIR}/src/core/libs/supl
      ${CMAKE_SOURCE_DIR}/src/core/libs/supl/asn-rrlp
      ${CMAKE_SOURCE_DIR}/src/core/libs/supl/asn-supl
+     ${CMAKE_SOURCE_DIR}/src/core/monitor
      ${CMAKE_SOURCE_DIR}/src/algorithms/libs
      ${CMAKE_SOURCE_DIR}/src/algorithms/libs/rtklib
      ${CMAKE_SOURCE_DIR}/src/algorithms/data_type_adapter/adapters


### PR DESCRIPTION
This PR adds a new block called "monitor" to GNSS-SDR, which allows sending a data stream with the receiver internal parameters ([Gnss_Synchro](https://github.com/gnss-sdr/gnss-sdr/blob/next/src/core/system_parameters/gnss_synchro.h) objects) to local or remote clients over UDP.

The monitor block, like all the other blocks, must be activated in the receiver configuration file.

For example, to send data to localhost on port 1337 in bursts of 1 ms:

```
;######### MONITOR CONFIG ############
Monitor.enable_monitor=true
Monitor.output_rate_ms=1
Monitor.udp_port=1337
Monitor.client_addresses=127.0.0.1
```

This communication mechanism is based on the [Boost.Serialization](https://www.boost.org/doc/libs/1_67_0/libs/serialization/doc/index.html) and [Boost.Asio](https://www.boost.org/doc/libs/1_67_0/doc/html/boost_asio.html) libraries, and is part of the effort to develop a non-invasive real-time monitoring system for GNSS-SDR.