### PR TITLE
Added acquisition and tracking monitors

### DIFF
--- a/conf/gnss-sdr_GPS_L1_monitor.conf
+++ b/conf/gnss-sdr_GPS_L1_monitor.conf
@@ -1,3 +1,8 @@
+; This is a GNSS-SDR configuration file
+; The configuration API is described at https://gnss-sdr.org/docs/sp-blocks/
+; SPDX-License-Identifier: GPL-3.0-or-later
+; SPDX-FileCopyrightText: (C) 2010-2020  (see AUTHORS file for a list of contributors)
+
 [GNSS-SDR]
 
 ;######### GLOBAL OPTIONS ##################

--- a/conf/gnss-sdr_GPS_L1_monitor.conf
+++ b/conf/gnss-sdr_GPS_L1_monitor.conf
@@ -67,9 +67,8 @@ PVT.flag_averaging=true
 PVT.output_rate_ms=10
 PVT.display_rate_ms=500
 PVT.enable_monitor=true
-PVT.decimation_factor=1
-PVT.client_addresses=127.0.0.1
-PVT.udp_port=1234
+PVT.monitor_client_addresses=127.0.0.1
+PVT.monitor_udp_port=1234
 
 ;######### MONITOR CONFIG ############
 Monitor.enable_monitor=true

--- a/conf/gnss-sdr_GPS_L1_monitor.conf
+++ b/conf/gnss-sdr_GPS_L1_monitor.conf
@@ -1,0 +1,85 @@
+[GNSS-SDR]
+
+;######### GLOBAL OPTIONS ##################
+GNSS-SDR.internal_fs_sps=2000000
+
+;######### SIGNAL_SOURCE CONFIG ############
+SignalSource.implementation=File_Signal_Source
+SignalSource.filename=/tmp/2013_04_04_GNSS_SIGNAL_at_CTTC_SPAIN.dat
+SignalSource.item_type=ishort
+SignalSource.sampling_frequency=4000000
+SignalSource.freq=1575420000
+SignalSource.samples=0
+SignalSource.enable_throttle_control=true
+
+;######### SIGNAL_CONDITIONER CONFIG ############
+SignalConditioner.implementation=Signal_Conditioner
+
+;######### DATA_TYPE_ADAPTER CONFIG ############
+DataTypeAdapter.implementation=Ishort_To_Complex
+
+;######### INPUT_FILTER CONFIG ############
+InputFilter.implementation=Pass_Through
+InputFilter.item_type=gr_complex
+
+;######### RESAMPLER CONFIG ############
+Resampler.implementation=Direct_Resampler
+Resampler.sample_freq_in=4000000
+Resampler.sample_freq_out=2000000
+Resampler.item_type=gr_complex
+
+;######### CHANNELS GLOBAL CONFIG ############
+Channels_1C.count=3
+Channels.in_acquisition=1
+Channel.signal=1C
+Channel0.satellite=1
+Channel1.satellite=11
+Channel2.satellite=17
+
+;######### ACQUISITION GLOBAL CONFIG ############
+Acquisition_1C.implementation=GPS_L1_CA_PCPS_Acquisition
+Acquisition_1C.item_type=gr_complex
+Acquisition_1C.threshold=0.008
+Acquisition_1C.doppler_max=10000
+Acquisition_1C.doppler_step=250
+
+;######### TRACKING GLOBAL CONFIG ############
+Tracking_1C.implementation=GPS_L1_CA_DLL_PLL_Tracking
+Tracking_1C.item_type=gr_complex
+Tracking_1C.pll_bw_hz=40.0;
+Tracking_1C.dll_bw_hz=4.0;
+
+;######### TELEMETRY DECODER GPS CONFIG ############
+TelemetryDecoder_1C.implementation=GPS_L1_CA_Telemetry_Decoder
+
+;######### OBSERVABLES CONFIG ############
+Observables.implementation=Hybrid_Observables
+
+;######### PVT CONFIG ############
+PVT.implementation=RTKLIB_PVT
+PVT.averaging_depth=100
+PVT.flag_averaging=true
+PVT.output_rate_ms=10
+PVT.display_rate_ms=500
+PVT.enable_monitor=true
+PVT.decimation_factor=1
+PVT.client_addresses=127.0.0.1
+PVT.udp_port=1234
+
+;######### MONITOR CONFIG ############
+Monitor.enable_monitor=true
+Monitor.decimation_factor=1
+Monitor.client_addresses=127.0.0.1
+Monitor.udp_port=1233
+
+;######### ACQUISITION MONITOR CONFIG ############
+AcquisitionMonitor.enable_monitor=true
+AcquisitionMonitor.decimation_factor=1
+AcquisitionMonitor.client_addresses=127.0.0.1
+AcquisitionMonitor.udp_port=1231
+
+;######### TRACKING MONITOR CONFIG ############
+TrackingMonitor.enable_monitor=true
+TrackingMonitor.decimation_factor=1
+TrackingMonitor.client_addresses=127.0.0.1
+TrackingMonitor.udp_port=1232

--- a/conf/gnss-sdr_GPS_L1_udp_with_monitor.conf
+++ b/conf/gnss-sdr_GPS_L1_udp_with_monitor.conf
@@ -1,3 +1,8 @@
+; This is a GNSS-SDR configuration file
+; The configuration API is described at https://gnss-sdr.org/docs/sp-blocks/
+; SPDX-License-Identifier: GPL-3.0-or-later
+; SPDX-FileCopyrightText: (C) 2010-2020  (see AUTHORS file for a list of contributors)
+
 [GNSS-SDR]
 
 ;######### GLOBAL OPTIONS ##################

--- a/conf/gnss-sdr_GPS_L1_udp_with_monitor.conf
+++ b/conf/gnss-sdr_GPS_L1_udp_with_monitor.conf
@@ -60,9 +60,8 @@ PVT.flag_averaging=true
 PVT.output_rate_ms=10
 PVT.display_rate_ms=500
 PVT.enable_monitor=true
-PVT.decimation_factor=1
-PVT.client_addresses=127.0.0.1
-PVT.udp_port=1234
+PVT.monitor_client_addresses=127.0.0.1
+PVT.monitor_udp_port=1234
 
 ;######### MONITOR CONFIG ############
 Monitor.enable_monitor=true

--- a/conf/gnss-sdr_GPS_L1_udp_with_monitor.conf
+++ b/conf/gnss-sdr_GPS_L1_udp_with_monitor.conf
@@ -1,0 +1,78 @@
+[GNSS-SDR]
+
+;######### GLOBAL OPTIONS ##################
+;internal_fs_sps: Internal signal sampling frequency after the signal conditioning stage [Sps]
+GNSS-SDR.internal_fs_sps=4000000
+
+;######### SIGNAL_SOURCE CONFIG ############
+SignalSource.implementation=Custom_UDP_Signal_Source
+SignalSource.item_type=gr_complex
+SignalSource.origin_address=127.0.0.1
+SignalSource.capture_device=lo
+SignalSource.port=1230
+;SignalSource.payload_bytes=1472 # Not used! Size is retrieved from UDP Packet
+SignalSource.sample_type=cfloat
+SignalSource.IQ_swap=true
+SignalSource.RF_channels=1
+SignalSource.channels_in_udp=1
+SignalSource.dump=false
+SignalSource.dump_filename=./signal_source.dat
+
+;######### SIGNAL_CONDITIONER CONFIG ############
+SignalConditioner.implementation=Pass_Through
+
+;######### CHANNELS GLOBAL CONFIG ############
+Channels_1C.count=3
+Channels.in_acquisition=1
+Channel.signal=1C
+Channel0.satellite=1
+Channel1.satellite=11
+Channel2.satellite=17
+
+;######### ACQUISITION GLOBAL CONFIG ############
+Acquisition_1C.implementation=GPS_L1_CA_PCPS_Acquisition
+Acquisition_1C.item_type=gr_complex
+Acquisition_1C.threshold=0.008
+Acquisition_1C.doppler_max=10000
+Acquisition_1C.doppler_step=250
+
+;######### TRACKING GLOBAL CONFIG ############
+Tracking_1C.implementation=GPS_L1_CA_DLL_PLL_Tracking
+Tracking_1C.item_type=gr_complex
+Tracking_1C.pll_bw_hz=40.0;
+Tracking_1C.dll_bw_hz=4.0;
+
+;######### TELEMETRY DECODER GPS CONFIG ############
+TelemetryDecoder_1C.implementation=GPS_L1_CA_Telemetry_Decoder
+
+;######### OBSERVABLES CONFIG ############
+Observables.implementation=Hybrid_Observables
+
+;######### PVT CONFIG ############
+PVT.implementation=RTKLIB_PVT
+PVT.averaging_depth=100
+PVT.flag_averaging=true
+PVT.output_rate_ms=10
+PVT.display_rate_ms=500
+PVT.enable_monitor=true
+PVT.decimation_factor=1
+PVT.client_addresses=127.0.0.1
+PVT.udp_port=1234
+
+;######### MONITOR CONFIG ############
+Monitor.enable_monitor=true
+Monitor.decimation_factor=1
+Monitor.client_addresses=127.0.0.1
+Monitor.udp_port=1233
+
+;######### ACQUISITION MONITOR CONFIG ############
+AcquisitionMonitor.enable_monitor=true
+AcquisitionMonitor.decimation_factor=1
+AcquisitionMonitor.client_addresses=127.0.0.1
+AcquisitionMonitor.udp_port=1231
+
+;######### TRACKING MONITOR CONFIG ############
+TrackingMonitor.enable_monitor=true
+TrackingMonitor.decimation_factor=1
+TrackingMonitor.client_addresses=127.0.0.1
+TrackingMonitor.udp_port=1232

