### PR TITLE
Add clock drift

### DIFF
--- a/docs/protobuf/monitor_pvt.proto
+++ b/docs/protobuf/monitor_pvt.proto
@@ -38,4 +38,6 @@ double gdop = 25;  // Geometric Dilution of Precision
 double pdop = 26;  // Position (3D) Dilution of Precision
 double hdop = 27;  // Horizontal Dilution of Precision
 double vdop = 28;  // Vertical Dilution of Precision
+
+double user_clk_drift_ppm = 29;  // User clock drift [ppm]
 }

--- a/src/algorithms/PVT/gnuradio_blocks/rtklib_pvt_gs.cc
+++ b/src/algorithms/PVT/gnuradio_blocks/rtklib_pvt_gs.cc
@@ -28,7 +28,6 @@
  * -------------------------------------------------------------------------
  */
 
-#include "rtklib_pvt_gs.h"
 #include "MATH_CONSTANTS.h"
 #include "beidou_dnav_almanac.h"
 #include "beidou_dnav_ephemeris.h"
@@ -61,6 +60,7 @@
 #include "pvt_conf.h"
 #include "rinex_printer.h"
 #include "rtcm_printer.h"
+#include "rtklib_pvt_gs.h"
 #include "rtklib_solver.h"
 #include <boost/any.hpp>                   // for any_cast, any
 #include <boost/archive/xml_iarchive.hpp>  // for xml_iarchive
@@ -4167,6 +4167,15 @@ int rtklib_pvt_gs::work(int noutput_items, gr_vector_const_void_star& input_item
 
                             std::cout << std::setprecision(ss);
                             DLOG(INFO) << "RX clock offset: " << d_user_pvt_solver->get_time_offset_s() << "[s]";
+
+                            std::cout
+                                << TEXT_BOLD_GREEN
+                                << "Velocity: " << std::fixed << std::setprecision(3)
+                                << "East: " << d_user_pvt_solver->get_rx_vel()[0] << " [m/s], North: " << d_user_pvt_solver->get_rx_vel()[1]
+                                << " [m/s], Up = " << d_user_pvt_solver->get_rx_vel()[2] << " [m/s]" << TEXT_RESET << std::endl;
+
+                            std::cout << std::setprecision(ss);
+                            DLOG(INFO) << "RX clock drift: " << d_user_pvt_solver->get_clock_drift_ppm() << " [ppm]";
 
                             // boost::posix_time::ptime p_time;
                             // gtime_t rtklib_utc_time = gpst2time(adjgpsweek(d_user_pvt_solver->gps_ephemeris_map.cbegin()->second.i_GPS_week), d_rx_time);

--- a/src/algorithms/PVT/libs/monitor_pvt.h
+++ b/src/algorithms/PVT/libs/monitor_pvt.h
@@ -89,6 +89,9 @@ public:
     double hdop;
     double vdop;
 
+    // User clock drift [ppm]
+    double user_clk_drift_ppm;
+
     /*!
      * \brief This member function serializes and restores
      * Monitor_Pvt objects from a byte stream.
@@ -134,6 +137,8 @@ public:
         ar& BOOST_SERIALIZATION_NVP(pdop);
         ar& BOOST_SERIALIZATION_NVP(hdop);
         ar& BOOST_SERIALIZATION_NVP(vdop);
+
+        ar& BOOST_SERIALIZATION_NVP(user_clk_drift_ppm);
     }
 };
 

--- a/src/algorithms/PVT/libs/pvt_solution.cc
+++ b/src/algorithms/PVT/libs/pvt_solution.cc
@@ -316,6 +316,16 @@ void Pvt_Solution::set_time_offset_s(double offset)
     d_rx_dt_s = offset;
 }
 
+double Pvt_Solution::get_clock_drift_ppm() const
+{
+    return d_rx_clock_drift_ppm;
+}
+
+
+void Pvt_Solution::set_clock_drift_ppm(double clock_drift_ppm)
+{
+    d_rx_clock_drift_ppm = clock_drift_ppm;
+}
 
 double Pvt_Solution::get_latitude() const
 {
@@ -404,9 +414,20 @@ void Pvt_Solution::set_rx_pos(const arma::vec &pos)
 }
 
 
-arma::vec Pvt_Solution::get_rx_pos() const
+const arma::vec& Pvt_Solution::get_rx_pos() const
 {
     return d_rx_pos;
+}
+
+void Pvt_Solution::set_rx_vel(arma::vec vel)
+{
+    d_rx_vel = vel;
+}
+
+
+const arma::vec& Pvt_Solution::get_rx_vel() const
+{
+    return d_rx_vel;
 }
 
 

--- a/src/algorithms/PVT/libs/pvt_solution.cc
+++ b/src/algorithms/PVT/libs/pvt_solution.cc
@@ -419,7 +419,7 @@ arma::vec Pvt_Solution::get_rx_pos() const
     return d_rx_pos;
 }
 
-void Pvt_Solution::set_rx_vel(arma::vec vel)
+void Pvt_Solution::set_rx_vel(const arma::vec &vel)
 {
     d_rx_vel = vel;
 }

--- a/src/algorithms/PVT/libs/pvt_solution.cc
+++ b/src/algorithms/PVT/libs/pvt_solution.cc
@@ -29,9 +29,9 @@
  * -------------------------------------------------------------------------
  */
 
-#include "pvt_solution.h"
 #include "GPS_L1_CA.h"
 #include "geofunctions.h"
+#include "pvt_solution.h"
 #include <glog/logging.h>
 #include <array>
 #include <cstddef>
@@ -414,7 +414,7 @@ void Pvt_Solution::set_rx_pos(const arma::vec &pos)
 }
 
 
