### PR TITLE
Extend GPX and KML output

### DIFF
--- a/src/algorithms/PVT/libs/kml_printer.cc
+++ b/src/algorithms/PVT/libs/kml_printer.cc
@@ -2,6 +2,7 @@
  * \file kml_printer.cc
  * \brief Implementation of a class that prints PVT information to a kml file
  * \author Javier Arribas, 2011. jarribas(at)cttc.es
+ *         Álvaro Cebrián Juan, 2018. acebrianjuan(at)gmail.com
  *
  *
  * -------------------------------------------------------------------------
@@ -75,6 +76,14 @@ Kml_Printer::Kml_Printer(const std::string& base_path)
         }
 
     kml_base_path = kml_base_path + boost::filesystem::path::preferred_separator;
+
+    boost::filesystem::path tmp_base_path = boost::filesystem::temp_directory_path();
+    boost::filesystem::path tmp_filename = boost::filesystem::unique_path();
+    boost::filesystem::path tmp_file = tmp_base_path / tmp_filename;
+
+    tmp_file_str = tmp_file.string();
+
+    point_id = 0;
 }
 
 
@@ -128,17 +137,61 @@ bool Kml_Printer::set_headers(std::string filename, bool time_tag_name)
     kml_filename = kml_base_path + kml_filename;
     kml_file.open(kml_filename.c_str());
 
-    if (kml_file.is_open())
+    tmp_file.open(tmp_file_str.c_str());
+
+    if (kml_file.is_open() && tmp_file.is_open())
         {
             DLOG(INFO) << "KML printer writing on " << filename.c_str();
             // Set iostream numeric format and precision
             kml_file.setf(kml_file.fixed, kml_file.floatfield);
             kml_file << std::setprecision(14);
+
+            tmp_file.setf(tmp_file.fixed, tmp_file.floatfield);
+            tmp_file << std::setprecision(14);
+
             kml_file << "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" << std::endl
-                     << "<kml xmlns=\"http://www.opengis.net/kml/2.2\">" << std::endl
+                     << "<kml xmlns=\"http://www.opengis.net/kml/2.2\" xmlns:gx=\"http://www.google.com/kml/ext/2.2\">" << std::endl
                      << indent << "<Document>" << std::endl
                      << indent << indent << "<name>GNSS Track</name>" << std::endl
-                     << indent << indent << "<description>GNSS-SDR Receiver position log file created at " << pt << "</description>" << std::endl
+                     << indent << indent << "<description><![CDATA[" << std::endl
+                     << indent << indent << indent << "<table>" << std::endl
+                     << indent << indent << indent << indent << "<tr><td>GNSS-SDR Receiver position log file created at " << pt << "</td></tr>" << std::endl
+                     << indent << indent << indent << indent << "<tr><td>https://gnss-sdr.org/</td></tr>" << std::endl
+                     << indent << indent << indent << "</table>" << std::endl
+                     << indent << indent << "]]></description>" << std::endl
+                     << indent << indent << "<!-- Normal track style -->" << std::endl
+                     << indent << indent << "<Style id=\"track_n\">" << std::endl
+                     << indent << indent << indent << "<IconStyle>" << std::endl
+                     << indent << indent << indent << indent << "<color>ff00ffff</color>" << std::endl
+                     << indent << indent << indent << indent << "<scale>0.3</scale>" << std::endl
+                     << indent << indent << indent << indent << "<Icon>" << std::endl
+                     << indent << indent << indent << indent << indent << "<href>http://maps.google.com/mapfiles/kml/shapes/shaded_dot.png</href>" << std::endl
+                     << indent << indent << indent << indent << "</Icon>" << std::endl
+                     << indent << indent << indent << "</IconStyle>" << std::endl
+                     << indent << indent << indent << "<LabelStyle>" << std::endl
+                     << indent << indent << indent << indent << "<scale>0</scale>" << std::endl
+                     << indent << indent << indent << "</LabelStyle>" << std::endl
+                     << indent << indent << "</Style>" << std::endl
+                     << indent << indent << "<!-- Highlighted track style -->" << std::endl
+                     << indent << indent << "<Style id=\"track_h\">" << std::endl
+                     << indent << indent << indent << "<IconStyle>" << std::endl
+                     << indent << indent << indent << indent << "<color>ff00ffff</color>" << std::endl
+                     << indent << indent << indent << indent << "<scale>1</scale>" << std::endl
+                     << indent << indent << indent << indent << "<Icon>" << std::endl
+                     << indent << indent << indent << indent << indent << "<href>http://maps.google.com/mapfiles/kml/shapes/shaded_dot.png</href>" << std::endl
+                     << indent << indent << indent << indent << "</Icon>" << std::endl
+                     << indent << indent << indent << "</IconStyle>" << std::endl
+                     << indent << indent << "</Style>" << std::endl
+                     << indent << indent << "<StyleMap id=\"track\">" << std::endl
+                     << indent << indent << indent << "<Pair>" << std::endl
+                     << indent << indent << indent << indent << "<key>normal</key>" << std::endl
+                     << indent << indent << indent << indent << "<styleUrl>#track_n</styleUrl>" << std::endl
+                     << indent << indent << indent << "</Pair>" << std::endl
+                     << indent << indent << indent << "<Pair>" << std::endl
+                     << indent << indent << indent << indent << "<key>highlight</key>" << std::endl
+                     << indent << indent << indent << indent << "<styleUrl>#track_h</styleUrl>" << std::endl
+                     << indent << indent << indent << "</Pair>" << std::endl
+                     << indent << indent << "</StyleMap>" << std::endl
                      << indent << indent << "<Style id=\"yellowLineGreenPoly\">" << std::endl
                      << indent << indent << indent << "<LineStyle>" << std::endl
                      << indent << indent << indent << indent << "<color>7f00ffff</color>" << std::endl
@@ -148,15 +201,9 @@ bool Kml_Printer::set_headers(std::string filename, bool time_tag_name)
                      << indent << indent << indent << indent << "<color>7f00ff00</color>" << std::endl
                      << indent << indent << indent << "</PolyStyle>" << std::endl
                      << indent << indent << "</Style>" << std::endl
-                     << indent << indent << "<Placemark>" << std::endl
-                     << indent << indent << indent << "<name>GNSS-SDR PVT</name>" << std::endl
-                     << indent << indent << indent << "<description>GNSS-SDR position log</description>" << std::endl
-                     << indent << indent << indent << "<styleUrl>#yellowLineGreenPoly</styleUrl>" << std::endl
-                     << indent << indent << indent << "<LineString>" << std::endl
-                     << indent << indent << indent << indent << "<extrude>0</extrude>" << std::endl
-                     << indent << indent << indent << indent << "<tessellate>1</tessellate>" << std::endl
-                     << indent << indent << indent << indent << "<altitudeMode>absolute</altitudeMode>" << std::endl
-                     << indent << indent << indent << indent << "<coordinates>" << std::endl;
+                     << indent << indent << "<Folder>" << std::endl
+                     << indent << indent << indent << "<name>Points</name>" << std::endl;
+
             return true;
         }
     else