--- a/src/algorithms/acquisition/adapters/galileo_e1_pcps_8ms_ambiguous_acquisition.cc
+++ b/src/algorithms/acquisition/adapters/galileo_e1_pcps_8ms_ambiguous_acquisition.cc
@@ -85,12 +85,14 @@ GalileoE1Pcps8msAmbiguousAcquisition::GalileoE1Pcps8msAmbiguousAcquisition(
 
     code_ = std::vector<std::complex<float>>(vector_length_);
 
+    bool enable_monitor_output = configuration->property("AcquisitionMonitor.enable_monitor", false);
+
     if (item_type_ == "gr_complex")
         {
             item_size_ = sizeof(gr_complex);
             acquisition_cc_ = galileo_pcps_8ms_make_acquisition_cc(sampled_ms_, max_dwells_,
                 doppler_max_, fs_in_, samples_per_ms, code_length_,
-                dump_, dump_filename_);
+                dump_, dump_filename_, enable_monitor_output);
             stream_to_vector_ = gr::blocks::stream_to_vector::make(item_size_, vector_length_);
             DLOG(INFO) << "stream_to_vector("
                        << stream_to_vector_->unique_id() << ")";

--- a/src/algorithms/acquisition/adapters/galileo_e1_pcps_cccwsr_ambiguous_acquisition.cc
+++ b/src/algorithms/acquisition/adapters/galileo_e1_pcps_cccwsr_ambiguous_acquisition.cc
@@ -78,12 +78,14 @@ GalileoE1PcpsCccwsrAmbiguousAcquisition::GalileoE1PcpsCccwsrAmbiguousAcquisition
     code_data_ = std::vector<std::complex<float>>(vector_length_);
     code_pilot_ = std::vector<std::complex<float>>(vector_length_);
 
+    bool enable_monitor_output = configuration_->property("AcquisitionMonitor.enable_monitor", false);
+
     if (item_type_ == "gr_complex")
         {
             item_size_ = sizeof(gr_complex);
             acquisition_cc_ = pcps_cccwsr_make_acquisition_cc(sampled_ms_, max_dwells_,
                 doppler_max_, fs_in_, samples_per_ms, code_length_,
-                dump_, dump_filename_);
+                dump_, dump_filename_, enable_monitor_output);
             stream_to_vector_ = gr::blocks::stream_to_vector::make(item_size_, vector_length_);
             DLOG(INFO) << "stream_to_vector("
                        << stream_to_vector_->unique_id() << ")";

--- a/src/algorithms/acquisition/adapters/galileo_e1_pcps_quicksync_ambiguous_acquisition.cc
+++ b/src/algorithms/acquisition/adapters/galileo_e1_pcps_quicksync_ambiguous_acquisition.cc
@@ -111,6 +111,8 @@ GalileoE1PcpsQuickSyncAmbiguousAcquisition::GalileoE1PcpsQuickSyncAmbiguousAcqui
     dump_filename_ = configuration_->property(role + ".dump_filename",
         default_dump_filename);
 
+    bool enable_monitor_output = configuration_->property("AcquisitionMonitor.enable_monitor", false);
+
     code_ = std::vector<std::complex<float>>(code_length_);
     LOG(INFO) << "Vector Length: " << vector_length_
               << ", Samples per ms: " << samples_per_ms
@@ -123,7 +125,7 @@ GalileoE1PcpsQuickSyncAmbiguousAcquisition::GalileoE1PcpsQuickSyncAmbiguousAcqui
             acquisition_cc_ = pcps_quicksync_make_acquisition_cc(folding_factor_,
                 sampled_ms_, max_dwells_, doppler_max_, fs_in_,
                 samples_per_ms, code_length_, bit_transition_flag_,
-                dump_, dump_filename_);
+                dump_, dump_filename_, enable_monitor_output);
             stream_to_vector_ = gr::blocks::stream_to_vector::make(item_size_,
                 vector_length_);
             DLOG(INFO) << "stream_to_vector_quicksync("

