### PR TITLE
Fifo source

### DIFF
--- a/conf/gnss-sdr_GPS_L1_fifo.conf
+++ b/conf/gnss-sdr_GPS_L1_fifo.conf
@@ -1,0 +1,47 @@
+[GNSS-SDR]
+
+;######### GLOBAL OPTIONS ##################
+GNSS-SDR.internal_fs_sps=25000000
+
+;######### SIGNAL_SOURCE CONFIG ############
+SignalSource.implementation=Fifo_Signal_Source
+SignalSource.filename=fifo.fifo	; example usage: mkfifo fifo.fifo && cat path_to.bin >> fifo.fifo
+SignalSource.sample_type=ishort;	; sample representation in fifo stream - will always output gr_complex
+SignalSource.dump=false
+;SignalSource.dump_filename=dump
+
+;######### SIGNAL_CONDITIONER CONFIG ############
+SignalConditioner.implementation=Pass_Through
+
+;######### CHANNELS GLOBAL CONFIG ############
+Channels_1C.count=8
+Channels.in_acquisition=1
+Channel.signal=1C
+
+;######### ACQUISITION GLOBAL CONFIG ############
+Acquisition_1C.implementation=GPS_L1_CA_PCPS_Acquisition
+Acquisition_1C.item_type=gr_complex
+Acquisition_1C.pfa=0.01
+Acquisition_1C.doppler_max=10000
+Acquisition_1C.doppler_step=250
+
+;######### TRACKING GLOBAL CONFIG ############
+Tracking_1C.implementation=GPS_L1_CA_DLL_PLL_Tracking
+Tracking_1C.item_type=gr_complex
+Tracking_1C.pll_bw_hz=40.0;
+Tracking_1C.dll_bw_hz=4.0;
+
+;######### TELEMETRY DECODER GPS CONFIG ############
+TelemetryDecoder_1C.implementation=GPS_L1_CA_Telemetry_Decoder
+
+;######### OBSERVABLES CONFIG ############
+Observables.implementation=Hybrid_Observables
+
+;######### PVT CONFIG ############
+PVT.implementation=RTKLIB_PVT
+PVT.positioning_mode=Single
+PVT.output_rate_ms=100
+PVT.display_rate_ms=500
+PVT.iono_model=Broadcast
+PVT.trop_model=Saastamoinen
+PVT.output_path=./files

--- a/conf/gnss-sdr_GPS_L1_fifo.conf
+++ b/conf/gnss-sdr_GPS_L1_fifo.conf
@@ -1,3 +1,12 @@
+; This is a GNSS-SDR configuration file
+; The configuration API is described at https://gnss-sdr.org/docs/sp-blocks/
+; SPDX-License-Identifier: GPL-3.0-or-later
+; SPDX-FileCopyrightText: (C) 2010-2021  (see AUTHORS file for a list of contributors)
+
+; You can define your own receiver and invoke it by doing
+; gnss-sdr --config_file=my_GNSS_SDR_configuration.conf
+;
+
 [GNSS-SDR]
 
 ;######### GLOBAL OPTIONS ##################

--- a/src/algorithms/signal_generator/gnuradio_blocks/signal_generator_c.cc
+++ b/src/algorithms/signal_generator/gnuradio_blocks/signal_generator_c.cc
@@ -272,7 +272,7 @@ void signal_generator_c::generate_codes()
                                 {
                                     for (unsigned int i = 0; i < vector_length_; i++)
                                         {
-                                            sampled_code_pilot_[sat][i] *= sqrt(std::pow(10.0F, CN0_dB_[sat] / 10.0F) / BW_BB_ / 2.0F);
+                                            sampled_code_pilot_[sat][i] *= std::sqrt(std::pow(10.0F, CN0_dB_[sat] / 10.0F) / BW_BB_ / 2.0F);
                                         }
                                 }
                         }
@@ -313,7 +313,7 @@ void signal_generator_c::generate_codes()
                                 {
                                     for (unsigned int i = 0; i < vector_length_; i++)
                                         {
-                                            sampled_code_pilot_[sat][i] *= sqrt(std::pow(10.0F, CN0_dB_[sat] / 10.0F) / BW_BB_ / 2.0F);
+                                            sampled_code_pilot_[sat][i] *= std::sqrt(std::pow(10.0F, CN0_dB_[sat] / 10.0F) / BW_BB_ / 2.0F);
                                         }
                                 }
                         }

