### PR TITLE
change sanity check to check the right thing

### DIFF
--- a/src/core/receiver/gnss_flowgraph.cc
+++ b/src/core/receiver/gnss_flowgraph.cc
@@ -1052,7 +1052,7 @@ int GNSSFlowgraph::connect_signal_sources_to_signal_conditioners()
                                 {
                                     // Connect the multichannel signal source to multiple signal conditioners
                                     // GNURADIO max_streams=-1 means infinite ports!
-                                    size_t output_size = src->item_size();
+                                    size_t output_size = src->get_right_block()->output_signature()->sizeof_stream_item(0);
                                     size_t input_size = sig_conditioner_.at(signal_conditioner_ID)->get_left_block()->input_signature()->sizeof_stream_item(0);
                                     // Check configuration inconsistencies
                                     if (output_size != input_size)


### PR DESCRIPTION
<!-- prettier-ignore-start -->
[comment]: # (
SPDX-License-Identifier: GPL-3.0-or-later
)

[comment]: # (
SPDX-FileCopyrightText: 2011-2020 Carles Fernandez-Prades <carles.fernandez@cttc.es>
)
<!-- prettier-ignore-end -->

This PR **correctly** (?!) addresses issue #515 by ensuring that the sanity check done in **gnss_flowgraph** tests the right thing.

The issue is highlighted by the **two_bit_packed_file_source** that _reads_ a byte but produces multiple `gr_complex` samples per byte. The sanity check test compared the **input** item size with the expected input size of the Signal Conditioner.

The fix is to explicitly extract the **output** item size from the block.

One might argue that the validity checks done here don't need to be done; the blocks won't connect if the output/input don't match. However, as a bug fix, this minimal change is submitted.