--- a/src/algorithms/acquisition/adapters/galileo_e1_pcps_tong_ambiguous_acquisition.cc
+++ b/src/algorithms/acquisition/adapters/galileo_e1_pcps_tong_ambiguous_acquisition.cc
@@ -77,6 +77,8 @@ GalileoE1PcpsTongAmbiguousAcquisition::GalileoE1PcpsTongAmbiguousAcquisition(
     dump_filename_ = configuration_->property(role + ".dump_filename",
         default_dump_filename);
 
+    bool enable_monitor_output = configuration_->property("AcquisitionMonitor.enable_monitor", false);
+
     // -- Find number of samples per spreading code (4 ms)  -----------------
 
     code_length_ = static_cast<unsigned int>(round(
@@ -93,7 +95,7 @@ GalileoE1PcpsTongAmbiguousAcquisition::GalileoE1PcpsTongAmbiguousAcquisition(
             item_size_ = sizeof(gr_complex);
             acquisition_cc_ = pcps_tong_make_acquisition_cc(sampled_ms_, doppler_max_,
                 fs_in_, samples_per_ms, code_length_, tong_init_val_,
-                tong_max_val_, tong_max_dwells_, dump_, dump_filename_);
+                tong_max_val_, tong_max_dwells_, dump_, dump_filename_, enable_monitor_output);
 
             stream_to_vector_ = gr::blocks::stream_to_vector::make(item_size_, vector_length_);
             DLOG(INFO) << "stream_to_vector("

--- a/src/algorithms/acquisition/adapters/galileo_e5a_noncoherent_iq_acquisition_caf.cc
+++ b/src/algorithms/acquisition/adapters/galileo_e5a_noncoherent_iq_acquisition_caf.cc
@@ -94,6 +94,8 @@ GalileoE5aNoncoherentIQAcquisitionCaf::GalileoE5aNoncoherentIQAcquisitionCaf(
     codeQ_ = std::vector<std::complex<float>>(vector_length_);
     both_signal_components = false;
 
+    bool enable_monitor_output = configuration->property("AcquisitionMonitor.enable_monitor", false);
+
     std::string sig_ = configuration_->property("Channel.signal", std::string("5X"));
     if (sig_.at(0) == '5' && sig_.at(1) == 'X')
         {
@@ -104,7 +106,7 @@ GalileoE5aNoncoherentIQAcquisitionCaf::GalileoE5aNoncoherentIQAcquisitionCaf(
             item_size_ = sizeof(gr_complex);
             acquisition_cc_ = galileo_e5a_noncoherentIQ_make_acquisition_caf_cc(sampled_ms_, max_dwells_,
                 doppler_max_, fs_in_, code_length_, code_length_, bit_transition_flag_,
-                dump_, dump_filename_, both_signal_components, CAF_window_hz_, Zero_padding);
+                dump_, dump_filename_, both_signal_components, CAF_window_hz_, Zero_padding, enable_monitor_output);
         }
     else
         {

--- a/src/algorithms/acquisition/adapters/gps_l1_ca_pcps_assisted_acquisition.cc
+++ b/src/algorithms/acquisition/adapters/gps_l1_ca_pcps_assisted_acquisition.cc
@@ -55,6 +55,7 @@ GpsL1CaPcpsAssistedAcquisition::GpsL1CaPcpsAssistedAcquisition(
     sampled_ms_ = configuration->property(role + ".coherent_integration_time_ms", 1);
     max_dwells_ = configuration->property(role + ".max_dwells", 1);
     dump_filename_ = configuration->property(role + ".dump_filename", default_dump_filename);
+    bool enable_monitor_output = configuration->property("AcquisitionMonitor.enable_monitor", false);
 
     // --- Find number of samples per spreading code -------------------------
     vector_length_ = static_cast<unsigned int>(round(fs_in_ / (GPS_L1_CA_CODE_RATE_CPS / GPS_L1_CA_CODE_LENGTH_CHIPS)));
@@ -66,7 +67,7 @@ GpsL1CaPcpsAssistedAcquisition::GpsL1CaPcpsAssistedAcquisition(
             item_size_ = sizeof(gr_complex);
             acquisition_cc_ = pcps_make_assisted_acquisition_cc(max_dwells_, sampled_ms_,
                 doppler_max_, doppler_min_, fs_in_, vector_length_,
-                dump_, dump_filename_);
+                dump_, dump_filename_, enable_monitor_output);
         }
     else
         {

--- a/src/algorithms/acquisition/adapters/gps_l1_ca_pcps_quicksync_acquisition.cc
+++ b/src/algorithms/acquisition/adapters/gps_l1_ca_pcps_quicksync_acquisition.cc
@@ -100,6 +100,8 @@ GpsL1CaPcpsQuickSyncAcquisition::GpsL1CaPcpsQuickSyncAcquisition(
 
     dump_filename_ = configuration_->property(role + ".dump_filename", default_dump_filename);
 
+    bool enable_monitor_output = configuration_->property("AcquisitionMonitor.enable_monitor", false);
+
     int samples_per_ms = round(code_length_);
     code_ = std::vector<std::complex<float>>(code_length_);
     /* Object relevant information for debugging */
@@ -116,7 +118,7 @@ GpsL1CaPcpsQuickSyncAcquisition::GpsL1CaPcpsQuickSyncAcquisition(
             acquisition_cc_ = pcps_quicksync_make_acquisition_cc(folding_factor_,
                 sampled_ms_, max_dwells_, doppler_max_, fs_in_,
                 samples_per_ms, code_length_, bit_transition_flag_,
-                dump_, dump_filename_);
+                dump_, dump_filename_, enable_monitor_output);
 
             stream_to_vector_ = gr::blocks::stream_to_vector::make(item_size_,
                 code_length_ * folding_factor_);

--- a/src/algorithms/acquisition/adapters/gps_l1_ca_pcps_tong_acquisition.cc
+++ b/src/algorithms/acquisition/adapters/gps_l1_ca_pcps_tong_acquisition.cc
@@ -67,6 +67,8 @@ GpsL1CaPcpsTongAcquisition::GpsL1CaPcpsTongAcquisition(
 
     dump_filename_ = configuration_->property(role + ".dump_filename", default_dump_filename);
 
+    bool enable_monitor_output = configuration_->property("AcquisitionMonitor.enable_monitor", false);
+
     // -- Find number of samples per spreading code -------------------------
     code_length_ = static_cast<unsigned int>(round(fs_in_ / (GPS_L1_CA_CODE_RATE_CPS / GPS_L1_CA_CODE_LENGTH_CHIPS)));
 
@@ -79,7 +81,7 @@ GpsL1CaPcpsTongAcquisition::GpsL1CaPcpsTongAcquisition(
             item_size_ = sizeof(gr_complex);
             acquisition_cc_ = pcps_tong_make_acquisition_cc(sampled_ms_, doppler_max_, fs_in_,
                 code_length_, code_length_, tong_init_val_, tong_max_val_, tong_max_dwells_,
-                dump_, dump_filename_);
+                dump_, dump_filename_, enable_monitor_output);
 
             stream_to_vector_ = gr::blocks::stream_to_vector::make(item_size_, vector_length_);
 

--- a/src/algorithms/acquisition/gnuradio_blocks/galileo_e5a_noncoherent_iq_acquisition_caf_cc.cc
+++ b/src/algorithms/acquisition/gnuradio_blocks/galileo_e5a_noncoherent_iq_acquisition_caf_cc.cc
@@ -46,11 +46,12 @@ galileo_e5a_noncoherentIQ_acquisition_caf_cc_sptr galileo_e5a_noncoherentIQ_make
     const std::string &dump_filename,
     bool both_signal_components_,
     int CAF_window_hz_,
-    int Zero_padding_)
+    int Zero_padding_,
+    bool enable_monitor_output)
 {
     return galileo_e5a_noncoherentIQ_acquisition_caf_cc_sptr(
         new galileo_e5a_noncoherentIQ_acquisition_caf_cc(sampled_ms, max_dwells, doppler_max, fs_in, samples_per_ms,
-            samples_per_code, bit_transition_flag, dump, dump_filename, both_signal_components_, CAF_window_hz_, Zero_padding_));
+            samples_per_code, bit_transition_flag, dump, dump_filename, both_signal_components_, CAF_window_hz_, Zero_padding_, enable_monitor_output));
 }
 
 
@@ -66,9 +67,10 @@ galileo_e5a_noncoherentIQ_acquisition_caf_cc::galileo_e5a_noncoherentIQ_acquisit
     const std::string &dump_filename,
     bool both_signal_components_,
     int CAF_window_hz_,
-    int Zero_padding_) : gr::block("galileo_e5a_noncoherentIQ_acquisition_caf_cc",
-                             gr::io_signature::make(1, 1, sizeof(gr_complex)),
-                             gr::io_signature::make(0, 0, sizeof(gr_complex)))
+    int Zero_padding_,
+    bool enable_monitor_output) : gr::block("galileo_e5a_noncoherentIQ_acquisition_caf_cc",
+                                  gr::io_signature::make(1, 1, sizeof(gr_complex)),
+                                  gr::io_signature::make(0, 1, sizeof(Gnss_Synchro)))
 {
     this->message_port_register_out(pmt::mp("events"));
     d_sample_counter = 0ULL;  // SAMPLE COUNTER
@@ -96,6 +98,7 @@ galileo_e5a_noncoherentIQ_acquisition_caf_cc::galileo_e5a_noncoherentIQ_acquisit
     d_buffer_count = 0;
     d_both_signal_components = both_signal_components_;
     d_CAF_window_hz = CAF_window_hz_;
+    d_enable_monitor_output = enable_monitor_output;
 
     d_inbuffer.reserve(d_fft_size);
     d_fft_code_I_A.reserve(d_fft_size);
@@ -285,7 +288,7 @@ void galileo_e5a_noncoherentIQ_acquisition_caf_cc::set_state(int state)
 
 int galileo_e5a_noncoherentIQ_acquisition_caf_cc::general_work(int noutput_items __attribute__((unused)),
     gr_vector_int &ninput_items, gr_vector_const_void_star &input_items,
-    gr_vector_void_star &output_items __attribute__((unused)))
+    gr_vector_void_star &output_items)
 {
     /*
      * By J.Arribas, L.Esteve, M.Molina and M.Sales
@@ -300,6 +303,7 @@ int galileo_e5a_noncoherentIQ_acquisition_caf_cc::general_work(int noutput_items
      */
 
     int acquisition_message = -1;  // 0=STOP_CHANNEL 1=ACQ_SUCCEES 2=ACQ_FAIL
+    int return_value = 0;  // 0=Produces no Gnss_Synchro objects
     /* States: 0 Stop Channel
      *         1 Load the buffer until it reaches fft_size
      *         2 Acquisition algorithm
@@ -726,6 +730,17 @@ int galileo_e5a_noncoherentIQ_acquisition_caf_cc::general_work(int noutput_items
                 this->message_port_pub(pmt::mp("events"), pmt::from_long(acquisition_message));
                 d_sample_counter += static_cast<uint64_t>(ninput_items[0]);  // sample counter
                 consume_each(ninput_items[0]);
+
+                // Copy and push current Gnss_Synchro to monitor queue
+                if (d_enable_monitor_output)
+                    {
+                        auto **out = reinterpret_cast<Gnss_Synchro **>(&output_items[0]);
+                        Gnss_Synchro current_synchro_data = Gnss_Synchro();
+                        current_synchro_data = *d_gnss_synchro;
+                        *out[0] = current_synchro_data;
+                        return_value = 1;  // Number of Gnss_Synchro objects produced
+                    }
+
                 break;
             }
         case 4:
@@ -752,5 +767,5 @@ int galileo_e5a_noncoherentIQ_acquisition_caf_cc::general_work(int noutput_items
             }
         }
 
-    return 0;
+    return return_value;
 }

--- a/src/algorithms/acquisition/gnuradio_blocks/galileo_e5a_noncoherent_iq_acquisition_caf_cc.h
+++ b/src/algorithms/acquisition/gnuradio_blocks/galileo_e5a_noncoherent_iq_acquisition_caf_cc.h
@@ -60,7 +60,8 @@ galileo_e5a_noncoherentIQ_acquisition_caf_cc_sptr galileo_e5a_noncoherentIQ_make
     const std::string& dump_filename,
     bool both_signal_components_,
     int CAF_window_hz_,
-    int Zero_padding_);
+    int Zero_padding_,
+    bool enable_monitor_output);
 
 /*!
  * \brief This class implements a Parallel Code Phase Search Acquisition.
@@ -186,7 +187,8 @@ private:
         const std::string& dump_filename,
         bool both_signal_components_,
         int CAF_window_hz_,
-        int Zero_padding_);
+        int Zero_padding_,
+        bool enable_monitor_output);
 
     galileo_e5a_noncoherentIQ_acquisition_caf_cc(
         unsigned int sampled_ms,
@@ -198,7 +200,8 @@ private:
         const std::string& dump_filename,
         bool both_signal_components_,
         int CAF_window_hz_,
-        int Zero_padding_);
+        int Zero_padding_,
+        bool enable_monitor_output);
 
     void calculate_magnitudes(gr_complex* fft_begin, int doppler_shift,
         int doppler_offset);
@@ -260,6 +263,7 @@ private:
     bool d_active;
     bool d_dump;
     bool d_both_signal_components;
+    bool d_enable_monitor_output;
 };
 
 #endif  // GNSS_SDR_GALILEO_E5A_NONCOHERENT_IQ_ACQUISITION_CAF_CC_H

--- a/src/algorithms/acquisition/gnuradio_blocks/galileo_pcps_8ms_acquisition_cc.cc
+++ b/src/algorithms/acquisition/gnuradio_blocks/galileo_pcps_8ms_acquisition_cc.cc
@@ -37,11 +37,13 @@ galileo_pcps_8ms_acquisition_cc_sptr galileo_pcps_8ms_make_acquisition_cc(
     int64_t fs_in,
     int32_t samples_per_ms,
     int32_t samples_per_code,
-    bool dump, const std::string &dump_filename)
+    bool dump,
+    const std::string &dump_filename,
+    bool enable_monitor_output)
 {
     return galileo_pcps_8ms_acquisition_cc_sptr(
         new galileo_pcps_8ms_acquisition_cc(sampled_ms, max_dwells, doppler_max, fs_in, samples_per_ms,
-            samples_per_code, dump, dump_filename));
+            samples_per_code, dump, dump_filename, enable_monitor_output));
 }
 
 
@@ -53,9 +55,10 @@ galileo_pcps_8ms_acquisition_cc::galileo_pcps_8ms_acquisition_cc(
     int32_t samples_per_ms,
     int32_t samples_per_code,
     bool dump,
-    const std::string &dump_filename) : gr::block("galileo_pcps_8ms_acquisition_cc",
-                                            gr::io_signature::make(1, 1, static_cast<int>(sizeof(gr_complex) * sampled_ms * samples_per_ms)),
-                                            gr::io_signature::make(0, 0, static_cast<int>(sizeof(gr_complex) * sampled_ms * samples_per_ms)))
+    const std::string &dump_filename,
+    bool enable_monitor_output) : gr::block("galileo_pcps_8ms_acquisition_cc",
+                                  gr::io_signature::make(1, 1, static_cast<int>(sizeof(gr_complex) * sampled_ms * samples_per_ms)),
+                                  gr::io_signature::make(0, 1, sizeof(Gnss_Synchro)))
 {
     this->message_port_register_out(pmt::mp("events"));
     d_sample_counter = 0ULL;  // SAMPLE COUNTER
@@ -86,6 +89,8 @@ galileo_pcps_8ms_acquisition_cc::galileo_pcps_8ms_acquisition_cc(
     // For dumping samples into a file
     d_dump = dump;
     d_dump_filename = dump_filename;
+
+    d_enable_monitor_output = enable_monitor_output;
 
     d_doppler_resolution = 0;
     d_threshold = 0;
@@ -199,7 +204,7 @@ void galileo_pcps_8ms_acquisition_cc::set_state(int32_t state)
 
 int galileo_pcps_8ms_acquisition_cc::general_work(int noutput_items,
     gr_vector_int &ninput_items, gr_vector_const_void_star &input_items,
-    gr_vector_void_star &output_items __attribute__((unused)))
+    gr_vector_void_star &output_items)
 {
     int32_t acquisition_message = -1;  // 0=STOP_CHANNEL 1=ACQ_SUCCEES 2=ACQ_FAIL
 
@@ -379,6 +384,16 @@ int galileo_pcps_8ms_acquisition_cc::general_work(int noutput_items,
 
                 acquisition_message = 1;
                 this->message_port_pub(pmt::mp("events"), pmt::from_long(acquisition_message));
+
+                // Copy and push current Gnss_Synchro to monitor queue
+                if (d_enable_monitor_output)
+                    {
+                        auto **out = reinterpret_cast<Gnss_Synchro **>(&output_items[0]);
+                        Gnss_Synchro current_synchro_data = Gnss_Synchro();
+                        current_synchro_data = *d_gnss_synchro;
+                        *out[0] = current_synchro_data;
+                        noutput_items = 1;  // Number of Gnss_Synchro objects produced
+                    }
 
                 break;
             }

--- a/src/algorithms/acquisition/gnuradio_blocks/galileo_pcps_8ms_acquisition_cc.h
+++ b/src/algorithms/acquisition/gnuradio_blocks/galileo_pcps_8ms_acquisition_cc.h
@@ -52,7 +52,8 @@ galileo_pcps_8ms_make_acquisition_cc(uint32_t sampled_ms,
     int32_t samples_per_ms,
     int32_t samples_per_code,
     bool dump,
-    const std::string& dump_filename);
+    const std::string& dump_filename,
+    bool enable_monitor_output);
 
 /*!
  * \brief This class implements a Parallel Code Phase Search Acquisition for
@@ -174,7 +175,8 @@ private:
         int32_t samples_per_ms,
         int32_t samples_per_code,
         bool dump,
-        const std::string& dump_filename);
+        const std::string& dump_filename,
+        bool enable_monitor_output);
 
     galileo_pcps_8ms_acquisition_cc(
         uint32_t sampled_ms,
@@ -184,7 +186,8 @@ private:
         int32_t samples_per_ms,
         int32_t samples_per_code,
         bool dump,
-        const std::string& dump_filename);
+        const std::string& dump_filename,
+        bool enable_monitor_output);
 
     void calculate_magnitudes(
         gr_complex* fft_begin,
@@ -230,6 +233,7 @@ private:
 
     bool d_active;
     bool d_dump;
+    bool d_enable_monitor_output;
 };
 
 #endif  // GNSS_SDR_PCPS_8MS_ACQUISITION_CC_H

--- a/src/algorithms/acquisition/gnuradio_blocks/pcps_acquisition.h
+++ b/src/algorithms/acquisition/gnuradio_blocks/pcps_acquisition.h
@@ -59,9 +59,9 @@
 #include <complex>
 #include <cstdint>
 #include <memory>
+#include <queue>
 #include <string>
 #include <utility>
-#include <queue>
 
 #if HAS_STD_SPAN
 #include <span>

--- a/src/algorithms/acquisition/gnuradio_blocks/pcps_acquisition.h
+++ b/src/algorithms/acquisition/gnuradio_blocks/pcps_acquisition.h
@@ -61,6 +61,7 @@
 #include <memory>
 #include <string>
 #include <utility>
+#include <queue>
 
 #if HAS_STD_SPAN
 #include <span>
@@ -284,6 +285,8 @@ private:
     bool d_step_two;
     bool d_use_CFAR_algorithm_flag;
     bool d_dump;
+
+    std::queue<Gnss_Synchro> d_monitor_queue;
 };
 
 #endif  // GNSS_SDR_PCPS_ACQUISITION_H

--- a/src/algorithms/acquisition/gnuradio_blocks/pcps_assisted_acquisition_cc.h
+++ b/src/algorithms/acquisition/gnuradio_blocks/pcps_assisted_acquisition_cc.h
@@ -67,7 +67,9 @@ pcps_assisted_acquisition_cc_sptr pcps_make_assisted_acquisition_cc(
     int32_t doppler_min,
     int64_t fs_in,
     int32_t samples_per_ms,
-    bool dump, const std::string& dump_filename);
+    bool dump,
+    const std::string& dump_filename,
+    bool enable_monitor_output);
 
 /*!
  * \brief This class implements a Parallel Code Phase Search Acquisition.
@@ -183,12 +185,12 @@ private:
     pcps_make_assisted_acquisition_cc(int32_t max_dwells, uint32_t sampled_ms,
         int32_t doppler_max, int32_t doppler_min, int64_t fs_in,
         int32_t samples_per_ms, bool dump,
-        const std::string& dump_filename);
+        const std::string& dump_filename, bool enable_monitor_output);
 
     pcps_assisted_acquisition_cc(int32_t max_dwells, uint32_t sampled_ms,
         int32_t doppler_max, int32_t doppler_min, int64_t fs_in,
         int32_t samples_per_ms, bool dump,
-        const std::string& dump_filename);
+        const std::string& dump_filename, bool enable_monitor_output);
 
     void calculate_magnitudes(gr_complex* fft_begin, int32_t doppler_shift,
         int32_t doppler_offset);
@@ -242,6 +244,7 @@ private:
     bool d_active;
     bool d_disable_assist;
     bool d_dump;
+    bool d_enable_monitor_output;
 };
 
 #endif  // GNSS_SDR_PCPS_ASSISTED_ACQUISITION_CC_H

--- a/src/algorithms/acquisition/gnuradio_blocks/pcps_cccwsr_acquisition_cc.cc
+++ b/src/algorithms/acquisition/gnuradio_blocks/pcps_cccwsr_acquisition_cc.cc
@@ -42,11 +42,13 @@ pcps_cccwsr_acquisition_cc_sptr pcps_cccwsr_make_acquisition_cc(
     int64_t fs_in,
     int32_t samples_per_ms,
     int32_t samples_per_code,
-    bool dump, const std::string &dump_filename)
+    bool dump,
+    const std::string &dump_filename,
+    bool enable_monitor_output)
 {
     return pcps_cccwsr_acquisition_cc_sptr(
         new pcps_cccwsr_acquisition_cc(sampled_ms, max_dwells, doppler_max, fs_in,
-            samples_per_ms, samples_per_code, dump, dump_filename));
+            samples_per_ms, samples_per_code, dump, dump_filename, enable_monitor_output));
 }
 
 
@@ -58,9 +60,10 @@ pcps_cccwsr_acquisition_cc::pcps_cccwsr_acquisition_cc(
     int32_t samples_per_ms,
     int32_t samples_per_code,
     bool dump,
-    const std::string &dump_filename) : gr::block("pcps_cccwsr_acquisition_cc",
-                                            gr::io_signature::make(1, 1, static_cast<int>(sizeof(gr_complex) * sampled_ms * samples_per_ms)),
-                                            gr::io_signature::make(0, 0, static_cast<int>(sizeof(gr_complex) * sampled_ms * samples_per_ms)))
+    const std::string &dump_filename,
+    bool enable_monitor_output) : gr::block("pcps_cccwsr_acquisition_cc",
+                                  gr::io_signature::make(1, 1, static_cast<int>(sizeof(gr_complex) * sampled_ms * samples_per_ms)),
+                                  gr::io_signature::make(0, 1, sizeof(Gnss_Synchro)))
 {
     this->message_port_register_out(pmt::mp("events"));
     d_sample_counter = 0ULL;  // SAMPLE COUNTER
@@ -95,6 +98,8 @@ pcps_cccwsr_acquisition_cc::pcps_cccwsr_acquisition_cc(
     // For dumping samples into a file
     d_dump = dump;
     d_dump_filename = dump_filename;
+
+    d_enable_monitor_output = enable_monitor_output;
 
     d_doppler_resolution = 0;
     d_threshold = 0;
@@ -208,7 +213,7 @@ void pcps_cccwsr_acquisition_cc::set_state(int32_t state)
 
 int pcps_cccwsr_acquisition_cc::general_work(int noutput_items,
     gr_vector_int &ninput_items, gr_vector_const_void_star &input_items,
-    gr_vector_void_star &output_items __attribute__((unused)))
+    gr_vector_void_star &output_items)
 {
     int32_t acquisition_message = -1;  // 0=STOP_CHANNEL 1=ACQ_SUCCEES 2=ACQ_FAIL
 
@@ -399,6 +404,16 @@ int pcps_cccwsr_acquisition_cc::general_work(int noutput_items,
 
                 acquisition_message = 1;
                 this->message_port_pub(pmt::mp("events"), pmt::from_long(acquisition_message));
+
+                // Copy and push current Gnss_Synchro to monitor queue
+                if (d_enable_monitor_output)
+                    {
+                        auto **out = reinterpret_cast<Gnss_Synchro **>(&output_items[0]);
+                        Gnss_Synchro current_synchro_data = Gnss_Synchro();
+                        current_synchro_data = *d_gnss_synchro;
+                        *out[0] = current_synchro_data;
+                        noutput_items = 1;  // Number of Gnss_Synchro objects produced
+                    }
 
                 break;
             }

--- a/src/algorithms/acquisition/gnuradio_blocks/pcps_cccwsr_acquisition_cc.h
+++ b/src/algorithms/acquisition/gnuradio_blocks/pcps_cccwsr_acquisition_cc.h
@@ -58,7 +58,8 @@ pcps_cccwsr_acquisition_cc_sptr pcps_cccwsr_make_acquisition_cc(
     int32_t samples_per_ms,
     int32_t samples_per_code,
     bool dump,
-    const std::string& dump_filename);
+    const std::string& dump_filename,
+    bool enable_monitor_output);
 
 /*!
  * \brief This class implements a Parallel Code Phase Search Acquisition with
@@ -176,12 +177,12 @@ private:
     pcps_cccwsr_make_acquisition_cc(uint32_t sampled_ms, uint32_t max_dwells,
         uint32_t doppler_max, int64_t fs_in,
         int32_t samples_per_ms, int32_t samples_per_code,
-        bool dump, const std::string& dump_filename);
+        bool dump, const std::string& dump_filename, bool enable_monitor_output);
 
     pcps_cccwsr_acquisition_cc(uint32_t sampled_ms, uint32_t max_dwells,
         uint32_t doppler_max, int64_t fs_in,
         int32_t samples_per_ms, int32_t samples_per_code,
-        bool dump, const std::string& dump_filename);
+        bool dump, const std::string& dump_filename, bool enable_monitor_output);
 
     void calculate_magnitudes(gr_complex* fft_begin, int32_t doppler_shift,
         int32_t doppler_offset);
@@ -231,6 +232,7 @@ private:
 
     bool d_active;
     bool d_dump;
+    bool d_enable_monitor_output;
 };
 
 #endif  // GNSS_SDR_PCPS_CCCWSR_ACQUISITION_CC_H

--- a/src/algorithms/acquisition/gnuradio_blocks/pcps_opencl_acquisition_cc.cc
+++ b/src/algorithms/acquisition/gnuradio_blocks/pcps_opencl_acquisition_cc.cc
@@ -61,11 +61,12 @@ pcps_opencl_acquisition_cc_sptr pcps_make_opencl_acquisition_cc(
     int samples_per_ms, int samples_per_code,
     bool bit_transition_flag,
     bool dump,
-    const std::string &dump_filename)
+    const std::string &dump_filename,
+    bool enable_monitor_output)
 {
     return pcps_opencl_acquisition_cc_sptr(
         new pcps_opencl_acquisition_cc(sampled_ms, max_dwells, doppler_max, fs_in, samples_per_ms,
-            samples_per_code, bit_transition_flag, dump, dump_filename));
+            samples_per_code, bit_transition_flag, dump, dump_filename, enable_monitor_output));
 }
 
 
@@ -78,9 +79,10 @@ pcps_opencl_acquisition_cc::pcps_opencl_acquisition_cc(
     int samples_per_code,
     bool bit_transition_flag,
     bool dump,
-    const std::string &dump_filename) : gr::block("pcps_opencl_acquisition_cc",
-                                            gr::io_signature::make(1, 1, static_cast<int>(sizeof(gr_complex) * sampled_ms * samples_per_ms)),
-                                            gr::io_signature::make(0, 0, static_cast<int>(sizeof(gr_complex) * sampled_ms * samples_per_ms)))
+    const std::string &dump_filename,
+    bool enable_monitor_output) : gr::block("pcps_opencl_acquisition_cc",
+                                  gr::io_signature::make(1, 1, static_cast<int>(sizeof(gr_complex) * sampled_ms * samples_per_ms)),
+                                  gr::io_signature::make(0, 1, sizeof(Gnss_Synchro)))
 {
     this->message_port_register_out(pmt::mp("events"));
     d_sample_counter = 0ULL;  // SAMPLE COUNTER
@@ -122,6 +124,8 @@ pcps_opencl_acquisition_cc::pcps_opencl_acquisition_cc(
     // For dumping samples into a file
     d_dump = dump;
     d_dump_filename = dump_filename;
+
+    d_enable_monitor_output = enable_monitor_output;
 }
 
 
@@ -658,7 +662,7 @@ void pcps_opencl_acquisition_cc::set_state(int state)
 
 int pcps_opencl_acquisition_cc::general_work(int noutput_items,
     gr_vector_int &ninput_items, gr_vector_const_void_star &input_items,
-    gr_vector_void_star &output_items __attribute__((unused)))
+    gr_vector_void_star &output_items)
 {
     int acquisition_message = -1;  // 0=STOP_CHANNEL 1=ACQ_SUCCEES 2=ACQ_FAIL
     switch (d_state)
@@ -760,6 +764,16 @@ int pcps_opencl_acquisition_cc::general_work(int noutput_items,
 
                 acquisition_message = 1;
                 this->message_port_pub(pmt::mp("events"), pmt::from_long(acquisition_message));
+
+                // Copy and push current Gnss_Synchro to monitor queue
+                if (d_enable_monitor_output)
+                    {
+                        auto **out = reinterpret_cast<Gnss_Synchro **>(&output_items[0]);
+                        Gnss_Synchro current_synchro_data = Gnss_Synchro();
+                        current_synchro_data = *d_gnss_synchro;
+                        *out[0] = current_synchro_data;
+                        noutput_items = 1;  // Number of Gnss_Synchro objects produced
+                    }
 
                 break;
             }

--- a/src/algorithms/acquisition/gnuradio_blocks/pcps_opencl_acquisition_cc.h
+++ b/src/algorithms/acquisition/gnuradio_blocks/pcps_opencl_acquisition_cc.h
@@ -75,7 +75,8 @@ pcps_opencl_acquisition_cc_sptr pcps_make_opencl_acquisition_cc(
     int samples_per_code,
     bool bit_transition_flag,
     bool dump,
-    const std::string& dump_filename);
+    const std::string& dump_filename,
+    bool enable_monitor_output);
 
 /*!
  * \brief This class implements a Parallel Code Phase Search Acquisition.
@@ -210,14 +211,16 @@ private:
         int samples_per_ms, int samples_per_code,
         bool bit_transition_flag,
         bool dump,
-        const std::string& dump_filename);
+        const std::string& dump_filename,
+        bool enable_monitor_output);
 
     pcps_opencl_acquisition_cc(uint32_t sampled_ms, uint32_t max_dwells,
         uint32_t doppler_max, int64_t fs_in,
         int samples_per_ms, int samples_per_code,
         bool bit_transition_flag,
         bool dump,
-        const std::string& dump_filename);
+        const std::string& dump_filename,
+        bool enable_monitor_output);
 
     void calculate_magnitudes(gr_complex* fft_begin, int doppler_shift,
         int doppler_offset);
@@ -290,6 +293,7 @@ private:
     bool d_active;
     bool d_core_working;
     bool d_dump;
+    bool d_enable_monitor_output;
 };
 
 #endif

--- a/src/algorithms/acquisition/gnuradio_blocks/pcps_quicksync_acquisition_cc.h
+++ b/src/algorithms/acquisition/gnuradio_blocks/pcps_quicksync_acquisition_cc.h
@@ -76,7 +76,8 @@ pcps_quicksync_acquisition_cc_sptr pcps_quicksync_make_acquisition_cc(
     int32_t samples_per_code,
     bool bit_transition_flag,
     bool dump,
-    const std::string& dump_filename);
+    const std::string& dump_filename,
+    bool enable_monitor_output);
 
 /*!
  * \brief This class implements a Parallel Code Phase Search Acquisition with
@@ -199,7 +200,8 @@ private:
         int32_t samples_per_ms, int32_t samples_per_code,
         bool bit_transition_flag,
         bool dump,
-        const std::string& dump_filename);
+        const std::string& dump_filename,
+        bool enable_monitor_output);
 
     pcps_quicksync_acquisition_cc(uint32_t folding_factor,
         uint32_t sampled_ms, uint32_t max_dwells,
@@ -207,7 +209,8 @@ private:
         int32_t samples_per_ms, int32_t samples_per_code,
         bool bit_transition_flag,
         bool dump,
-        const std::string& dump_filename);
+        const std::string& dump_filename,
+        bool enable_monitor_output);
 
     void calculate_magnitudes(gr_complex* fft_begin, int32_t doppler_shift,
         int32_t doppler_offset);
@@ -261,6 +264,7 @@ private:
     bool d_bit_transition_flag;
     bool d_active;
     bool d_dump;
+    bool d_enable_monitor_output;
 };
 
 #endif  // GNSS_SDR_PCPS_QUICKSYNC_ACQUISITION_CC_H

--- a/src/algorithms/acquisition/gnuradio_blocks/pcps_tong_acquisition_cc.cc
+++ b/src/algorithms/acquisition/gnuradio_blocks/pcps_tong_acquisition_cc.cc
@@ -58,11 +58,13 @@ pcps_tong_acquisition_cc_sptr pcps_tong_make_acquisition_cc(
     uint32_t tong_init_val,
     uint32_t tong_max_val,
     uint32_t tong_max_dwells,
-    bool dump, const std::string &dump_filename)
+    bool dump,
+    const std::string &dump_filename,
+    bool enable_monitor_output)
 {
     return pcps_tong_acquisition_cc_sptr(
         new pcps_tong_acquisition_cc(sampled_ms, doppler_max, fs_in, samples_per_ms, samples_per_code,
-            tong_init_val, tong_max_val, tong_max_dwells, dump, dump_filename));
+            tong_init_val, tong_max_val, tong_max_dwells, dump, dump_filename, enable_monitor_output));
 }
 
 
@@ -76,9 +78,10 @@ pcps_tong_acquisition_cc::pcps_tong_acquisition_cc(
     uint32_t tong_max_val,
     uint32_t tong_max_dwells,
     bool dump,
-    const std::string &dump_filename) : gr::block("pcps_tong_acquisition_cc",
-                                            gr::io_signature::make(1, 1, static_cast<int>(sizeof(gr_complex) * sampled_ms * samples_per_ms)),
-                                            gr::io_signature::make(0, 0, static_cast<int>(sizeof(gr_complex) * sampled_ms * samples_per_ms)))
+    const std::string &dump_filename,
+    bool enable_monitor_output) : gr::block("pcps_tong_acquisition_cc",
+                                  gr::io_signature::make(1, 1, static_cast<int>(sizeof(gr_complex) * sampled_ms * samples_per_ms)),
+                                  gr::io_signature::make(0, 1, sizeof(Gnss_Synchro)))
 {
     this->message_port_register_out(pmt::mp("events"));
     d_sample_counter = 0ULL;  // SAMPLE COUNTER
@@ -111,6 +114,8 @@ pcps_tong_acquisition_cc::pcps_tong_acquisition_cc(
     // For dumping samples into a file
     d_dump = dump;
     d_dump_filename = dump_filename;
+
+    d_enable_monitor_output = enable_monitor_output;
 
     d_doppler_resolution = 0;
     d_threshold = 0;
@@ -224,7 +229,7 @@ void pcps_tong_acquisition_cc::set_state(int32_t state)
 
 int pcps_tong_acquisition_cc::general_work(int noutput_items,
     gr_vector_int &ninput_items, gr_vector_const_void_star &input_items,
-    gr_vector_void_star &output_items __attribute__((unused)))
+    gr_vector_void_star &output_items)
 {
     int32_t acquisition_message = -1;  // 0=STOP_CHANNEL 1=ACQ_SUCCEES 2=ACQ_FAIL
 
@@ -400,6 +405,16 @@ int pcps_tong_acquisition_cc::general_work(int noutput_items,
 
                 acquisition_message = 1;
                 this->message_port_pub(pmt::mp("events"), pmt::from_long(acquisition_message));
+
+                // Copy and push current Gnss_Synchro to monitor queue
+                if (d_enable_monitor_output)
+                    {
+                        auto **out = reinterpret_cast<Gnss_Synchro **>(&output_items[0]);
+                        Gnss_Synchro current_synchro_data = Gnss_Synchro();
+                        current_synchro_data = *d_gnss_synchro;
+                        *out[0] = current_synchro_data;
+                        noutput_items = 1;  // Number of Gnss_Synchro objects produced
+                    }
 
                 break;
             }

--- a/src/algorithms/acquisition/gnuradio_blocks/pcps_tong_acquisition_cc.h
+++ b/src/algorithms/acquisition/gnuradio_blocks/pcps_tong_acquisition_cc.h
@@ -73,7 +73,8 @@ pcps_tong_acquisition_cc_sptr pcps_tong_make_acquisition_cc(
     uint32_t tong_max_val,
     uint32_t tong_max_dwells,
     bool dump,
-    const std::string& dump_filename);
+    const std::string& dump_filename,
+    bool enable_monitor_output);
 
 /*!
  * \brief This class implements a Parallel Code Phase Search Acquisition with
@@ -191,13 +192,13 @@ private:
         int64_t fs_in, int32_t samples_per_ms,
         int32_t samples_per_code, uint32_t tong_init_val,
         uint32_t tong_max_val, uint32_t tong_max_dwells,
-        bool dump, const std::string& dump_filename);
+        bool dump, const std::string& dump_filename, bool enable_monitor_output);
 
     pcps_tong_acquisition_cc(uint32_t sampled_ms, uint32_t doppler_max,
         int64_t fs_in, int32_t samples_per_ms,
         int32_t samples_per_code, uint32_t tong_init_val,
         uint32_t tong_max_val, uint32_t tong_max_dwells,
-        bool dump, const std::string& dump_filename);
+        bool dump, const std::string& dump_filename, bool enable_monitor_output);
 
     void calculate_magnitudes(gr_complex* fft_begin, int32_t doppler_shift,
         int32_t doppler_offset);
@@ -246,6 +247,7 @@ private:
 
     bool d_active;
     bool d_dump;
+    bool d_enable_monitor_output;
 };
 
 #endif  // GNSS_SDR_PCPS_TONG_ACQUISITION_CC_H

--- a/src/algorithms/acquisition/libs/acq_conf.cc
+++ b/src/algorithms/acquisition/libs/acq_conf.cc
@@ -56,6 +56,7 @@ Acq_Conf::Acq_Conf()
     resampler_ratio = 1.0;
     resampled_fs = 0LL;
     resampler_latency_samples = 0U;
+    enable_monitor_output = false;
 }
 
 
@@ -120,6 +121,8 @@ void Acq_Conf::SetFromConfiguration(const ConfigurationInterface *configuration,
             // if pfa is not set, we use the first_vs_second_peak_statistic metric
             use_CFAR_algorithm_flag = false;
         }
+
+    enable_monitor_output = configuration->property("AcquisitionMonitor.enable_monitor", false);
 
     SetDerivedParams();
 }

--- a/src/algorithms/acquisition/libs/acq_conf.h
+++ b/src/algorithms/acquisition/libs/acq_conf.h
@@ -67,6 +67,7 @@ public:
     bool blocking_on_standby;  // enable it only for unit testing to avoid sample consume on idle status
     bool make_2_steps;
     bool use_automatic_resampler;
+    bool enable_monitor_output;
 
 private:
     void SetDerivedParams();

--- a/src/algorithms/channel/adapters/channel.cc
+++ b/src/algorithms/channel/adapters/channel.cc
@@ -174,6 +174,10 @@ gr::basic_block_sptr Channel::get_left_block_trk()
     return trk_->get_left_block();
 }
 
+gr::basic_block_sptr Channel::get_right_block_trk()
+{
+    return trk_->get_right_block();
+}
 
 gr::basic_block_sptr Channel::get_left_block_acq()
 {
@@ -184,6 +188,10 @@ gr::basic_block_sptr Channel::get_left_block_acq()
     return acq_->get_left_block();
 }
 
+gr::basic_block_sptr Channel::get_right_block_acq()
+{
+    return acq_->get_right_block();
+}
 
 gr::basic_block_sptr Channel::get_right_block()
 {

--- a/src/algorithms/channel/adapters/channel.h
+++ b/src/algorithms/channel/adapters/channel.h
@@ -68,11 +68,11 @@ public:
     void connect(gr::top_block_sptr top_block) override;  //!< Connects the tracking block to the top_block and to the telemetry
     void disconnect(gr::top_block_sptr top_block) override;
     gr::basic_block_sptr get_left_block() override;
-    gr::basic_block_sptr get_left_block_trk() override;  //!< Gets the GNU Radio tracking block input pointer
+    gr::basic_block_sptr get_left_block_trk() override;   //!< Gets the GNU Radio tracking block input pointer
     gr::basic_block_sptr get_right_block_trk() override;  //!< Gets the GNU Radio tracking block output pointer
-    gr::basic_block_sptr get_left_block_acq() override;  //!< Gets the GNU Radio acquisition block input pointer
+    gr::basic_block_sptr get_left_block_acq() override;   //!< Gets the GNU Radio acquisition block input pointer
     gr::basic_block_sptr get_right_block_acq() override;  //!< Gets the GNU Radio acquisition block output pointer
-    gr::basic_block_sptr get_right_block() override;     //!< Gets the GNU Radio channel block output pointer
+    gr::basic_block_sptr get_right_block() override;      //!< Gets the GNU Radio channel block output pointer
 
     inline std::string role() override { return role_; }
     inline std::string implementation() override { return std::string("Channel"); }  //!< Returns "Channel"

--- a/src/algorithms/channel/adapters/channel.h
+++ b/src/algorithms/channel/adapters/channel.h
@@ -69,7 +69,9 @@ public:
     void disconnect(gr::top_block_sptr top_block) override;
     gr::basic_block_sptr get_left_block() override;
     gr::basic_block_sptr get_left_block_trk() override;  //!< Gets the GNU Radio tracking block input pointer
+    gr::basic_block_sptr get_right_block_trk() override;  //!< Gets the GNU Radio tracking block output pointer
     gr::basic_block_sptr get_left_block_acq() override;  //!< Gets the GNU Radio acquisition block input pointer
+    gr::basic_block_sptr get_right_block_acq() override;  //!< Gets the GNU Radio acquisition block output pointer
     gr::basic_block_sptr get_right_block() override;     //!< Gets the GNU Radio channel block output pointer
 
     inline std::string role() override { return role_; }

--- a/src/algorithms/tracking/gnuradio_blocks/galileo_e1_tcp_connector_tracking_cc.cc
+++ b/src/algorithms/tracking/gnuradio_blocks/galileo_e1_tcp_connector_tracking_cc.cc
@@ -283,6 +283,7 @@ int Galileo_E1_Tcp_Connector_Tracking_cc::general_work(int noutput_items __attri
     // process vars
     float carr_error_filt_hz = 0.0;
     float code_error_filt_chips = 0.0;
+    bool loss_of_lock = false;
 
     Tcp_Packet_Data tcp_data;
     // GNSS_SYNCHRO OBJECT to interchange data between tracking->telemetry_decoder
@@ -420,6 +421,7 @@ int Galileo_E1_Tcp_Connector_Tracking_cc::general_work(int noutput_items __attri
 
                             d_carrier_lock_fail_counter = 0;
                             d_enable_tracking = false;  // TODO: check if disabling tracking is consistent with the channel state machine
+                            loss_of_lock = true;
                         }
                 }
 
@@ -433,7 +435,7 @@ int Galileo_E1_Tcp_Connector_Tracking_cc::general_work(int noutput_items __attri
             current_synchro_data.Carrier_phase_rads = static_cast<double>(d_acc_carrier_phase_rad);
             current_synchro_data.Carrier_Doppler_hz = static_cast<double>(d_carrier_doppler_hz);
             current_synchro_data.CN0_dB_hz = static_cast<double>(d_CN0_SNV_dB_Hz);
-            current_synchro_data.Flag_valid_symbol_output = true;
+            current_synchro_data.Flag_valid_symbol_output = !loss_of_lock;
             current_synchro_data.correlation_length_ms = 4;
         }
     else
@@ -524,7 +526,7 @@ int Galileo_E1_Tcp_Connector_Tracking_cc::general_work(int noutput_items __attri
     consume_each(d_current_prn_length_samples);        // this is needed in gr::block derivates
     d_sample_counter += d_current_prn_length_samples;  // count for the processed samples
 
-    if (d_enable_tracking)
+    if (d_enable_tracking || loss_of_lock)
         {
             return 1;
         }

--- a/src/algorithms/tracking/gnuradio_blocks/glonass_l1_ca_dll_pll_c_aid_tracking_cc.cc
+++ b/src/algorithms/tracking/gnuradio_blocks/glonass_l1_ca_dll_pll_c_aid_tracking_cc.cc
@@ -572,6 +572,7 @@ int glonass_l1_ca_dll_pll_c_aid_tracking_cc::general_work(int noutput_items __at
     double code_error_filt_secs_Ti = 0.0;
     double CURRENT_INTEGRATION_TIME_S = 0.0;
     double CORRECTED_INTEGRATION_TIME_S = 0.0;
+    bool loss_of_lock = false;
 
     if (d_enable_tracking == true)
         {
@@ -780,6 +781,7 @@ int glonass_l1_ca_dll_pll_c_aid_tracking_cc::general_work(int noutput_items __at
                                     this->message_port_pub(pmt::mp("events"), pmt::from_long(3));  // 3 -> loss of lock
                                     d_carrier_lock_fail_counter = 0;
                                     d_enable_tracking = false;  // TODO: check if disabling tracking is consistent with the channel state machine
+                                    loss_of_lock = true;
                                 }
                             check_carrier_phase_coherent_initialization();
                         }
@@ -791,7 +793,7 @@ int glonass_l1_ca_dll_pll_c_aid_tracking_cc::general_work(int noutput_items __at
                     current_synchro_data.Carrier_phase_rads = TWO_PI * d_acc_carrier_phase_cycles;
                     current_synchro_data.Carrier_Doppler_hz = d_carrier_doppler_hz;
                     current_synchro_data.CN0_dB_hz = d_CN0_SNV_dB_Hz;
-                    current_synchro_data.Flag_valid_symbol_output = true;
+                    current_synchro_data.Flag_valid_symbol_output = !loss_of_lock;
                     if (d_preamble_synchronized == true)
                         {
                             current_synchro_data.correlation_length_ms = d_extend_correlation_ms;

--- a/src/algorithms/tracking/gnuradio_blocks/glonass_l1_ca_dll_pll_c_aid_tracking_sc.cc
+++ b/src/algorithms/tracking/gnuradio_blocks/glonass_l1_ca_dll_pll_c_aid_tracking_sc.cc
@@ -575,6 +575,7 @@ int glonass_l1_ca_dll_pll_c_aid_tracking_sc::general_work(int noutput_items __at
     double code_error_filt_secs_Ti = 0.0;
     double CURRENT_INTEGRATION_TIME_S = 0.0;
     double CORRECTED_INTEGRATION_TIME_S = 0.0;
+    bool loss_of_lock = false;
 
     if (d_enable_tracking == true)
         {
@@ -781,6 +782,7 @@ int glonass_l1_ca_dll_pll_c_aid_tracking_sc::general_work(int noutput_items __at
                                     this->message_port_pub(pmt::mp("events"), pmt::from_long(3));  // 3 -> loss of lock
                                     d_carrier_lock_fail_counter = 0;
                                     d_enable_tracking = false;  // TODO: check if disabling tracking is consistent with the channel state machine
+                                    loss_of_lock = true;
                                 }
                             check_carrier_phase_coherent_initialization();
                         }
@@ -793,7 +795,7 @@ int glonass_l1_ca_dll_pll_c_aid_tracking_sc::general_work(int noutput_items __at
                     current_synchro_data.Carrier_phase_rads = TWO_PI * d_acc_carrier_phase_cycles;
                     current_synchro_data.Carrier_Doppler_hz = d_carrier_doppler_hz;
                     current_synchro_data.CN0_dB_hz = d_CN0_SNV_dB_Hz;
-                    current_synchro_data.Flag_valid_symbol_output = true;
+                    current_synchro_data.Flag_valid_symbol_output = !loss_of_lock;
                     if (d_preamble_synchronized == true)
                         {
                             current_synchro_data.correlation_length_ms = d_extend_correlation_ms;

--- a/src/algorithms/tracking/gnuradio_blocks/glonass_l1_ca_dll_pll_tracking_cc.cc
+++ b/src/algorithms/tracking/gnuradio_blocks/glonass_l1_ca_dll_pll_tracking_cc.cc
@@ -507,6 +507,7 @@ int Glonass_L1_Ca_Dll_Pll_Tracking_cc::general_work(int noutput_items __attribut
     double carr_error_filt_hz = 0.0;
     double code_error_chips = 0.0;
     double code_error_filt_chips = 0.0;
+    bool loss_of_lock = false;
 
     // Block input data and block output stream pointers
     const auto *in = reinterpret_cast<const gr_complex *>(input_items[0]);  // PRN start block alignment
@@ -628,6 +629,7 @@ int Glonass_L1_Ca_Dll_Pll_Tracking_cc::general_work(int noutput_items __attribut
                             this->message_port_pub(pmt::mp("events"), pmt::from_long(3));  // 3 -> loss of lock
                             d_carrier_lock_fail_counter = 0;
                             d_enable_tracking = false;  // TODO: check if disabling tracking is consistent with the channel state machine
+                            loss_of_lock = true;
                         }
                     check_carrier_phase_coherent_initialization();
                 }
@@ -639,7 +641,7 @@ int Glonass_L1_Ca_Dll_Pll_Tracking_cc::general_work(int noutput_items __attribut
             current_synchro_data.Carrier_phase_rads = d_acc_carrier_phase_rad;
             current_synchro_data.Carrier_Doppler_hz = d_carrier_doppler_hz;
             current_synchro_data.CN0_dB_hz = d_CN0_SNV_dB_Hz;
-            current_synchro_data.Flag_valid_symbol_output = true;
+            current_synchro_data.Flag_valid_symbol_output = !loss_of_lock;
             current_synchro_data.correlation_length_ms = 1;
         }
     else

--- a/src/algorithms/tracking/gnuradio_blocks/glonass_l2_ca_dll_pll_c_aid_tracking_cc.cc
+++ b/src/algorithms/tracking/gnuradio_blocks/glonass_l2_ca_dll_pll_c_aid_tracking_cc.cc
@@ -571,6 +571,7 @@ int glonass_l2_ca_dll_pll_c_aid_tracking_cc::general_work(int noutput_items __at
     double code_error_filt_secs_Ti = 0.0;
     double CURRENT_INTEGRATION_TIME_S = 0.0;
     double CORRECTED_INTEGRATION_TIME_S = 0.0;
+    bool loss_of_lock = false;
 
     if (d_enable_tracking == true)
         {
@@ -779,6 +780,7 @@ int glonass_l2_ca_dll_pll_c_aid_tracking_cc::general_work(int noutput_items __at
                                     this->message_port_pub(pmt::mp("events"), pmt::from_long(3));  // 3 -> loss of lock
                                     d_carrier_lock_fail_counter = 0;
                                     d_enable_tracking = false;  // TODO: check if disabling tracking is consistent with the channel state machine
+                                    loss_of_lock = true;
                                 }
                             check_carrier_phase_coherent_initialization();
                         }
@@ -790,7 +792,7 @@ int glonass_l2_ca_dll_pll_c_aid_tracking_cc::general_work(int noutput_items __at
                     current_synchro_data.Carrier_phase_rads = TWO_PI * d_acc_carrier_phase_cycles;
                     current_synchro_data.Carrier_Doppler_hz = d_carrier_doppler_hz;
                     current_synchro_data.CN0_dB_hz = d_CN0_SNV_dB_Hz;
-                    current_synchro_data.Flag_valid_symbol_output = true;
+                    current_synchro_data.Flag_valid_symbol_output = !loss_of_lock;
                     if (d_preamble_synchronized == true)
                         {
                             current_synchro_data.correlation_length_ms = d_extend_correlation_ms;

--- a/src/algorithms/tracking/gnuradio_blocks/glonass_l2_ca_dll_pll_c_aid_tracking_sc.cc
+++ b/src/algorithms/tracking/gnuradio_blocks/glonass_l2_ca_dll_pll_c_aid_tracking_sc.cc
@@ -573,6 +573,7 @@ int glonass_l2_ca_dll_pll_c_aid_tracking_sc::general_work(int noutput_items __at
     double code_error_filt_secs_Ti = 0.0;
     double CURRENT_INTEGRATION_TIME_S = 0.0;
     double CORRECTED_INTEGRATION_TIME_S = 0.0;
+    bool loss_of_lock = false;
 
     if (d_enable_tracking == true)
         {
@@ -779,6 +780,7 @@ int glonass_l2_ca_dll_pll_c_aid_tracking_sc::general_work(int noutput_items __at
                                     this->message_port_pub(pmt::mp("events"), pmt::from_long(3));  // 3 -> loss of lock
                                     d_carrier_lock_fail_counter = 0;
                                     d_enable_tracking = false;  // TODO: check if disabling tracking is consistent with the channel state machine
+                                    loss_of_lock = true;
                                 }
                             check_carrier_phase_coherent_initialization();
                         }
@@ -791,7 +793,7 @@ int glonass_l2_ca_dll_pll_c_aid_tracking_sc::general_work(int noutput_items __at
                     current_synchro_data.Carrier_phase_rads = TWO_PI * d_acc_carrier_phase_cycles;
                     current_synchro_data.Carrier_Doppler_hz = d_carrier_doppler_hz;
                     current_synchro_data.CN0_dB_hz = d_CN0_SNV_dB_Hz;
-                    current_synchro_data.Flag_valid_symbol_output = true;
+                    current_synchro_data.Flag_valid_symbol_output = !loss_of_lock;
                     if (d_preamble_synchronized == true)
                         {
                             current_synchro_data.correlation_length_ms = d_extend_correlation_ms;

--- a/src/algorithms/tracking/gnuradio_blocks/glonass_l2_ca_dll_pll_tracking_cc.cc
+++ b/src/algorithms/tracking/gnuradio_blocks/glonass_l2_ca_dll_pll_tracking_cc.cc
@@ -509,6 +509,7 @@ int Glonass_L2_Ca_Dll_Pll_Tracking_cc::general_work(int noutput_items __attribut
     double carr_error_filt_hz = 0.0;
     double code_error_chips = 0.0;
     double code_error_filt_chips = 0.0;
+    bool loss_of_lock = false;
 
     // Block input data and block output stream pointers
     const auto *in = reinterpret_cast<const gr_complex *>(input_items[0]);  // PRN start block alignment
@@ -630,6 +631,7 @@ int Glonass_L2_Ca_Dll_Pll_Tracking_cc::general_work(int noutput_items __attribut
                             this->message_port_pub(pmt::mp("events"), pmt::from_long(3));  // 3 -> loss of lock
                             d_carrier_lock_fail_counter = 0;
                             d_enable_tracking = false;  // TODO: check if disabling tracking is consistent with the channel state machine
+                            loss_of_lock = true;
                         }
                     check_carrier_phase_coherent_initialization();
                 }
@@ -641,7 +643,7 @@ int Glonass_L2_Ca_Dll_Pll_Tracking_cc::general_work(int noutput_items __attribut
             current_synchro_data.Carrier_phase_rads = d_acc_carrier_phase_rad;
             current_synchro_data.Carrier_Doppler_hz = d_carrier_doppler_hz;
             current_synchro_data.CN0_dB_hz = d_CN0_SNV_dB_Hz;
-            current_synchro_data.Flag_valid_symbol_output = true;
+            current_synchro_data.Flag_valid_symbol_output = !loss_of_lock;
             current_synchro_data.correlation_length_ms = 1;
         }
     else

--- a/src/algorithms/tracking/gnuradio_blocks/gps_l1_ca_dll_pll_tracking_gpu_cc.cc
+++ b/src/algorithms/tracking/gnuradio_blocks/gps_l1_ca_dll_pll_tracking_gpu_cc.cc
@@ -328,6 +328,8 @@ int Gps_L1_Ca_Dll_Pll_Tracking_GPU_cc::general_work(int noutput_items __attribut
     double CORRECTED_INTEGRATION_TIME_S = 0.001;
     double dll_code_error_secs_Ti = 0.0;
     double carr_phase_error_secs_Ti = 0.0;
+    bool loss_of_lock = false;
+
     if (d_enable_tracking == true)
         {
             // Fill the acquisition data
@@ -446,6 +448,7 @@ int Gps_L1_Ca_Dll_Pll_Tracking_GPU_cc::general_work(int noutput_items __attribut
                             this->message_port_pub(pmt::mp("events"), pmt::from_long(3));  // 3 -> loss of lock
                             d_carrier_lock_fail_counter = 0;
                             d_enable_tracking = false;  // TODO: check if disabling tracking is consistent with the channel state machine
+                            loss_of_lock = true;
                         }
                     check_carrier_phase_coherent_initialization();
                 }
@@ -458,7 +461,7 @@ int Gps_L1_Ca_Dll_Pll_Tracking_GPU_cc::general_work(int noutput_items __attribut
             current_synchro_data.Carrier_phase_rads = TWO_PI * d_acc_carrier_phase_cycles;
             current_synchro_data.Carrier_Doppler_hz = d_carrier_doppler_hz;
             current_synchro_data.CN0_dB_hz = d_CN0_SNV_dB_Hz;
-            current_synchro_data.Flag_valid_symbol_output = true;
+            current_synchro_data.Flag_valid_symbol_output = !loss_of_lock;
             current_synchro_data.correlation_length_ms = 1;
         }
     else
@@ -545,7 +548,7 @@ int Gps_L1_Ca_Dll_Pll_Tracking_GPU_cc::general_work(int noutput_items __attribut
     consume_each(d_correlation_length_samples);        // this is necessary in gr::block derivates
     d_sample_counter += d_correlation_length_samples;  // count for the processed samples
 
-    if (d_enable_tracking)
+    if (d_enable_tracking || loss_of_lock)
         {
             return 1;
         }

--- a/src/algorithms/tracking/gnuradio_blocks/gps_l1_ca_kf_tracking_cc.cc
+++ b/src/algorithms/tracking/gnuradio_blocks/gps_l1_ca_kf_tracking_cc.cc
@@ -621,6 +621,7 @@ int Gps_L1_Ca_Kf_Tracking_cc::general_work(int noutput_items __attribute__((unus
     d_carr_phase_error_rad = 0.0;
     code_error_chips = 0.0;
     code_error_filt_chips = 0.0;
+    bool loss_of_lock = false;
 
     // Block input data and block output stream pointers
     const auto *in = reinterpret_cast<const gr_complex *>(input_items[0]);
@@ -800,6 +801,7 @@ int Gps_L1_Ca_Kf_Tracking_cc::general_work(int noutput_items __attribute__((unus
                             this->message_port_pub(pmt::mp("events"), pmt::from_long(3));  // 3 -> loss of lock
                             d_carrier_lock_fail_counter = 0;
                             d_enable_tracking = false;
+                            loss_of_lock = true;
                         }
                 }
             // ########### Output the tracking data to navigation and PVT ##########
@@ -810,7 +812,7 @@ int Gps_L1_Ca_Kf_Tracking_cc::general_work(int noutput_items __attribute__((unus
             current_synchro_data.Carrier_phase_rads = d_acc_carrier_phase_rad;
             current_synchro_data.Carrier_Doppler_hz = d_carrier_doppler_hz;
             current_synchro_data.CN0_dB_hz = d_CN0_SNV_dB_Hz;
-            current_synchro_data.Flag_valid_symbol_output = true;
+            current_synchro_data.Flag_valid_symbol_output = !loss_of_lock;
             current_synchro_data.correlation_length_ms = 1;
 
             kf_iter++;

--- a/src/core/interfaces/channel_interface.h
+++ b/src/core/interfaces/channel_interface.h
@@ -41,7 +41,9 @@ class ChannelInterface : public GNSSBlockInterface
 {
 public:
     virtual gr::basic_block_sptr get_left_block_trk() = 0;
+    virtual gr::basic_block_sptr get_right_block_trk() = 0;
     virtual gr::basic_block_sptr get_left_block_acq() = 0;
+    virtual gr::basic_block_sptr get_right_block_acq() = 0;
     virtual gr::basic_block_sptr get_left_block() = 0;
     virtual gr::basic_block_sptr get_right_block() = 0;
     virtual Gnss_Signal get_signal() const = 0;

--- a/src/core/monitor/gnss_synchro_monitor.h
+++ b/src/core/monitor/gnss_synchro_monitor.h
@@ -24,8 +24,8 @@
 #define GNSS_SDR_GNSS_SYNCHRO_MONITOR_H
 
 #include "gnss_synchro_udp_sink.h"
-#include <gnuradio/runtime_types.h>  // for gr_vector_void_star
 #include <gnuradio/block.h>
+#include <gnuradio/runtime_types.h>  // for gr_vector_void_star
 #include <memory>
 #include <string>
 #include <vector>

--- a/src/core/monitor/gnss_synchro_monitor.h
+++ b/src/core/monitor/gnss_synchro_monitor.h
@@ -25,7 +25,7 @@
 
 #include "gnss_synchro_udp_sink.h"
 #include <gnuradio/runtime_types.h>  // for gr_vector_void_star
-#include <gnuradio/sync_block.h>
+#include <gnuradio/block.h>
 #include <memory>
 #include <string>
 #include <vector>
@@ -54,13 +54,13 @@ gnss_synchro_monitor_sptr gnss_synchro_make_monitor(int n_channels,
  * a data stream with the receiver internal parameters (Gnss_Synchro objects)
  * to local or remote clients over UDP.
  */
-class gnss_synchro_monitor : public gr::sync_block
+class gnss_synchro_monitor : public gr::block
 {
 public:
     ~gnss_synchro_monitor() = default;  //!< Default destructor
-
-    int work(int noutput_items, gr_vector_const_void_star& input_items,
-        gr_vector_void_star& output_items);
+    void forecast(int noutput_items, gr_vector_int& ninput_items_required);
+    int general_work(int noutput_items, gr_vector_int& ninput_items,
+        gr_vector_const_void_star& input_items, gr_vector_void_star& output_items);
 
 private:
     friend gnss_synchro_monitor_sptr gnss_synchro_make_monitor(int n_channels,
@@ -78,7 +78,6 @@ private:
     int d_nchannels;
     int d_decimation_factor;
     std::unique_ptr<Gnss_Synchro_Udp_Sink> udp_sink_ptr;
-    int count;
 };
 
 #endif

--- a/src/core/receiver/gnss_flowgraph.cc
+++ b/src/core/receiver/gnss_flowgraph.cc
@@ -1706,7 +1706,6 @@ void GNSSFlowgraph::init()
                 configuration_->property("TrackingMonitor.udp_port", 1236),
                 udp_addr_vec, enable_protobuf);
         }
-
 }
 
 

--- a/src/core/receiver/gnss_flowgraph.cc
+++ b/src/core/receiver/gnss_flowgraph.cc
@@ -715,6 +715,44 @@ void GNSSFlowgraph::connect()
                     return;
                 }
         }