--- a/src/algorithms/signal_source/adapters/CMakeLists.txt
+++ b/src/algorithms/signal_source/adapters/CMakeLists.txt
@@ -95,6 +95,7 @@ set(SIGNAL_SOURCE_ADAPTER_SOURCES
     signal_source_base.cc
     file_source_base.cc
     file_signal_source.cc
+    fifo_signal_source.cc
     multichannel_file_signal_source.cc
     gen_signal_source.cc
     nsr_file_signal_source.cc
@@ -111,6 +112,7 @@ set(SIGNAL_SOURCE_ADAPTER_HEADERS
     signal_source_base.h
     file_source_base.h
     file_signal_source.h
+    fifo_signal_source.h
     multichannel_file_signal_source.h
     gen_signal_source.h
     nsr_file_signal_source.h

--- a/src/algorithms/signal_source/adapters/fifo_signal_source.cc
+++ b/src/algorithms/signal_source/adapters/fifo_signal_source.cc
@@ -1,7 +1,7 @@
 /*!
- * \file file_source_base.cc
+ * \file fifo_signal_source.cc
  *
- * \brief Implementation of the class for retrieving samples through a Unix fifo
+ * \brief Implementation of the class for retrieving samples through a Unix FIFO
  * \author Malte Lenhart, 2021. malte.lenhart(at)mailbox.org
  *
  * -----------------------------------------------------------------------------
@@ -18,12 +18,10 @@
 #include "fifo_signal_source.h"
 #include "configuration_interface.h"
 #include "fifo_reader.h"
-#include "gnss_sdr_flags.h"
 #include "gnss_sdr_string_literals.h"
 #include <glog/logging.h>
 #include <gnuradio/blocks/file_sink.h>
 #include <gnuradio/blocks/file_source.h>
-#include <cmath>  // ceil, floor
 
 
 using namespace std::string_literals;
@@ -69,7 +67,7 @@ void FifoSignalSource::disconnect(gr::top_block_sptr top_block)
     if (dump_)
         {
             top_block->disconnect(fifo_reader_, 0, file_sink_, 0);
-            DLOG(INFO) << "disconnected source to file sink";
+            DLOG(INFO) << "disconnected source from file sink";
         }
 }
 

--- a/src/algorithms/signal_source/adapters/fifo_signal_source.cc
+++ b/src/algorithms/signal_source/adapters/fifo_signal_source.cc
@@ -1,0 +1,93 @@
+/*!
+ * \file file_source_base.cc
+ *
+ * \brief Implementation of the class for retrieving samples through a Unix fifo
+ * \author Malte Lenhart, 2021. malte.lenhart(at)mailbox.org
+ *
+ * -----------------------------------------------------------------------------
+ *
+ * GNSS-SDR is a Global Navigation Satellite System software-defined receiver.
+ * This file is part of GNSS-SDR.
+ *
+ * Copyright (C) 2010-2021  (see AUTHORS file for a list of contributors)
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ *
+ * -----------------------------------------------------------------------------
+ */
+
+#include "fifo_signal_source.h"
+#include "configuration_interface.h"
+#include "fifo_reader.h"
+#include "gnss_sdr_filesystem.h"
+#include "gnss_sdr_flags.h"
+#include "gnss_sdr_string_literals.h"
+#include "gnss_sdr_valve.h"
+#include <glog/logging.h>
+#include <cmath>  // ceil, floor
+#include <fstream>
+#include <utility>  // move
+
+
+using namespace std::string_literals;
+
+FifoSignalSource::FifoSignalSource(ConfigurationInterface const* configuration,
+    std::string const& role, unsigned int in_streams, unsigned int out_streams,
+    Concurrent_Queue<pmt::pmt_t>* queue)
+    : SignalSourceBase(configuration, role, "Fifo_Signal_Source"s),
+      item_size_(sizeof(gr_complex)),  // currenty output item size is always gr_complex
+      fifo_reader_(FifoReader::make(configuration->property(role + ".filename"s, "../data/example_capture.dat"s),
+          configuration->property(role + ".sample_type"s, "ishort"s))),
+      dump_(configuration->property(role + ".dump", false)),
+      dump_filename_(configuration->property(role + ".dump_filename"s, "./data/signal_source.dat"s))
+{
+    if (dump_)
+        {
+            DLOG(INFO) << "Dumping output into file " << (dump_filename_ + ".bin"s);
+            file_sink_ = gr::blocks::file_sink::make(item_size_, (dump_filename_ + ".bin").c_str());
+        }
+
+    if (in_streams > 0)
+        {
+            LOG(ERROR) << "A signal source does not have an input stream";
+        }
+    if (out_streams > 1)
+        {
+            LOG(ERROR) << "This implementation only supports one output stream";
+        }
+}
+
+void FifoSignalSource::connect(gr::top_block_sptr top_block)
+{
+    // here we could add a throttle as done in the file_source_base if required
+    if (dump_)
+        {
+            top_block->connect(fifo_reader_, 0, file_sink_, 0);
+            DLOG(INFO) << "connected source to file sink";
+        }
+}
+
+void FifoSignalSource::disconnect(gr::top_block_sptr top_block)
+{
+    if (dump_)
+        {
+            top_block->disconnect(fifo_reader_, 0, file_sink_, 0);
+            DLOG(INFO) << "disconnected source to file sink";
+        }
+}
+
+size_t FifoSignalSource::item_size()
+{
+    return item_size_;
+}
+
+gr::basic_block_sptr FifoSignalSource::get_left_block()
+{
+    LOG(WARNING) << "Left block of a signal source should not be retrieved";
+    return gr::blocks::file_source::sptr();
+}
+
+
+gr::basic_block_sptr FifoSignalSource::get_right_block()
+{
+    return fifo_reader_;
+}

--- a/src/algorithms/signal_source/adapters/fifo_signal_source.cc
+++ b/src/algorithms/signal_source/adapters/fifo_signal_source.cc
@@ -18,14 +18,12 @@
 #include "fifo_signal_source.h"
 #include "configuration_interface.h"
 #include "fifo_reader.h"
-#include "gnss_sdr_filesystem.h"
 #include "gnss_sdr_flags.h"
 #include "gnss_sdr_string_literals.h"
-#include "gnss_sdr_valve.h"
 #include <glog/logging.h>
+#include <gnuradio/blocks/file_sink.h>
+#include <gnuradio/blocks/file_source.h>
 #include <cmath>  // ceil, floor
-#include <fstream>
-#include <utility>  // move
 
 
 using namespace std::string_literals;

--- a/src/algorithms/signal_source/adapters/fifo_signal_source.cc
+++ b/src/algorithms/signal_source/adapters/fifo_signal_source.cc
@@ -28,7 +28,7 @@ using namespace std::string_literals;
 
 FifoSignalSource::FifoSignalSource(ConfigurationInterface const* configuration,
     std::string const& role, unsigned int in_streams, unsigned int out_streams,
-    Concurrent_Queue<pmt::pmt_t>* queue)
+    [[maybe_unused]] Concurrent_Queue<pmt::pmt_t>* queue)
     : SignalSourceBase(configuration, role, "Fifo_Signal_Source"s),
       item_size_(sizeof(gr_complex)),  // currenty output item size is always gr_complex
       fifo_reader_(FifoReader::make(configuration->property(role + ".filename"s, "../data/example_capture.dat"s),

--- a/src/algorithms/signal_source/adapters/fifo_signal_source.h
+++ b/src/algorithms/signal_source/adapters/fifo_signal_source.h
@@ -44,7 +44,7 @@ class ConfigurationInterface;
 //!             - may be overridden by the -signal_source or -s command-line arguments
 //!
 //!   .sample_type - data type read out from the fifo. default ishort ;
-//!				   - note: not output format. that is always gr_complex
+//!                - note: not output format. that is always gr_complex
 //!
 //!   .dump     - whether to archive input data
 //!

--- a/src/algorithms/signal_source/adapters/fifo_signal_source.h
+++ b/src/algorithms/signal_source/adapters/fifo_signal_source.h
@@ -1,0 +1,83 @@
+/*!
+ * \file file_source_base.h
+ *
+ * \brief Header file of the class for retrieving samples through a Unix fifo
+ * \author Malte Lenhart, 2021. malte.lenhart(at)mailbox.org
+ *
+ *
+ * -----------------------------------------------------------------------------
+ *
+ * GNSS-SDR is a Global Navigation Satellite System software-defined receiver.
+ * This file is part of GNSS-SDR.
+ *
+ * Copyright (C) 2010-2021  (see AUTHORS file for a list of contributors)
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ *
+ * -----------------------------------------------------------------------------
+ */
+
+#ifndef GNSS_SDR_FIFO_SOURCE_BASE_H
+#define GNSS_SDR_FIFO_SOURCE_BASE_H
+
+#include "concurrent_queue.h"
+#include "file_source_base.h"
+#include "gnss_block_interface.h"
+#include <gnuradio/blocks/file_source.h>
+#include <gnuradio/blocks/throttle.h>
+#include <pmt/pmt.h>
+#include <tuple>
+
+// for dump
+#include <gnuradio/blocks/file_sink.h>
+#include <cstddef>
+#include <string>
+
+
+class ConfigurationInterface;
+
+
+//! \brief Class that reads a sample stream from a Unix fifo
+//!
+//! This class supports the following properties:
+//!
+//!   .filename - the path to the input file
+//!             - may be overridden by the -signal_source or -s command-line arguments
+//!
+//!   .sample_type - data type read out from the fifo. default ishort ;
+//!				   - note: not output format. that is always gr_complex
+//!
+//!   .dump     - whether to archive input data
+//!
+//!   .dump_filename - if dumping, path to file for output
+
+
+class FifoSignalSource : public SignalSourceBase
+{
+public:
+    FifoSignalSource(const ConfigurationInterface* configuration, const std::string& role,
+        unsigned int in_streams, unsigned int out_streams,
+        Concurrent_Queue<pmt::pmt_t>* queue);
+
+    ~FifoSignalSource() = default;
+
+    //! override methods from GNSSBlockInterface
+    void connect(gr::top_block_sptr top_block) override;
+    void disconnect(gr::top_block_sptr top_block) override;
+    size_t item_size() override;
+    gr::basic_block_sptr get_left_block() override;
+    gr::basic_block_sptr get_right_block() override;
+
+protected:
+private:
+    //! output size - always gr_complex
+    const size_t item_size_;
+    //! internal fifo_reader_ class acts as signal source
+    const gnss_shared_ptr<gr::block> fifo_reader_;
+
+    gnss_shared_ptr<gr::block> file_sink_;
+    const bool dump_;
+    const std::string dump_filename_;
+};
+
+
+#endif

--- a/src/algorithms/signal_source/adapters/fifo_signal_source.h
+++ b/src/algorithms/signal_source/adapters/fifo_signal_source.h
@@ -16,25 +16,20 @@
  * -----------------------------------------------------------------------------
  */
 
-#ifndef GNSS_SDR_FIFO_SOURCE_BASE_H
-#define GNSS_SDR_FIFO_SOURCE_BASE_H
+#ifndef GNSS_SDR_FIFO_SIGNAL_SOURCE_H
+#define GNSS_SDR_FIFO_SIGNAL_SOURCE_H
 
 #include "concurrent_queue.h"
-#include "file_source_base.h"
-#include "gnss_block_interface.h"
-#include <gnuradio/blocks/file_source.h>
-#include <gnuradio/blocks/throttle.h>
+#include "signal_source_base.h"
 #include <pmt/pmt.h>
-#include <tuple>
 
-// for dump
-#include <gnuradio/blocks/file_sink.h>
-#include <cstddef>
-#include <string>
 
+/** \addtogroup Signal_Source
+ * \{ */
+/** \addtogroup Signal_Source_adapters
+ * \{ */
 
 class ConfigurationInterface;
-
 
 //! \brief Class that reads a sample stream from a Unix fifo
 //!
@@ -79,5 +74,6 @@ private:
     const std::string dump_filename_;
 };
 
-
-#endif
+/** \} */
+/** \} */
+#endif  // GNSS_SDR_FIFO_SIGNAL_SOURCE_H

--- a/src/algorithms/signal_source/adapters/fifo_signal_source.h
+++ b/src/algorithms/signal_source/adapters/fifo_signal_source.h
@@ -1,7 +1,7 @@
 /*!
- * \file file_source_base.h
+ * \file fifo_signal_source.h
  *
- * \brief Header file of the class for retrieving samples through a Unix fifo
+ * \brief Header file of the class for retrieving samples through a Unix FIFO
  * \author Malte Lenhart, 2021. malte.lenhart(at)mailbox.org
  *
  *
@@ -29,23 +29,23 @@
 /** \addtogroup Signal_Source_adapters
  * \{ */
 
+// forward declaration to avoid include in header
 class ConfigurationInterface;
 
-//! \brief Class that reads a sample stream from a Unix fifo
+//! \brief Class that reads a sample stream from a Unix FIFO.
 //!
 //! This class supports the following properties:
 //!
 //!   .filename - the path to the input file
 //!             - may be overridden by the -signal_source or -s command-line arguments
 //!
-//!   .sample_type - data type read out from the fifo. default ishort ;
+//!   .sample_type - data type read out from the FIFO. default ishort ;
 //!                - note: not output format. that is always gr_complex
 //!
 //!   .dump     - whether to archive input data
 //!
 //!   .dump_filename - if dumping, path to file for output
-
-
+//!
 class FifoSignalSource : public SignalSourceBase
 {
 public:

--- a/src/algorithms/signal_source/adapters/file_source_base.cc
+++ b/src/algorithms/signal_source/adapters/file_source_base.cc
@@ -261,7 +261,7 @@ uint64_t FileSourceBase::samples() const
 
 std::tuple<size_t, bool> FileSourceBase::itemTypeToSize()
 {
-    auto is_complex_t = false;
+    auto is_interleaved = false;
     auto item_size = size_t(0);
 
     if (item_type_ == "gr_complex")
@@ -279,7 +279,7 @@ std::tuple<size_t, bool> FileSourceBase::itemTypeToSize()
     else if (item_type_ == "ishort")
         {
             item_size = sizeof(int16_t);
-            is_complex_t = true;
+            is_interleaved = true;
         }
     else if (item_type_ == "byte")
         {
@@ -288,7 +288,7 @@ std::tuple<size_t, bool> FileSourceBase::itemTypeToSize()
     else if (item_type_ == "ibyte")
         {
             item_size = sizeof(int8_t);
-            is_complex_t = true;
+            is_interleaved = true;
         }
     else
         {
@@ -297,7 +297,7 @@ std::tuple<size_t, bool> FileSourceBase::itemTypeToSize()
             item_size = sizeof(gr_complex);
         }
 
-    return std::make_tuple(item_size, is_complex_t);
+    return std::make_tuple(item_size, is_interleaved);
 }
 
 
@@ -338,7 +338,7 @@ size_t FileSourceBase::samplesToSkip() const
 
 size_t FileSourceBase::computeSamplesInFile() const
 {
-    auto n_samples = size_t(samples());
+    auto n_samples = static_cast<size_t>(samples());
 
     // if configured with 0 samples (read the whole file), figure out how many samples are in the file, and go from there
     if (n_samples == 0)
@@ -467,7 +467,7 @@ gnss_shared_ptr<gr::block> FileSourceBase::create_valve()
     if (samples() > 0)
         {
             // if a number of samples is specified, honor it by creating a valve
-            // In practice, this is always true
+            // in practice, this is always true
             valve_ = gnss_sdr_make_valve(source_item_size(), samples(), queue_);
             DLOG(INFO) << "valve(" << valve_->unique_id() << ")";
 
@@ -499,7 +499,7 @@ void FileSourceBase::create_valve_hook() {}
 void FileSourceBase::create_sink_hook() {}
 
 
-// Subclass hooks for connection/disconnectino
+// Subclass hooks for connection/disconnection
 void FileSourceBase::pre_connect_hook(gr::top_block_sptr top_block [[maybe_unused]]) {}      // NOLINT(performance-unnecessary-value-param)
 void FileSourceBase::post_connect_hook(gr::top_block_sptr top_block [[maybe_unused]]) {}     // NOLINT(performance-unnecessary-value-param)
 void FileSourceBase::pre_disconnect_hook(gr::top_block_sptr top_block [[maybe_unused]]) {}   // NOLINT(performance-unnecessary-value-param)

--- a/src/algorithms/signal_source/gnuradio_blocks/CMakeLists.txt
+++ b/src/algorithms/signal_source/gnuradio_blocks/CMakeLists.txt
@@ -14,6 +14,7 @@ endif()
 
 
 set(SIGNAL_SOURCE_GR_BLOCKS_SOURCES
+    fifo_reader.cc
     unpack_byte_2bit_samples.cc
     unpack_byte_2bit_cpx_samples.cc
     unpack_byte_4bit_samples.cc
@@ -27,6 +28,7 @@ set(SIGNAL_SOURCE_GR_BLOCKS_SOURCES
 
 
 set(SIGNAL_SOURCE_GR_BLOCKS_HEADERS
+    fifo_reader.h
     unpack_byte_2bit_samples.h
     unpack_byte_2bit_cpx_samples.h
     unpack_byte_4bit_samples.h

--- a/src/algorithms/signal_source/gnuradio_blocks/fifo_reader.cc
+++ b/src/algorithms/signal_source/gnuradio_blocks/fifo_reader.cc
@@ -1,0 +1,111 @@
+/*!
+ * \file fifo_reader.cc
+ *
+ * \brief Implementation of the class to retrieve samples from an existing Unix FIFO
+ * \author Malte Lenhart, 2021. malte.lenhart(at)mailbox.org
+ *
+ * -----------------------------------------------------------------------------
+ *
+ * GNSS-SDR is a Global Navigation Satellite System software-defined receiver.
+ * This file is part of GNSS-SDR.
+ *
+ * Copyright (C) 2010-2020  (see AUTHORS file for a list of contributors)
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ *
+ * -----------------------------------------------------------------------------
+ */
+
+#include "fifo_reader.h"
+#include <glog/logging.h>
+#include <cstdlib>
+#include <fstream>
+#include <iostream>
+#include <string>
+
+// initial construction; pass to private constructor
+FifoReader::sptr FifoReader::make(const std::string &file_name, const std::string &sample_type)
+{
+    return gnuradio::get_initial_sptr(new FifoReader(file_name, sample_type));
+}
+
+// private constructor called by ::make
+FifoReader::FifoReader(const std::string &file_name, const std::string &sample_type)
+    : gr::sync_block("fifo_reader",
+          gr::io_signature::make(0, 0, 0),                    // no input
+          gr::io_signature::make(1, 1, sizeof(gr_complex))),  // <+MIN_OUT+>, <+MAX_OUT+>, sizeof(<+OTYPE+>)
+      file_name_(file_name),
+      sample_type_(sample_type)
+{
+    std::cout << "Starting FifoReader\n";
+    // instream: https://en.cppreference.com/w/cpp/io/basic_ifstream
+}
+
+bool FifoReader::start()
+{
+    fifo_.open(file_name_, std::ios::binary);
+    if (!fifo_.is_open())
+        {
+            DLOG(ERROR) << "Error opening fifo\n";
+            return false;
+        }
+    return true;
+}
+
+// work loop
+// taken from here: https://stackoverflow.com/questions/25546619/work-with-fifo-in-c-blocking-read
+int FifoReader::work(int noutput_items,
+    __attribute__((unused)) gr_vector_const_void_star &input_items,
+    gr_vector_void_star &output_items)
+{
+    if (output_items.size() > 1)
+        {
+            DLOG(ERROR) << "FifoReader connected to too many outputs\n";
+        }
+
+    // read samples out
+    size_t items_retrieved = 0;
+    if (sample_type_ == "ishort")
+        {
+            // ishort == int16_t
+            items_retrieved = read_interleaved<int16_t>(noutput_items, output_items);
+        }
+    else if (sample_type_ == "gr_complex")
+        {
+            DLOG(WARNING) << sample_type_ << " is not yet tested. Please consider removing this warning if tested successfully\n";
+            items_retrieved = read_gr_complex(noutput_items, output_items);
+        }
+    else
+        {
+            // please see gr_complex_ip_packet_source for inspiration on how to implement other sample types
+            DLOG(ERROR) << sample_type_ << " is unfortunately not yet implemented as sample type\n";
+        }
+
+    // we return varying number of data -> call produce & return flag
+    produce(0, items_retrieved);
+    return this->WORK_CALLED_PRODUCE;
+}
+
+// read gr_complex items from fifo
+size_t FifoReader::read_gr_complex(int noutput_items, gr_vector_void_star &output_items)
+{
+    size_t items_retrieved = 0;
+    for (int n = 0; n < noutput_items; n++)
+        {
+            std::vector<char> buffer(4);
+            fifo_.read((char *)&buffer[0], buffer.size());
+            if (fifo_.good())
+                {
+                    gr_complex sample;
+                    memcpy(&sample, &buffer[0], sizeof(sample));
+                    static_cast<gr_complex *>(output_items.at(0))[n] = sample;
+                    items_retrieved++;
+                }
+            else if (fifo_.eof() || fifo_.fail())
+                {
+                    // not enough samples.. what if we did not have a complete sample? need to reassemble in between loops
+                    fifo_.clear();
+                    break;
+                }
+        }
+    return items_retrieved;
+}

--- a/src/algorithms/signal_source/gnuradio_blocks/fifo_reader.cc
+++ b/src/algorithms/signal_source/gnuradio_blocks/fifo_reader.cc
@@ -101,9 +101,14 @@ size_t FifoReader::read_gr_complex(int noutput_items, gr_vector_void_star &outpu
                 }
             else
                 {
-                    LOG(ERROR) << "unhandled FIFO event";
+                    fifo_error_output();
                     break;
                 }
         }
     return items_retrieved;
+}
+
+void FifoReader::fifo_error_output() const
+{
+    LOG(ERROR) << "unhandled FIFO event";
 }

--- a/src/algorithms/signal_source/gnuradio_blocks/fifo_reader.h
+++ b/src/algorithms/signal_source/gnuradio_blocks/fifo_reader.h
@@ -1,0 +1,93 @@
+/*!
+ * \file fifo_reader.h
+ *
+ * \brief Header file to retrieve samples from an existing Unix FIFO
+ * \author Malte Lenhart, 2021. malte.lenhart(at)mailbox.org
+ *
+ * -----------------------------------------------------------------------------
+ *
+ * GNSS-SDR is a Global Navigation Satellite System software-defined receiver.
+ * This file is part of GNSS-SDR.
+ *
+ * Copyright (C) 2010-2020  (see AUTHORS file for a list of contributors)
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ *
+ * -----------------------------------------------------------------------------
+ */
+
+#ifndef GNSS_SDR_FIFO_READER_H_
+#define GNSS_SDR_FIFO_READER_H_
+
+#include "gnss_block_interface.h"
+#include <gnuradio/sync_block.h>
+#include <fstream>  // std::ifstream
+
+/** \addtogroup Signal_Source
+ * \{ */
+/** \addtogroup Signal_Source_gnuradio_blocks
+ * \{ */
+
+class FifoReader : virtual public gr::sync_block
+{
+public:
+    //! \brief static function to create a class instance
+    using sptr = gnss_shared_ptr<FifoReader>;
+    static sptr make(const std::string &file_name, const std::string &sample_type);
+
+    ~FifoReader() = default;
+
+    //! initialize istream resource for fifo
+    bool start();
+
+    // gnu radio work cycle function
+    int work(int noutput_items,
+        gr_vector_const_void_star &input_items,
+        gr_vector_void_star &output_items);
+
+private:
+    //! \brief Constructor
+    //! private constructor called by function make
+    //! (gr handles this with public and private header pair)
+    FifoReader(const std::string &file_name, const std::string &sample_type);
+
+
+    size_t read_gr_complex(int noutput_items, gr_vector_void_star &output_items);
+    //! function to read data out of fifo which is stored as interleaved I/Q stream.
+    //! template argument determines sample_type
+    template <typename Type>
+    size_t read_interleaved(int noutput_items, gr_vector_void_star &output_items)
+    {
+        size_t items_retrieved = 0;
+        for (int n = 0; n < noutput_items; n++)
+            {
+                // TODO: try if performance increases if we copy larger chunks to vector.
+                // read from fifo: https://en.cppreference.com/w/cpp/io/basic_ifstream
+                std::vector<char> buffer(4);  // dynamically change buffer size depending on read speed? where to throttle?
+                fifo_.read((char *)&buffer[0], buffer.size());
+                if (fifo_.good())
+                    {
+                        Type real;
+                        Type imag;
+                        memcpy(&real, &buffer[0], sizeof(real));
+                        memcpy(&imag, &buffer[2], sizeof(imag));
+                        static_cast<gr_complex *>(output_items.at(0))[n] = gr_complex(imag, real);
+                        items_retrieved++;
+                    }
+                else if (fifo_.eof() || fifo_.fail())
+                    {
+                        // not enough samples.. what if we did not have a complete sample? need to reassemble in between loops
+                        fifo_.clear();
+                        break;
+                    }
+            }
+        return items_retrieved;
+    }
+
+    const std::string file_name_;
+    const std::string sample_type_;
+    std::ifstream fifo_;
+};
+
+/** \} */
+/** \} */
+#endif /* GNSS_SDR_FIFO_READER_H_ */

--- a/src/algorithms/signal_source/gnuradio_blocks/fifo_reader.h
+++ b/src/algorithms/signal_source/gnuradio_blocks/fifo_reader.h
@@ -26,7 +26,6 @@
  * \{ */
 /** \addtogroup Signal_Source_gnuradio_blocks
  * \{ */
-
 class FifoReader : virtual public gr::sync_block
 {
 public:
@@ -80,12 +79,16 @@ private:
                     }
                 else
                     {
-                        LOG(ERROR) << "unhandled FIFO event";
+                        fifo_error_output();
                         break;
                     }
             }
         return items_retrieved;
     }
+
+    //! this function moves logging output from this header into the source file
+    //! thereby eliminating the need to include glog/logging.h in this header
+    void fifo_error_output() const;
 
     const std::string file_name_;
     const std::string sample_type_;

--- a/src/algorithms/signal_source/gnuradio_blocks/gr_complex_ip_packet_source.cc
+++ b/src/algorithms/signal_source/gnuradio_blocks/gr_complex_ip_packet_source.cc
@@ -27,7 +27,7 @@
 #include <boost/bind/bind.hpp>
 #endif
 
-const int FIFO_SIZE = 1'472'000;
+const int FIFO_SIZE = 1472000;
 
 
 /* 4 bytes IP address */

--- a/src/algorithms/signal_source/gnuradio_blocks/gr_complex_ip_packet_source.cc
+++ b/src/algorithms/signal_source/gnuradio_blocks/gr_complex_ip_packet_source.cc
@@ -27,7 +27,7 @@
 #include <boost/bind/bind.hpp>
 #endif
 
-const int FIFO_SIZE = 1472000;
+const int FIFO_SIZE = 1'472'000;
 
 
 /* 4 bytes IP address */
@@ -104,6 +104,7 @@ Gr_Complex_Ip_Packet_Source::Gr_Complex_Ip_Packet_Source(std::string src_device,
           gr::io_signature::make(1, 4, item_size))  // 1 to 4 baseband complex channels
 {
     std::cout << "Start Ethernet packet capture\n";
+    std::cout << "Overflow events will be indicated by o's\n";
 
     d_n_baseband_channels = n_baseband_channels;
     if (wire_sample_type == "cbyte")
@@ -120,6 +121,11 @@ Gr_Complex_Ip_Packet_Source::Gr_Complex_Ip_Packet_Source(std::string src_device,
         {
             d_wire_sample_type = 3;
             d_bytes_per_sample = d_n_baseband_channels * 8;
+        }
+    else if (wire_sample_type == "ishort")
+        {
+            d_wire_sample_type = 4;
+            d_bytes_per_sample = d_n_baseband_channels * 4;
         }
     else
         {
@@ -307,7 +313,7 @@ void Gr_Complex_Ip_Packet_Source::pcap_callback(__attribute__((unused)) u_char *
                     else
                         {
                             // notify overflow
-                            std::cout << "O" << std::flush;
+                            std::cout << "o" << std::flush;
                         }
                 }
         }
@@ -397,6 +403,25 @@ void Gr_Complex_Ip_Packet_Source::demux_samples(const gr_vector_void_star &outpu
                                 }
                         }
                     break;
+                case 4:  // interleaved short samples
+                    for (const auto &output_item : output_items)
+                        {
+                            int16_t real;
+                            int16_t imag;
+                            memcpy(&real, &fifo_buff[fifo_read_ptr], sizeof(real));
+                            fifo_read_ptr += 2;  // two bytes in short
+                            memcpy(&imag, &fifo_buff[fifo_read_ptr], sizeof(imag));
+                            fifo_read_ptr += 2;  // two bytes in short
+                            if (d_IQ_swap)
+                                {
+                                    static_cast<gr_complex *>(output_item)[n] = gr_complex(real, imag);
+                                }
+                            else
+                                {
+                                    static_cast<gr_complex *>(output_item)[n] = gr_complex(imag, real);
+                                }
+                        }
+                    break;
                 default:
                     std::cout << "Unknown wire sample type\n";
                     exit(0);
@@ -422,36 +447,20 @@ int Gr_Complex_Ip_Packet_Source::work(int noutput_items,
 
     if (output_items.size() > static_cast<uint64_t>(d_n_baseband_channels))
         {
-            std::cout << "Configuration error: more baseband channels connected than the available in the UDP source\n";
+            std::cout << "Configuration error: more baseband channels connected than available in the UDP source\n";
             exit(0);
         }
     int num_samples_readed;
     int bytes_requested;
-    switch (d_wire_sample_type)
+
+    bytes_requested = noutput_items * d_bytes_per_sample;
+    if (bytes_requested < fifo_items)
         {
-        case 1:  // complex byte samples
-        case 2:  // complex 4 bits samples
-        case 3:  // complex float samples
-            bytes_requested = noutput_items * d_bytes_per_sample;
-            if (bytes_requested < fifo_items)
-                {
-                    num_samples_readed = noutput_items;  // read all
-                }
-            else
-                {
-                    num_samples_readed = fifo_items / d_bytes_per_sample;  // read what we have
-                }
-            break;
-        default:  // complex byte samples
-            bytes_requested = noutput_items * d_bytes_per_sample;
-            if (bytes_requested < fifo_items)
-                {
-                    num_samples_readed = noutput_items;  // read all
-                }
-            else
-                {
-                    num_samples_readed = fifo_items / d_bytes_per_sample;  // read what we have
-                }
+            num_samples_readed = noutput_items;  // read all
+        }
+    else
+        {
+            num_samples_readed = fifo_items / d_bytes_per_sample;  // read what we have
         }
 
     bytes_requested = num_samples_readed * d_bytes_per_sample;

--- a/src/core/receiver/gnss_block_factory.cc
+++ b/src/core/receiver/gnss_block_factory.cc
@@ -37,8 +37,8 @@
 #include "channel.h"
 #include "configuration_interface.h"
 #include "direct_resampler_conditioner.h"
-#include "file_signal_source.h"
 #include "fifo_signal_source.h"
+#include "file_signal_source.h"
 #include "fir_filter.h"
 #include "freq_xlating_fir_filter.h"
 #include "galileo_e1_dll_pll_veml_tracking.h"
@@ -649,11 +649,11 @@ std::unique_ptr<GNSSBlockInterface> GNSSBlockFactory::GetBlock(
 
             // SIGNAL SOURCES ----------------------------------------------------------
             else if (implementation == "Fifo_Signal_Source")
-            	{
-            		std::unique_ptr<GNSSBlockInterface> block_ = std::make_unique<FifoSignalSource>(configuration, role, in_streams,
-						out_streams, queue);
-					block = std::move(block_);
-            	}
+                {
+                    std::unique_ptr<GNSSBlockInterface> block_ = std::make_unique<FifoSignalSource>(configuration, role, in_streams,
+                        out_streams, queue);
+                    block = std::move(block_);
+                }
             else if (implementation == "File_Signal_Source")
                 {
                     std::unique_ptr<GNSSBlockInterface> block_ = std::make_unique<FileSignalSource>(configuration, role, in_streams,

--- a/src/core/receiver/gnss_block_factory.cc
+++ b/src/core/receiver/gnss_block_factory.cc
@@ -38,6 +38,7 @@
 #include "configuration_interface.h"
 #include "direct_resampler_conditioner.h"
 #include "file_signal_source.h"
+#include "fifo_signal_source.h"
 #include "fir_filter.h"
 #include "freq_xlating_fir_filter.h"
 #include "galileo_e1_dll_pll_veml_tracking.h"
@@ -647,6 +648,12 @@ std::unique_ptr<GNSSBlockInterface> GNSSBlockFactory::GetBlock(
                 }
 
             // SIGNAL SOURCES ----------------------------------------------------------
+            else if (implementation == "Fifo_Signal_Source")
+            	{
+            		std::unique_ptr<GNSSBlockInterface> block_ = std::make_unique<FifoSignalSource>(configuration, role, in_streams,
+						out_streams, queue);
+					block = std::move(block_);
+            	}
             else if (implementation == "File_Signal_Source")
                 {
                     std::unique_ptr<GNSSBlockInterface> block_ = std::make_unique<FileSignalSource>(configuration, role, in_streams,

--- a/src/core/system_parameters/galileo_inav_message.h
+++ b/src/core/system_parameters/galileo_inav_message.h
@@ -366,7 +366,7 @@ private:
 
     int32_t current_IODnav{};
 
-    std::vector<uint8_t> rs_buffer; // Reed-Solomon buffer
+    std::vector<uint8_t> rs_buffer;  // Reed-Solomon buffer
 
     uint8_t IODnav_LSB17{};
     uint8_t IODnav_LSB18{};


### PR DESCRIPTION
Hello,
as suggested by Jim when I asked on the mailing list, I wrote a custom fifo signal source, (the `file_signal_source` is not compatible).

I think the fifo reader is in a state that is acceptable for gnss-sdr, but I am happy to discuss/take feedback on that and adapt things (still quite new to the whole environment). 

Especially interesting are opinions if the performance improves if I read larger chunks from the fifo at once vs. iterating over the items one at a time (which i currently do - I count on the compiler optimization to do some loop unrolling for me, but still..).

Example use cases for the `fifo_signal_source`:
    - multiplex signal streams outside of gnss-sdr
    - another program holds access to the SDR
    - the SDR is not supported by gnss-sdr but can dump the signal to a fifo

Iin separate commits included in this PR I edited a few unrelated files:
- `signal generator`: added missing `std::` to sqrt calls as suggested by clang-tidy
- `file_source_base`: renamed `is_complex_t` to `is_interleaved` to better describe its behavior; modernized c-style cast, fixed typo
- `custom_udp_signal_source`: added ishort support. removed redundant switch block, made overflow events less confusing (`O` is confusable w/ `0`, so I changed it to lower case). Also added overflow explanation to class startup (confused me when I tested the example config file until I checked the code. being more verbose on overflow events is not feasible either as it happens repeatedly).

I also noticed that there are far more signal sources in the code than documented on the website. I was quite fascinated when I discovered some. Is there some decision which ones get mentioned or are the majority just not documented enough? In that case I would (suggest to) add a small list of implementations to the homepage. Even without much description/examples it would be worth it in my opinion.

Cheers!