### PR TITLE
Fix uio dev assignment

### DIFF
--- a/src/algorithms/acquisition/adapters/CMakeLists.txt
+++ b/src/algorithms/acquisition/adapters/CMakeLists.txt
@@ -132,7 +132,7 @@ if(ENABLE_FPGA)
     target_include_directories(acquisition_adapters
         PUBLIC
             ${CMAKE_SOURCE_DIR}/src/core/libs
-	)
+    )
 endif()
 
 target_include_directories(acquisition_adapters

--- a/src/algorithms/acquisition/adapters/CMakeLists.txt
+++ b/src/algorithms/acquisition/adapters/CMakeLists.txt
@@ -129,6 +129,10 @@ if(ENABLE_FPGA)
             Volk::volk
             Volkgnsssdr::volkgnsssdr
     )
+    target_include_directories(acquisition_adapters
+        PUBLIC
+            ${CMAKE_SOURCE_DIR}/src/core/libs
+	)
 endif()
 
 target_include_directories(acquisition_adapters

--- a/src/algorithms/acquisition/adapters/galileo_e1_pcps_ambiguous_acquisition_fpga.cc
+++ b/src/algorithms/acquisition/adapters/galileo_e1_pcps_ambiguous_acquisition_fpga.cc
@@ -82,11 +82,10 @@ GalileoE1PcpsAmbiguousAcquisitionFpga::GalileoE1PcpsAmbiguousAcquisitionFpga(
 
     // UIO device file
     std::string device_io_name;
-    std::string device_name = configuration->property(role + ".devicename", default_device_name);
-    // find the uio device file corresponding to the GNSS reset module
-    if (find_uio_dev_file_name(device_io_name, device_name, 0) < 0)
+    // find the uio device file corresponding to the acquisition
+    if (find_uio_dev_file_name(device_io_name, acquisition_device_name, 0) < 0)
         {
-            std::cout << "Cannot find the FPGA uio device file corresponding to device name " << device_name << std::endl;
+            std::cout << "Cannot find the FPGA uio device file corresponding to device name " << acquisition_device_name << std::endl;
             throw std::exception();
         }
     acq_parameters.device_name = device_io_name;

--- a/src/algorithms/acquisition/adapters/galileo_e1_pcps_ambiguous_acquisition_fpga.cc
+++ b/src/algorithms/acquisition/adapters/galileo_e1_pcps_ambiguous_acquisition_fpga.cc
@@ -24,6 +24,7 @@
 #include "galileo_e1_signal_replica.h"
 #include "gnss_sdr_flags.h"
 #include "gnss_sdr_make_unique.h"
+#include "uio_fpga.h"
 #include <glog/logging.h>
 #include <gnuradio/fft/fft.h>     // for fft_complex
 #include <gnuradio/gr_complex.h>  // for gr_complex
@@ -77,11 +78,19 @@ GalileoE1PcpsAmbiguousAcquisitionFpga::GalileoE1PcpsAmbiguousAcquisitionFpga(
     float nbits = ceilf(log2f(static_cast<float>(code_length) * 2.0F));
     uint32_t nsamples_total = pow(2, nbits);
     uint32_t select_queue_Fpga = configuration->property(role + ".select_queue_Fpga", 0);
-
     acq_parameters.select_queue_Fpga = select_queue_Fpga;
-    std::string default_device_name = "/dev/uio0";
+
+    // UIO device file
+    std::string device_io_name;
     std::string device_name = configuration->property(role + ".devicename", default_device_name);
-    acq_parameters.device_name = device_name;
+    // find the uio device file corresponding to the GNSS reset module
+    if (find_uio_dev_file_name(device_io_name, device_name, 0) < 0)
+        {
+            std::cout << "Cannot find the FPGA uio device file corresponding to device name " << device_name << std::endl;
+            throw std::exception();
+        }
+    acq_parameters.device_name = device_io_name;
+
     acq_parameters.samples_per_code = nsamples_total;
     acq_parameters.excludelimit = static_cast<unsigned int>(1 + ceil((1.0 / GALILEO_E1_CODE_CHIP_RATE_CPS) * static_cast<float>(fs_in)));
 

--- a/src/algorithms/acquisition/adapters/galileo_e1_pcps_ambiguous_acquisition_fpga.h
+++ b/src/algorithms/acquisition/adapters/galileo_e1_pcps_ambiguous_acquisition_fpga.h
@@ -183,7 +183,7 @@ public:
     void set_resampler_latency(uint32_t latency_samples __attribute__((unused))) override{};
 
 private:
-    const std::string default_device_name = "acquisition_S00_AXI";  // UIO device name
+    const std::string acquisition_device_name = "acquisition_S00_AXI";  // UIO device name
 
     // the following flags are FPGA-specific and they are using arrange the values of the fft of the local code in the way the FPGA
     // expects. This arrangement is done in the initialisation to avoid consuming unnecessary clock cycles during tracking.

--- a/src/algorithms/acquisition/adapters/galileo_e1_pcps_ambiguous_acquisition_fpga.h
+++ b/src/algorithms/acquisition/adapters/galileo_e1_pcps_ambiguous_acquisition_fpga.h
@@ -183,6 +183,8 @@ public:
     void set_resampler_latency(uint32_t latency_samples __attribute__((unused))) override{};
 
 private:
+    const std::string default_device_name = "acquisition_S00_AXI";  // UIO device name
+
     // the following flags are FPGA-specific and they are using arrange the values of the fft of the local code in the way the FPGA
     // expects. This arrangement is done in the initialisation to avoid consuming unnecessary clock cycles during tracking.
     static const uint32_t quant_bits_local_code = 16;

--- a/src/algorithms/acquisition/adapters/galileo_e5a_pcps_acquisition_fpga.cc
+++ b/src/algorithms/acquisition/adapters/galileo_e5a_pcps_acquisition_fpga.cc
@@ -84,11 +84,10 @@ GalileoE5aPcpsAcquisitionFpga::GalileoE5aPcpsAcquisitionFpga(
 
     // UIO device file
     std::string device_io_name;
-    std::string device_name = configuration->property(role + ".devicename", default_device_name);
-    // find the uio device file corresponding to the GNSS reset module
-    if (find_uio_dev_file_name(device_io_name, device_name, 0) < 0)
+    // find the uio device file corresponding to the acquisition
+    if (find_uio_dev_file_name(device_io_name, acquisition_device_name, 0) < 0)
         {
-            std::cout << "Cannot find the FPGA uio device file corresponding to device name " << device_name << std::endl;
+            std::cout << "Cannot find the FPGA uio device file corresponding to device name " << acquisition_device_name << std::endl;
             throw std::exception();
         }
     acq_parameters.device_name = device_io_name;

--- a/src/algorithms/acquisition/adapters/galileo_e5a_pcps_acquisition_fpga.cc
+++ b/src/algorithms/acquisition/adapters/galileo_e5a_pcps_acquisition_fpga.cc
@@ -24,6 +24,7 @@
 #include "galileo_e5_signal_replica.h"
 #include "gnss_sdr_flags.h"
 #include "gnss_sdr_make_unique.h"
+#include "uio_fpga.h"
 #include <glog/logging.h>
 #include <gnuradio/fft/fft.h>     // for fft_complex
 #include <gnuradio/gr_complex.h>  // for gr_complex
@@ -80,11 +81,19 @@ GalileoE5aPcpsAcquisitionFpga::GalileoE5aPcpsAcquisitionFpga(
     uint32_t nsamples_total = pow(2, nbits);
     uint32_t select_queue_Fpga = configuration->property(role + ".select_queue_Fpga", 1);
     acq_parameters.select_queue_Fpga = select_queue_Fpga;
-    std::string default_device_name = "/dev/uio0";
-    std::string device_name = configuration->property(role + ".devicename", default_device_name);
-    acq_parameters.device_name = device_name;
-    acq_parameters.samples_per_code = nsamples_total;
 
+    // UIO device file
+    std::string device_io_name;
+    std::string device_name = configuration->property(role + ".devicename", default_device_name);
+    // find the uio device file corresponding to the GNSS reset module
+    if (find_uio_dev_file_name(device_io_name, device_name, 0) < 0)
+        {
+            std::cout << "Cannot find the FPGA uio device file corresponding to device name " << device_name << std::endl;
+            throw std::exception();
+        }
+    acq_parameters.device_name = device_io_name;
+
+    acq_parameters.samples_per_code = nsamples_total;
     acq_parameters.excludelimit = static_cast<unsigned int>(1 + ceil((1.0 / GALILEO_E5A_CODE_CHIP_RATE_CPS) * static_cast<float>(fs_in)));
 
     // compute all the GALILEO E5 PRN Codes (this is done only once in the class constructor in order to avoid re-computing the PRN codes every time

--- a/src/algorithms/acquisition/adapters/galileo_e5a_pcps_acquisition_fpga.h
+++ b/src/algorithms/acquisition/adapters/galileo_e5a_pcps_acquisition_fpga.h
@@ -191,6 +191,8 @@ public:
     void set_resampler_latency(uint32_t latency_samples __attribute__((unused))) override{};
 
 private:
+    const std::string default_device_name = "acquisition_S00_AXI";  // UIO device name
+
     // the following flags are FPGA-specific and they are using arrange the values of the fft of the local code in the way the FPGA
     // expects. This arrangement is done in the initialisation to avoid consuming unnecessary clock cycles during tracking.
     static const uint32_t quant_bits_local_code = 16;

--- a/src/algorithms/acquisition/adapters/galileo_e5a_pcps_acquisition_fpga.h
+++ b/src/algorithms/acquisition/adapters/galileo_e5a_pcps_acquisition_fpga.h
@@ -191,7 +191,7 @@ public:
     void set_resampler_latency(uint32_t latency_samples __attribute__((unused))) override{};
 
 private:
-    const std::string default_device_name = "acquisition_S00_AXI";  // UIO device name
+    const std::string acquisition_device_name = "acquisition_S00_AXI";  // UIO device name
 
     // the following flags are FPGA-specific and they are using arrange the values of the fft of the local code in the way the FPGA
     // expects. This arrangement is done in the initialisation to avoid consuming unnecessary clock cycles during tracking.

--- a/src/algorithms/acquisition/adapters/galileo_e5b_pcps_acquisition_fpga.cc
+++ b/src/algorithms/acquisition/adapters/galileo_e5b_pcps_acquisition_fpga.cc
@@ -83,11 +83,10 @@ GalileoE5bPcpsAcquisitionFpga::GalileoE5bPcpsAcquisitionFpga(const Configuration
 
     // UIO device file
     std::string device_io_name;
-    std::string device_name = configuration->property(role + ".devicename", default_device_name);
-    // find the uio device file corresponding to the GNSS reset module
-    if (find_uio_dev_file_name(device_io_name, device_name, 0) < 0)
+    // find the uio device file corresponding to the acquisition
+    if (find_uio_dev_file_name(device_io_name, acquisition_device_name, 0) < 0)
         {
-            std::cout << "Cannot find the FPGA uio device file corresponding to device name " << device_name << std::endl;
+            std::cout << "Cannot find the FPGA uio device file corresponding to device name " << acquisition_device_name << std::endl;
             throw std::exception();
         }
     acq_parameters.device_name = device_io_name;

--- a/src/algorithms/acquisition/adapters/galileo_e5b_pcps_acquisition_fpga.cc
+++ b/src/algorithms/acquisition/adapters/galileo_e5b_pcps_acquisition_fpga.cc
@@ -24,6 +24,7 @@
 #include "configuration_interface.h"
 #include "galileo_e5_signal_replica.h"
 #include "gnss_sdr_flags.h"
+#include "uio_fpga.h"
 #include <glog/logging.h>
 #include <gnuradio/fft/fft.h>     // for fft_complex
 #include <gnuradio/gr_complex.h>  // for gr_complex
@@ -79,11 +80,19 @@ GalileoE5bPcpsAcquisitionFpga::GalileoE5bPcpsAcquisitionFpga(const Configuration
     uint32_t nsamples_total = pow(2, nbits);
     uint32_t select_queue_Fpga = configuration->property(role + ".select_queue_Fpga", 1);
     acq_parameters.select_queue_Fpga = select_queue_Fpga;
-    std::string default_device_name = "/dev/uio0";
-    std::string device_name = configuration->property(role + ".devicename", default_device_name);
-    acq_parameters.device_name = device_name;
-    acq_parameters.samples_per_code = nsamples_total;
 
+    // UIO device file
+    std::string device_io_name;
+    std::string device_name = configuration->property(role + ".devicename", default_device_name);
+    // find the uio device file corresponding to the GNSS reset module
+    if (find_uio_dev_file_name(device_io_name, device_name, 0) < 0)
+        {
+            std::cout << "Cannot find the FPGA uio device file corresponding to device name " << device_name << std::endl;
+            throw std::exception();
+        }
+    acq_parameters.device_name = device_io_name;
+
+    acq_parameters.samples_per_code = nsamples_total;
     acq_parameters.excludelimit = static_cast<unsigned int>(1 + ceil((1.0 / GALILEO_E5B_CODE_CHIP_RATE_CPS) * static_cast<float>(fs_in)));
 
     // compute all the GALILEO E5b PRN Codes (this is done only once in the class constructor in order to avoid re-computing the PRN codes every time

--- a/src/algorithms/acquisition/adapters/galileo_e5b_pcps_acquisition_fpga.h
+++ b/src/algorithms/acquisition/adapters/galileo_e5b_pcps_acquisition_fpga.h
@@ -190,8 +190,7 @@ public:
     void set_resampler_latency(uint32_t latency_samples __attribute__((unused))) override{};
 
 private:
-
-    const std::string default_device_name = "acquisition_S00_AXI"; // UIO device name
+    const std::string acquisition_device_name = "acquisition_S00_AXI";  // UIO device name
 
     // the following flags are FPGA-specific and they are using arrange the values of the fft of the local code in the way the FPGA
     // expects. This arrangement is done in the initialisation to avoid consuming unnecessary clock cycles during tracking.

--- a/src/algorithms/acquisition/adapters/galileo_e5b_pcps_acquisition_fpga.h
+++ b/src/algorithms/acquisition/adapters/galileo_e5b_pcps_acquisition_fpga.h
@@ -190,6 +190,9 @@ public:
     void set_resampler_latency(uint32_t latency_samples __attribute__((unused))) override{};
 
 private:
+
+    const std::string default_device_name = "acquisition_S00_AXI"; // UIO device name
+
     // the following flags are FPGA-specific and they are using arrange the values of the fft of the local code in the way the FPGA
     // expects. This arrangement is done in the initialisation to avoid consuming unnecessary clock cycles during tracking.
     static const uint32_t quant_bits_local_code = 16;

--- a/src/algorithms/acquisition/adapters/gps_l1_ca_pcps_acquisition_fpga.cc
+++ b/src/algorithms/acquisition/adapters/gps_l1_ca_pcps_acquisition_fpga.cc
@@ -27,6 +27,7 @@
 #include "gnss_sdr_flags.h"
 #include "gnss_sdr_make_unique.h"
 #include "gps_sdr_signal_replica.h"
+#include "uio_fpga.h"
 #include <glog/logging.h>
 #include <gnuradio/fft/fft.h>
 #include <gnuradio/gr_complex.h>  // for gr_complex
@@ -72,9 +73,18 @@ GpsL1CaPcpsAcquisitionFpga::GpsL1CaPcpsAcquisitionFpga(
     uint32_t nsamples_total = pow(2, nbits);
     uint32_t select_queue_Fpga = configuration->property(role + ".select_queue_Fpga", 0);
     acq_parameters.select_queue_Fpga = select_queue_Fpga;
-    std::string default_device_name = "/dev/uio0";
+
+    // UIO device file
+    std::string device_io_name;
     std::string device_name = configuration->property(role + ".devicename", default_device_name);
-    acq_parameters.device_name = device_name;
+    // find the uio device file corresponding to the GNSS reset module
+    if (find_uio_dev_file_name(device_io_name, device_name, 0) < 0)
+        {
+            std::cout << "Cannot find the FPGA uio device file corresponding to device name " << device_name << std::endl;
+            throw std::exception();
+        }
+    acq_parameters.device_name = device_io_name;
+
     acq_parameters.samples_per_code = nsamples_total;
     acq_parameters.excludelimit = static_cast<unsigned int>(1 + ceil(GPS_L1_CA_CHIP_PERIOD_S * static_cast<float>(fs_in)));
 

--- a/src/algorithms/acquisition/adapters/gps_l1_ca_pcps_acquisition_fpga.cc
+++ b/src/algorithms/acquisition/adapters/gps_l1_ca_pcps_acquisition_fpga.cc
@@ -76,11 +76,10 @@ GpsL1CaPcpsAcquisitionFpga::GpsL1CaPcpsAcquisitionFpga(
 
     // UIO device file
     std::string device_io_name;
-    std::string device_name = configuration->property(role + ".devicename", default_device_name);
-    // find the uio device file corresponding to the GNSS reset module
-    if (find_uio_dev_file_name(device_io_name, device_name, 0) < 0)
+    // find the uio device file corresponding to the acquisition
+    if (find_uio_dev_file_name(device_io_name, acquisition_device_name, 0) < 0)
         {
-            std::cout << "Cannot find the FPGA uio device file corresponding to device name " << device_name << std::endl;
+            std::cout << "Cannot find the FPGA uio device file corresponding to device name " << acquisition_device_name << std::endl;
             throw std::exception();
         }
     acq_parameters.device_name = device_io_name;

--- a/src/algorithms/acquisition/adapters/gps_l1_ca_pcps_acquisition_fpga.h
+++ b/src/algorithms/acquisition/adapters/gps_l1_ca_pcps_acquisition_fpga.h
@@ -187,7 +187,7 @@ public:
 private:
     static const uint32_t NUM_PRNs = 32;
 
-    const std::string default_device_name = "acquisition_S00_AXI";  // UIO device name
+    const std::string acquisition_device_name = "acquisition_S00_AXI";  // UIO device name
 
     // the following flags are FPGA-specific and they are using arrange the values of the fft of the local code in the way the FPGA
     // expects. This arrangement is done in the initialisation to avoid consuming unnecessary clock cycles during tracking.

--- a/src/algorithms/acquisition/adapters/gps_l1_ca_pcps_acquisition_fpga.h
+++ b/src/algorithms/acquisition/adapters/gps_l1_ca_pcps_acquisition_fpga.h
@@ -187,6 +187,8 @@ public:
 private:
     static const uint32_t NUM_PRNs = 32;
 
+    const std::string default_device_name = "acquisition_S00_AXI";  // UIO device name
+
     // the following flags are FPGA-specific and they are using arrange the values of the fft of the local code in the way the FPGA
     // expects. This arrangement is done in the initialisation to avoid consuming unnecessary clock cycles during tracking.
     static const uint32_t quant_bits_local_code = 16;

--- a/src/algorithms/acquisition/adapters/gps_l2_m_pcps_acquisition_fpga.cc
+++ b/src/algorithms/acquisition/adapters/gps_l2_m_pcps_acquisition_fpga.cc
@@ -74,11 +74,10 @@ GpsL2MPcpsAcquisitionFpga::GpsL2MPcpsAcquisitionFpga(
 
     // UIO device file
     std::string device_io_name;
-    std::string device_name = configuration->property(role + ".devicename", default_device_name);
-    // find the uio device file corresponding to the GNSS reset module
-    if (find_uio_dev_file_name(device_io_name, device_name, 0) < 0)
+    // find the uio device file corresponding to the acquisition
+    if (find_uio_dev_file_name(device_io_name, acquisition_device_name, 0) < 0)
         {
-            std::cout << "Cannot find the FPGA uio device file corresponding to device name " << device_name << std::endl;
+            std::cout << "Cannot find the FPGA uio device file corresponding to device name " << acquisition_device_name << std::endl;
             throw std::exception();
         }
     acq_parameters.device_name = device_io_name;

--- a/src/algorithms/acquisition/adapters/gps_l2_m_pcps_acquisition_fpga.h
+++ b/src/algorithms/acquisition/adapters/gps_l2_m_pcps_acquisition_fpga.h
@@ -151,7 +151,7 @@ public:
     void set_resampler_latency(uint32_t latency_samples __attribute__((unused))) override{};
 
 private:
-    const std::string default_device_name = "acquisition_S00_AXI";  // UIO device name
+    const std::string acquisition_device_name = "acquisition_S00_AXI";  // UIO device name
 
     static const uint32_t NUM_PRNs = 32;
     static const uint32_t QUANT_BITS_LOCAL_CODE = 16;

--- a/src/algorithms/acquisition/adapters/gps_l2_m_pcps_acquisition_fpga.h
+++ b/src/algorithms/acquisition/adapters/gps_l2_m_pcps_acquisition_fpga.h
@@ -151,6 +151,8 @@ public:
     void set_resampler_latency(uint32_t latency_samples __attribute__((unused))) override{};
 
 private:
+    const std::string default_device_name = "acquisition_S00_AXI";  // UIO device name
+
     static const uint32_t NUM_PRNs = 32;
     static const uint32_t QUANT_BITS_LOCAL_CODE = 16;
     static const uint32_t SELECT_LSBits = 0x0000FFFF;         // Select the 10 LSbits out of a 20-bit word

--- a/src/algorithms/acquisition/adapters/gps_l5i_pcps_acquisition_fpga.cc
+++ b/src/algorithms/acquisition/adapters/gps_l5i_pcps_acquisition_fpga.cc
@@ -27,6 +27,7 @@
 #include "gnss_sdr_flags.h"
 #include "gnss_sdr_make_unique.h"
 #include "gps_l5_signal_replica.h"
+#include "uio_fpga.h"
 #include <glog/logging.h>
 #include <gnuradio/fft/fft.h>     // for fft_complex
 #include <gnuradio/gr_complex.h>  // for gr_complex
@@ -76,11 +77,19 @@ GpsL5iPcpsAcquisitionFpga::GpsL5iPcpsAcquisitionFpga(
     uint32_t nsamples_total = pow(2, nbits);
     uint32_t select_queue_Fpga = configuration->property(role + ".select_queue_Fpga", 1);
     acq_parameters.select_queue_Fpga = select_queue_Fpga;
-    std::string default_device_name = "/dev/uio0";
-    std::string device_name = configuration->property(role + ".devicename", default_device_name);
-    acq_parameters.device_name = device_name;
-    acq_parameters.samples_per_code = nsamples_total;
 
+    // UIO device file
+    std::string device_io_name;
+    std::string device_name = configuration->property(role + ".devicename", default_device_name);
+    // find the uio device file corresponding to the GNSS reset module
+    if (find_uio_dev_file_name(device_io_name, device_name, 0) < 0)
+        {
+            std::cout << "Cannot find the FPGA uio device file corresponding to device name " << device_name << std::endl;
+            throw std::exception();
+        }
+    acq_parameters.device_name = device_io_name;
+
+    acq_parameters.samples_per_code = nsamples_total;
     acq_parameters.excludelimit = static_cast<unsigned int>(1 + ceil((1.0 / GPS_L5I_CODE_RATE_CPS) * static_cast<float>(fs_in)));
 
     // compute all the GPS L5 PRN Codes (this is done only once upon the class constructor in order to avoid re-computing the PRN codes every time

--- a/src/algorithms/acquisition/adapters/gps_l5i_pcps_acquisition_fpga.cc
+++ b/src/algorithms/acquisition/adapters/gps_l5i_pcps_acquisition_fpga.cc
@@ -80,11 +80,10 @@ GpsL5iPcpsAcquisitionFpga::GpsL5iPcpsAcquisitionFpga(
 
     // UIO device file
     std::string device_io_name;
-    std::string device_name = configuration->property(role + ".devicename", default_device_name);
-    // find the uio device file corresponding to the GNSS reset module
-    if (find_uio_dev_file_name(device_io_name, device_name, 0) < 0)
+    // find the uio device file corresponding to the acquisition
+    if (find_uio_dev_file_name(device_io_name, acquisition_device_name, 0) < 0)
         {
-            std::cout << "Cannot find the FPGA uio device file corresponding to device name " << device_name << std::endl;
+            std::cout << "Cannot find the FPGA uio device file corresponding to device name " << acquisition_device_name << std::endl;
             throw std::exception();
         }
     acq_parameters.device_name = device_io_name;

--- a/src/algorithms/acquisition/adapters/gps_l5i_pcps_acquisition_fpga.h
+++ b/src/algorithms/acquisition/adapters/gps_l5i_pcps_acquisition_fpga.h
@@ -187,7 +187,7 @@ public:
 private:
     static const uint32_t NUM_PRNs = 32;
 
-    const std::string default_device_name = "acquisition_S00_AXI";  // UIO device name
+    const std::string acquisition_device_name = "acquisition_S00_AXI";  // UIO device name
 
     // the following flags are FPGA-specific and they are using arrange the values of the fft of the local code in the way the FPGA
     // expects. This arrangement is done in the initialisation to avoid consuming unnecessary clock cycles during tracking.

--- a/src/algorithms/acquisition/adapters/gps_l5i_pcps_acquisition_fpga.h
+++ b/src/algorithms/acquisition/adapters/gps_l5i_pcps_acquisition_fpga.h
@@ -187,6 +187,8 @@ public:
 private:
     static const uint32_t NUM_PRNs = 32;
 
+    const std::string default_device_name = "acquisition_S00_AXI";  // UIO device name
+
     // the following flags are FPGA-specific and they are using arrange the values of the fft of the local code in the way the FPGA
     // expects. This arrangement is done in the initialisation to avoid consuming unnecessary clock cycles during tracking.
     static const uint32_t quant_bits_local_code = 16;

--- a/src/algorithms/signal_source/adapters/CMakeLists.txt
+++ b/src/algorithms/signal_source/adapters/CMakeLists.txt
@@ -147,10 +147,10 @@ target_include_directories(signal_source_adapters
 )
 
 if(ENABLE_FPGA)
-	target_include_directories(signal_source_adapters
-	    PUBLIC
-		${CMAKE_SOURCE_DIR}/src/core/libs
-	)
+    target_include_directories(signal_source_adapters
+        PUBLIC
+            ${CMAKE_SOURCE_DIR}/src/core/libs
+    )
 endif()
 
 target_link_libraries(signal_source_adapters

--- a/src/algorithms/signal_source/adapters/CMakeLists.txt
+++ b/src/algorithms/signal_source/adapters/CMakeLists.txt
@@ -146,6 +146,13 @@ target_include_directories(signal_source_adapters
         ${CMAKE_SOURCE_DIR}/src/core/interfaces
 )
 
+if(ENABLE_FPGA)
+	target_include_directories(signal_source_adapters
+	    PUBLIC
+		${CMAKE_SOURCE_DIR}/src/core/libs
+	)
+endif()
+
 target_link_libraries(signal_source_adapters
     PUBLIC
         Boost::headers

--- a/src/algorithms/signal_source/adapters/ad9361_fpga_signal_source.cc
+++ b/src/algorithms/signal_source/adapters/ad9361_fpga_signal_source.cc
@@ -28,6 +28,7 @@
 #include "ad9361_manager.h"
 #include "configuration_interface.h"
 #include "gnss_sdr_flags.h"
+#include "uio_fpga.h"
 #include <glog/logging.h>
 #include <iio.h>
 #include <algorithm>  // for max
@@ -90,9 +91,17 @@ Ad9361FpgaSignalSource::Ad9361FpgaSignalSource(const ConfigurationInterface *con
 
     rf_shutdown_ = configuration->property(role + ".rf_shutdown", FLAGS_rf_shutdown);
 
-    // turn switch to A/D position
-    const std::string default_device_name("/dev/uio1");
-    const std::string device_name = configuration->property(role + ".devicename", default_device_name);
+
+    // Switch UIO device file
+    std::string device_io_name;
+    std::string device_name = configuration->property(role + ".devicename", default_device_name);
+    // find the uio device file corresponding to the GNSS reset module
+    if (find_uio_dev_file_name(device_io_name, device_name, 0) < 0)
+        {
+            std::cout << "Cannot find the FPGA uio device file corresponding to device name " << device_name << std::endl;
+            throw std::exception();
+        }
+
     switch_position = configuration->property(role + ".switch_position", 0);
     if (switch_position != 0 && switch_position != 2)
         {
@@ -101,7 +110,7 @@ Ad9361FpgaSignalSource::Ad9361FpgaSignalSource(const ConfigurationInterface *con
             switch_position = 0;
         }
 
-    switch_fpga = std::make_shared<Fpga_Switch>(device_name);
+    switch_fpga = std::make_shared<Fpga_Switch>(device_io_name);
     switch_fpga->set_switch_position(switch_position);
 
     item_size_ = sizeof(gr_complex);

--- a/src/algorithms/signal_source/adapters/ad9361_fpga_signal_source.cc
+++ b/src/algorithms/signal_source/adapters/ad9361_fpga_signal_source.cc
@@ -94,7 +94,7 @@ Ad9361FpgaSignalSource::Ad9361FpgaSignalSource(const ConfigurationInterface *con
 
     // Switch UIO device file
     std::string device_io_name;
-    // find the uio device file corresponding to the GNSS reset module
+    // find the uio device file corresponding to the switch.
     if (find_uio_dev_file_name(device_io_name, switch_device_name, 0) < 0)
         {
             std::cout << "Cannot find the FPGA uio device file corresponding to device name " << switch_device_name << std::endl;
@@ -303,11 +303,14 @@ Ad9361FpgaSignalSource::Ad9361FpgaSignalSource(const ConfigurationInterface *con
         {
             std::string device_io_name_dyn_bit_sel_0, device_io_name_dyn_bit_sel_1;
 
+            // find the uio device file corresponding to the dynamic bit selector 0 module.
             if (find_uio_dev_file_name(device_io_name_dyn_bit_sel_0, dyn_bit_sel_device_name, 0) < 0)
                 {
                     std::cout << "Cannot find the FPGA uio device file corresponding to device name " << dyn_bit_sel_device_name << std::endl;
                     throw std::exception();
                 }
+
+            // find the uio device file corresponding to the dynamic bit selector 1 module.
             if (find_uio_dev_file_name(device_io_name_dyn_bit_sel_1, dyn_bit_sel_device_name, 1) < 0)
                 {
                     std::cout << "Cannot find the FPGA uio device file corresponding to device name " << dyn_bit_sel_device_name << std::endl;

--- a/src/algorithms/signal_source/adapters/ad9361_fpga_signal_source.cc
+++ b/src/algorithms/signal_source/adapters/ad9361_fpga_signal_source.cc
@@ -94,11 +94,10 @@ Ad9361FpgaSignalSource::Ad9361FpgaSignalSource(const ConfigurationInterface *con
 
     // Switch UIO device file
     std::string device_io_name;
-    std::string device_name = configuration->property(role + ".devicename", default_device_name);
     // find the uio device file corresponding to the GNSS reset module
-    if (find_uio_dev_file_name(device_io_name, device_name, 0) < 0)
+    if (find_uio_dev_file_name(device_io_name, switch_device_name, 0) < 0)
         {
-            std::cout << "Cannot find the FPGA uio device file corresponding to device name " << device_name << std::endl;
+            std::cout << "Cannot find the FPGA uio device file corresponding to device name " << switch_device_name << std::endl;
             throw std::exception();
         }
 
@@ -302,11 +301,19 @@ Ad9361FpgaSignalSource::Ad9361FpgaSignalSource(const ConfigurationInterface *con
     enable_dynamic_bit_selection_ = configuration->property(role + ".enable_dynamic_bit_selection", true);
     if (enable_dynamic_bit_selection_)
         {
-            const std::string dynamic_bit_selection_default_device_name1("/dev/uio48");
-            std::string device_name1 = configuration->property(role + ".dyn_bits_sel_devicename", dynamic_bit_selection_default_device_name1);
-            const std::string dynamic_bit_selection_default_device_name2("/dev/uio49");
-            std::string device_name2 = configuration->property(role + ".dyn_bits_sel_devicename", dynamic_bit_selection_default_device_name2);
-            dynamic_bit_selection_fpga = std::make_shared<Fpga_dynamic_bit_selection>(device_name1, device_name2);
+            std::string device_io_name_dyn_bit_sel_0, device_io_name_dyn_bit_sel_1;
+
+            if (find_uio_dev_file_name(device_io_name_dyn_bit_sel_0, dyn_bit_sel_device_name, 0) < 0)
+                {
+                    std::cout << "Cannot find the FPGA uio device file corresponding to device name " << dyn_bit_sel_device_name << std::endl;
+                    throw std::exception();
+                }
+            if (find_uio_dev_file_name(device_io_name_dyn_bit_sel_1, dyn_bit_sel_device_name, 1) < 0)
+                {
+                    std::cout << "Cannot find the FPGA uio device file corresponding to device name " << dyn_bit_sel_device_name << std::endl;
+                    throw std::exception();
+                }
+            dynamic_bit_selection_fpga = std::make_shared<Fpga_dynamic_bit_selection>(device_io_name_dyn_bit_sel_0, device_io_name_dyn_bit_sel_1);
             thread_dynamic_bit_selection = std::thread([&] { run_dynamic_bit_selection_process(); });
         }
 

--- a/src/algorithms/signal_source/adapters/ad9361_fpga_signal_source.h
+++ b/src/algorithms/signal_source/adapters/ad9361_fpga_signal_source.h
@@ -76,7 +76,8 @@ public:
     gr::basic_block_sptr get_right_block() override;
 
 private:
-    const std::string default_device_name = "AXIS_Switch_v1_0_0";  // Switch UIO device name
+    const std::string switch_device_name = "AXIS_Switch_v1_0_0";          // Switch UIO device name
+    const std::string dyn_bit_sel_device_name = "dynamic_bits_selector";  // Switch UIO device name
 
     // perform dynamic bit selection every 500 ms by default
     static const uint32_t Gain_control_period_ms = 500;

--- a/src/algorithms/signal_source/adapters/ad9361_fpga_signal_source.h
+++ b/src/algorithms/signal_source/adapters/ad9361_fpga_signal_source.h
@@ -76,6 +76,8 @@ public:
     gr::basic_block_sptr get_right_block() override;
 
 private:
+    const std::string default_device_name = "AXIS_Switch_v1_0_0";  // Switch UIO device name
+
     // perform dynamic bit selection every 500 ms by default
     static const uint32_t Gain_control_period_ms = 500;
 

--- a/src/algorithms/tracking/adapters/CMakeLists.txt
+++ b/src/algorithms/tracking/adapters/CMakeLists.txt
@@ -109,6 +109,14 @@ target_include_directories(tracking_adapters
         ${CMAKE_SOURCE_DIR}/src/core/interfaces
 )
 
+if(ENABLE_FPGA)
+	target_include_directories(tracking_adapters
+	    PUBLIC
+		${CMAKE_SOURCE_DIR}/src/core/libs
+	)
+endif()
+
+
 if(ENABLE_CUDA)
     if(CMAKE_VERSION VERSION_GREATER 3.11)
         target_include_directories(tracking_adapters

--- a/src/algorithms/tracking/adapters/CMakeLists.txt
+++ b/src/algorithms/tracking/adapters/CMakeLists.txt
@@ -110,10 +110,10 @@ target_include_directories(tracking_adapters
 )
 
 if(ENABLE_FPGA)
-	target_include_directories(tracking_adapters
-	    PUBLIC
-		${CMAKE_SOURCE_DIR}/src/core/libs
-	)
+    target_include_directories(tracking_adapters
+        PUBLIC
+            ${CMAKE_SOURCE_DIR}/src/core/libs
+    )
 endif()
 
 

--- a/src/algorithms/tracking/adapters/galileo_e1_dll_pll_veml_tracking_fpga.cc
+++ b/src/algorithms/tracking/adapters/galileo_e1_dll_pll_veml_tracking_fpga.cc
@@ -187,7 +187,7 @@ void GalileoE1DllPllVemlTrackingFpga::set_channel(unsigned int channel)
 
     // UIO device file
     std::string device_io_name;
-    // find the uio device file corresponding to the GNSS reset module
+    // find the uio device file corresponding to the tracking multicorrelator
     if (find_uio_dev_file_name(device_io_name, device_name, channel - num_prev_assigned_ch) < 0)
         {
             std::cout << "Cannot find the FPGA uio device file corresponding to device name " << device_name << std::endl;

--- a/src/algorithms/tracking/adapters/galileo_e1_dll_pll_veml_tracking_fpga.h
+++ b/src/algorithms/tracking/adapters/galileo_e1_dll_pll_veml_tracking_fpga.h
@@ -126,10 +126,15 @@ public:
     void stop_tracking() override;
 
 private:
+    const std::string default_device_name = "multicorrelator_resampler_5_1_AXI";  // UIO device name
+
     // the following flags are FPGA-specific and they are using arrange the values of the local code in the way the FPGA
     // expects. This arrangement is done in the initialisation to avoid consuming unnecessary clock cycles during tracking.
     static const int32_t LOCAL_CODE_FPGA_ENABLE_WRITE_MEMORY = 0x0C000000;      // flag that enables WE (Write Enable) of the local code FPGA
     static const int32_t LOCAL_CODE_FPGA_CORRELATOR_SELECT_COUNT = 0x20000000;  // flag that selects the writing of the pilot code in the FPGA (as opposed to the data code)
+
+    std::string device_name;
+    uint32_t num_prev_assigned_ch;
 
     dll_pll_veml_tracking_fpga_sptr tracking_fpga_sc;
     uint32_t channel_;

--- a/src/algorithms/tracking/adapters/galileo_e5a_dll_pll_tracking_fpga.cc
+++ b/src/algorithms/tracking/adapters/galileo_e5a_dll_pll_tracking_fpga.cc
@@ -25,6 +25,7 @@
 #include "dll_pll_conf_fpga.h"
 #include "galileo_e5_signal_replica.h"
 #include "gnss_sdr_flags.h"
+#include "uio_fpga.h"
 #include <glog/logging.h>
 #include <volk_gnsssdr/volk_gnsssdr_alloc.h>
 #include <array>
@@ -60,19 +61,18 @@ GalileoE5aDllPllTrackingFpga::GalileoE5aDllPllTrackingFpga(
 
     d_data_codes = nullptr;
 
-    // FPGA configuration parameters
-    // obtain the number of the first uio device corresponding to a HW accelerator in the FPGA
-    // that can be assigned to the tracking of the E5a signal
-    trk_params_fpga.dev_file_num = configuration->property(role + ".dev_file_num", 27);
+    // UIO device file
+    device_name = configuration->property(role + ".devicename", default_device_name);
+
     // compute the number of tracking channels that have already been instantiated. The order in which
     // GNSS-SDR instantiates the tracking channels i L1, L2, L5, E1, E5a
     // However E5a can use the same tracking HW accelerators as L5 (but not simultaneously).
     // Therefore for the proper assignment of the FPGA tracking device file numbers to the E5a tracking channels,
     // the number of channels that have already been assigned to L5 must not be substracted to this channel number,
     // so they are not counted here.
-    trk_params_fpga.num_prev_assigned_ch = configuration->property("Channels_1C.count", 0) +
-                                           configuration->property("Channels_2S.count", 0) +
-                                           configuration->property("Channels_1B.count", 0);
+    num_prev_assigned_ch = configuration->property("Channels_1C.count", 0) +
+                           configuration->property("Channels_2S.count", 0) +
+                           configuration->property("Channels_1B.count", 0);
 
     // ################# PRE-COMPUTE ALL THE CODES #################
     uint32_t code_samples_per_chip = 1;
@@ -207,7 +207,16 @@ void GalileoE5aDllPllTrackingFpga::stop_tracking()
 void GalileoE5aDllPllTrackingFpga::set_channel(unsigned int channel)
 {
     channel_ = channel;
-    tracking_fpga_sc->set_channel(channel);
+
+    // UIO device file
+    std::string device_io_name;
+    // find the uio device file corresponding to the GNSS reset module
+    if (find_uio_dev_file_name(device_io_name, device_name, channel - num_prev_assigned_ch) < 0)
+        {
+            std::cout << "Cannot find the FPGA uio device file corresponding to device name " << device_name << std::endl;
+            throw std::exception();
+        }
+    tracking_fpga_sc->set_channel(channel, device_io_name);
 }
 
 

--- a/src/algorithms/tracking/adapters/galileo_e5a_dll_pll_tracking_fpga.cc
+++ b/src/algorithms/tracking/adapters/galileo_e5a_dll_pll_tracking_fpga.cc
@@ -210,7 +210,7 @@ void GalileoE5aDllPllTrackingFpga::set_channel(unsigned int channel)
 
     // UIO device file
     std::string device_io_name;
-    // find the uio device file corresponding to the GNSS reset module
+    // find the uio device file corresponding to the tracking multicorrelator
     if (find_uio_dev_file_name(device_io_name, device_name, channel - num_prev_assigned_ch) < 0)
         {
             std::cout << "Cannot find the FPGA uio device file corresponding to device name " << device_name << std::endl;

--- a/src/algorithms/tracking/adapters/galileo_e5a_dll_pll_tracking_fpga.h
+++ b/src/algorithms/tracking/adapters/galileo_e5a_dll_pll_tracking_fpga.h
@@ -119,11 +119,15 @@ public:
     void stop_tracking() override;
 
 private:
+    const std::string default_device_name = "multicorrelator_resampler_3_1_AXI";  // UIO device name
+
     // the following flags are FPGA-specific and they are using arrange the values of the local code in the way the FPGA
     // expects. This arrangement is done in the initialisation to avoid consuming unnecessary clock cycles during tracking.
     static const int32_t LOCAL_CODE_FPGA_ENABLE_WRITE_MEMORY = 0x0C000000;      // flag that enables WE (Write Enable) of the local code FPGA
     static const int32_t LOCAL_CODE_FPGA_CORRELATOR_SELECT_COUNT = 0x20000000;  // flag that selects the writing of the pilot code in the FPGA (as opposed to the data code)
 
+    std::string device_name;
+    uint32_t num_prev_assigned_ch;
 
     dll_pll_veml_tracking_fpga_sptr tracking_fpga_sc;
     uint32_t channel_;

--- a/src/algorithms/tracking/adapters/gps_l1_ca_dll_pll_tracking_fpga.cc
+++ b/src/algorithms/tracking/adapters/gps_l1_ca_dll_pll_tracking_fpga.cc
@@ -156,7 +156,7 @@ void GpsL1CaDllPllTrackingFpga::set_channel(unsigned int channel)
 
     // UIO device file
     std::string device_io_name;
-    // find the uio device file corresponding to the GNSS reset module
+    // find the uio device file corresponding to the tracking multicorrelator
     if (find_uio_dev_file_name(device_io_name, device_name, channel - num_prev_assigned_ch) < 0)
         {
             std::cout << "Cannot find the FPGA uio device file corresponding to device name " << device_name << std::endl;

--- a/src/algorithms/tracking/adapters/gps_l1_ca_dll_pll_tracking_fpga.cc
+++ b/src/algorithms/tracking/adapters/gps_l1_ca_dll_pll_tracking_fpga.cc
@@ -30,6 +30,7 @@
 #include "dll_pll_conf_fpga.h"
 #include "gnss_sdr_flags.h"
 #include "gps_sdr_signal_replica.h"
+#include "uio_fpga.h"
 #include <glog/logging.h>
 #include <volk_gnsssdr/volk_gnsssdr.h>
 #include <array>
@@ -68,13 +69,12 @@ GpsL1CaDllPllTrackingFpga::GpsL1CaDllPllTrackingFpga(
     const std::array<char, 3> sig_{'1', 'C', '\0'};
     std::memcpy(trk_params_fpga.signal, sig_.data(), 3);
 
-    // FPGA configuration parameters
-    // obtain the number of the first uio device corresponding to a HW accelerator in the FPGA
-    // that can be assigned to the tracking of the L1 signal
-    trk_params_fpga.dev_file_num = configuration->property(role + ".dev_file_num", 3);
+    // UIO device file
+    device_name = configuration->property(role + ".devicename", default_device_name);
+
     // compute the number of tracking channels that have already been instantiated. The order in which
     // GNSS-SDR instantiates the tracking channels i L1, l2, L5, E1, E5a
-    trk_params_fpga.num_prev_assigned_ch = 0;
+    num_prev_assigned_ch = 0;
 
     // ################# PRE-COMPUTE ALL THE CODES #################
     d_ca_codes = static_cast<int32_t*>(volk_gnsssdr_malloc(static_cast<int32_t>(GPS_L1_CA_CODE_LENGTH_CHIPS * NUM_PRNs) * sizeof(int32_t), volk_gnsssdr_get_alignment()));
@@ -153,7 +153,17 @@ void GpsL1CaDllPllTrackingFpga::stop_tracking()
 void GpsL1CaDllPllTrackingFpga::set_channel(unsigned int channel)
 {
     channel_ = channel;
-    tracking_fpga_sc->set_channel(channel);
+
+    // UIO device file
+    std::string device_io_name;
+    // find the uio device file corresponding to the GNSS reset module
+    if (find_uio_dev_file_name(device_io_name, device_name, channel - num_prev_assigned_ch) < 0)
+        {
+            std::cout << "Cannot find the FPGA uio device file corresponding to device name " << device_name << std::endl;
+            throw std::exception();
+        }
+
+    tracking_fpga_sc->set_channel(channel, device_io_name);
 }
 
 

--- a/src/algorithms/tracking/adapters/gps_l1_ca_dll_pll_tracking_fpga.h
+++ b/src/algorithms/tracking/adapters/gps_l1_ca_dll_pll_tracking_fpga.h
@@ -124,12 +124,16 @@ public:
     void stop_tracking() override;
 
 private:
+    const std::string default_device_name = "multicorrelator_resampler_S00_AXI";  // UIO device name
+
     static const uint32_t NUM_PRNs = 32;  // total number of PRNs
     static const int32_t GPS_CA_BIT_DURATION_MS = 20;
     // the following flag is FPGA-specific and they are using arrange the values of the local code in the way the FPGA
     // expects. This arrangement is done in the initialisation to avoid consuming unnecessary clock cycles during tracking.
     static const int32_t LOCAL_CODE_FPGA_ENABLE_WRITE_MEMORY = 0x0C000000;  // flag that enables WE (Write Enable) of the local code FPGA
 
+    std::string device_name;
+    uint32_t num_prev_assigned_ch;
 
     dll_pll_veml_tracking_fpga_sptr tracking_fpga_sc;
     uint32_t channel_;

--- a/src/algorithms/tracking/adapters/gps_l2_m_dll_pll_tracking_fpga.cc
+++ b/src/algorithms/tracking/adapters/gps_l2_m_dll_pll_tracking_fpga.cc
@@ -32,6 +32,7 @@
 #include "gnss_sdr_flags.h"
 #include "gnss_synchro.h"
 #include "gps_l2c_signal_replica.h"
+#include "uio_fpga.h"
 #include <glog/logging.h>
 #include <volk_gnsssdr/volk_gnsssdr_alloc.h>
 #include <array>
@@ -66,12 +67,12 @@ GpsL2MDllPllTrackingFpga::GpsL2MDllPllTrackingFpga(
     const std::array<char, 3> sig_{'2', 'S', '\0'};
     std::memcpy(trk_params_fpga.signal, sig_.data(), 3);
 
-    // FPGA configuration parameters
-    // obtain the number of the first uio device file that is assigned to the FPGA L2 tracking multicorrelator HW accelerators
-    trk_params_fpga.dev_file_num = configuration->property(role + ".dev_file_num", 27);
+    // UIO device file
+    device_name = configuration->property(role + ".devicename", default_device_name);
+
     // compute the number of tracking channels that have already been instantiated. The order in which
     // GNSS-SDR instantiates the tracking channels i L1, L2, L5, E1, E5a
-    trk_params_fpga.num_prev_assigned_ch = configuration->property("Channels_1C.count", 0);
+    num_prev_assigned_ch = configuration->property("Channels_1C.count", 0);
 
     volk_gnsssdr::vector<float> ca_codes_f(static_cast<unsigned int>(GPS_L2_M_CODE_LENGTH_CHIPS), 0.0);
     // ################# PRE-COMPUTE ALL THE CODES #################
@@ -130,7 +131,17 @@ void GpsL2MDllPllTrackingFpga::stop_tracking()
 void GpsL2MDllPllTrackingFpga::set_channel(unsigned int channel)
 {
     channel_ = channel;
-    tracking_fpga_sc->set_channel(channel);
+
+    // UIO device file
+    std::string device_io_name;
+    // find the uio device file corresponding to the GNSS reset module
+    if (find_uio_dev_file_name(device_io_name, device_name, channel - num_prev_assigned_ch) < 0)
+        {
+            std::cout << "Cannot find the FPGA uio device file corresponding to device name " << device_name << std::endl;
+            throw std::exception();
+        }
+
+    tracking_fpga_sc->set_channel(channel, device_io_name);
 }
 
 

--- a/src/algorithms/tracking/adapters/gps_l2_m_dll_pll_tracking_fpga.cc
+++ b/src/algorithms/tracking/adapters/gps_l2_m_dll_pll_tracking_fpga.cc
@@ -134,7 +134,7 @@ void GpsL2MDllPllTrackingFpga::set_channel(unsigned int channel)
 
     // UIO device file
     std::string device_io_name;
-    // find the uio device file corresponding to the GNSS reset module
+    // find the uio device file corresponding to the tracking multicorrelator
     if (find_uio_dev_file_name(device_io_name, device_name, channel - num_prev_assigned_ch) < 0)
         {
             std::cout << "Cannot find the FPGA uio device file corresponding to device name " << device_name << std::endl;

--- a/src/algorithms/tracking/adapters/gps_l2_m_dll_pll_tracking_fpga.h
+++ b/src/algorithms/tracking/adapters/gps_l2_m_dll_pll_tracking_fpga.h
@@ -95,6 +95,11 @@ public:
     void stop_tracking() override;
 
 private:
+    const std::string default_device_name = "multicorrelator_resampler_S00_AXI";  // UIO device name
+
+    std::string device_name;
+    uint32_t num_prev_assigned_ch;
+
     static const uint32_t NUM_PRNs = 32;
     dll_pll_veml_tracking_fpga_sptr tracking_fpga_sc;
     unsigned int channel_;

--- a/src/algorithms/tracking/adapters/gps_l5_dll_pll_tracking_fpga.cc
+++ b/src/algorithms/tracking/adapters/gps_l5_dll_pll_tracking_fpga.cc
@@ -32,6 +32,7 @@
 #include "dll_pll_conf_fpga.h"
 #include "gnss_sdr_flags.h"
 #include "gps_l5_signal_replica.h"
+#include "uio_fpga.h"
 #include <glog/logging.h>
 #include <volk_gnsssdr/volk_gnsssdr_alloc.h>
 #include <array>
@@ -65,14 +66,13 @@ GpsL5DllPllTrackingFpga::GpsL5DllPllTrackingFpga(
     const std::array<char, 3> sig_{'L', '5', '\0'};
     std::memcpy(trk_params_fpga.signal, sig_.data(), 3);
 
-    // FPGA configuration parameters
-    // obtain the number of the first uio device corresponding to a HW accelerator in the FPGA
-    // that can be assigned to the tracking of the L5 signal
-    trk_params_fpga.dev_file_num = configuration->property(role + ".dev_file_num", 27);
+    // UIO device file
+    device_name = configuration->property(role + ".devicename", default_device_name);
+
     // compute the number of tracking channels that have already been instantiated. The order in which
     // GNSS-SDR instantiates the tracking channels i L1, L2, L5, E1, E5a
-    trk_params_fpga.num_prev_assigned_ch = configuration->property("Channels_1C.count", 0) +
-                                           configuration->property("Channels_2S.count", 0);
+    num_prev_assigned_ch = configuration->property("Channels_1C.count", 0) +
+                           configuration->property("Channels_2S.count", 0);
 
     // ################# PRE-COMPUTE ALL THE CODES #################
     uint32_t code_samples_per_chip = 1;
@@ -215,7 +215,17 @@ void GpsL5DllPllTrackingFpga::stop_tracking()
 void GpsL5DllPllTrackingFpga::set_channel(unsigned int channel)
 {
     channel_ = channel;
-    tracking_fpga_sc->set_channel(channel);
+
+    // UIO device file
+    std::string device_io_name;
+    // find the uio device file corresponding to the GNSS reset module
+    if (find_uio_dev_file_name(device_io_name, device_name, channel - num_prev_assigned_ch) < 0)
+        {
+            std::cout << "Cannot find the FPGA uio device file corresponding to device name " << device_name << std::endl;
+            throw std::exception();
+        }
+
+    tracking_fpga_sc->set_channel(channel, device_io_name);
 }
 
 

--- a/src/algorithms/tracking/adapters/gps_l5_dll_pll_tracking_fpga.cc
+++ b/src/algorithms/tracking/adapters/gps_l5_dll_pll_tracking_fpga.cc
@@ -218,7 +218,7 @@ void GpsL5DllPllTrackingFpga::set_channel(unsigned int channel)
 
     // UIO device file
     std::string device_io_name;
-    // find the uio device file corresponding to the GNSS reset module
+    // find the uio device file corresponding to the tracking multicorrelator
     if (find_uio_dev_file_name(device_io_name, device_name, channel - num_prev_assigned_ch) < 0)
         {
             std::cout << "Cannot find the FPGA uio device file corresponding to device name " << device_name << std::endl;

--- a/src/algorithms/tracking/adapters/gps_l5_dll_pll_tracking_fpga.h
+++ b/src/algorithms/tracking/adapters/gps_l5_dll_pll_tracking_fpga.h
@@ -125,12 +125,17 @@ public:
     void stop_tracking() override;
 
 private:
+    const std::string default_device_name = "multicorrelator_resampler_3_1_AXI";  // UIO device name
+
     static const uint32_t NUM_PRNs = 32;  // total number of PRNs
 
     // the following flags are FPGA-specific and they are using arrange the values of the local code in the way the FPGA
     // expects. This arrangement is done in the initialisation to avoid consuming unnecessary clock cycles during tracking.
     static const int32_t LOCAL_CODE_FPGA_ENABLE_WRITE_MEMORY = 0x0C000000;      // flag that enables WE (Write Enable) of the local code FPGA
     static const int32_t LOCAL_CODE_FPGA_CORRELATOR_SELECT_COUNT = 0x20000000;  // flag that selects the writing of the pilot code in the FPGA (as opposed to the data code)
+
+    std::string device_name;
+    uint32_t num_prev_assigned_ch;
 
     dll_pll_veml_tracking_fpga_sptr tracking_fpga_sc;
     uint32_t channel_;

--- a/src/algorithms/tracking/gnuradio_blocks/dll_pll_veml_tracking_fpga.cc
+++ b/src/algorithms/tracking/gnuradio_blocks/dll_pll_veml_tracking_fpga.cc
@@ -466,12 +466,9 @@ dll_pll_veml_tracking_fpga::dll_pll_veml_tracking_fpga(const Dll_Pll_Conf_Fpga &
                 }
         }
     // create multicorrelator class
-    const std::string device_name = d_trk_parameters.device_name;
-    const uint32_t dev_file_num = d_trk_parameters.dev_file_num;
-    const uint32_t num_prev_assigned_ch = d_trk_parameters.num_prev_assigned_ch;
     int32_t *ca_codes = d_trk_parameters.ca_codes;
     int32_t *data_codes = d_trk_parameters.data_codes;
-    d_multicorrelator_fpga = std::make_shared<Fpga_Multicorrelator_8sc>(d_n_correlator_taps, device_name, dev_file_num, num_prev_assigned_ch, ca_codes, data_codes, d_code_length_chips, d_trk_parameters.track_pilot, d_code_samples_per_chip);
+    d_multicorrelator_fpga = std::make_shared<Fpga_Multicorrelator_8sc>(d_n_correlator_taps, ca_codes, data_codes, d_code_length_chips, d_trk_parameters.track_pilot, d_code_samples_per_chip);
     d_multicorrelator_fpga->set_output_vectors(d_correlator_outs.data(), d_Prompt_Data.data());
     d_sample_counter_next = 0ULL;
 
@@ -1313,12 +1310,12 @@ int32_t dll_pll_veml_tracking_fpga::save_matfile() const
 }
 
 
-void dll_pll_veml_tracking_fpga::set_channel(uint32_t channel)
+void dll_pll_veml_tracking_fpga::set_channel(uint32_t channel, std::string device_io_name)
 {
     gr::thread::scoped_lock l(d_setlock);
 
     d_channel = channel;
-    d_multicorrelator_fpga->set_channel(d_channel);
+    d_multicorrelator_fpga->open_channel(device_io_name, channel);
     LOG(INFO) << "Tracking Channel set to " << d_channel;
     // ############# ENABLE DATA FILE LOG #################
     if (d_dump)

--- a/src/algorithms/tracking/gnuradio_blocks/dll_pll_veml_tracking_fpga.h
+++ b/src/algorithms/tracking/gnuradio_blocks/dll_pll_veml_tracking_fpga.h
@@ -69,7 +69,7 @@ public:
     /*!
      * \brief Set the channel number and configure some multicorrelator parameters
      */
-    void set_channel(uint32_t channel);
+    void set_channel(uint32_t channel, std::string device_io_name);
 
     /*!
      * \brief This function is used with two purposes:

--- a/src/algorithms/tracking/libs/dll_pll_conf_fpga.cc
+++ b/src/algorithms/tracking/libs/dll_pll_conf_fpga.cc
@@ -75,8 +75,6 @@ Dll_Pll_Conf_Fpga::Dll_Pll_Conf_Fpga()
     signal[1] = 'C';
     signal[2] = '\0';
     device_name = "/dev/uio";
-    dev_file_num = 3;
-    num_prev_assigned_ch = 0;
     code_length_chips = 0U;
     code_samples_per_chip = 0U;
     ca_codes = nullptr;

--- a/src/algorithms/tracking/libs/dll_pll_conf_fpga.h
+++ b/src/algorithms/tracking/libs/dll_pll_conf_fpga.h
@@ -68,8 +68,6 @@ public:
     uint32_t bit_synchronization_time_limit_s;
     uint32_t vector_length;
     uint32_t smoother_length;
-    uint32_t dev_file_num;
-    uint32_t num_prev_assigned_ch;
     uint32_t code_length_chips;
     uint32_t code_samples_per_chip;
     uint32_t extend_fpga_integration_periods;

--- a/src/algorithms/tracking/libs/fpga_multicorrelator.h
+++ b/src/algorithms/tracking/libs/fpga_multicorrelator.h
@@ -47,9 +47,6 @@ public:
      * \brief Constructor
      */
     Fpga_Multicorrelator_8sc(int32_t n_correlators,
-        const std::string &device_name,
-        uint32_t dev_file_num,
-        uint32_t num_prev_assigned_ch,
         int32_t *ca_codes,
         int32_t *data_codes,
         uint32_t code_length_chips,
@@ -95,9 +92,9 @@ public:
     bool free();
 
     /*!
-     * \brief Set channel number and open the FPGA device driver
+     * \brief Open the FPGA device driver
      */
-    void set_channel(uint32_t channel);
+    void open_channel(std::string device_io_name, uint32_t channel);
 
     /*!
      * \brief Set the initial sample number where the tracking process begins
@@ -193,7 +190,6 @@ private:
     static const uint32_t enable_secondary_code = 2;            // bit 1 of drop_samples_reg_addr
     static const uint32_t init_secondary_code_addresses = 4;    // bit 2 of drop_samples_reg_addr
     static const uint32_t page_size = 0x10000;
-    static const uint32_t max_length_deviceio_name = 50;
     static const uint32_t max_code_resampler_counter = 1 << 31;  // 2^(number of bits of precision of the code resampler)
     static const uint32_t local_code_fpga_clear_address_counter = 0x10000000;
     static const uint32_t test_register_track_writeval = 0x55AA;
@@ -237,7 +233,6 @@ private:
     volatile uint32_t *d_map_base;  // driver memory map
 
     // configuration data received from the interface
-    uint32_t d_channel;  // channel number
     uint32_t d_correlator_length_samples;
     uint32_t d_code_samples_per_chip;
 
@@ -246,11 +241,6 @@ private:
     int32_t d_rem_carr_phase_rad_int;
     int32_t d_phase_step_rad_int;
     int32_t d_carrier_phase_rate_step_rad_int;
-
-    // driver
-    std::string d_device_name;
-    uint32_t d_dev_file_num;
-    uint32_t d_num_prev_assigned_ch;
 
     // PRN codes
     int32_t *d_ca_codes;

--- a/src/core/libs/CMakeLists.txt
+++ b/src/core/libs/CMakeLists.txt
@@ -36,13 +36,13 @@ if(ENABLE_FPGA)
         ${CORE_LIBS_SOURCES}
         gnss_sdr_fpga_sample_counter.cc
         gnss_sdr_time_counter.cc
-	uio_fpga.cc
+        uio_fpga.cc
     )
     set(CORE_LIBS_HEADERS
         ${CORE_LIBS_HEADERS}
         gnss_sdr_fpga_sample_counter.h
         gnss_sdr_time_counter.h
-	uio_fpga.h
+        uio_fpga.h
     )
 endif()
 

--- a/src/core/libs/CMakeLists.txt
+++ b/src/core/libs/CMakeLists.txt
@@ -36,11 +36,13 @@ if(ENABLE_FPGA)
         ${CORE_LIBS_SOURCES}
         gnss_sdr_fpga_sample_counter.cc
         gnss_sdr_time_counter.cc
+	uio_fpga.cc
     )
     set(CORE_LIBS_HEADERS
         ${CORE_LIBS_HEADERS}
         gnss_sdr_fpga_sample_counter.h
         gnss_sdr_time_counter.h
+	uio_fpga.h
     )
 endif()
 

--- a/src/core/libs/gnss_sdr_fpga_sample_counter.cc
+++ b/src/core/libs/gnss_sdr_fpga_sample_counter.cc
@@ -135,7 +135,7 @@ void gnss_sdr_fpga_sample_counter::open_device()
 {
     // UIO device file
     std::string device_io_name;
-    // find the uio device file corresponding to the GNSS reset module
+    // find the uio device file corresponding to the sample counter module
     if (find_uio_dev_file_name(device_io_name, device_name, 0) < 0)
         {
             std::cout << "Cannot find the FPGA uio device file corresponding to device name " << device_name << std::endl;

--- a/src/core/libs/gnss_sdr_fpga_sample_counter.cc
+++ b/src/core/libs/gnss_sdr_fpga_sample_counter.cc
@@ -21,6 +21,7 @@
 
 #include "gnss_sdr_fpga_sample_counter.h"
 #include "gnss_synchro.h"
+#include "uio_fpga.h"
 #include <glog/logging.h>
 #include <gnuradio/io_signature.h>
 #include <pmt/pmt.h>        // for from_double
@@ -132,11 +133,20 @@ void gnss_sdr_fpga_sample_counter::configure_samples_per_output(uint32_t interva
 
 void gnss_sdr_fpga_sample_counter::open_device()
 {
-    // open communication with HW accelerator
-    if ((fd = open(device_name.c_str(), O_RDWR | O_SYNC)) == -1)
+    // UIO device file
+    std::string device_io_name;
+    // find the uio device file corresponding to the GNSS reset module
+    if (find_uio_dev_file_name(device_io_name, device_name, 0) < 0)
         {
-            LOG(WARNING) << "Cannot open deviceio" << device_name;
-            std::cout << "Counter-Intr: cannot open deviceio" << device_name << '\n';
+            std::cout << "Cannot find the FPGA uio device file corresponding to device name " << device_name << std::endl;
+            throw std::exception();
+        }
+
+    // open communication with HW accelerator
+    if ((fd = open(device_io_name.c_str(), O_RDWR | O_SYNC)) == -1)
+        {
+            LOG(WARNING) << "Cannot open deviceio" << device_io_name;
+            std::cout << "Counter-Intr: cannot open deviceio" << device_io_name << '\n';
         }
     map_base = reinterpret_cast<volatile uint32_t *>(mmap(nullptr, page_size,
         PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0));
@@ -144,7 +154,7 @@ void gnss_sdr_fpga_sample_counter::open_device()
     if (map_base == reinterpret_cast<void *>(-1))
         {
             LOG(WARNING) << "Cannot map the FPGA acquisition module into user memory";
-            std::cout << "Counter-Intr: cannot map deviceio" << device_name << '\n';
+            std::cout << "Counter-Intr: cannot map deviceio" << device_io_name << '\n';
         }
 
     // sanity check : check test register

--- a/src/core/libs/gnss_sdr_fpga_sample_counter.h
+++ b/src/core/libs/gnss_sdr_fpga_sample_counter.h
@@ -50,6 +50,8 @@ public:
         gr_vector_void_star &output_items);
 
 private:
+    const std::string device_name = "counter";  // UIO device name
+
     static const uint32_t page_size = 0x10000;             // default page size for the multicorrelator memory map
     static const uint32_t test_reg_sanity_check = 0x55AA;  // value to check the presence of the test register (to detect the hw)
 
@@ -63,8 +65,7 @@ private:
     bool stop();
     void wait_for_interrupt(void);
 
-    volatile uint32_t *map_base;            // driver memory map
-    std::string device_name = "/dev/uio2";  // HW device name
+    volatile uint32_t *map_base;  // driver memory map
 
     double fs;
     uint64_t sample_counter;

--- a/src/core/libs/uio_fpga.cc
+++ b/src/core/libs/uio_fpga.cc
@@ -1,0 +1,115 @@
+/*!
+ * \file uio_fpga.cc
+ * \brief This library contains functions to determine the uio device driver file that
+ * corresponds to a hardware accelerator device name in the FPGA
+ * \author Marc Majoral, 2020. mmajoral(at)cttc.es
+ *
+ * -----------------------------------------------------------------------------
+ *
+ * Copyright (C) 2010-2020  (see AUTHORS file for a list of contributors)
+ *
+ * GNSS-SDR is a software defined Global Navigation
+ *          Satellite Systems receiver
+ *
+ * This file is part of GNSS-SDR.
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ *
+ * -----------------------------------------------------------------------------
+ */
+
+#include "uio_fpga.h"
+#include <dirent.h>  // scandir()
+#include <fstream>   // ifstream
+#include <iostream>  // cout
+#include <sstream>   // std::stringstream
+
+int32_t get_uio_num(std::string uio_name)
+{
+    size_t i = 0;
+    // search first digit
+    for (; i < uio_name.length(); i++)
+        {
+            if (isdigit(uio_name[i])) break;
+        }
+
+    // remove the first chars, which aren't digits
+    std::string uio_num = uio_name.substr(i, uio_name.length() - i);
+
+    // convert the remaining text to an integer
+    return atoi(uio_num.c_str());
+}
+
+void get_uio_name(uint32_t uio_num, std::string &uio_name)
+{
+    std::stringstream filename;
+    filename << uio_dir << uio_filename << uio_num << uio_subdir_name;
+
+    std::ifstream infile;
+    infile.open(filename.str());
+    if (infile.is_open())
+        {
+            getline(infile, uio_name);
+            if (infile.bad())
+                {
+                    std::cout << "Could not read the FPGA uio device information file" << std::endl;
+                    throw std::exception();
+                }
+            infile.close();
+        }
+    else
+        {
+            std::cout << "Could not open the FPGA uio device information file" << std::endl;
+            throw std::exception();
+        }
+}
+
+int32_t find_uio_num(const std::string &device_name, uint32_t device_num)
+{
+    struct dirent **files;
+    int32_t uio_num;
+
+    // get the number of directory entries in the uio driver description system directories
+    uint32_t num_dir_entries = scandir(uio_dir.c_str(), &files, 0, versionsort);
+
+    uint32_t device_count = 0, uio_count = 0;
+
+    // search for the requested device driver
+    while (device_count < num_dir_entries)
+        {
+            // get the uio number corresponding to directory entry n
+            uio_num = get_uio_num(files[device_count]->d_name);
+            if (uio_num >= 0)  // valid uio number
+                {
+                    std::string nametemp;
+                    get_uio_name(uio_num, nametemp);
+                    if (device_name.compare(nametemp) == 0)
+                        {
+                            if (uio_count == device_num)
+                                {
+                                    return uio_num;
+                                }
+                            else
+                                {
+                                    uio_count++;
+                                }
+                        }
+                }
+            device_count++;
+        }
+    return -1;  // uio number not found
+}
+
+int32_t find_uio_dev_file_name(std::string &device_file_name, const std::string &device_name, uint32_t device_num)
+{
+    int32_t uio_num = find_uio_num(device_name, device_num);
+    if (uio_num >= 0)
+        {
+            std::stringstream device_file_name_tmp;
+            device_file_name_tmp << "/dev/uio" << uio_num;
+            device_file_name = device_file_name_tmp.str();
+            return 0;
+        }
+
+    return -1;
+}

--- a/src/core/libs/uio_fpga.h
+++ b/src/core/libs/uio_fpga.h
@@ -1,0 +1,36 @@
+/*!
+ * \file uio_fpga.h
+ * \brief This library contains functions to determine the uio device driver file that
+ * corresponds to a hardware accelerator device name in the FPGA
+ * \author Marc Majoral, 2020. mmajoral(at)cttc.es
+ *
+ * -----------------------------------------------------------------------------
+ *
+ * Copyright (C) 2010-2020  (see AUTHORS file for a list of contributors)
+ *
+ * GNSS-SDR is a software defined Global Navigation
+ *          Satellite Systems receiver
+ *
+ * This file is part of GNSS-SDR.
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ *
+ * -----------------------------------------------------------------------------
+ */
+
+#ifndef GNSS_SDR_SIM_GNSS_UIO_FPGA_H
+#define GNSS_SDR_SIM_GNSS_UIO_FPGA_H
+
+#include <string>  // string, memset()
+
+const std::string uio_dir = "/sys/class/uio/";
+const std::string uio_filename = "uio";
+const std::string uio_subdir_name = "/name";
+
+/*!
+ * \brief This function finds the uio device driver device file name out of the device name and the device number
+ */
+int32_t find_uio_dev_file_name(std::string &device_file_name, const std::string &device_name, uint32_t device_num);
+
+
+#endif  // GNSS_SDR_GNSS_UIO_FPGA_H


### PR DESCRIPTION
The classes that control the FPGA HW accelerators find the number of the uio device file that is assigned to them using the names of the HW accelerators.