### PR TITLE
return the correct right block

### DIFF
--- a/src/algorithms/signal_source/adapters/two_bit_packed_file_signal_source.cc
+++ b/src/algorithms/signal_source/adapters/two_bit_packed_file_signal_source.cc
@@ -46,6 +46,11 @@ TwoBitPackedFileSignalSource::TwoBitPackedFileSignalSource(
 }
 
 
+gr::basic_block_sptr TwoBitPackedFileSignalSource::get_right_block()
+{
+    return char_to_float_;
+}
+
 std::tuple<size_t, bool> TwoBitPackedFileSignalSource::itemTypeToSize()
 {
     auto is_complex_t = false;

--- a/src/algorithms/signal_source/adapters/two_bit_packed_file_signal_source.h
+++ b/src/algorithms/signal_source/adapters/two_bit_packed_file_signal_source.h
@@ -47,6 +47,9 @@ public:
 
     ~TwoBitPackedFileSignalSource() = default;
 
+    // This is a chain; override the default implementation
+    gr::basic_block_sptr get_right_block() override;
+
 private:
     inline bool big_endian_items() const
     {


### PR DESCRIPTION
:+1::tada: Hello, and thanks for contributing to
[GNSS-SDR](https://gnss-sdr.org)! :tada::+1:

<!-- prettier-ignore-start -->
[comment]: # (
SPDX-License-Identifier: GPL-3.0-or-later
)

[comment]: # (
SPDX-FileCopyrightText: 2011-2020 Carles Fernandez-Prades <carles.fernandez@cttc.es>
)
<!-- prettier-ignore-end -->

This PR addresses the problem #515 where a two-bit packed file source cannot be configured into the graph, because it incorrectly returns the wrong right-hand block. This results in a size mis-match between the signal source and the signal conditioner.

@carlesfernandez don't merge this too quickly; I haven't had time to look for other signal sources that might suffer from the same problem.