-const arma::vec& Pvt_Solution::get_rx_pos() const
+arma::vec Pvt_Solution::get_rx_pos() const
 {
     return d_rx_pos;
 }
@@ -425,7 +425,7 @@ void Pvt_Solution::set_rx_vel(arma::vec vel)
 }
 
 
-const arma::vec& Pvt_Solution::get_rx_vel() const
+arma::vec Pvt_Solution::get_rx_vel() const
 {
     return d_rx_vel;
 }

--- a/src/algorithms/PVT/libs/pvt_solution.h
+++ b/src/algorithms/PVT/libs/pvt_solution.h
@@ -72,6 +72,9 @@ public:
     void set_rx_pos(const arma::vec &pos);  //!< Set position: Latitude [deg], longitude [deg], height [m]
     arma::vec get_rx_pos() const;
 
+    void set_rx_vel(const arma::vec &vel);  //!< Set velocity: East [m/s], North [m/s], Up [m/s]
+    arma::vec get_rx_vel() const;
+
     bool is_valid_position() const;
     void set_valid_position(bool is_valid);
 

--- a/src/algorithms/PVT/libs/pvt_solution.h
+++ b/src/algorithms/PVT/libs/pvt_solution.h
@@ -53,11 +53,11 @@ public:
     double get_time_offset_s() const;            //!< Get RX time offset [s]
     void set_time_offset_s(double offset);       //!< Set RX time offset [s]
 
-    double get_clock_drift_ppm() const;    //!< Get the Rx clock drift [ppm]
-    void set_clock_drift_ppm(double clock_drift_ppm ); //!< Set the Rx clock drift [ppm]
-    double get_latitude() const;   //!< Get RX position Latitude WGS84 [deg]
-    double get_longitude() const;  //!< Get RX position Longitude WGS84 [deg]
-    double get_height() const;     //!< Get RX position height WGS84 [m]
+    double get_clock_drift_ppm() const;                //!< Get the Rx clock drift [ppm]
+    void set_clock_drift_ppm(double clock_drift_ppm);  //!< Set the Rx clock drift [ppm]
+    double get_latitude() const;                       //!< Get RX position Latitude WGS84 [deg]
+    double get_longitude() const;                      //!< Get RX position Longitude WGS84 [deg]
+    double get_height() const;                         //!< Get RX position height WGS84 [m]
 
     double get_speed_over_ground() const;          //!< Get RX speed over ground [m/s]
     void set_speed_over_ground(double speed_m_s);  //!< Set RX speed over ground [m/s]
@@ -134,8 +134,8 @@ public:
 protected:
     bool d_pre_2009_file;  // Flag to correct week rollover in post processing mode for signals older than 2009
 private:
-    double d_rx_dt_s;  // RX time offset [s]
-    double d_rx_clock_drift_ppm; // RX clock drift [ppm]
+    double d_rx_dt_s;             // RX time offset [s]
+    double d_rx_clock_drift_ppm;  // RX clock drift [ppm]
 
     double d_latitude_d;             // RX position Latitude WGS84 [deg]
     double d_longitude_d;            // RX position Longitude WGS84 [deg]

--- a/src/algorithms/PVT/libs/pvt_solution.h
+++ b/src/algorithms/PVT/libs/pvt_solution.h
@@ -53,6 +53,8 @@ public:
     double get_time_offset_s() const;            //!< Get RX time offset [s]
     void set_time_offset_s(double offset);       //!< Set RX time offset [s]
 
