### PR TITLE
Update the max satellite prn number of BDS

### DIFF
--- a/src/algorithms/libs/rtklib/rtklib.h
+++ b/src/algorithms/libs/rtklib/rtklib.h
@@ -202,7 +202,7 @@ const int NSYSQZS = 0;
 #define ENABDS
 #ifdef ENABDS
 const int MINPRNBDS = 1;                          //!<   min satellite sat number of BeiDou
-const int MAXPRNBDS = 37;                         //!<   max satellite sat number of BeiDou
+const int MAXPRNBDS = 63;                         //!<   max satellite sat number of BeiDou
 const int NSATBDS = (MAXPRNBDS - MINPRNBDS + 1);  //!<   number of BeiDou satellites
 const int NSYSBDS = 1;
 #else


### PR DESCRIPTION
Modify the 'MAXPRNBDS' value from '37' to '63' at 'rtklib.h', according to the latest BDS-3 ICD.

