### PR TITLE
Rename the decimation factor parameter of the Monitor block configuration

### DIFF
--- a/src/core/monitor/gnss_synchro_monitor.cc
+++ b/src/core/monitor/gnss_synchro_monitor.cc
@@ -43,25 +43,25 @@ using google::LogMessage;
 
 
 gnss_synchro_monitor_sptr gnss_synchro_make_monitor(unsigned int n_channels,
-    int output_rate_ms,
+    int decimation_factor,
     int udp_port,
     const std::vector<std::string>& udp_addresses)
 {
     return gnss_synchro_monitor_sptr(new gnss_synchro_monitor(n_channels,
-        output_rate_ms,
+        decimation_factor,
         udp_port,
         udp_addresses));
 }
 
 
 gnss_synchro_monitor::gnss_synchro_monitor(unsigned int n_channels,
-    int output_rate_ms,
+    int decimation_factor,
     int udp_port,
     const std::vector<std::string>& udp_addresses) : gr::sync_block("gnss_synchro_monitor",
-                                                  gr::io_signature::make(n_channels, n_channels, sizeof(Gnss_Synchro)),
-                                                  gr::io_signature::make(0, 0, 0))
+                                                         gr::io_signature::make(n_channels, n_channels, sizeof(Gnss_Synchro)),
+                                                         gr::io_signature::make(0, 0, 0))
 {
-    d_output_rate_ms = output_rate_ms;
+    d_decimation_factor = decimation_factor;
     d_nchannels = n_channels;
 
     udp_sink_ptr = std::unique_ptr<Gnss_Synchro_Udp_Sink>(new Gnss_Synchro_Udp_Sink(udp_addresses, udp_port));
@@ -80,7 +80,7 @@ int gnss_synchro_monitor::work(int noutput_items, gr_vector_const_void_star& inp
     for (int epoch = 0; epoch < noutput_items; epoch++)
         {
             count++;
-            if (count >= d_output_rate_ms)
+            if (count >= d_decimation_factor)
                 {
                     for (unsigned int i = 0; i < d_nchannels; i++)
                         {

--- a/src/core/monitor/gnss_synchro_monitor.h
+++ b/src/core/monitor/gnss_synchro_monitor.h
@@ -46,7 +46,7 @@ class gnss_synchro_monitor;
 using gnss_synchro_monitor_sptr = boost::shared_ptr<gnss_synchro_monitor>;
 
 gnss_synchro_monitor_sptr gnss_synchro_make_monitor(unsigned int n_channels,
-    int output_rate_ms,
+    int decimation_factor,
     int udp_port,
     const std::vector<std::string>& udp_addresses);
 
@@ -57,13 +57,13 @@ class gnss_synchro_monitor : public gr::sync_block
 {
 private:
     friend gnss_synchro_monitor_sptr gnss_synchro_make_monitor(unsigned int nchannels,
-        int output_rate_ms,
+        int decimation_factor,
         int udp_port,
         const std::vector<std::string>& udp_addresses);
 
     unsigned int d_nchannels;
 
-    int d_output_rate_ms;
+    int d_decimation_factor;
 
     std::unique_ptr<Gnss_Synchro_Udp_Sink> udp_sink_ptr;
 
@@ -72,7 +72,7 @@ private:
 
 public:
     gnss_synchro_monitor(unsigned int nchannels,
-        int output_rate_ms,
+        int decimation_factor,
         int udp_port,
         const std::vector<std::string>& udp_addresses);
 

--- a/src/core/receiver/gnss_flowgraph.cc
+++ b/src/core/receiver/gnss_flowgraph.cc
@@ -1538,7 +1538,7 @@ void GNSSFlowgraph::init()
     if (enable_monitor_)
         {
             GnssSynchroMonitor_ = gr::basic_block_sptr(new gnss_synchro_monitor(channels_count_,
-                configuration_->property("Monitor.output_rate_ms", 1),
+                configuration_->property("Monitor.decimation_factor", 1),
                 configuration_->property("Monitor.udp_port", 1234),
                 udp_addr_vec));
         }


### PR DESCRIPTION
This PR renames the decimation factor parameter of the _Monitor_ block configuration from `output_rate_ms` to `decimation_factor`, which is more accurate.

This change was envisioned since PR #205 

Old syntax:
```
Monitor.output_rate_ms=1000
```

New syntax:
```
Monitor.decimation_factor=1000
```
