### PR TITLE
increased the number of bits of the PRN code resampler in the FPGA

### DIFF
--- a/src/algorithms/tracking/libs/fpga_multicorrelator.h
+++ b/src/algorithms/tracking/libs/fpga_multicorrelator.h
@@ -189,7 +189,7 @@ private:
     static const uint32_t init_secondary_code_addresses = 4;    // bit 2 of drop_samples_reg_addr
     static const uint32_t page_size = 0x10000;
     static const uint32_t max_length_deviceio_name = 50;
-    static const uint32_t max_code_resampler_counter = 1 << 20;  // 2^(number of bits of precision of the code resampler)
+    static const uint32_t max_code_resampler_counter = 1 << 31;  // 2^(number of bits of precision of the code resampler)
     static const uint32_t local_code_fpga_clear_address_counter = 0x10000000;
     static const uint32_t test_register_track_writeval = 0x55AA;
 


### PR DESCRIPTION
Increased the number of bits of the PRN code resampler register in the FPGA in order to improve the accuracy of the receiver.