+
+    // GNSS SYNCHRO ACQUISITION MONITOR
+    if (enable_acquisition_monitor_)
+        {
+            try
+                {
+                    for (int i = 0; i < channels_count_; i++)
+                        {
+                            top_block_->connect(channels_.at(i)->get_right_block_acq(), 0, GnssSynchroAcquisitionMonitor_, i);
+                        }
+                }
+            catch (const std::exception& e)
+                {
+                    LOG(WARNING) << "Can't connect acquisition intermediate outputs to Monitor block";
+                    LOG(ERROR) << e.what();
+                    top_block_->disconnect_all();
+                    return;
+                }
+        }
+
+    // GNSS SYNCHRO TRACKING MONITOR
+    if (enable_tracking_monitor_)
+        {
+            try
+                {
+                    for (int i = 0; i < channels_count_; i++)
+                        {
+                            top_block_->connect(channels_.at(i)->get_right_block_trk(), 0, GnssSynchroTrackingMonitor_, i);
+                        }
+                }
+            catch (const std::exception& e)
+                {
+                    LOG(WARNING) << "Can't connect tracking outputs to Monitor block";
+                    LOG(ERROR) << e.what();
+                    top_block_->disconnect_all();
+                    return;
+                }
+        }
 #ifndef ENABLE_FPGA
     // Activate acquisition in enabled channels
     for (int i = 0; i < channels_count_; i++)
