### PR TITLE
fix pointer to the FPGA tracking uio device drivers

### DIFF
--- a/src/algorithms/tracking/adapters/galileo_e1_dll_pll_veml_tracking_fpga.cc
+++ b/src/algorithms/tracking/adapters/galileo_e1_dll_pll_veml_tracking_fpga.cc
@@ -173,7 +173,7 @@ GalileoE1DllPllVemlTrackingFpga::GalileoE1DllPllVemlTrackingFpga(
     std::string default_device_name = "/dev/uio";
     std::string device_name = configuration->property(role + ".devicename", default_device_name);
     trk_param_fpga.device_name = device_name;
-    uint32_t device_base = configuration->property(role + ".device_base", 15);
+    int32_t device_base = configuration->property(role + ".device_base", 15);
     trk_param_fpga.device_base = device_base;
 
     //################# PRE-COMPUTE ALL THE CODES #################

--- a/src/algorithms/tracking/adapters/galileo_e5a_dll_pll_tracking_fpga.cc
+++ b/src/algorithms/tracking/adapters/galileo_e5a_dll_pll_tracking_fpga.cc
@@ -168,7 +168,7 @@ GalileoE5aDllPllTrackingFpga::GalileoE5aDllPllTrackingFpga(
     std::string default_device_name = "/dev/uio";
     std::string device_name = configuration->property(role + ".devicename", default_device_name);
     trk_param_fpga.device_name = device_name;
-    uint32_t device_base = configuration->property(role + ".device_base", 27);
+    int32_t device_base = configuration->property(role + ".device_base", 27);
     trk_param_fpga.device_base = device_base;
 
     // ################# PRE-COMPUTE ALL THE CODES #################

--- a/src/algorithms/tracking/adapters/gps_l1_ca_dll_pll_tracking_fpga.cc
+++ b/src/algorithms/tracking/adapters/gps_l1_ca_dll_pll_tracking_fpga.cc
@@ -174,7 +174,7 @@ GpsL1CaDllPllTrackingFpga::GpsL1CaDllPllTrackingFpga(
     std::string default_device_name = "/dev/uio";
     std::string device_name = configuration->property(role + ".devicename", default_device_name);
     trk_param_fpga.device_name = device_name;
-    uint32_t device_base = configuration->property(role + ".device_base", 3);
+    int32_t device_base = configuration->property(role + ".device_base", 3);
     trk_param_fpga.device_base = device_base;
 
     // ################# PRE-COMPUTE ALL THE CODES #################

--- a/src/algorithms/tracking/adapters/gps_l5_dll_pll_tracking_fpga.cc
+++ b/src/algorithms/tracking/adapters/gps_l5_dll_pll_tracking_fpga.cc
@@ -173,7 +173,7 @@ GpsL5DllPllTrackingFpga::GpsL5DllPllTrackingFpga(
     std::string default_device_name = "/dev/uio";
     std::string device_name = configuration->property(role + ".devicename", default_device_name);
     trk_param_fpga.device_name = device_name;
-    uint32_t device_base = configuration->property(role + ".device_base", 27);
+    int32_t device_base = configuration->property(role + ".device_base", 27);
     trk_param_fpga.device_base = device_base;
 
     // ################# PRE-COMPUTE ALL THE CODES #################

--- a/src/algorithms/tracking/gnuradio_blocks/dll_pll_veml_tracking_fpga.cc
+++ b/src/algorithms/tracking/gnuradio_blocks/dll_pll_veml_tracking_fpga.cc
@@ -449,7 +449,7 @@ dll_pll_veml_tracking_fpga::dll_pll_veml_tracking_fpga(const Dll_Pll_Conf_Fpga &
         }
     // create multicorrelator class
     std::string device_name = trk_parameters.device_name;
-    uint32_t device_base = trk_parameters.device_base;
+    int32_t device_base = trk_parameters.device_base;
     int32_t *ca_codes = trk_parameters.ca_codes;
     int32_t *data_codes = trk_parameters.data_codes;
     multicorrelator_fpga = std::make_shared<Fpga_Multicorrelator_8sc>(d_n_correlator_taps, device_name, device_base, ca_codes, data_codes, d_code_length_chips, trk_parameters.track_pilot, d_code_samples_per_chip);

--- a/src/algorithms/tracking/libs/dll_pll_conf_fpga.cc
+++ b/src/algorithms/tracking/libs/dll_pll_conf_fpga.cc
@@ -77,7 +77,7 @@ Dll_Pll_Conf_Fpga::Dll_Pll_Conf_Fpga()
     signal[1] = 'C';
     signal[2] = '\0';
     device_name = "/dev/uio";
-    device_base = 1U;
+    device_base = 1;
     code_length_chips = 0U;
     code_samples_per_chip = 0U;
     ca_codes = nullptr;

--- a/src/algorithms/tracking/libs/dll_pll_conf_fpga.h
+++ b/src/algorithms/tracking/libs/dll_pll_conf_fpga.h
@@ -81,7 +81,7 @@ public:
     char system;
     char signal[3];
     std::string device_name;
-    uint32_t device_base;
+    int32_t device_base;
     uint32_t code_length_chips;
     uint32_t code_samples_per_chip;
     int32_t* ca_codes;

--- a/src/algorithms/tracking/libs/fpga_multicorrelator.cc
+++ b/src/algorithms/tracking/libs/fpga_multicorrelator.cc
@@ -61,7 +61,7 @@ const float PHASE_CARR_MAX_DIV_PI = 683565275.5764316;  // 2^(31)/pi
 const float TWO_PI = 6.283185307179586;
 
 Fpga_Multicorrelator_8sc::Fpga_Multicorrelator_8sc(int32_t n_correlators,
-    std::string device_name, uint32_t device_base, int32_t *ca_codes, int32_t *data_codes, uint32_t code_length_chips, bool track_pilot,
+    std::string device_name, int32_t device_base, int32_t *ca_codes, int32_t *data_codes, uint32_t code_length_chips, bool track_pilot,
     uint32_t code_samples_per_chip)
 
 {

--- a/src/algorithms/tracking/libs/fpga_multicorrelator.h
+++ b/src/algorithms/tracking/libs/fpga_multicorrelator.h
@@ -53,7 +53,7 @@ public:
 	 */
     Fpga_Multicorrelator_8sc(int32_t n_correlators,
         std::string device_name,
-        uint32_t device_base,
+        int32_t device_base,
         int32_t *ca_codes,
         int32_t *data_codes,
         uint32_t code_length_chips,
@@ -236,7 +236,7 @@ private:
 
     // driver
     std::string d_device_name;
-    uint32_t d_device_base;
+    int32_t d_device_base;
 
     // PRN codes
     int32_t *d_ca_codes;


### PR DESCRIPTION
The SW tracking modules use the uio driver to communicate with the FPGA HW accelerators.
The uio drivers are indexed using the device_base parameter and the channel number that is assigned to the tracking modules. When using more than one frequency band or GNSS constellation, sometimes we need a negative number for device_base such that the SW tracking module points to the correct uio driver.  