### PR TITLE
Fix fpga post proc mode progr termination

### DIFF
--- a/src/algorithms/signal_source/adapters/ad9361_fpga_signal_source.cc
+++ b/src/algorithms/signal_source/adapters/ad9361_fpga_signal_source.cc
@@ -146,7 +146,7 @@ Ad9361FpgaSignalSource::Ad9361FpgaSignalSource(const ConfigurationInterface *con
                     freq_band = "L1L2";
                 }
 
-            thread_file_to_dma = std::thread([&] { run_DMA_process(freq_band, filename_rx1, filename_rx2, enable_DMA_); });
+            thread_file_to_dma = std::thread([&] { run_DMA_process(freq_band, filename_rx1, filename_rx2); });
         }
     if (switch_position == 2)  // Real-time via AD9361
         {
@@ -304,7 +304,9 @@ Ad9361FpgaSignalSource::~Ad9361FpgaSignalSource()
     /* cleanup and exit */
     if (switch_position == 0)  // read samples from a file via DMA
         {
+            std::unique_lock<std::mutex> lock(dma_mutex);
             enable_DMA_ = false;  // disable the DMA
+            lock.unlock();
             if (thread_file_to_dma.joinable())
                 {
                     thread_file_to_dma.join();
@@ -336,7 +338,7 @@ Ad9361FpgaSignalSource::~Ad9361FpgaSignalSource()
 }
 
 
-void Ad9361FpgaSignalSource::run_DMA_process(const std::string &FreqBand, const std::string &Filename1, const std::string &Filename2, bool enable_DMA)
+void Ad9361FpgaSignalSource::run_DMA_process(const std::string &FreqBand, const std::string &Filename1, const std::string &Filename2)
 {
     const int MAX_INPUT_SAMPLES_TOTAL = 16384;
     int max_value = 0;
@@ -390,7 +392,8 @@ void Ad9361FpgaSignalSource::run_DMA_process(const std::string &FreqBand, const 
     //**************************************************************************
     int nsamples = 0;
 
-    while ((file_completed == 0) && (enable_DMA == true))
+    //while ((file_completed == 0) && (enable_DMA == true))
+    while ((file_completed == 0))
         {
             unsigned int dma_index = 0;
 
@@ -410,7 +413,7 @@ void Ad9361FpgaSignalSource::run_DMA_process(const std::string &FreqBand, const 
                         }
                     else
                         {
-                            nread_elements = 0;
+                            nread_elements = infile1.gcount();
                         }
                     nsamples += (nread_elements / 2);
 
@@ -442,7 +445,7 @@ void Ad9361FpgaSignalSource::run_DMA_process(const std::string &FreqBand, const 
                         }
                     else
                         {
-                            nread_elements = 0;
+                            nread_elements = infile1.gcount();
                         }
                     nsamples += (nread_elements / 2);
 
@@ -474,7 +477,7 @@ void Ad9361FpgaSignalSource::run_DMA_process(const std::string &FreqBand, const 
                         }
                     else
                         {
-                            nread_elements = 0;
+                            nread_elements = infile1.gcount();
                         }
                     try
                         {
@@ -490,7 +493,7 @@ void Ad9361FpgaSignalSource::run_DMA_process(const std::string &FreqBand, const 
                         }
                     else
                         {
-                            nread_elements2 = 0;
+                            nread_elements2 = infile2.gcount();
                         }
 
                     if (nread_elements > nread_elements2)
@@ -551,12 +554,22 @@ void Ad9361FpgaSignalSource::run_DMA_process(const std::string &FreqBand, const 
                 {
                     file_completed = 1;
                 }
+
+            std::unique_lock<std::mutex> lock(dma_mutex);
+            if (enable_DMA_ == false)
+                {
+                    file_completed = true;
+                }
+            lock.unlock();
         }
 
     try
         {
             infile1.close();
-            infile2.close();
+            if (FreqBand == "L1L2")
+                {
+                    infile2.close();
+                }
         }
     catch (const std::ifstream::failure &e)
         {

--- a/src/algorithms/signal_source/adapters/ad9361_fpga_signal_source.h
+++ b/src/algorithms/signal_source/adapters/ad9361_fpga_signal_source.h
@@ -27,6 +27,7 @@
 #include <pmt/pmt.h>
 #include <cstdint>
 #include <memory>
+#include <mutex>
 #include <string>
 #include <thread>
 
@@ -67,8 +68,7 @@ public:
 private:
     void run_DMA_process(const std::string &FreqBand,
         const std::string &Filename1,
-        const std::string &Filename2,
-        bool enable_DMA);
+        const std::string &Filename2);
 
     std::thread thread_file_to_dma;
 
@@ -116,6 +116,8 @@ private:
     bool rx2_enable_;
     bool enable_DMA_;
     bool rf_shutdown_;
+
+    std::mutex dma_mutex;
 };
 
 #endif  // GNSS_SDR_AD9361_FPGA_SIGNAL_SOURCE_H


### PR DESCRIPTION
fixed program termination when using the FPGA in post-processing mode.
The DMA process was not properly checking enable_DMA_, this caused the DMA process not to stop when the user pressed 'q'. This caused the Ad9361FpgaSignalSource destructor to remain in a waiting state.