@@ -956,6 +994,14 @@ void GNSSFlowgraph::disconnect()
                     if (enable_monitor_)
                         {
                             top_block_->disconnect(observables_->get_right_block(), i, GnssSynchroMonitor_, i);
+                        }
+                    if (enable_acquisition_monitor_)
+                        {
+                            top_block_->disconnect(channels_.at(i)->get_right_block_acq(), 0, GnssSynchroAcquisitionMonitor_, i);
+                        }
+                    if (enable_tracking_monitor_)
+                        {
+                            top_block_->disconnect(channels_.at(i)->get_right_block_trk(), 0, GnssSynchroTrackingMonitor_, i);
                         }
                     top_block_->msg_disconnect(channels_.at(i)->get_right_block(), pmt::mp("telemetry"), pvt_->get_left_block(), pmt::mp("telemetry"));
                 }
@@ -1595,23 +1641,72 @@ void GNSSFlowgraph::init()
      * Instantiate the receiver monitor block, if required
      */
     enable_monitor_ = configuration_->property("Monitor.enable_monitor", false);
-    bool enable_protobuf = configuration_->property("Monitor.enable_protobuf", true);
-    if (configuration_->property("PVT.enable_protobuf", false) == true)
-        {
-            enable_protobuf = true;
-        }
-    std::string address_string = configuration_->property("Monitor.client_addresses", std::string("127.0.0.1"));
-    std::vector<std::string> udp_addr_vec = split_string(address_string, '_');
-    std::sort(udp_addr_vec.begin(), udp_addr_vec.end());
-    udp_addr_vec.erase(std::unique(udp_addr_vec.begin(), udp_addr_vec.end()), udp_addr_vec.end());
-
     if (enable_monitor_)
         {
+            // Retrieve monitor properties
+            bool enable_protobuf = configuration_->property("Monitor.enable_protobuf", true);
+            if (configuration_->property("PVT.enable_protobuf", false) == true)
+                {
+                    enable_protobuf = true;
+                }
+            std::string address_string = configuration_->property("Monitor.client_addresses", std::string("127.0.0.1"));
+            std::vector<std::string> udp_addr_vec = split_string(address_string, '_');
+            std::sort(udp_addr_vec.begin(), udp_addr_vec.end());
+            udp_addr_vec.erase(std::unique(udp_addr_vec.begin(), udp_addr_vec.end()), udp_addr_vec.end());
+
+            // Instantiate monitor object
             GnssSynchroMonitor_ = gnss_synchro_make_monitor(channels_count_,
                 configuration_->property("Monitor.decimation_factor", 1),
                 configuration_->property("Monitor.udp_port", 1234),
                 udp_addr_vec, enable_protobuf);
         }
