### PR TITLE
Fix code for Boost 1.67

### DIFF
--- a/src/algorithms/PVT/libs/galileo_e1_ls_pvt.cc
+++ b/src/algorithms/PVT/libs/galileo_e1_ls_pvt.cc
@@ -184,7 +184,7 @@ bool galileo_e1_ls_pvt::get_PVT(std::map<int,Gnss_Synchro> gnss_pseudoranges_map
                     // Compute Gregorian time
                     utc = galileo_utc_model.GST_to_UTC_time(GST, Galileo_week_number);
                     // get time string Gregorian calendar
-                    boost::posix_time::time_duration t = boost::posix_time::seconds(utc);
+                    boost::posix_time::time_duration t = boost::posix_time::seconds(static_cast<int64_t>(utc));
                     // 22 August 1999 00:00 last Galileo start GST epoch (ICD sec 5.1.2)
                     boost::posix_time::ptime p_time(boost::gregorian::date(1999, 8, 22), t);
                     d_position_UTC_time = p_time;

--- a/src/algorithms/PVT/libs/gps_l1_ca_ls_pvt.cc
+++ b/src/algorithms/PVT/libs/gps_l1_ca_ls_pvt.cc
@@ -190,7 +190,7 @@ bool gps_l1_ca_ls_pvt::get_PVT(std::map<int,Gnss_Synchro> gnss_pseudoranges_map,
 
                     // Compute UTC time and print PVT solution
                     double secondsperweek = 604800.0; // number of seconds in one week (7*24*60*60)
-                    boost::posix_time::time_duration t = boost::posix_time::seconds(utc + secondsperweek * static_cast<double>(GPS_week));
+                    boost::posix_time::time_duration t = boost::posix_time::seconds(static_cast<int64_t>(utc + secondsperweek * static_cast<double>(GPS_week)));
                     // 22 August 1999 last GPS time roll over
                     boost::posix_time::ptime p_time(boost::gregorian::date(1999, 8, 22), t);
                     d_position_UTC_time = p_time;

--- a/src/algorithms/PVT/libs/hybrid_ls_pvt.cc
+++ b/src/algorithms/PVT/libs/hybrid_ls_pvt.cc
@@ -317,7 +317,7 @@ bool hybrid_ls_pvt::get_PVT(std::map<int,Gnss_Synchro> gnss_observables_map, dou
                         }
 
                     // get time string Gregorian calendar
-                    boost::posix_time::time_duration t = boost::posix_time::seconds(utc);
+                    boost::posix_time::time_duration t = boost::posix_time::seconds(static_cast<int64_t>(utc));
                     // 22 August 1999 00:00 last Galileo start GST epoch (ICD sec 5.1.2)
                     boost::posix_time::ptime p_time(boost::gregorian::date(1999, 8, 22), t);
                     d_position_UTC_time = p_time;

--- a/src/algorithms/PVT/libs/rinex_printer.cc
+++ b/src/algorithms/PVT/libs/rinex_printer.cc
@@ -4856,7 +4856,7 @@ boost::posix_time::ptime Rinex_Printer::compute_UTC_time(const Gps_Navigation_Me
     // if we are processing a file -> wait to leap second to resolve the ambiguity else take the week from the local system time
     //: idea resolve the ambiguity with the leap second  http://www.colorado.edu/geography/gcraft/notes/gps/gpseow.htm
     const double utc_t = nav_msg.utc_time(nav_msg.d_TOW);
-    boost::posix_time::time_duration t = boost::posix_time::millisec((utc_t + 604800 * static_cast<double>(nav_msg.i_GPS_week)) * 1000);
+    boost::posix_time::time_duration t = boost::posix_time::millisec(static_cast<int64_t>((utc_t + 604800 * static_cast<double>(nav_msg.i_GPS_week)) * 1000));
     boost::posix_time::ptime p_time(boost::gregorian::date(1999, 8, 22), t);
     return p_time;
 }
@@ -4869,7 +4869,7 @@ boost::posix_time::ptime Rinex_Printer::compute_GPS_time(const Gps_Ephemeris& ep
     // (see Pag. 17 in http://igscb.jpl.nasa.gov/igscb/data/format/rinex300.pdf)
     // --??? No time correction here, since it will be done in the RINEX processor
     const double gps_t = obs_time;
-    boost::posix_time::time_duration t = boost::posix_time::millisec((gps_t + 604800 * static_cast<double>(eph.i_GPS_week % 1024)) * 1000);
+    boost::posix_time::time_duration t = boost::posix_time::millisec(static_cast<int64_t>((gps_t + 604800 * static_cast<double>(eph.i_GPS_week % 1024)) * 1000));
     boost::posix_time::ptime p_time(boost::gregorian::date(1999, 8, 22), t);
     return p_time;
 }
@@ -4882,7 +4882,7 @@ boost::posix_time::ptime Rinex_Printer::compute_GPS_time(const Gps_CNAV_Ephemeri
     // (see Pag. 17 in http://igscb.jpl.nasa.gov/igscb/data/format/rinex300.pdf)
     // --??? No time correction here, since it will be done in the RINEX processor
     const double gps_t = obs_time;
-    boost::posix_time::time_duration t = boost::posix_time::millisec((gps_t + 604800 * static_cast<double>(eph.i_GPS_week % 1024)) * 1000);
+    boost::posix_time::time_duration t = boost::posix_time::millisec(static_cast<int64_t>((gps_t + 604800 * static_cast<double>(eph.i_GPS_week % 1024)) * 1000));
     boost::posix_time::ptime p_time(boost::gregorian::date(1999, 8, 22), t);
     return p_time;
 }
@@ -4894,7 +4894,7 @@ boost::posix_time::ptime Rinex_Printer::compute_Galileo_time(const Galileo_Ephem
     // (see Pag. 17 in http://igscb.jpl.nasa.gov/igscb/data/format/rinex301.pdf)
     // --??? No time correction here, since it will be done in the RINEX processor
     double galileo_t = obs_time;
-    boost::posix_time::time_duration t = boost::posix_time::millisec((galileo_t + 604800 * static_cast<double>(eph.WN_5)) * 1000); //
+    boost::posix_time::time_duration t = boost::posix_time::millisec(static_cast<int64_t>((galileo_t + 604800 * static_cast<double>(eph.WN_5)) * 1000)); //
     boost::posix_time::ptime p_time(boost::gregorian::date(1999, 8, 22), t);
     return p_time;
 }

--- a/src/core/system_parameters/rtcm.cc
+++ b/src/core/system_parameters/rtcm.cc
@@ -2563,7 +2563,7 @@ std::map<std::string, int> Rtcm::galileo_signal_map = []
 boost::posix_time::ptime Rtcm::compute_GPS_time(const Gps_Ephemeris & eph, double obs_time) const
 {
     const double gps_t = obs_time;
-    boost::posix_time::time_duration t = boost::posix_time::millisec((gps_t + 604800 * static_cast<double>(eph.i_GPS_week % 1024)) * 1000);
+    boost::posix_time::time_duration t = boost::posix_time::millisec(static_cast<int64_t>((gps_t + 604800 * static_cast<double>(eph.i_GPS_week % 1024)) * 1000));
     boost::posix_time::ptime p_time(boost::gregorian::date(1999, 8, 22), t);
     return p_time;
 }
@@ -2572,7 +2572,7 @@ boost::posix_time::ptime Rtcm::compute_GPS_time(const Gps_Ephemeris & eph, doubl
 boost::posix_time::ptime Rtcm::compute_GPS_time(const Gps_CNAV_Ephemeris & eph, double obs_time) const
 {
     const double gps_t = obs_time;
-    boost::posix_time::time_duration t = boost::posix_time::millisec((gps_t + 604800 * static_cast<double>(eph.i_GPS_week % 1024)) * 1000);
+    boost::posix_time::time_duration t = boost::posix_time::millisec(static_cast<int64_t>((gps_t + 604800 * static_cast<double>(eph.i_GPS_week % 1024)) * 1000));
     boost::posix_time::ptime p_time(boost::gregorian::date(1999, 8, 22), t);
     return p_time;
 }
@@ -2581,7 +2581,7 @@ boost::posix_time::ptime Rtcm::compute_GPS_time(const Gps_CNAV_Ephemeris & eph, 
 boost::posix_time::ptime Rtcm::compute_Galileo_time(const Galileo_Ephemeris & eph, double obs_time) const
 {
     double galileo_t = obs_time;
-    boost::posix_time::time_duration t = boost::posix_time::millisec((galileo_t + 604800 * static_cast<double>(eph.WN_5)) * 1000);
+    boost::posix_time::time_duration t = boost::posix_time::millisec(static_cast<int64_t>((galileo_t + 604800 * static_cast<double>(eph.WN_5)) * 1000));
     boost::posix_time::ptime p_time(boost::gregorian::date(1999, 8, 22), t);
     return p_time;
 }
@@ -3031,7 +3031,7 @@ int Rtcm::set_DF031(unsigned int antenna_setup_id)
 int Rtcm::set_DF051(const Gps_Ephemeris & gps_eph, double obs_time)
 {
     const double gps_t = obs_time;
-    boost::posix_time::time_duration t = boost::posix_time::millisec((gps_t + 604800 * static_cast<double>(gps_eph.i_GPS_week % 1024)) * 1000);
+    boost::posix_time::time_duration t = boost::posix_time::millisec(static_cast<int64_t>((gps_t + 604800 * static_cast<double>(gps_eph.i_GPS_week % 1024)) * 1000));
     boost::posix_time::ptime p_time(boost::gregorian::date(1999, 8, 22), t);
     std::string now_ptime = to_iso_string(p_time);
     std::string today_ptime = now_ptime.substr(0, 8);
@@ -3045,7 +3045,7 @@ int Rtcm::set_DF051(const Gps_Ephemeris & gps_eph, double obs_time)
 int Rtcm::set_DF052(const Gps_Ephemeris & gps_eph, double obs_time)
 {
     const double gps_t = obs_time;
-    boost::posix_time::time_duration t = boost::posix_time::millisec((gps_t + 604800 * static_cast<double>(gps_eph.i_GPS_week % 1024)) * 1000);
+    boost::posix_time::time_duration t = boost::posix_time::millisec(static_cast<int64_t>((gps_t + 604800 * static_cast<double>(gps_eph.i_GPS_week % 1024)) * 1000));
     boost::posix_time::ptime p_time(boost::gregorian::date(1999, 8, 22), t);
     std::string now_ptime = to_iso_string(p_time);
     std::string hours = now_ptime.substr(9, 2);

--- a/src/main/main.cc
+++ b/src/main/main.cc
@@ -119,7 +119,7 @@ int main(int argc, char** argv)
                                       << std::endl;
                             boost::system::error_code ec;
                             boost::filesystem::create_directory(p, ec);
-                            if(ec != 0)
+                            if(ec)
                                 {
                                     std::cout << "Could not create the " << FLAGS_log_dir << " folder. GNSS-SDR program ended." << std::endl;
                                     google::ShutDownCommandLineFlags();


### PR DESCRIPTION
Hi!

GNSS-SDR does not compile with recent versions of Boost (I am using 1.67 at the moment). The two attached patches should fix that, hopefully without changing the program behaviour. Could you please confirm me they are correct?

Thanks, Giovanni.