### PR TITLE
fixed DMA input file configuration options

### DIFF
--- a/src/algorithms/signal_source/adapters/ad9361_fpga_signal_source.cc
+++ b/src/algorithms/signal_source/adapters/ad9361_fpga_signal_source.cc
@@ -337,8 +337,23 @@ Ad9361FpgaSignalSource::Ad9361FpgaSignalSource(ConfigurationInterface *configura
         {
             enable_DMA_ = true;
             std::string empty_string;
-            filename_rx1 = configuration->property(role + ".filename_rx1", empty_string);
-            filename_rx2 = configuration->property(role + ".filename_rx2", empty_string);
+            filename_rx1 = configuration->property(role + ".filename", empty_string);
+
+            // override value with commandline flag, if present
+            if (FLAGS_signal_source != "-")
+                {
+            		filename_rx1 = FLAGS_signal_source;
+                }
+            if (FLAGS_s != "-")
+                {
+            		filename_rx1 = FLAGS_s;
+                }
+
+            if (filename_rx1.empty())
+				{
+					filename_rx1 = configuration->property(role + ".filename0", empty_string);
+					filename_rx2 = configuration->property(role + ".filename1", empty_string);
+				}
             int l1_band = configuration->property("Channels_1C.count", 0) +
                           configuration->property("Channels_1B.count", 0);
 


### PR DESCRIPTION
added the -s command line options
+ replaced configuration options:

SignalSource.filename_rx1
SignalSource.filename_rx2

by

SignalSource.filename0
SignalSource.filename1