+    double get_clock_drift_ppm() const;    //!< Get the Rx clock drift [ppm]
+    void set_clock_drift_ppm(double clock_drift_ppm ); //!< Set the Rx clock drift [ppm]
     double get_latitude() const;   //!< Get RX position Latitude WGS84 [deg]
     double get_longitude() const;  //!< Get RX position Longitude WGS84 [deg]
     double get_height() const;     //!< Get RX position height WGS84 [m]
@@ -133,6 +135,7 @@ protected:
     bool d_pre_2009_file;  // Flag to correct week rollover in post processing mode for signals older than 2009
 private:
     double d_rx_dt_s;  // RX time offset [s]
+    double d_rx_clock_drift_ppm; // RX clock drift [ppm]
 
     double d_latitude_d;             // RX position Latitude WGS84 [deg]
     double d_longitude_d;            // RX position Longitude WGS84 [deg]
@@ -154,6 +157,7 @@ private:
     int d_averaging_depth;  // Length of averaging window
 
     arma::vec d_rx_pos;
+    arma::vec d_rx_vel;
     boost::posix_time::ptime d_position_UTC_time;
     int d_valid_observations;
 };

--- a/src/algorithms/PVT/libs/rtklib_solver.cc
+++ b/src/algorithms/PVT/libs/rtklib_solver.cc
@@ -1071,21 +1071,15 @@ bool Rtklib_Solver::get_PVT(const std::map<int, Gnss_Synchro> &gnss_observables_
                     monitor_pvt.pdop = dop_[1];
                     monitor_pvt.hdop = dop_[2];
                     monitor_pvt.vdop = dop_[3];
-                    double vel_enu[3];
-                    double pos[3];
-                    pos[0] = rx_position_and_time(0);
-                    pos[1] = rx_position_and_time(1);
-                    pos[2] = rx_position_and_time(2);
-                    ecef2enu(pos, &pvt_sol.rr[3], vel_enu);
 
                     arma::vec rx_vel_enu(3);
-                    rx_vel_enu(0) = vel_enu[0];
-                    rx_vel_enu(1) = vel_enu[1];
-                    rx_vel_enu(2) = vel_enu[2];
+                    rx_vel_enu(0) = enuv[0];
+                    rx_vel_enu(1) = enuv[1];
+                    rx_vel_enu(2) = enuv[2];
 
                     this->set_rx_vel(rx_vel_enu);
 
-                    double clock_drift_ppm = pvt_sol.dtr[5] / GPS_C_m_s * 1e6;
+                    double clock_drift_ppm = pvt_sol.dtr[5] / GPS_C_M_S * 1e6;
 
                     this->set_clock_drift_ppm(clock_drift_ppm);
 

--- a/src/algorithms/PVT/libs/rtklib_solver.cc
+++ b/src/algorithms/PVT/libs/rtklib_solver.cc
@@ -51,7 +51,6 @@
  *
  * -----------------------------------------------------------------------*/
 
-#include "rtklib_solver.h"
 #include "Beidou_B1I.h"
 #include "Beidou_B3I.h"
 #include "Beidou_DNAV.h"
@@ -61,6 +60,7 @@
 #include "rtklib_conversions.h"
 #include "rtklib_rtkpos.h"
 #include "rtklib_solution.h"
+#include "rtklib_solver.h"
 #include <glog/logging.h>
 #include <matio.h>
 #include <exception>
@@ -1076,18 +1076,18 @@ bool Rtklib_Solver::get_PVT(const std::map<int, Gnss_Synchro> &gnss_observables_
                     pos[0] = rx_position_and_time(0);
                     pos[1] = rx_position_and_time(1);
                     pos[2] = rx_position_and_time(2);
-                    ecef2enu( pos, &pvt_sol.rr[3], vel_enu );
+                    ecef2enu(pos, &pvt_sol.rr[3], vel_enu);
 
                     arma::vec rx_vel_enu(3);
-                    rx_vel_enu(0) = vel_enu[ 0 ];
-                    rx_vel_enu(1) = vel_enu[ 1 ];
-                    rx_vel_enu(2) = vel_enu[ 2 ];
+                    rx_vel_enu(0) = vel_enu[0];
+                    rx_vel_enu(1) = vel_enu[1];
+                    rx_vel_enu(2) = vel_enu[2];
 
-                    this->set_rx_vel( rx_vel_enu );
+                    this->set_rx_vel(rx_vel_enu);
 
-                    double clock_drift_ppm = pvt_sol.dtr[5] / GPS_C_m_s *1e6;
+                    double clock_drift_ppm = pvt_sol.dtr[5] / GPS_C_m_s * 1e6;
 
-                    this->set_clock_drift_ppm( clock_drift_ppm );
+                    this->set_clock_drift_ppm(clock_drift_ppm);
 
                     // ######## LOG FILE #########
                     if (d_flag_dump_enabled == true)

--- a/src/algorithms/PVT/libs/rtklib_solver.cc
+++ b/src/algorithms/PVT/libs/rtklib_solver.cc
@@ -1082,6 +1082,8 @@ bool Rtklib_Solver::get_PVT(const std::map<int, Gnss_Synchro> &gnss_observables_
                     double clock_drift_ppm = pvt_sol.dtr[5] / GPS_C_M_S * 1e6;
 
                     this->set_clock_drift_ppm(clock_drift_ppm);
+                    // User clock drift [ppm]
+                    monitor_pvt.user_clk_drift_ppm = clock_drift_ppm;
 
                     // ######## LOG FILE #########
                     if (d_flag_dump_enabled == true)

--- a/src/algorithms/PVT/libs/rtklib_solver.cc
+++ b/src/algorithms/PVT/libs/rtklib_solver.cc
@@ -1071,6 +1071,23 @@ bool Rtklib_Solver::get_PVT(const std::map<int, Gnss_Synchro> &gnss_observables_
                     monitor_pvt.pdop = dop_[1];
                     monitor_pvt.hdop = dop_[2];
                     monitor_pvt.vdop = dop_[3];
+                    double vel_enu[3];
+                    double pos[3];
+                    pos[0] = rx_position_and_time(0);
+                    pos[1] = rx_position_and_time(1);
+                    pos[2] = rx_position_and_time(2);
+                    ecef2enu( pos, &pvt_sol.rr[3], vel_enu );
+
+                    arma::vec rx_vel_enu(3);
+                    rx_vel_enu(0) = vel_enu[ 0 ];
+                    rx_vel_enu(1) = vel_enu[ 1 ];
+                    rx_vel_enu(2) = vel_enu[ 2 ];
+
+                    this->set_rx_vel( rx_vel_enu );
+
+                    double clock_drift_ppm = pvt_sol.dtr[5] / GPS_C_m_s *1e6;
+
+                    this->set_clock_drift_ppm( clock_drift_ppm );
 
                     // ######## LOG FILE #########
                     if (d_flag_dump_enabled == true)

--- a/src/algorithms/PVT/libs/serdes_monitor_pvt.h
+++ b/src/algorithms/PVT/libs/serdes_monitor_pvt.h
@@ -116,6 +116,7 @@ public:
         monitor_.set_pdop(monitor->pdop);
         monitor_.set_hdop(monitor->hdop);
         monitor_.set_vdop(monitor->vdop);
+        monitor_.set_user_clk_drift_ppm(monitor->user_clk_drift_ppm);
 
         monitor_.SerializeToString(&data);
         return data;
@@ -153,6 +154,7 @@ public:
         monitor.pdop = mon.pdop();
         monitor.hdop = mon.hdop();
         monitor.vdop = mon.vdop();
+        monitor.user_clk_drift_ppm = mon.user_clk_drift_ppm();
 
         return monitor;
     }

--- a/src/algorithms/libs/rtklib/rtklib_pntpos.cc
+++ b/src/algorithms/libs/rtklib/rtklib_pntpos.cc
@@ -972,6 +972,7 @@ void estvel(const obsd_t *obs, int n, const double *rs, const double *dts,
                         {
                             sol->rr[i + 3] = x[i];
                         }
+                    sol->dtr[5] = x[3];
                     break;
                 }
         }


### PR DESCRIPTION
I work with a lot of low cost front ends which often have a large clock drift (usually measured in parts per million). It would be very useful to be able to extract this information from gnss-sdr. This pull request attempts to do this.

Unfortunately, the RTKLIB engine does not store the clock drift in its output structure, even though the drift is naturally computed as part of the velocity solution (in the same way as clock bias is computed as part of the position solution). So I've used the previously unused field `pvt_sol.dtr[5]` to capture the drift as it is computed in RTKLIB (in unts of m/s). 

I've added `clock_drift_ppm` field to the `RtklibSolver` class and also added `user_clk_drift_ppm` to the `monitor_pvt` class. I've added this as the last element in the hope that the serialization/deserialization won't be an issue across different versions (at least the protobuf version should be Ok, not so sure about Boost serialization). Note for the gnss-sdr variables I'm storing the drift in parts per million as I think this is the natural choice, but we can easily revert to m/s to be in keeping with RTKLIB or s/s to be in keeping with the clock bias fields.