### PR TITLE
init nread_elements to prevent compiler warning.

### DIFF
--- a/src/algorithms/signal_source/adapters/ad9361_fpga_signal_source.cc
+++ b/src/algorithms/signal_source/adapters/ad9361_fpga_signal_source.cc
@@ -372,8 +372,8 @@ void Ad9361FpgaSignalSource::run_DMA_process(const std::string &FreqBand, const 
     std::vector<int8_t> input_samples2(MAX_INPUT_SAMPLES_TOTAL * 2);
     std::vector<int8_t> input_samples_dma(MAX_INPUT_SAMPLES_TOTAL * 2 * 2);
 
-    int nread_elements;
-    int nread_elements2;
+    int nread_elements = 0;   // num bytes read from the file corresponding to frequency band 1
+    int nread_elements2 = 0;  // num bytes read from the file corresponding to frequency band 2
     int file_completed = 0;
     int num_transferred_bytes;
 


### PR DESCRIPTION
init nread_elements to prevent compiler warning.
