### PR TITLE
Add an IP address parser to enable specifying multiple clients in the…

### DIFF
--- a/src/core/receiver/gnss_flowgraph.cc
+++ b/src/core/receiver/gnss_flowgraph.cc
@@ -1157,11 +1157,10 @@ void GNSSFlowgraph::init()
 	 */
     enable_monitor_ = configuration_->property("Monitor.enable_monitor", false);
 
-    std::vector<std::string> udp_addr_vec;
-
     std::string address_string = configuration_->property("Monitor.client_addresses", std::string("127.0.0.1"));
-    //todo: split the string in substrings using the separator and fill the address vector.
-    udp_addr_vec.push_back(address_string);
+    std::vector<std::string> udp_addr_vec = split_string(address_string, '_');
+    std::sort(udp_addr_vec.begin(), udp_addr_vec.end());
+    udp_addr_vec.erase(std::unique(udp_addr_vec.begin(), udp_addr_vec.end()), udp_addr_vec.end());
 
     if (enable_monitor_)
         {
@@ -1598,4 +1597,18 @@ Gnss_Signal GNSSFlowgraph::search_next_signal(std::string searched_signal, bool 
             break;
         }
     return result;
+}
+
+std::vector<std::string> GNSSFlowgraph::split_string(const std::string &s, char delim)
+{
+    std::vector<std::string> v;
+    std::stringstream ss(s);
+    std::string item;
+
+    while (std::getline(ss, item, delim))
+    {
+        *(std::back_inserter(v)++) = item;
+    }
+
+    return v;
 }

--- a/src/core/receiver/gnss_flowgraph.h
+++ b/src/core/receiver/gnss_flowgraph.h
@@ -186,6 +186,7 @@ private:
 
     bool enable_monitor_;
     gr::basic_block_sptr GnssSynchroMonitor_;
+    std::vector<std::string> split_string(const std::string &s, char delim);
 };
 
 #endif /*GNSS_SDR_GNSS_FLOWGRAPH_H_*/


### PR DESCRIPTION
This PR adds a private function called `split_string` to the GNSSFlowgraph class, which is used by the _Monitor_ block to parse a string of IPv4 addresses.

This feature allows specifying multiple clients in the `Monitor.client_addresses` field of the receiver configuration, separated by an underscore delimiter character ( `_` ):

For example:

```
;######### MONITOR CONFIG ############
Monitor.enable_monitor=true
Monitor.output_rate_ms=1
Monitor.udp_port=1337
Monitor.client_addresses=10.10.10.1_10.10.10.2
```

In the above configuration, the _Monitor_ block will stream the receiver information to the addresses `10.10.10.1` and `10.10.10.2` on port `1337` UDP.

The user can add as many IP addresses as necessary.

Duplicate addresses are ignored by the parser.