### PR TITLE
close the DMA descriptor properly.

### DIFF
--- a/src/algorithms/signal_source/adapters/ad9361_fpga_signal_source.cc
+++ b/src/algorithms/signal_source/adapters/ad9361_fpga_signal_source.cc
@@ -592,6 +592,11 @@ void Ad9361FpgaSignalSource::run_DMA_process(const std::string &FreqBand, const 
             lock.unlock();
         }
 
+    if (close(tx_fd) < 0)
+        {
+            std::cerr << "Error closing loop device " << '\n';
+        }
+
     try
         {
             infile1.close();


### PR DESCRIPTION
close the DMA descriptor properly when running in post-processing mode.