### PR TITLE
proper initialization of samples_to_skip_. Change samples_ from uint6…

### DIFF
--- a/src/algorithms/signal_source/adapters/ad9361_fpga_signal_source.h
+++ b/src/algorithms/signal_source/adapters/ad9361_fpga_signal_source.h
@@ -79,7 +79,7 @@ private:
         const std::string &filename1,
         uint64_t &samples_to_skip,
         size_t &item_size,
-        uint64_t &samples,
+        int64_t &samples,
         bool &repeat,
         uint32_t &dma_buff_offset_pos,
         Concurrent_Queue<pmt::pmt_t> *queue);
@@ -143,7 +143,7 @@ private:
     bool rf_shutdown_;
 
     // post-processing mode
-    uint64_t samples_;
+    int64_t samples_;
     uint64_t samples_to_skip_;
     bool repeat_;
     uint32_t num_freq_bands_;


### PR DESCRIPTION
proper initialization of samples_to_skip_. Change samples_ from uint64_t to int64_t for the proper checking of the number of samples to process.