### PR TITLE
acquire_pilot option for L5 when using the FPGA

### DIFF
--- a/src/algorithms/acquisition/adapters/gps_l5i_pcps_acquisition_fpga.cc
+++ b/src/algorithms/acquisition/adapters/gps_l5i_pcps_acquisition_fpga.cc
@@ -78,6 +78,8 @@ GpsL5iPcpsAcquisitionFpga::GpsL5iPcpsAcquisitionFpga(
     uint32_t sampled_ms = configuration_->property(role + ".coherent_integration_time_ms", 1);
     acq_parameters.sampled_ms = sampled_ms;
 
+    acq_pilot_ = configuration_->property(role + ".acquire_pilot", false);
+
     // -- Find number of samples per spreading code -------------------------
     auto code_length = static_cast<uint32_t>(std::round(static_cast<double>(fs_in) / (GPS_L5I_CODE_RATE_CPS / static_cast<double>(GPS_L5I_CODE_LENGTH_CHIPS))));
     acq_parameters.code_length = code_length;
@@ -109,8 +111,14 @@ GpsL5iPcpsAcquisitionFpga::GpsL5iPcpsAcquisitionFpga(
 
     for (uint32_t PRN = 1; PRN <= NUM_PRNs; PRN++)
         {
-            gps_l5i_code_gen_complex_sampled(code, PRN, fs_in);
-
+    		if (acq_pilot_)
+    			{
+    				gps_l5q_code_gen_complex_sampled(code, PRN, fs_in);
+    			}
+    		else
+    			{
+    				gps_l5i_code_gen_complex_sampled(code, PRN, fs_in);
+    			}
             for (uint32_t s = code_length; s < 2 * code_length; s++)
                 {
                     code[s] = code[s - code_length];

--- a/src/algorithms/acquisition/adapters/gps_l5i_pcps_acquisition_fpga.h
+++ b/src/algorithms/acquisition/adapters/gps_l5i_pcps_acquisition_fpga.h
@@ -202,6 +202,7 @@ private:
     ConfigurationInterface* configuration_;
     pcps_acquisition_fpga_sptr acquisition_fpga_;
     std::string item_type_;
+    bool acq_pilot_;
     uint32_t channel_;
     std::weak_ptr<ChannelFsm> channel_fsm_;
     uint32_t doppler_max_;


### PR DESCRIPTION
Option to acquire L5 using the pilot signal, when using the FPGA.