### PR TITLE
Fix tracking fpga dev file num

### DIFF
--- a/src/algorithms/tracking/adapters/galileo_e5a_dll_pll_tracking_fpga.cc
+++ b/src/algorithms/tracking/adapters/galileo_e5a_dll_pll_tracking_fpga.cc
@@ -181,9 +181,11 @@ GalileoE5aDllPllTrackingFpga::GalileoE5aDllPllTrackingFpga(
     trk_param_fpga.dev_file_num = configuration->property(role + ".dev_file_num", 27);
     // compute the number of tracking channels that have already been instantiated. The order in which
     // GNSS-SDR instantiates the tracking channels i L1, L2, L5, E1, E5a
+    // However E5a uses the same tracking HW accelerators as L5. Therefore for the proper assignment of
+    // the FPGA tracking device file numbers to the E5a tracking channels, the number of channels that have
+    // already been assigned to L5 must not be substracted to this channel number, so they are not counted here.
     trk_param_fpga.num_prev_assigned_ch = configuration->property("Channels_1C.count", 0) +
                                           configuration->property("Channels_2S.count", 0) +
-                                          configuration->property("Channels_L5.count", 0) +
                                           configuration->property("Channels_1B.count", 0);
 
     // ################# PRE-COMPUTE ALL THE CODES #################

--- a/src/algorithms/tracking/adapters/galileo_e5a_dll_pll_tracking_fpga.cc
+++ b/src/algorithms/tracking/adapters/galileo_e5a_dll_pll_tracking_fpga.cc
@@ -181,9 +181,10 @@ GalileoE5aDllPllTrackingFpga::GalileoE5aDllPllTrackingFpga(
     trk_param_fpga.dev_file_num = configuration->property(role + ".dev_file_num", 27);
     // compute the number of tracking channels that have already been instantiated. The order in which
     // GNSS-SDR instantiates the tracking channels i L1, L2, L5, E1, E5a
-    // However E5a uses the same tracking HW accelerators as L5. Therefore for the proper assignment of
-    // the FPGA tracking device file numbers to the E5a tracking channels, the number of channels that have
-    // already been assigned to L5 must not be substracted to this channel number, so they are not counted here.
+    // However E5a can use the same tracking HW accelerators as L5 (but not simultaneously).
+    // Therefore for the proper assignment of the FPGA tracking device file numbers to the E5a tracking channels,
+    // the number of channels that have already been assigned to L5 must not be substracted to this channel number,
+    // so they are not counted here.
     trk_param_fpga.num_prev_assigned_ch = configuration->property("Channels_1C.count", 0) +
                                           configuration->property("Channels_2S.count", 0) +
                                           configuration->property("Channels_1B.count", 0);


### PR DESCRIPTION
fixed the range of FPGA device file numbers used by the E5A tracking class