### PR TITLE
Fix fpga cn0 and tracking lock status

### DIFF
--- a/src/algorithms/tracking/gnuradio_blocks/dll_pll_veml_tracking_fpga.cc
+++ b/src/algorithms/tracking/gnuradio_blocks/dll_pll_veml_tracking_fpga.cc
@@ -600,11 +600,12 @@ bool dll_pll_veml_tracking_fpga::cn0_and_tracking_lock_status(double coh_integra
     if (d_cn0_estimation_counter < trk_parameters.cn0_samples)
         {
             // fill buffer with prompt correlator output values
-            d_Prompt_buffer[d_cn0_estimation_counter++] = d_P_accu;
+            d_Prompt_buffer[d_cn0_estimation_counter] = d_P_accu;
+            d_cn0_estimation_counter++;
             return true;
         }
-    d_cn0_estimation_counter = 0;
-    d_Prompt_buffer[d_cn0_estimation_counter++] = d_P_accu;
+    d_Prompt_buffer[d_cn0_estimation_counter % trk_parameters.cn0_samples] = d_P_accu;
+    d_cn0_estimation_counter++;
     // Code lock indicator
     float d_CN0_SNV_dB_Hz_raw = cn0_svn_estimator(d_Prompt_buffer.data(), trk_parameters.cn0_samples, static_cast<float>(coh_integration_time_s));
     d_CN0_SNV_dB_Hz = d_cn0_smoother.smooth(d_CN0_SNV_dB_Hz_raw);


### PR DESCRIPTION
Solved a bug in the cn0_and_tracking_lock_status function which caused a long delay in the receiver when a satellite is not visible anymore and the receiver had to stop tracking this satellite. This prevented the receiver from computing the PVT solution during this transitory.