@@ -167,7 +214,7 @@ bool Kml_Printer::set_headers(std::string filename, bool time_tag_name)
 }
 
 
-bool Kml_Printer::print_position(const std::shared_ptr<Pvt_Solution>& position, bool print_average_values)
+bool Kml_Printer::print_position(const std::shared_ptr<rtklib_solver>& position, bool print_average_values)
 {
     double latitude;
     double longitude;
@@ -175,7 +222,18 @@ bool Kml_Printer::print_position(const std::shared_ptr<Pvt_Solution>& position, 
 
     positions_printed = true;
 
-    std::shared_ptr<Pvt_Solution> position_ = position;
+    std::shared_ptr<rtklib_solver> position_ = position;
+
+    double speed_over_ground = position_->get_speed_over_ground();    // expressed in m/s
+    double course_over_ground = position_->get_course_over_ground();  // expressed in deg
+
+    double hdop = position_->get_hdop();
+    double vdop = position_->get_vdop();
+    double pdop = position_->get_pdop();
+    std::string utc_time = to_iso_extended_string(position_->get_position_UTC_time());
+    if (utc_time.length() < 23) utc_time += ".";
+    utc_time.resize(23, '0');  // time up to ms
+    utc_time.append("Z");      // UTC time zone
 
     if (print_average_values == false)
         {
@@ -190,10 +248,38 @@ bool Kml_Printer::print_position(const std::shared_ptr<Pvt_Solution>& position, 
             height = position_->get_avg_height();
         }
 
-    if (kml_file.is_open())
+    if (kml_file.is_open() && tmp_file.is_open())
         {
-            kml_file << indent << indent << indent << indent << indent
+            point_id++;
+            kml_file << indent << indent << indent << "<Placemark>" << std::endl
+                     << indent << indent << indent << indent << "<name>" << point_id << "</name>" << std::endl
+                     << indent << indent << indent << indent << "<snippet/>" << std::endl
+                     << indent << indent << indent << indent << "<description><![CDATA[" << std::endl
+                     << indent << indent << indent << indent << indent << "<table>" << std::endl
+                     << indent << indent << indent << indent << indent << indent << "<tr><td>Time:</td><td>" << utc_time << "</td></tr>" << std::endl
+                     << indent << indent << indent << indent << indent << indent << "<tr><td>Longitude:</td><td>" << longitude << "</td><td>deg</td></tr>" << std::endl
+                     << indent << indent << indent << indent << indent << indent << "<tr><td>Latitude:</td><td>" << latitude << "</td><td>deg</td></tr>" << std::endl
+                     << indent << indent << indent << indent << indent << indent << "<tr><td>Altitude:</td><td>" << height << "</td><td>m</td></tr>" << std::endl
+                     << indent << indent << indent << indent << indent << indent << "<tr><td>Speed:</td><td>" << speed_over_ground << "</td><td>m/s</td></tr>" << std::endl
+                     << indent << indent << indent << indent << indent << indent << "<tr><td>Course:</td><td>" << course_over_ground << "</td><td>deg</td></tr>" << std::endl
+                     << indent << indent << indent << indent << indent << indent << "<tr><td>HDOP:</td><td>" << hdop << "</td></tr>" << std::endl
+                     << indent << indent << indent << indent << indent << indent << "<tr><td>VDOP:</td><td>" << vdop << "</td></tr>" << std::endl
+                     << indent << indent << indent << indent << indent << indent << "<tr><td>PDOP:</td><td>" << pdop << "</td></tr>" << std::endl
+                     << indent << indent << indent << indent << indent << "</table>" << std::endl
+                     << indent << indent << indent << indent << "]]></description>" << std::endl
+                     << indent << indent << indent << indent << "<TimeStamp>" << std::endl
+                     << indent << indent << indent << indent << indent << "<when>" << utc_time << "</when>" << std::endl
+                     << indent << indent << indent << indent << "</TimeStamp>" << std::endl
+                     << indent << indent << indent << indent << "<styleUrl>#track</styleUrl>" << std::endl
+                     << indent << indent << indent << indent << "<Point>" << std::endl
+                     << indent << indent << indent << indent << indent << "<altitudeMode>absolute</altitudeMode>" << std::endl
+                     << indent << indent << indent << indent << indent << "<coordinates>" << longitude << "," << latitude << "," << height << "</coordinates>" << std::endl
+                     << indent << indent << indent << indent << "</Point>" << std::endl
+                     << indent << indent << indent << "</Placemark>" << std::endl;
+
+            tmp_file << indent << indent << indent << indent << indent
                      << longitude << "," << latitude << "," << height << std::endl;
+
             return true;
         }
     else
@@ -205,14 +291,32 @@ bool Kml_Printer::print_position(const std::shared_ptr<Pvt_Solution>& position, 
 
 bool Kml_Printer::close_file()
 {
-    if (kml_file.is_open())
+    if (kml_file.is_open() && tmp_file.is_open())
         {
+            tmp_file.close();
+
+            kml_file << indent << indent << "</Folder>"
+                     << indent << indent << "<Placemark>" << std::endl
+                     << indent << indent << indent << "<name>Path</name>" << std::endl
+                     << indent << indent << indent << "<styleUrl>#yellowLineGreenPoly</styleUrl>" << std::endl
+                     << indent << indent << indent << "<LineString>" << std::endl
+                     << indent << indent << indent << indent << "<extrude>0</extrude>" << std::endl
+                     << indent << indent << indent << indent << "<tessellate>1</tessellate>" << std::endl
+                     << indent << indent << indent << indent << "<altitudeMode>absolute</altitudeMode>" << std::endl
+                     << indent << indent << indent << indent << "<coordinates>" << std::endl;
+
+            // Copy the contents of tmp_file into kml_file
+            std::ifstream src(tmp_file_str, std::ios::binary);
+            kml_file << src.rdbuf();
+
             kml_file << indent << indent << indent << indent << "</coordinates>" << std::endl
                      << indent << indent << indent << "</LineString>" << std::endl
                      << indent << indent << "</Placemark>" << std::endl
                      << indent << "</Document>" << std::endl
                      << "</kml>";
+
             kml_file.close();
+
             return true;
         }
     else

--- a/src/algorithms/PVT/libs/kml_printer.cc
+++ b/src/algorithms/PVT/libs/kml_printer.cc
@@ -43,6 +43,7 @@ using google::LogMessage;
 Kml_Printer::Kml_Printer(const std::string& base_path)
 {
     positions_printed = false;
+    indent = "  ";
     kml_base_path = base_path;
     boost::filesystem::path full_path(boost::filesystem::current_path());
     const boost::filesystem::path p(kml_base_path);
@@ -135,28 +136,27 @@ bool Kml_Printer::set_headers(std::string filename, bool time_tag_name)
             kml_file << std::setprecision(14);
             kml_file << "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" << std::endl
                      << "<kml xmlns=\"http://www.opengis.net/kml/2.2\">" << std::endl
-                     << "    <Document>" << std::endl
-                     << "    <name>GNSS Track</name>" << std::endl
-                     << "    <description>GNSS-SDR Receiver position log file created at " << pt
-                     << "    </description>" << std::endl
-                     << "<Style id=\"yellowLineGreenPoly\">" << std::endl
-                     << " <LineStyle>" << std::endl
-                     << "     <color>7f00ffff</color>" << std::endl
-                     << "        <width>1</width>" << std::endl
-                     << "    </LineStyle>" << std::endl
-                     << "<PolyStyle>" << std::endl
-                     << "    <color>7f00ff00</color>" << std::endl
-                     << "</PolyStyle>" << std::endl
-                     << "</Style>" << std::endl
-                     << "<Placemark>" << std::endl
-                     << "<name>GNSS-SDR PVT</name>" << std::endl
-                     << "<description>GNSS-SDR position log</description>" << std::endl
-                     << "<styleUrl>#yellowLineGreenPoly</styleUrl>" << std::endl
-                     << "<LineString>" << std::endl
-                     << "<extrude>0</extrude>" << std::endl
-                     << "<tessellate>1</tessellate>" << std::endl
-                     << "<altitudeMode>absolute</altitudeMode>" << std::endl
-                     << "<coordinates>" << std::endl;
+                     << indent << "<Document>" << std::endl
+                     << indent << indent << "<name>GNSS Track</name>" << std::endl
+                     << indent << indent << "<description>GNSS-SDR Receiver position log file created at " << pt << "</description>" << std::endl
+                     << indent << indent << "<Style id=\"yellowLineGreenPoly\">" << std::endl
+                     << indent << indent << indent << "<LineStyle>" << std::endl
+                     << indent << indent << indent << indent << "<color>7f00ffff</color>" << std::endl
+                     << indent << indent << indent << indent << "<width>1</width>" << std::endl
+                     << indent << indent << indent << "</LineStyle>" << std::endl
+                     << indent << indent << indent << "<PolyStyle>" << std::endl
+                     << indent << indent << indent << indent << "<color>7f00ff00</color>" << std::endl
+                     << indent << indent << indent << "</PolyStyle>" << std::endl
+                     << indent << indent << "</Style>" << std::endl
+                     << indent << indent << "<Placemark>" << std::endl
+                     << indent << indent << indent << "<name>GNSS-SDR PVT</name>" << std::endl
+                     << indent << indent << indent << "<description>GNSS-SDR position log</description>" << std::endl
+                     << indent << indent << indent << "<styleUrl>#yellowLineGreenPoly</styleUrl>" << std::endl
+                     << indent << indent << indent << "<LineString>" << std::endl
+                     << indent << indent << indent << indent << "<extrude>0</extrude>" << std::endl
+                     << indent << indent << indent << indent << "<tessellate>1</tessellate>" << std::endl
+                     << indent << indent << indent << indent << "<altitudeMode>absolute</altitudeMode>" << std::endl
+                     << indent << indent << indent << indent << "<coordinates>" << std::endl;
             return true;
         }
     else
@@ -192,7 +192,8 @@ bool Kml_Printer::print_position(const std::shared_ptr<Pvt_Solution>& position, 
 
     if (kml_file.is_open())
         {
-            kml_file << longitude << "," << latitude << "," << height << std::endl;
+            kml_file << indent << indent << indent << indent << indent
+                     << longitude << "," << latitude << "," << height << std::endl;
             return true;
         }
     else
@@ -206,10 +207,10 @@ bool Kml_Printer::close_file()
 {
     if (kml_file.is_open())
         {
-            kml_file << "</coordinates>" << std::endl
-                     << "</LineString>" << std::endl
-                     << "</Placemark>" << std::endl
-                     << "</Document>" << std::endl
+            kml_file << indent << indent << indent << indent << "</coordinates>" << std::endl
+                     << indent << indent << indent << "</LineString>" << std::endl
+                     << indent << indent << "</Placemark>" << std::endl
+                     << indent << "</Document>" << std::endl
                      << "</kml>";
             kml_file.close();
             return true;

--- a/src/algorithms/PVT/libs/kml_printer.h
+++ b/src/algorithms/PVT/libs/kml_printer.h
@@ -2,7 +2,7 @@
  * \file kml_printer.h
  * \brief Interface of a class that prints PVT information to a kml file
  * \author Javier Arribas, 2011. jarribas(at)cttc.es
- *
+ *         Álvaro Cebrián Juan, 2018. acebrianjuan(at)gmail.com
  *
  * -------------------------------------------------------------------------
  *
@@ -34,6 +34,7 @@
 #define GNSS_SDR_KML_PRINTER_H_
 
 #include "pvt_solution.h"
+#include "rtklib_solver.h"
 #include <fstream>
 #include <memory>
 #include <string>
@@ -48,16 +49,19 @@ class Kml_Printer
 {
 private:
     std::ofstream kml_file;
+    std::ofstream tmp_file;
     bool positions_printed;
     std::string kml_filename;
-    std::string indent;
     std::string kml_base_path;
+    std::string tmp_file_str;
+    unsigned int point_id;
+    std::string indent;
 
 public:
     Kml_Printer(const std::string& base_path = std::string("."));
     ~Kml_Printer();
     bool set_headers(std::string filename, bool time_tag_name = true);
-    bool print_position(const std::shared_ptr<Pvt_Solution>& position, bool print_average_values);
+    bool print_position(const std::shared_ptr<rtklib_solver>& position, bool print_average_values);
     bool close_file();
 };
 

--- a/src/algorithms/PVT/libs/kml_printer.h
+++ b/src/algorithms/PVT/libs/kml_printer.h
@@ -50,6 +50,7 @@ private:
     std::ofstream kml_file;
     bool positions_printed;
     std::string kml_filename;
+    std::string indent;
     std::string kml_base_path;
 
 public:


### PR DESCRIPTION
This PR adds the following features to GNSS-SDR:

GPX:

- Recording of Speed over ground and Course over ground using Garmin extensions.

KML:

- Recording of Time, Speed over ground, Course over ground and Dilution of Precision.
- All coordinate points are now also available inside a folder and they can be clicked on for metadata inspection.
- Time animations are now available using the slider and play button.
- Speed charts are now available in the _Show Elevation Profile_ feature.

<table style="width:100%">
  <tr>
    <th colspan=1>Detail of the path + points</th>
  </tr>
  <tr>
    <td><img src="https://user-images.githubusercontent.com/34104100/48175320-c4c21800-e30b-11e8-98cb-5acd50b32ffe.png"/></td>
  </tr>
</table>
<table style="width:100%">
  <tr>
    <th colspan=1>Detail of the recorded metadata</th>
  </tr>
  <tr>
    <td><img src="https://user-images.githubusercontent.com/34104100/48175321-c5f34500-e30b-11e8-940f-2b394c62c928.png"/></td>
  </tr>
</table>
<table style="width:100%">
  <tr>
    <th colspan=1>Detail of the elevation and speed profiles</th>
  </tr>
  <tr>
    <td><img src="https://user-images.githubusercontent.com/34104100/48175733-7e6db880-e30d-11e8-96da-e86fef1c124d.png"/></td>
  </tr>
</table>