+
+    /*
+     * Instantiate the receiver acquisition monitor block, if required
+     */
+    enable_acquisition_monitor_ = configuration_->property("AcquisitionMonitor.enable_monitor", false);
+    if (enable_acquisition_monitor_)
+        {
+            // Retrieve monitor properties
+            bool enable_protobuf = configuration_->property("AcquisitionMonitor.enable_protobuf", true);
+            if (configuration_->property("PVT.enable_protobuf", false) == true)
+                {
+                    enable_protobuf = true;
+                }
+            std::string address_string = configuration_->property("AcquisitionMonitor.client_addresses", std::string("127.0.0.1"));
+            std::vector<std::string> udp_addr_vec = split_string(address_string, '_');
+            std::sort(udp_addr_vec.begin(), udp_addr_vec.end());
+            udp_addr_vec.erase(std::unique(udp_addr_vec.begin(), udp_addr_vec.end()), udp_addr_vec.end());
+
+            GnssSynchroAcquisitionMonitor_ = gnss_synchro_make_monitor(channels_count_,
+                configuration_->property("AcquisitionMonitor.decimation_factor", 1),
+                configuration_->property("AcquisitionMonitor.udp_port", 1235),
+                udp_addr_vec, enable_protobuf);
+        }
+
+    /*
+     * Instantiate the receiver tracking monitor block, if required
+     */
+    enable_tracking_monitor_ = configuration_->property("TrackingMonitor.enable_monitor", false);
+    if (enable_tracking_monitor_)
+        {
+            // Retrieve monitor properties
+            bool enable_protobuf = configuration_->property("TrackingMonitor.enable_protobuf", true);
+            if (configuration_->property("PVT.enable_protobuf", false) == true)
+                {
+                    enable_protobuf = true;
+                }
+            std::string address_string = configuration_->property("TrackingMonitor.client_addresses", std::string("127.0.0.1"));
+            std::vector<std::string> udp_addr_vec = split_string(address_string, '_');
+            std::sort(udp_addr_vec.begin(), udp_addr_vec.end());
+            udp_addr_vec.erase(std::unique(udp_addr_vec.begin(), udp_addr_vec.end()), udp_addr_vec.end());
+
+            GnssSynchroTrackingMonitor_ = gnss_synchro_make_monitor(channels_count_,
+                configuration_->property("TrackingMonitor.decimation_factor", 1),
+                configuration_->property("TrackingMonitor.udp_port", 1236),
+                udp_addr_vec, enable_protobuf);
+        }
+
 }
 
 

