### PR TITLE
File dma fix

### DIFF
--- a/src/algorithms/signal_source/adapters/ad9361_fpga_signal_source.cc
+++ b/src/algorithms/signal_source/adapters/ad9361_fpga_signal_source.cc
@@ -323,14 +323,11 @@ Ad9361FpgaSignalSource::Ad9361FpgaSignalSource(ConfigurationInterface *configura
             filename_rx1 = configuration->property(role + ".filename_rx1", empty_string);
             filename_rx2 = configuration->property(role + ".filename_rx2", empty_string);
             int l1_band = configuration->property("Channels_1C.count", 0) +
-                          configuration->property("Channels_1B.count", 0) +
-                          configuration->property("Channels_L5.count", 0) +
-                          configuration->property("Channels_2S.count", 0) +
-                          configuration->property("Channels_5X.count", 0);
+                          configuration->property("Channels_1B.count", 0);
 
-            int l2_band = configuration->property("Channels_L5.count", 0) * configuration->property("Channels_1C.count", 0) +
-                          configuration->property("Channels_5X.count", 0) * configuration->property("Channels_1B.count", 0) +
-                          configuration->property("Channels_2S.count", 0) * configuration->property("Channels_1C.count", 0);
+            int l2_band = configuration->property("Channels_L5.count", 0) +
+                          configuration->property("Channels_5X.count", 0) +
+                          configuration->property("Channels_2S.count", 0);
 
             if (l1_band != 0)
                 {

--- a/src/algorithms/signal_source/adapters/ad9361_fpga_signal_source.cc
+++ b/src/algorithms/signal_source/adapters/ad9361_fpga_signal_source.cc
@@ -41,7 +41,7 @@
 #include <fcntl.h>   // for open, O_WRONLY
 #include <fstream>   // for std::ifstream
 #include <iostream>  // for cout, endl
-#include <string>	 // for string manipulation
+#include <string>    // for string manipulation
 #include <unistd.h>  // for write
 #include <utility>
 #include <vector>
@@ -248,11 +248,11 @@ void run_DMA_process(const std::string &FreqBand, const std::string &Filename1, 
             if (nread_elements > 0)
                 {
                     num_transferred_bytes = nread_elements * 2;
-					int num_bytes_sent = write(tx_fd, input_samples_dma.data(), nread_elements * 2);
-					if (num_bytes_sent != num_transferred_bytes)
-						{
-							std::cerr << "Error: DMA could not send all the required samples " << std::endl;
-						}
+                    int num_bytes_sent = write(tx_fd, input_samples_dma.data(), nread_elements * 2);
+                    if (num_bytes_sent != num_transferred_bytes)
+                        {
+                            std::cerr << "Error: DMA could not send all the required samples " << std::endl;
+                        }
                 }
 
             if (nread_elements != MAX_INPUT_SAMPLES_TOTAL * 2)
@@ -318,7 +318,7 @@ Ad9361FpgaSignalSource::Ad9361FpgaSignalSource(ConfigurationInterface *configura
 
     if (switch_position == 0)  // Inject file(s) via DMA
         {
-    		enable_DMA_ = true;
+            enable_DMA_ = true;
             std::string empty_string;
             filename_rx1 = configuration->property(role + ".filename_rx1", empty_string);
             filename_rx2 = configuration->property(role + ".filename_rx2", empty_string);
@@ -386,11 +386,11 @@ Ad9361FpgaSignalSource::~Ad9361FpgaSignalSource()
 {
     /* cleanup and exit */
 
-	// std::cout<<"* AD9361 Disabling streaming channels\n";
+    // std::cout<<"* AD9361 Disabling streaming channels\n";
     // if (rx0_i) { iio_channel_disable(rx0_i); }
     // if (rx0_q) { iio_channel_disable(rx0_q); }
 
-	enable_DMA_ = false; // disable the DMA
+    enable_DMA_ = false;  // disable the DMA
 
     if (enable_dds_lo_)
         {

--- a/src/algorithms/signal_source/adapters/ad9361_fpga_signal_source.cc
+++ b/src/algorithms/signal_source/adapters/ad9361_fpga_signal_source.cc
@@ -47,7 +47,7 @@
 #include <vector>
 
 
-void run_DMA_process(const std::string &FreqBand, const std::string &Filename1, const std::string &Filename2)
+void run_DMA_process(const std::string &FreqBand, const std::string &Filename1, const std::string &Filename2, const bool &enable_DMA)
 {
     const int MAX_INPUT_SAMPLES_TOTAL = 8192;
     int max_value = 0;
@@ -101,7 +101,7 @@ void run_DMA_process(const std::string &FreqBand, const std::string &Filename1, 
     //**************************************************************************
     int nsamples = 0;
 
-    while (file_completed == 0)
+    while ((file_completed == 0) && (enable_DMA == true))
         {
             unsigned int dma_index = 0;
 
@@ -318,6 +318,7 @@ Ad9361FpgaSignalSource::Ad9361FpgaSignalSource(ConfigurationInterface *configura
 
     if (switch_position == 0)  // Inject file(s) via DMA
         {
+    		enable_DMA_ = true;
             std::string empty_string;
             filename_rx1 = configuration->property(role + ".filename_rx1", empty_string);
             filename_rx2 = configuration->property(role + ".filename_rx2", empty_string);
@@ -344,7 +345,7 @@ Ad9361FpgaSignalSource::Ad9361FpgaSignalSource(ConfigurationInterface *configura
                     freq_band = "L1L2";
                 }
 
-            thread_file_to_dma = std::thread([&] { run_DMA_process(freq_band, filename_rx1, filename_rx2); });
+            thread_file_to_dma = std::thread([&] { run_DMA_process(freq_band, filename_rx1, filename_rx2, enable_DMA_); });
         }
     if (switch_position == 2)  // Real-time via AD9361
         {
@@ -387,9 +388,12 @@ Ad9361FpgaSignalSource::Ad9361FpgaSignalSource(ConfigurationInterface *configura
 Ad9361FpgaSignalSource::~Ad9361FpgaSignalSource()
 {
     /* cleanup and exit */
-    // std::cout<<"* AD9361 Disabling streaming channels\n";
+
+	// std::cout<<"* AD9361 Disabling streaming channels\n";
     // if (rx0_i) { iio_channel_disable(rx0_i); }
     // if (rx0_q) { iio_channel_disable(rx0_q); }
+
+	enable_DMA_ = false; // disable the DMA
 
     if (enable_dds_lo_)
         {

--- a/src/algorithms/signal_source/adapters/ad9361_fpga_signal_source.cc
+++ b/src/algorithms/signal_source/adapters/ad9361_fpga_signal_source.cc
@@ -37,12 +37,11 @@
 #include "configuration_interface.h"
 #include <glog/logging.h>
 #include <iio.h>
-#include <cassert>  // for assert
 #include <exception>
 #include <fcntl.h>   // for open, O_WRONLY
 #include <fstream>   // for std::ifstream
 #include <iostream>  // for cout, endl
-#include <string>
+#include <string>	 // for string manipulation
 #include <unistd.h>  // for write
 #include <utility>
 #include <vector>
@@ -249,8 +248,11 @@ void run_DMA_process(const std::string &FreqBand, const std::string &Filename1, 
             if (nread_elements > 0)
                 {
                     num_transferred_bytes = nread_elements * 2;
-                    assert(num_transferred_bytes ==
-                           write(tx_fd, input_samples_dma.data(), nread_elements * 2));
+					int num_bytes_sent = write(tx_fd, input_samples_dma.data(), nread_elements * 2);
+					if (num_bytes_sent != num_transferred_bytes)
+						{
+							std::cerr << "Error: DMA could not send all the required samples " << std::endl;
+						}
                 }
 
             if (nread_elements != MAX_INPUT_SAMPLES_TOTAL * 2)

--- a/src/algorithms/signal_source/adapters/ad9361_fpga_signal_source.h
+++ b/src/algorithms/signal_source/adapters/ad9361_fpga_signal_source.h
@@ -122,6 +122,8 @@ private:
     std::string filename_rx1;
     std::string filename_rx2;
     std::string freq_band;
+
+    bool enable_DMA_;
 };
 
 #endif  // GNSS_SDR_AD9361_FPGA_SIGNAL_SOURCE_H_

--- a/src/core/receiver/gnss_block_factory.cc
+++ b/src/core/receiver/gnss_block_factory.cc
@@ -1446,15 +1446,6 @@ std::unique_ptr<GNSSBlockInterface> GNSSBlockFactory::GetBlock(
         }
 #endif
 
-#if AD9361_DRIVER
-    else if (implementation == "Ad9361_Fpga_Signal_Source")
-        {
-            std::unique_ptr<GNSSBlockInterface> block_(new Ad9361FpgaSignalSource(configuration.get(), role, in_streams,
-                out_streams, queue));
-            block = std::move(block_);
-        }
-#endif
-
 #if FLEXIBAND_DRIVER
     else if (implementation == "Flexiband_Signal_Source")
         {
@@ -1927,6 +1918,18 @@ std::unique_ptr<GNSSBlockInterface> GNSSBlockFactory::GetBlock(
                 out_streams));
             block = std::move(block_);
         }
+
+#if AD9361_DRIVER
+    // The AD9361_DRIVER Driver is instantiated last. In this way, when using the FPGA, and when using the GNSS receiver
+    // in post-processing mode, the receiver is configured and ready when the DMA starts sending samples to the receiver.
+    else if (implementation == "Ad9361_Fpga_Signal_Source")
+        {
+            std::unique_ptr<GNSSBlockInterface> block_(new Ad9361FpgaSignalSource(configuration.get(), role, in_streams,
+                out_streams, queue));
+            block = std::move(block_);
+        }
+#endif
+
     else
         {
             // Log fatal. This causes execution to stop.


### PR DESCRIPTION
Fixed the code that uses the DMA to send the files containing the recorded signals to the gnss-sdr receiver. This code is used when the receiver is using the FPGA and the receiver is working in post-processing mode.