### PR TITLE
BeiDou D2NAV decoding fix.

### DIFF
--- a/src/algorithms/telemetry_decoder/gnuradio_blocks/beidou_b1i_telemetry_decoder_cc.cc
+++ b/src/algorithms/telemetry_decoder/gnuradio_blocks/beidou_b1i_telemetry_decoder_cc.cc
@@ -317,8 +317,13 @@ void beidou_b1i_telemetry_decoder_cc::set_satellite(const Gnss_Satellite &satell
             volk_gnsssdr_free(d_secondary_code_symbols);
             volk_gnsssdr_free(d_subframe_symbols);
 
+            d_samples_per_symbol = (BEIDOU_B1I_CODE_RATE_HZ / BEIDOU_B1I_CODE_LENGTH_CHIPS) / BEIDOU_D2NAV_SYMBOL_RATE_SPS;
+            d_symbols_per_preamble = BEIDOU_DNAV_PREAMBLE_LENGTH_SYMBOLS;
+            d_samples_per_preamble = BEIDOU_DNAV_PREAMBLE_LENGTH_SYMBOLS * d_samples_per_symbol;
             d_secondary_code_symbols = nullptr;
             d_preamble_samples = static_cast<int32_t *>(volk_gnsssdr_malloc(d_samples_per_preamble * sizeof(int32_t), volk_gnsssdr_get_alignment()));
+            d_preamble_period_samples = BEIDOU_DNAV_PREAMBLE_PERIOD_SYMBOLS*d_samples_per_symbol;
+            //d_subframe_length_symbols = BEIDOU_DNAV_PREAMBLE_PERIOD_SYMBOLS;
 
             // Setting samples of preamble code
             int32_t n = 0;

--- a/src/utils/matlab/hybrid_observables_plot_sample.m
+++ b/src/utils/matlab/hybrid_observables_plot_sample.m
@@ -29,10 +29,10 @@
 clearvars;
 close all;
 addpath('./libs');
-samplingFreq       = 6625000;     %[Hz]
-channels=5;
-path='/archive/';
-observables_log_path=[path 'glo_observables.dat'];
+samplingFreq       = 25000000;     %[Hz]
+channels=10;
+path='/home/dmiralles/Documents/gnss-sdr/';
+observables_log_path=[path 'observables.dat'];
 GNSS_observables= read_hybrid_observables_dump(channels,observables_log_path);
 
 %%


### PR DESCRIPTION
Hello team:
This is a pull request and a bug report at the same time. I have been working on this for quite a while without much success, so maybe your insight can add value to it. A while ago a merge removed some key portion of code for dealing with D2 BeiDou navigation messages, and something else seems to be going on with the observables portion.
This fix only handles the error inserted while decoding D2 messages. However, an issue is still present with the computation of the observables as it seems like the measurements get spiked when new observables are present. This issue was not present before and it seems to be affecting the BeiDou solution only?. See attached observables metric to see what happens with the pseudorange computation around   n=1119. A sneak peak is offerd below
```
ans =
   1.0e+09 *
                   0                   0   0.018344675838665   0.018344674668244
                   0   0.018049331208311   0.018049330730315   0.018049330279122
                   0                   0   0.020013442075330   0.020013438698085
                   0   0.017849684684389   0.017849683085111   0.017849681056977
                   0                   0                   0                   0
   0.017953850956541   1.697391200413440   1.697391200516190   1.697391200292820
   0.018800594395234   1.698237943123970   1.698237943414340   1.698237942896140
   0.017896848331023   1.697334197707510   1.697334196546030   1.697334196273520
   0.019005816000715   1.698443165560360   1.698443165582700   1.698443165520160
                   0                   0                   0                   0
```
[beidou_b1i_observables.mat](https://github.com/gnss-sdr/gnss-sdr/files/2934014/observables.txt)

A data file with BeiDou B1I is available here (https://drive.google.com/open?id=1roLaeNZoBxWdXoiNi8po_cCSWx4c5HMn). It will be good if we could create some kind of test to validate that new code does not accidentally break the PVT solution.