### PR TITLE
fix uio device file assignment when using the same type of tracking m…

### DIFF
--- a/src/algorithms/tracking/adapters/galileo_e1_dll_pll_veml_tracking_fpga.cc
+++ b/src/algorithms/tracking/adapters/galileo_e1_dll_pll_veml_tracking_fpga.cc
@@ -66,9 +66,15 @@ GalileoE1DllPllVemlTrackingFpga::GalileoE1DllPllVemlTrackingFpga(
 
     // compute the number of tracking channels that have already been instantiated. The order in which
     // GNSS-SDR instantiates the tracking channels i L1, L2, L5, E1, E5a
-    num_prev_assigned_ch = configuration->property("Channels_1C.count", 0) +
-                           configuration->property("Channels_2S.count", 0) +
-                           configuration->property("Channels_L5.count", 0);
+
+    uint32_t num_prev_assigned_ch_1C = 0;
+    if (configuration->property("Tracking_1C.devicename", std::string("")).compare(device_name) != 0)
+        {
+            num_prev_assigned_ch_1C = configuration->property("Channels_1C.count", 0);
+        }
+    uint32_t num_prev_assigned_ch_2S = configuration->property("Channels_2S.count", 0);
+    uint32_t num_prev_assigned_ch_L5 = configuration->property("Channels_L5.count", 0);
+    num_prev_assigned_ch = num_prev_assigned_ch_1C + num_prev_assigned_ch_2S + num_prev_assigned_ch_L5;
 
     // ################# PRE-COMPUTE ALL THE CODES #################
     uint32_t code_samples_per_chip = 2;

--- a/src/algorithms/tracking/adapters/galileo_e5a_dll_pll_tracking_fpga.cc
+++ b/src/algorithms/tracking/adapters/galileo_e5a_dll_pll_tracking_fpga.cc
@@ -67,9 +67,15 @@ GalileoE5aDllPllTrackingFpga::GalileoE5aDllPllTrackingFpga(
     // Therefore for the proper assignment of the FPGA tracking device file numbers to the E5a tracking channels,
     // the number of channels that have already been assigned to L5 must not be substracted to this channel number,
     // so they are not counted here.
-    num_prev_assigned_ch = configuration->property("Channels_1C.count", 0) +
-                           configuration->property("Channels_2S.count", 0) +
-                           configuration->property("Channels_1B.count", 0);
+
+    uint32_t num_prev_assigned_ch_1C = configuration->property("Channels_1C.count", 0);
+    uint32_t num_prev_assigned_ch_2S = 0;
+    if (configuration->property("Tracking_2S.devicename", std::string("")) != device_name)
+        {
+            num_prev_assigned_ch_2S = configuration->property("Channels_2S.count", 0);
+        }
+    uint32_t num_prev_assigned_ch_1B = configuration->property("Channels_1B.count", 0);
+    num_prev_assigned_ch = num_prev_assigned_ch_1C + num_prev_assigned_ch_2S + num_prev_assigned_ch_1B;
 
     // ################# PRE-COMPUTE ALL THE CODES #################
     uint32_t code_samples_per_chip = 1;

--- a/src/algorithms/tracking/adapters/gps_l5_dll_pll_tracking_fpga.cc
+++ b/src/algorithms/tracking/adapters/gps_l5_dll_pll_tracking_fpga.cc
@@ -68,8 +68,14 @@ GpsL5DllPllTrackingFpga::GpsL5DllPllTrackingFpga(
 
     // compute the number of tracking channels that have already been instantiated. The order in which
     // GNSS-SDR instantiates the tracking channels i L1, L2, L5, E1, E5a
-    num_prev_assigned_ch = configuration->property("Channels_1C.count", 0) +
-                           configuration->property("Channels_2S.count", 0);
+
+    uint32_t num_prev_assigned_ch_1C = configuration->property("Channels_1C.count", 0);
+    uint32_t num_prev_assigned_ch_2S = 0;
+    if (configuration->property("Tracking_2S.devicename", std::string("")) != device_name)
+        {
+            num_prev_assigned_ch_2S = configuration->property("Channels_2S.count", 0);
+        }
+    num_prev_assigned_ch = num_prev_assigned_ch_1C + num_prev_assigned_ch_2S;
 
     // ################# PRE-COMPUTE ALL THE CODES #################
     uint32_t code_samples_per_chip = 1;


### PR DESCRIPTION
fix uio device file assignment when using the same type of tracking multicorrelator HW accelerators with different types of GNSS signals in the same frequency band.