### PR TITLE
Refractored example code for navigation message listener

### DIFF
--- a/src/utils/nav-listener/main.cc
+++ b/src/utils/nav-listener/main.cc
@@ -35,13 +35,13 @@ int main(int argc, char *argv[])
             while (true)
                 {
                     gnss_sdr::navMsg message;
-                    if (udp_listener.read_nav_message(message))
+                    if (udp_listener.receive_and_parse_nav_message(message))
                         {
                             udp_listener.print_message(message);
                         }
                     else
                         {
-                            std::cout << "Error: the message cannot be parsed.\n";
+                            std::cout << "Error: the message cannot be parsed." << std::endl;
                         }
                 }
         }

--- a/src/utils/nav-listener/main.cc
+++ b/src/utils/nav-listener/main.cc
@@ -34,7 +34,15 @@ int main(int argc, char *argv[])
 
             while (true)
                 {
-                    udp_listener.print_content();
+                    gnss_sdr::navMsg message;
+                    if (udp_listener.read_nav_message(message))
+                        {
+                            udp_listener.print_message(message);
+                        }
+                    else
+                        {
+                            std::cout << "Error: the message cannot be parsed.\n";
+                        }
                 }
         }
     catch (std::exception &e)

--- a/src/utils/nav-listener/nav_msg_udp_listener.cc
+++ b/src/utils/nav-listener/nav_msg_udp_listener.cc
@@ -30,7 +30,7 @@ Nav_Msg_Udp_Listener::Nav_Msg_Udp_Listener(unsigned short port)
  * \param[out] message navigation message class to contain parsed output
  * \return true if message parsed succesfully, false ow
  */
-bool Nav_Msg_Udp_Listener::read_nav_message(gnss_sdr::navMsg &message)
+bool Nav_Msg_Udp_Listener::receive_and_parse_nav_message(gnss_sdr::navMsg &message)
 {
     char buff[8192];  // Buffer for storing the received data.
 

--- a/src/utils/nav-listener/nav_msg_udp_listener.cc
+++ b/src/utils/nav-listener/nav_msg_udp_listener.cc
@@ -25,44 +25,40 @@ Nav_Msg_Udp_Listener::Nav_Msg_Udp_Listener(unsigned short port)
     socket.bind(endpoint, error);             // Bind the socket to the given local endpoint.
 }
 
-
+/**
+ * !\brief blocking call to read nav_message from UDP port
+ * \param[out] message navigation message class to contain parsed output
+ * \return true if message parsed succesfully, false ow
+ */
 bool Nav_Msg_Udp_Listener::read_nav_message(gnss_sdr::navMsg &message)
 {
     char buff[8192];  // Buffer for storing the received data.
 
-    message_ = message;
     // This call will block until one or more bytes of data has been received.
     int bytes = socket.receive(boost::asio::buffer(buff));
 
     std::string data(&buff[0], bytes);
     // Deserialize a stock of Nav_Msg objects from the binary string.
-    return message_.ParseFromString(data);
+    return message.ParseFromString(data);
 }
 
-
-bool Nav_Msg_Udp_Listener::print_content()
+/*
+ * !\brief prints navigation message content
+ * \param[in] message nav message to be printed
+ */
+void Nav_Msg_Udp_Listener::print_message(gnss_sdr::navMsg &message) const
 {
-    if (read_nav_message(message_))
-        {
-            std::string system = message_.system();
-            std::string signal = message_.signal();
-            int prn = message_.prn();
-            int tow_at_current_symbol_ms = message_.tow_at_current_symbol_ms();
-            std::string nav_message = message_.nav_message();
+    std::string system = message.system();
+    std::string signal = message.signal();
+    int prn = message.prn();
+    int tow_at_current_symbol_ms = message.tow_at_current_symbol_ms();
+    std::string nav_message = message.nav_message();
 
-            std::cout << "\nNew Data received:\n";
-            std::cout << "System: " << system << '\n';
-            std::cout << "Signal: " << signal << '\n';
-            std::cout << "PRN: " << prn << '\n';
-            std::cout << "TOW of last symbol [ms]: "
-                      << tow_at_current_symbol_ms << '\n';
-            std::cout << "Nav message: " << nav_message << "\n\n";
-        }
-    else
-        {
-            std::cout << "Error: the message cannot be parsed.\n";
-            return false;
-        }
-
-    return true;
+    std::cout << "\nNew Data received:\n";
+    std::cout << "System: " << system << '\n';
+    std::cout << "Signal: " << signal << '\n';
+    std::cout << "PRN: " << prn << '\n';
+    std::cout << "TOW of last symbol [ms]: "
+              << tow_at_current_symbol_ms << '\n';
+    std::cout << "Nav message: " << nav_message << "\n\n";
 }

