### PR TITLE
Fixed GNSS Synchro Monitor Decimation

### DIFF
--- a/src/core/monitor/gnss_synchro_monitor.cc
+++ b/src/core/monitor/gnss_synchro_monitor.cc
@@ -84,10 +84,10 @@ int gnss_synchro_monitor::general_work(int noutput_items __attribute__((unused))
                             udp_sink_ptr->write_gnss_synchro(stocks);
                             // Reset count variable
                             count = 0;
+                            // Consume the number of items for the input stream channel
+                            consume(channel_index, ninput_items[channel_index]);
                         }
                 }
-            // Consume the number of items for the input stream channel
-            consume(channel_index, ninput_items[channel_index]);
         }
 
     // Not producing any outputs


### PR DESCRIPTION
The GNSS Synchro Monitor Decimation does not currently work properly. If the decimation value is set to 50, then one should receive one message per channel every second. However, this is not the case. When set to 50, the GNSS Synchro messages are never sent (on my system). I made an issue on the GitHub shedding more details on this problem. #485 

I have debugged this and determined this line to be the cause of the issue. Instead of being after the loop where it is ran every time, it needs to only be run when the decimation value is reached, in the if statement. Preliminary tests show this seems to work properly. 

The only thing I cannot confirm is that when the if statement is reached, is the most recent or oldest of the GNSS Synchro messages sent? I would like to believe that it is the most recent GNSS Synchro message that is sent since it is at the end of the vector. I cannot confirm this, so I hope someone else out there may be able to confirm this for me.

Jaxon