### PR TITLE
Use the Galileo E1 FPGA tracking multicorrelators for the GPS L1 C/A …

### DIFF
--- a/src/algorithms/tracking/adapters/galileo_e1_dll_pll_veml_tracking_fpga.cc
+++ b/src/algorithms/tracking/adapters/galileo_e1_dll_pll_veml_tracking_fpga.cc
@@ -62,13 +62,35 @@ GalileoE1DllPllVemlTrackingFpga::GalileoE1DllPllVemlTrackingFpga(
     std::memcpy(trk_params_fpga.signal, sig_.data(), 3);
 
     // UIO device file
-    device_name = configuration->property(role + ".devicename", default_device_name);
+    device_name = configuration->property(role + ".devicename", default_device_name_Galileo_E1);
 
     // compute the number of tracking channels that have already been instantiated. The order in which
     // GNSS-SDR instantiates the tracking channels i L1, L2, L5, E1, E5a
-    num_prev_assigned_ch = configuration->property("Channels_1C.count", 0) +
-                           configuration->property("Channels_2S.count", 0) +
-                           configuration->property("Channels_L5.count", 0);
+
+    uint32_t num_prev_assigned_ch_1C = 0;
+    std::string device_io_name;
+
+    if (configuration->property("Tracking_1C.devicename", default_device_name_GPS_L1).compare(default_device_name_GPS_L1) == 0)
+        {
+            for (uint32_t k = 0; k < configuration->property("Channels_1C.count", 0); k++)
+                {
+                    if (find_uio_dev_file_name(device_io_name, default_device_name_GPS_L1, k + 1) == 0)
+                        {
+                            num_prev_assigned_ch_1C = num_prev_assigned_ch_1C + 1;
+                        }
+                }
+        }
+    else
+        {
+            if (configuration->property("Tracking_1C.devicename", std::string("")).compare(device_name) != 0)
+                {
+                    num_prev_assigned_ch_1C = configuration->property("Channels_1C.count", 0);
+                }
+        }
+
+    uint32_t num_prev_assigned_ch_2S = configuration->property("Channels_2S.count", 0);
+    uint32_t num_prev_assigned_ch_L5 = configuration->property("Channels_L5.count", 0);
+    num_prev_assigned_ch = num_prev_assigned_ch_1C + num_prev_assigned_ch_2S + num_prev_assigned_ch_L5;
 
     // ################# PRE-COMPUTE ALL THE CODES #################
     uint32_t code_samples_per_chip = 2;

--- a/src/algorithms/tracking/adapters/galileo_e1_dll_pll_veml_tracking_fpga.h
+++ b/src/algorithms/tracking/adapters/galileo_e1_dll_pll_veml_tracking_fpga.h
@@ -123,7 +123,8 @@ public:
     void stop_tracking() override;
 
 private:
-    const std::string default_device_name = "multicorrelator_resampler_5_1_AXI";  // UIO device name
+    const std::string default_device_name_Galileo_E1 = "multicorrelator_resampler_5_1_AXI";  // UIO device name
+    const std::string default_device_name_GPS_L1 = "multicorrelator_resampler_S00_AXI";      // UIO device name
 
     // the following flags are FPGA-specific and they are using arrange the values of the local code in the way the FPGA
     // expects. This arrangement is done in the initialisation to avoid consuming unnecessary clock cycles during tracking.

--- a/src/algorithms/tracking/adapters/galileo_e5a_dll_pll_tracking_fpga.cc
+++ b/src/algorithms/tracking/adapters/galileo_e5a_dll_pll_tracking_fpga.cc
@@ -59,7 +59,7 @@ GalileoE5aDllPllTrackingFpga::GalileoE5aDllPllTrackingFpga(
     d_data_codes = nullptr;
 
     // UIO device file
-    device_name = configuration->property(role + ".devicename", default_device_name);
+    device_name = configuration->property(role + ".devicename", default_device_name_Galileo_E5a);
 
     // compute the number of tracking channels that have already been instantiated. The order in which
     // GNSS-SDR instantiates the tracking channels i L1, L2, L5, E1, E5a
@@ -67,9 +67,15 @@ GalileoE5aDllPllTrackingFpga::GalileoE5aDllPllTrackingFpga(
     // Therefore for the proper assignment of the FPGA tracking device file numbers to the E5a tracking channels,
     // the number of channels that have already been assigned to L5 must not be substracted to this channel number,
     // so they are not counted here.
-    num_prev_assigned_ch = configuration->property("Channels_1C.count", 0) +
-                           configuration->property("Channels_2S.count", 0) +
-                           configuration->property("Channels_1B.count", 0);
+
+    uint32_t num_prev_assigned_ch_1C = configuration->property("Channels_1C.count", 0);
+    uint32_t num_prev_assigned_ch_2S = 0;
+    if (configuration->property("Tracking_2S.devicename", std::string("")) != device_name)
+        {
+            num_prev_assigned_ch_2S = configuration->property("Channels_2S.count", 0);
+        }
+    uint32_t num_prev_assigned_ch_1B = configuration->property("Channels_1B.count", 0);
+    num_prev_assigned_ch = num_prev_assigned_ch_1C + num_prev_assigned_ch_2S + num_prev_assigned_ch_1B;
 
     // ################# PRE-COMPUTE ALL THE CODES #################
     uint32_t code_samples_per_chip = 1;

--- a/src/algorithms/tracking/adapters/galileo_e5a_dll_pll_tracking_fpga.h
+++ b/src/algorithms/tracking/adapters/galileo_e5a_dll_pll_tracking_fpga.h
@@ -116,7 +116,7 @@ public:
     void stop_tracking() override;
 
 private:
-    const std::string default_device_name = "multicorrelator_resampler_3_1_AXI";  // UIO device name
+    const std::string default_device_name_Galileo_E5a = "multicorrelator_resampler_3_1_AXI";  // UIO device name
 
     // the following flags are FPGA-specific and they are using arrange the values of the local code in the way the FPGA
     // expects. This arrangement is done in the initialisation to avoid consuming unnecessary clock cycles during tracking.

--- a/src/algorithms/tracking/adapters/gps_l1_ca_dll_pll_tracking_fpga.cc
+++ b/src/algorithms/tracking/adapters/gps_l1_ca_dll_pll_tracking_fpga.cc
@@ -67,7 +67,7 @@ GpsL1CaDllPllTrackingFpga::GpsL1CaDllPllTrackingFpga(
     std::memcpy(trk_params_fpga.signal, sig_.data(), 3);
 
     // UIO device file
-    device_name = configuration->property(role + ".devicename", default_device_name);
+    device_name = configuration->property(role + ".devicename", default_device_name_GPS_L1);
 
     // compute the number of tracking channels that have already been instantiated. The order in which
     // GNSS-SDR instantiates the tracking channels i L1, l2, L5, E1, E5a
@@ -153,11 +153,31 @@ void GpsL1CaDllPllTrackingFpga::set_channel(unsigned int channel)
 
     // UIO device file
     std::string device_io_name;
+
     // find the uio device file corresponding to the tracking multicorrelator
     if (find_uio_dev_file_name(device_io_name, device_name, channel - num_prev_assigned_ch) < 0)
         {
-            std::cout << "Cannot find the FPGA uio device file corresponding to device name " << device_name << std::endl;
-            throw std::exception();
+            bool alt_device_found = false;  // alternative compatible HW accelerator device not found by default
+
+            // If the HW accelerator is the default one in the L1 band then look for an alternative hardware accelerator
+            if (device_name.compare(default_device_name_GPS_L1) == 0)
+                {
+                    if (find_uio_dev_file_name(device_io_name, default_device_name_Galileo_E1, channel - num_prev_assigned_ch) < 0)
+                        {
+                            std::cout << "Cannot find the FPGA uio device file corresponding to device names " << device_name << " or " << default_device_name_Galileo_E1 << std::endl;
+                            throw std::exception();
+                        }
+                    else
+                        {
+                            alt_device_found = true;  // alternative compatible HW accelerator device has been found
+                        }
+                }
+
+            if (!alt_device_found)
+                {
+                    std::cout << "Cannot find the FPGA uio device file corresponding to device name " << device_name << std::endl;
+                    throw std::exception();
+                }
         }
 
     tracking_fpga_sc->set_channel(channel, device_io_name);

--- a/src/algorithms/tracking/adapters/gps_l1_ca_dll_pll_tracking_fpga.h
+++ b/src/algorithms/tracking/adapters/gps_l1_ca_dll_pll_tracking_fpga.h
@@ -121,7 +121,8 @@ public:
     void stop_tracking() override;
 
 private:
-    const std::string default_device_name = "multicorrelator_resampler_S00_AXI";  // UIO device name
+    const std::string default_device_name_GPS_L1 = "multicorrelator_resampler_S00_AXI";      // UIO device name
+    const std::string default_device_name_Galileo_E1 = "multicorrelator_resampler_5_1_AXI";  // UIO alternative device name
 
     static const uint32_t NUM_PRNs = 32;  // total number of PRNs
     static const int32_t GPS_CA_BIT_DURATION_MS = 20;

--- a/src/algorithms/tracking/adapters/gps_l2_m_dll_pll_tracking_fpga.cc
+++ b/src/algorithms/tracking/adapters/gps_l2_m_dll_pll_tracking_fpga.cc
@@ -65,7 +65,7 @@ GpsL2MDllPllTrackingFpga::GpsL2MDllPllTrackingFpga(
     std::memcpy(trk_params_fpga.signal, sig_.data(), 3);
 
     // UIO device file
-    device_name = configuration->property(role + ".devicename", default_device_name);
+    device_name = configuration->property(role + ".devicename", default_device_name_GPS_L2);
 
     // compute the number of tracking channels that have already been instantiated. The order in which
     // GNSS-SDR instantiates the tracking channels i L1, L2, L5, E1, E5a

--- a/src/algorithms/tracking/adapters/gps_l2_m_dll_pll_tracking_fpga.h
+++ b/src/algorithms/tracking/adapters/gps_l2_m_dll_pll_tracking_fpga.h
@@ -92,7 +92,7 @@ public:
     void stop_tracking() override;
 
 private:
-    const std::string default_device_name = "multicorrelator_resampler_S00_AXI";  // UIO device name
+    const std::string default_device_name_GPS_L2 = "multicorrelator_resampler_S00_AXI";  // UIO device name
 
     std::string device_name;
     uint32_t num_prev_assigned_ch;

--- a/src/algorithms/tracking/adapters/gps_l5_dll_pll_tracking_fpga.cc
+++ b/src/algorithms/tracking/adapters/gps_l5_dll_pll_tracking_fpga.cc
@@ -64,12 +64,18 @@ GpsL5DllPllTrackingFpga::GpsL5DllPllTrackingFpga(
     std::memcpy(trk_params_fpga.signal, sig_.data(), 3);
 
     // UIO device file
-    device_name = configuration->property(role + ".devicename", default_device_name);
+    device_name = configuration->property(role + ".devicename", default_device_name_GPS_L5);
 
     // compute the number of tracking channels that have already been instantiated. The order in which
     // GNSS-SDR instantiates the tracking channels i L1, L2, L5, E1, E5a
-    num_prev_assigned_ch = configuration->property("Channels_1C.count", 0) +
-                           configuration->property("Channels_2S.count", 0);
+
+    uint32_t num_prev_assigned_ch_1C = configuration->property("Channels_1C.count", 0);
+    uint32_t num_prev_assigned_ch_2S = 0;
+    if (configuration->property("Tracking_2S.devicename", std::string("")) != device_name)
+        {
+            num_prev_assigned_ch_2S = configuration->property("Channels_2S.count", 0);
+        }
+    num_prev_assigned_ch = num_prev_assigned_ch_1C + num_prev_assigned_ch_2S;
 
     // ################# PRE-COMPUTE ALL THE CODES #################
     uint32_t code_samples_per_chip = 1;

--- a/src/algorithms/tracking/adapters/gps_l5_dll_pll_tracking_fpga.h
+++ b/src/algorithms/tracking/adapters/gps_l5_dll_pll_tracking_fpga.h
@@ -122,7 +122,7 @@ public:
     void stop_tracking() override;
 
 private:
-    const std::string default_device_name = "multicorrelator_resampler_3_1_AXI";  // UIO device name
+    const std::string default_device_name_GPS_L5 = "multicorrelator_resampler_3_1_AXI";  // UIO device name
 
     static const uint32_t NUM_PRNs = 32;  // total number of PRNs
 


### PR DESCRIPTION
Use the Galileo E1 FPGA tracking multicorrelators for the GPS L1 C/A channels if not enough GPS L1 C/A tracking multicorrelators are present in the FPGA. This is the case for instance when the receiver has a limited number of FPGA tracking multicorrelators in the L1/E1 band, which can be used either for GPS L1 C/A or for Galileo E1b+c.
This selection is done automatically only if the GPS L1 C/A channels are assigned to the GPS L1 C/A FPGA tracking multicorrelators. This is the default assignment, but it may not be the case when testing.