--- a/src/utils/nav-listener/nav_msg_udp_listener.h
+++ b/src/utils/nav-listener/nav_msg_udp_listener.h
@@ -24,7 +24,7 @@ class Nav_Msg_Udp_Listener
 public:
     explicit Nav_Msg_Udp_Listener(unsigned short port);
     void print_message(gnss_sdr::navMsg &message) const;
-    bool read_nav_message(gnss_sdr::navMsg &message);
+    bool receive_and_parse_nav_message(gnss_sdr::navMsg &message);
 
 private:
     boost::asio::io_service io_service;

--- a/src/utils/nav-listener/nav_msg_udp_listener.h
+++ b/src/utils/nav-listener/nav_msg_udp_listener.h
@@ -23,15 +23,14 @@ class Nav_Msg_Udp_Listener
 {
 public:
     explicit Nav_Msg_Udp_Listener(unsigned short port);
-    bool print_content();
+    void print_message(gnss_sdr::navMsg &message) const;
+    bool read_nav_message(gnss_sdr::navMsg &message);
 
 private:
-    bool read_nav_message(gnss_sdr::navMsg &message);
     boost::asio::io_service io_service;
     boost::asio::ip::udp::socket socket;
     boost::system::error_code error;
     boost::asio::ip::udp::endpoint endpoint;
-    gnss_sdr::navMsg message_;
 };
 
 #endif


### PR DESCRIPTION
Changed example code for navigation message listener:
- old print_content() function hid blocking udp call (unintuitive, less modular design)
- member variable nav_msg unnecessary (and confusing: was previously assigned to itself in read_nav_msg fct after being passed in as fct argument)
- udp_listener class can now be used as library to integrate into custom projects


===========================
Apart from that I noticed that gnss-sdr now has a few of these monitor functions scattered around the code base.
My question is, is that by chance or by design? 

**Nav-Message:**
- src/util/nav-listener as standalone project to receive messages
- src/libs/nav_message_monitor and udp sink (+conversion and message definition files) 

**Gnss-synchro**:
- src/core/monitor for the gnss_synchro_monitor and udp sink files + serialization of synchro messages
- receiver project only in documentation [here](https://gnss-sdr.org/docs/tutorials/monitoring-software-receiver-internal-status/)

**Pvt_monitor** & ephemeris :
- algorithms/PVT/libs/serdes_monitor_pvt.h , monitor_pvt, monitor_pvt_udp_sink, monitor_ephemeris...
- has no receiver I think.. (but this is implemented accordingly in gnss-sdr-monitor for instance)

So what I want to say here, is that there is a lot of code duplication with the monitor fcts, the udp source/sinks and it is a bit difficult to find where these components live (e.g., one could move the /core/lib/nav_msg files to the /core/monitor folder, maybe even put all udp streaming things here? I am no cmake expert, not sure how that would work out..)

Another question: would it be useful to expand the utils/nav-listener folder to also have components to receive other streams? (taken from the documentation or gnss-sdr-monitor, or so? In a current project I use it anyhow, wouldn't be too much work to add snippets..)

Cheers!