--- a/src/core/receiver/gnss_flowgraph.h
+++ b/src/core/receiver/gnss_flowgraph.h
@@ -191,6 +191,8 @@ private:
     std::vector<gr::blocks::null_sink::sptr> null_sinks_;
 
     gr::basic_block_sptr GnssSynchroMonitor_;
+    gr::basic_block_sptr GnssSynchroAcquisitionMonitor_;
+    gr::basic_block_sptr GnssSynchroTrackingMonitor_;
     channel_status_msg_receiver_sptr channels_status_;  // class that receives and stores the current status of the receiver channels
     gnss_sdr_sample_counter_sptr ch_out_sample_counter_;
 #if ENABLE_FPGA
@@ -240,6 +242,8 @@ private:
     bool running_;
     bool multiband_;
     bool enable_monitor_;
+    bool enable_acquisition_monitor_;
+    bool enable_tracking_monitor_;
 };
 
 #endif  // GNSS_SDR_GNSS_FLOWGRAPH_H


### PR DESCRIPTION
Added acquisition and tracking monitors to view intermediate outputs of GNSS-SDR from monitoring clients. Each monitor (acquisition, tracking, original monitor, and pvt) pushes its data to a different UDP port.

* Added instantiations of the gnss_synchro_monitor called GnssSynchroAcquisitionMonitor_ and GnssSynchroTrackingMonitor_ in the gnss_flowgraph. Instantiated/connected/disconnected them at runtime based upon "AcquisitionMonitor.enable_monitor" and "TrackingMonitor.enable_monitor" configuration keys, respectively. The AcquisitionMonitor and TrackingMonitor have the same configuration keys as the original Monitor since they are instantiations of the same block.
* Modified the gnss_synchro_monitor from a gr::sync_block to a gr::block to support independent inputs from streams which allows monitor outputs from a single channel to be pushed to the UDP sink without waiting for the rest of the channels.
* Modified the channel_interface and the channel to add getter functions for the acquisition and tracking right blocks.
* Modified all tracking blocks (except for FPGA blocks) to output a Gnss_Synchro object on loss of lock with the Flag_valid_symbol_output set to false. This provides an active indication to applications using the TrackingMonitor that tracking on that channel has stopped.
* Modified the acq_conf to retrieve the "AcquisitionMonitor.enable_monitor" configuration key and set it as a member variable.
* Modified all acquisition blocks (except for fpga blocks) to have an optional Gnss_Synchro output and push the state of their Gnss_Syncho object to the output when positive acquisition is achieved. The Gnss_Synchro object is only pushed when "AcquisitionMonitor.enable_monitor" configuration key is set to true.
* Added gnss-sdr_GPS_L1_monitor.conf to test the new monitors with a signal source from file.
* Added gnss-sdr_GPS_L1_udp_with_monitor.conf to test the new monitors with a signal source from UDP.
* The changes above were only tested with the gnss-sdr_GPS_L1_udp_with_monitor.conf and gnss-sdr_GPS_L1_monitor.conf configuration files, meaning only GPS L1 C/A was functionally verified.

