### PR TITLE
Fix fpga device filename assignment

### DIFF
--- a/src/algorithms/tracking/adapters/galileo_e1_dll_pll_veml_tracking_fpga.cc
+++ b/src/algorithms/tracking/adapters/galileo_e1_dll_pll_veml_tracking_fpga.cc
@@ -181,7 +181,8 @@ GalileoE1DllPllVemlTrackingFpga::GalileoE1DllPllVemlTrackingFpga(
     std::string default_device_name = "/dev/uio";
     std::string device_name = configuration->property(role + ".devicename", default_device_name);
     trk_param_fpga.device_name = device_name;
-    // obtain the number of the first uio device file that is assigned to the FPGA E1 tracking multicorrelator HW accelerators
+    // obtain the number of the first uio device corresponding to a HW accelerator in the FPGA
+    // that can be assigned to the tracking of the E1 signal
     trk_param_fpga.dev_file_num = configuration->property(role + ".dev_file_num", 15);
     // compute the number of tracking channels that have already been instantiated. The order in which
     // GNSS-SDR instantiates the tracking channels i L1, L2, L5, E1, E5a

--- a/src/algorithms/tracking/adapters/galileo_e1_dll_pll_veml_tracking_fpga.cc
+++ b/src/algorithms/tracking/adapters/galileo_e1_dll_pll_veml_tracking_fpga.cc
@@ -181,8 +181,13 @@ GalileoE1DllPllVemlTrackingFpga::GalileoE1DllPllVemlTrackingFpga(
     std::string default_device_name = "/dev/uio";
     std::string device_name = configuration->property(role + ".devicename", default_device_name);
     trk_param_fpga.device_name = device_name;
-    int32_t device_base = configuration->property(role + ".device_base", 15);
-    trk_param_fpga.device_base = device_base;
+    // obtain the number of the first uio device file that is assigned to the FPGA E1 tracking multicorrelator HW accelerators
+    trk_param_fpga.dev_file_num = configuration->property(role + ".dev_file_num", 15);
+    // compute the number of tracking channels that have already been instantiated. The order in which
+    // GNSS-SDR instantiates the tracking channels i L1, L2, L5, E1, E5a
+    trk_param_fpga.num_prev_assigned_ch = configuration->property("Channels_1C.count", 0) +
+											configuration->property("Channels_2S.count", 0) +
+											configuration->property("Channels_L5.count", 0);
 
     //################# PRE-COMPUTE ALL THE CODES #################
     uint32_t code_samples_per_chip = 2;

--- a/src/algorithms/tracking/adapters/galileo_e1_dll_pll_veml_tracking_fpga.cc
+++ b/src/algorithms/tracking/adapters/galileo_e1_dll_pll_veml_tracking_fpga.cc
@@ -187,8 +187,8 @@ GalileoE1DllPllVemlTrackingFpga::GalileoE1DllPllVemlTrackingFpga(
     // compute the number of tracking channels that have already been instantiated. The order in which
     // GNSS-SDR instantiates the tracking channels i L1, L2, L5, E1, E5a
     trk_param_fpga.num_prev_assigned_ch = configuration->property("Channels_1C.count", 0) +
-											configuration->property("Channels_2S.count", 0) +
-											configuration->property("Channels_L5.count", 0);
+                                          configuration->property("Channels_2S.count", 0) +
+                                          configuration->property("Channels_L5.count", 0);
 
     //################# PRE-COMPUTE ALL THE CODES #################
     uint32_t code_samples_per_chip = 2;

--- a/src/algorithms/tracking/adapters/galileo_e5a_dll_pll_tracking_fpga.cc
+++ b/src/algorithms/tracking/adapters/galileo_e5a_dll_pll_tracking_fpga.cc
@@ -176,8 +176,9 @@ GalileoE5aDllPllTrackingFpga::GalileoE5aDllPllTrackingFpga(
     std::string default_device_name = "/dev/uio";
     std::string device_name = configuration->property(role + ".devicename", default_device_name);
     trk_param_fpga.device_name = device_name;
-    // obtain the number of the first uio device file that is assigned to the FPGA E5a tracking multicorrelator HW accelerators
-    trk_param_fpga.dev_file_num = configuration->property(role + ".dev_file_num", 38);
+    // obtain the number of the first uio device corresponding to a HW accelerator in the FPGA
+    // that can be assigned to the tracking of the E5a signal
+    trk_param_fpga.dev_file_num = configuration->property(role + ".dev_file_num", 27);
     // compute the number of tracking channels that have already been instantiated. The order in which
     // GNSS-SDR instantiates the tracking channels i L1, L2, L5, E1, E5a
     trk_param_fpga.num_prev_assigned_ch = configuration->property("Channels_1C.count", 0) +

--- a/src/algorithms/tracking/adapters/galileo_e5a_dll_pll_tracking_fpga.cc
+++ b/src/algorithms/tracking/adapters/galileo_e5a_dll_pll_tracking_fpga.cc
@@ -182,9 +182,9 @@ GalileoE5aDllPllTrackingFpga::GalileoE5aDllPllTrackingFpga(
     // compute the number of tracking channels that have already been instantiated. The order in which
     // GNSS-SDR instantiates the tracking channels i L1, L2, L5, E1, E5a
     trk_param_fpga.num_prev_assigned_ch = configuration->property("Channels_1C.count", 0) +
-											configuration->property("Channels_2S.count", 0) +
-											configuration->property("Channels_L5.count", 0) +
-											configuration->property("Channels_1B.count", 0);
+                                          configuration->property("Channels_2S.count", 0) +
+                                          configuration->property("Channels_L5.count", 0) +
+                                          configuration->property("Channels_1B.count", 0);
 
     // ################# PRE-COMPUTE ALL THE CODES #################
     uint32_t code_samples_per_chip = 1;

--- a/src/algorithms/tracking/adapters/galileo_e5a_dll_pll_tracking_fpga.cc
+++ b/src/algorithms/tracking/adapters/galileo_e5a_dll_pll_tracking_fpga.cc
@@ -176,8 +176,14 @@ GalileoE5aDllPllTrackingFpga::GalileoE5aDllPllTrackingFpga(
     std::string default_device_name = "/dev/uio";
     std::string device_name = configuration->property(role + ".devicename", default_device_name);
     trk_param_fpga.device_name = device_name;
-    int32_t device_base = configuration->property(role + ".device_base", 27);
-    trk_param_fpga.device_base = device_base;
+    // obtain the number of the first uio device file that is assigned to the FPGA E5a tracking multicorrelator HW accelerators
+    trk_param_fpga.dev_file_num = configuration->property(role + ".dev_file_num", 38);
+    // compute the number of tracking channels that have already been instantiated. The order in which
+    // GNSS-SDR instantiates the tracking channels i L1, L2, L5, E1, E5a
+    trk_param_fpga.num_prev_assigned_ch = configuration->property("Channels_1C.count", 0) +
+											configuration->property("Channels_2S.count", 0) +
+											configuration->property("Channels_L5.count", 0) +
+											configuration->property("Channels_1B.count", 0);
 
     // ################# PRE-COMPUTE ALL THE CODES #################
     uint32_t code_samples_per_chip = 1;

--- a/src/algorithms/tracking/adapters/gps_l1_ca_dll_pll_tracking_fpga.cc
+++ b/src/algorithms/tracking/adapters/gps_l1_ca_dll_pll_tracking_fpga.cc
@@ -182,8 +182,11 @@ GpsL1CaDllPllTrackingFpga::GpsL1CaDllPllTrackingFpga(
     std::string default_device_name = "/dev/uio";
     std::string device_name = configuration->property(role + ".devicename", default_device_name);
     trk_param_fpga.device_name = device_name;
-    int32_t device_base = configuration->property(role + ".device_base", 3);
-    trk_param_fpga.device_base = device_base;
+    // obtain the number of the first uio device file that is assigned to the FPGA L1 tracking multicorrelator HW accelerators
+    trk_param_fpga.dev_file_num = configuration->property(role + ".dev_file_num", 3);
+    // compute the number of tracking channels that have already been instantiated. The order in which
+    // GNSS-SDR instantiates the tracking channels i L1, l2, L5, E1, E5a
+    trk_param_fpga.num_prev_assigned_ch = 0;
 
     // ################# PRE-COMPUTE ALL THE CODES #################
     d_ca_codes = static_cast<int32_t*>(volk_gnsssdr_malloc(static_cast<int32_t>(GPS_L1_CA_CODE_LENGTH_CHIPS * NUM_PRNs) * sizeof(int32_t), volk_gnsssdr_get_alignment()));

--- a/src/algorithms/tracking/adapters/gps_l1_ca_dll_pll_tracking_fpga.cc
+++ b/src/algorithms/tracking/adapters/gps_l1_ca_dll_pll_tracking_fpga.cc
@@ -182,7 +182,8 @@ GpsL1CaDllPllTrackingFpga::GpsL1CaDllPllTrackingFpga(
     std::string default_device_name = "/dev/uio";
     std::string device_name = configuration->property(role + ".devicename", default_device_name);
     trk_param_fpga.device_name = device_name;
-    // obtain the number of the first uio device file that is assigned to the FPGA L1 tracking multicorrelator HW accelerators
+    // obtain the number of the first uio device corresponding to a HW accelerator in the FPGA
+    // that can be assigned to the tracking of the L1 signal
     trk_param_fpga.dev_file_num = configuration->property(role + ".dev_file_num", 3);
     // compute the number of tracking channels that have already been instantiated. The order in which
     // GNSS-SDR instantiates the tracking channels i L1, l2, L5, E1, E5a

--- a/src/algorithms/tracking/adapters/gps_l2_m_dll_pll_tracking_fpga.cc
+++ b/src/algorithms/tracking/adapters/gps_l2_m_dll_pll_tracking_fpga.cc
@@ -107,19 +107,16 @@ GpsL2MDllPllTrackingFpga::GpsL2MDllPllTrackingFpga(
     trk_param_fpga.carrier_lock_test_smoother_samples = configuration->property(role + ".carrier_lock_test_smoother_samples", trk_param_fpga.carrier_lock_test_smoother_samples);
     trk_param_fpga.carrier_lock_test_smoother_alpha = configuration->property(role + ".carrier_lock_test_smoother_alpha", trk_param_fpga.carrier_lock_test_smoother_alpha);
 
-    //    int32_t max_lock_fail = configuration->property(role + ".max_lock_fail", 50);
-    //    if (FLAGS_max_lock_fail != 50)
-    //        {
-    //            max_lock_fail = FLAGS_max_lock_fail;
-    //        }
-    //    trk_param_fpga.max_lock_fail = max_lock_fail;
-
     // FPGA configuration parameters
     std::string default_device_name = "/dev/uio";
     std::string device_name = configuration->property(role + ".devicename", default_device_name);
     trk_param_fpga.device_name = device_name;
-    unsigned int device_base = configuration->property(role + ".device_base", 1);
-    trk_param_fpga.device_base = device_base;
+    // obtain the number of the first uio device file that is assigned to the FPGA L2 tracking multicorrelator HW accelerators
+    trk_param_fpga.dev_file_num = configuration->property(role + ".dev_file_num", 27);
+    // compute the number of tracking channels that have already been instantiated. The order in which
+    // GNSS-SDR instantiates the tracking channels i L1, L2, L5, E1, E5a
+    trk_param_fpga.num_prev_assigned_ch = configuration->property("Channels_1C.count", 0);
+
 
     auto* ca_codes_f = static_cast<float*>(volk_gnsssdr_malloc(static_cast<unsigned int>(GPS_L2_M_CODE_LENGTH_CHIPS) * sizeof(float), volk_gnsssdr_get_alignment()));
 

--- a/src/algorithms/tracking/adapters/gps_l5_dll_pll_tracking_fpga.cc
+++ b/src/algorithms/tracking/adapters/gps_l5_dll_pll_tracking_fpga.cc
@@ -181,7 +181,7 @@ GpsL5DllPllTrackingFpga::GpsL5DllPllTrackingFpga(
     // compute the number of tracking channels that have already been instantiated. The order in which
     // GNSS-SDR instantiates the tracking channels i L1, L2, L5, E1, E5a
     trk_param_fpga.num_prev_assigned_ch = configuration->property("Channels_1C.count", 0) +
-											configuration->property("Channels_2S.count", 0);
+                                          configuration->property("Channels_2S.count", 0);
 
     // tracking lock tests smoother parameters
     trk_param_fpga.cn0_smoother_samples = configuration->property(role + ".cn0_smoother_samples", trk_param_fpga.cn0_smoother_samples);

--- a/src/algorithms/tracking/adapters/gps_l5_dll_pll_tracking_fpga.cc
+++ b/src/algorithms/tracking/adapters/gps_l5_dll_pll_tracking_fpga.cc
@@ -175,7 +175,8 @@ GpsL5DllPllTrackingFpga::GpsL5DllPllTrackingFpga(
     std::string default_device_name = "/dev/uio";
     std::string device_name = configuration->property(role + ".devicename", default_device_name);
     trk_param_fpga.device_name = device_name;
-    // obtain the number of the first uio device file that is assigned to the FPGA L5 tracking multicorrelator HW accelerators
+    // obtain the number of the first uio device corresponding to a HW accelerator in the FPGA
+    // that can be assigned to the tracking of the L5 signal
     trk_param_fpga.dev_file_num = configuration->property(role + ".dev_file_num", 27);
     // compute the number of tracking channels that have already been instantiated. The order in which
     // GNSS-SDR instantiates the tracking channels i L1, L2, L5, E1, E5a

--- a/src/algorithms/tracking/adapters/gps_l5_dll_pll_tracking_fpga.cc
+++ b/src/algorithms/tracking/adapters/gps_l5_dll_pll_tracking_fpga.cc
@@ -175,8 +175,12 @@ GpsL5DllPllTrackingFpga::GpsL5DllPllTrackingFpga(
     std::string default_device_name = "/dev/uio";
     std::string device_name = configuration->property(role + ".devicename", default_device_name);
     trk_param_fpga.device_name = device_name;
-    int32_t device_base = configuration->property(role + ".device_base", 27);
-    trk_param_fpga.device_base = device_base;
+    // obtain the number of the first uio device file that is assigned to the FPGA L5 tracking multicorrelator HW accelerators
+    trk_param_fpga.dev_file_num = configuration->property(role + ".dev_file_num", 27);
+    // compute the number of tracking channels that have already been instantiated. The order in which
+    // GNSS-SDR instantiates the tracking channels i L1, L2, L5, E1, E5a
+    trk_param_fpga.num_prev_assigned_ch = configuration->property("Channels_1C.count", 0) +
+											configuration->property("Channels_2S.count", 0);
 
     // tracking lock tests smoother parameters
     trk_param_fpga.cn0_smoother_samples = configuration->property(role + ".cn0_smoother_samples", trk_param_fpga.cn0_smoother_samples);

--- a/src/algorithms/tracking/gnuradio_blocks/dll_pll_veml_tracking_fpga.cc
+++ b/src/algorithms/tracking/gnuradio_blocks/dll_pll_veml_tracking_fpga.cc
@@ -453,10 +453,11 @@ dll_pll_veml_tracking_fpga::dll_pll_veml_tracking_fpga(const Dll_Pll_Conf_Fpga &
         }
     // create multicorrelator class
     std::string device_name = trk_parameters.device_name;
-    int32_t device_base = trk_parameters.device_base;
+    uint32_t dev_file_num = trk_parameters.dev_file_num;
+    uint32_t num_prev_assigned_ch = trk_parameters.num_prev_assigned_ch;
     int32_t *ca_codes = trk_parameters.ca_codes;
     int32_t *data_codes = trk_parameters.data_codes;
-    multicorrelator_fpga = std::make_shared<Fpga_Multicorrelator_8sc>(d_n_correlator_taps, device_name, device_base, ca_codes, data_codes, d_code_length_chips, trk_parameters.track_pilot, d_code_samples_per_chip);
+    multicorrelator_fpga = std::make_shared<Fpga_Multicorrelator_8sc>(d_n_correlator_taps, device_name, dev_file_num, num_prev_assigned_ch, ca_codes, data_codes, d_code_length_chips, trk_parameters.track_pilot, d_code_samples_per_chip);
     multicorrelator_fpga->set_output_vectors(d_correlator_outs, d_Prompt_Data);
     d_sample_counter_next = 0ULL;
 

--- a/src/algorithms/tracking/libs/dll_pll_conf_fpga.cc
+++ b/src/algorithms/tracking/libs/dll_pll_conf_fpga.cc
@@ -81,7 +81,8 @@ Dll_Pll_Conf_Fpga::Dll_Pll_Conf_Fpga()
     signal[1] = 'C';
     signal[2] = '\0';
     device_name = "/dev/uio";
-    device_base = 1;
+    dev_file_num = 3;
+    num_prev_assigned_ch = 0;
     code_length_chips = 0U;
     code_samples_per_chip = 0U;
     ca_codes = nullptr;

--- a/src/algorithms/tracking/libs/dll_pll_conf_fpga.h
+++ b/src/algorithms/tracking/libs/dll_pll_conf_fpga.h
@@ -87,7 +87,8 @@ public:
     char system;
     char signal[3];
     std::string device_name;
-    int32_t device_base;
+    uint32_t dev_file_num;
+    uint32_t num_prev_assigned_ch;
     uint32_t code_length_chips;
     uint32_t code_samples_per_chip;
     int32_t* ca_codes;

--- a/src/algorithms/tracking/libs/fpga_multicorrelator.cc
+++ b/src/algorithms/tracking/libs/fpga_multicorrelator.cc
@@ -67,8 +67,8 @@ Fpga_Multicorrelator_8sc::Fpga_Multicorrelator_8sc(int32_t n_correlators,
 {
     d_n_correlators = n_correlators;
     d_device_name = device_name;
-	d_dev_file_num = dev_file_num;
-	d_num_prev_assigned_ch = num_prev_assigned_ch;
+    d_dev_file_num = dev_file_num;
+    d_num_prev_assigned_ch = num_prev_assigned_ch;
 
     d_track_pilot = track_pilot;
     d_device_descriptor = 0;

--- a/src/algorithms/tracking/libs/fpga_multicorrelator.cc
+++ b/src/algorithms/tracking/libs/fpga_multicorrelator.cc
@@ -61,13 +61,15 @@ const float PHASE_CARR_MAX_DIV_PI = 683565275.5764316;  // 2^(31)/pi
 const float TWO_PI = 6.283185307179586;
 
 Fpga_Multicorrelator_8sc::Fpga_Multicorrelator_8sc(int32_t n_correlators,
-    const std::string &device_name, int32_t device_base, int32_t *ca_codes, int32_t *data_codes, uint32_t code_length_chips, bool track_pilot,
+    const std::string &device_name, uint32_t dev_file_num, uint32_t num_prev_assigned_ch, int32_t *ca_codes, int32_t *data_codes, uint32_t code_length_chips, bool track_pilot,
     uint32_t code_samples_per_chip)
 
 {
     d_n_correlators = n_correlators;
     d_device_name = device_name;
-    d_device_base = device_base;
+	d_dev_file_num = dev_file_num;
+	d_num_prev_assigned_ch = num_prev_assigned_ch;
+
     d_track_pilot = track_pilot;
     d_device_descriptor = 0;
     d_map_base = nullptr;
@@ -243,7 +245,7 @@ void Fpga_Multicorrelator_8sc::set_channel(uint32_t channel)
     // open the device corresponding to the assigned channel
     std::string mergedname;
     std::stringstream devicebasetemp;
-    int32_t numdevice = d_device_base + d_channel;
+    uint32_t numdevice = d_dev_file_num + d_channel - d_num_prev_assigned_ch;
     devicebasetemp << numdevice;
     mergedname = d_device_name + devicebasetemp.str();
 

--- a/src/algorithms/tracking/libs/fpga_multicorrelator.h
+++ b/src/algorithms/tracking/libs/fpga_multicorrelator.h
@@ -53,8 +53,8 @@ public:
 	 */
     Fpga_Multicorrelator_8sc(int32_t n_correlators,
         const std::string &device_name,
-		uint32_t dev_file_num,
-		uint32_t num_prev_assigned_ch,
+        uint32_t dev_file_num,
+        uint32_t num_prev_assigned_ch,
         int32_t *ca_codes,
         int32_t *data_codes,
         uint32_t code_length_chips,
@@ -237,8 +237,8 @@ private:
 
     // driver
     std::string d_device_name;
-	uint32_t d_dev_file_num;
-	uint32_t d_num_prev_assigned_ch;
+    uint32_t d_dev_file_num;
+    uint32_t d_num_prev_assigned_ch;
 
     // PRN codes
     int32_t *d_ca_codes;

--- a/src/algorithms/tracking/libs/fpga_multicorrelator.h
+++ b/src/algorithms/tracking/libs/fpga_multicorrelator.h
@@ -53,7 +53,8 @@ public:
 	 */
     Fpga_Multicorrelator_8sc(int32_t n_correlators,
         const std::string &device_name,
-        int32_t device_base,
+		uint32_t dev_file_num,
+		uint32_t num_prev_assigned_ch,
         int32_t *ca_codes,
         int32_t *data_codes,
         uint32_t code_length_chips,
@@ -236,7 +237,8 @@ private:
 
     // driver
     std::string d_device_name;
-    int32_t d_device_base;
+	uint32_t d_dev_file_num;
+	uint32_t d_num_prev_assigned_ch;
 
     // PRN codes
     int32_t *d_ca_codes;


### PR DESCRIPTION
Replaced the device_base tracking parameter by the dev_file_num parameter. dev_file_num specifies for each GNSS signal the first /dev/uio<X> driver that is associated to an FPGA HW accelerator that can be used for the tracking process of that GNSS signal. This parameter depends on the FPGA compilation and it is independant of the number of channels that are used for the tracking of other GNSS signals or any other parameter.