### PR TITLE
Add a decimator to the Monitor block

### DIFF
--- a/src/core/monitor/gnss_synchro_monitor.cc
+++ b/src/core/monitor/gnss_synchro_monitor.cc
@@ -1,6 +1,9 @@
 /*!
  * \file gnss_synchro_monitor.cc
- * \brief Interface of a Position Velocity and Time computation block
+ * \brief Implementation of a receiver monitoring block which allows sending
+ * a data stream with the receiver internal parameters (Gnss_Synchro objects)
+ * to local or remote clients over UDP.
+ *
  * \author Álvaro Cebrián Juan, 2018. acebrianjuan(at)gmail.com
  *
  * -------------------------------------------------------------------------

--- a/src/core/monitor/gnss_synchro_monitor.cc
+++ b/src/core/monitor/gnss_synchro_monitor.cc
@@ -61,6 +61,8 @@ gnss_synchro_monitor::gnss_synchro_monitor(unsigned int n_channels,
     d_nchannels = n_channels;
 
     udp_sink_ptr = std::unique_ptr<Gnss_Synchro_Udp_Sink>(new Gnss_Synchro_Udp_Sink(udp_addresses, udp_port));
+
+    count = 0;
 }
 
 
@@ -75,17 +77,16 @@ int gnss_synchro_monitor::work(int noutput_items, gr_vector_const_void_star& inp
     const Gnss_Synchro** in = reinterpret_cast<const Gnss_Synchro**>(&input_items[0]);  // Get the input buffer pointer
     for (int epoch = 0; epoch < noutput_items; epoch++)
         {
-            // ############ 1. READ PSEUDORANGES ####
-            for (unsigned int i = 0; i < d_nchannels; i++)
+            count++;
+            if (count >= d_output_rate_ms)
                 {
-                    //if (in[i][epoch].Flag_valid_pseudorange)
-                    //    {
-                    //    }
-                    //todo: send the gnss_synchro objects
-
-                    std::vector<Gnss_Synchro> stocks;
-                    stocks.push_back(in[i][epoch]);
-                    udp_sink_ptr->write_gnss_synchro(stocks);
+                    for (unsigned int i = 0; i < d_nchannels; i++)
+                        {
+                            std::vector<Gnss_Synchro> stocks;
+                            stocks.push_back(in[i][epoch]);
+                            udp_sink_ptr->write_gnss_synchro(stocks);
+                        }
+                    count = 0;
                 }
         }
     return noutput_items;

--- a/src/core/monitor/gnss_synchro_monitor.h
+++ b/src/core/monitor/gnss_synchro_monitor.h
@@ -65,6 +65,8 @@ private:
 
     std::unique_ptr<Gnss_Synchro_Udp_Sink> udp_sink_ptr;
 
+    unsigned int count;
+
 
 public:
     gnss_synchro_monitor(unsigned int nchannels,

--- a/src/core/monitor/gnss_synchro_monitor.h
+++ b/src/core/monitor/gnss_synchro_monitor.h
@@ -68,7 +68,7 @@ private:
 
     std::unique_ptr<Gnss_Synchro_Udp_Sink> udp_sink_ptr;
 
-    unsigned int count;
+    int count;
 
 
 public:

--- a/src/core/monitor/gnss_synchro_monitor.h
+++ b/src/core/monitor/gnss_synchro_monitor.h
@@ -1,6 +1,9 @@
 /*!
  * \file gnss_synchro_monitor.h
- * \brief Interface of a Position Velocity and Time computation block
+ * \brief Interface of a receiver monitoring block which allows sending
+ * a data stream with the receiver internal parameters (Gnss_Synchro objects)
+ * to local or remote clients over UDP.
+ *
  * \author Álvaro Cebrián Juan, 2018. acebrianjuan(at)gmail.com
  *
  * -------------------------------------------------------------------------


### PR DESCRIPTION
This PR adds decimation capabilities to the _Monitor_ block in order to allow streaming a fraction of the samples from the receiver to the clients. This fraction can be adjusted via the `Monitor.output_rate_ms`(*) field in the receiver configuration file by specifying the decimation integer factor (`N`). Once set, the _Monitor_ block will send data to the clients only for every `N`<sup>th</sup> sample.

For example, if we wish to stream all the samples (`N = 1`) we would do:
```
Monitor.output_rate_ms=1
```
whereas if we wanted to stream 1 out of 5 samples (`N = 5`), we would do:
```
Monitor.output_rate_ms=5
```
Zero or negative values of `N` will be treated as `N = 1`.

<sub>(*): This field name will likely change in the future in favor of a more accurate/descriptive one.</sub>