### PR TITLE
Fix acq perf test

### DIFF
--- a/src/tests/unit-tests/signal-processing-blocks/acquisition/acq_performance_test.cc
+++ b/src/tests/unit-tests/signal-processing-blocks/acquisition/acq_performance_test.cc
@@ -282,7 +282,8 @@ protected:
 
         num_thresholds = pfa_vector.size();
 
-        int aux2 = ((generated_signal_duration_s * 900 - (FLAGS_acq_test_coherent_time_ms * FLAGS_acq_test_max_dwells)) / (FLAGS_acq_test_coherent_time_ms * FLAGS_acq_test_max_dwells));
+        // the gnss simulator does not dump the trk observables for the last 100 ms of generated signal
+        int aux2 = floor((generated_signal_duration_s * ms_per_s - 100) / (FLAGS_acq_test_coherent_time_ms * FLAGS_acq_test_max_dwells) - 1);
         if ((FLAGS_acq_test_num_meas > 0) and (FLAGS_acq_test_num_meas < aux2))
             {
                 num_of_measurements = static_cast<unsigned int>(FLAGS_acq_test_num_meas);
@@ -369,6 +370,8 @@ protected:
     std::string signal_id;
 
 private:
+    static const uint32_t ms_per_s = 1000;
+
     std::string generator_binary;
     std::string p1;
     std::string p2;

--- a/src/tests/unit-tests/signal-processing-blocks/acquisition/acq_performance_test.cc
+++ b/src/tests/unit-tests/signal-processing-blocks/acquisition/acq_performance_test.cc
@@ -991,7 +991,7 @@ TEST_F(AcquisitionPerformanceTest, ROC)
                                             for (int i = 0; i < num_clean_executions - 1; i++)
 
                                                 {
-                                                    if (abs(clean_delay_estimation_error(i)) < 0.5 and abs(clean_doppler_estimation_error(i)) < static_cast<float>(config->property("Acquisition.doppler_step", 1)) / 2.0)
+                                                    if (abs(clean_delay_estimation_error(i)) < 0.5 and abs(clean_doppler_estimation_error(i)) < static_cast<float>(config->property("Acquisition.doppler_step", 1)))
                                                         {
                                                             correctly_detected = correctly_detected + 1.0;
                                                         }

--- a/src/tests/unit-tests/signal-processing-blocks/acquisition/acq_performance_test.cc
+++ b/src/tests/unit-tests/signal-processing-blocks/acquisition/acq_performance_test.cc
@@ -283,7 +283,15 @@ protected:
         num_thresholds = pfa_vector.size();
 
         // the gnss simulator does not dump the trk observables for the last 100 ms of generated signal
-        int aux2 = floor((generated_signal_duration_s * ms_per_s - 100) / (FLAGS_acq_test_coherent_time_ms * FLAGS_acq_test_max_dwells) - 1);
+        int aux2;
+        if (FLAGS_acq_test_bit_transition_flag)
+            {
+                aux2 = floor((generated_signal_duration_s * ms_per_s - 100) / (FLAGS_acq_test_coherent_time_ms * 2.0) - 1);
+            }
+        else
+            {
+                aux2 = floor((generated_signal_duration_s * ms_per_s - 100) / (FLAGS_acq_test_coherent_time_ms * FLAGS_acq_test_max_dwells) - 1);
+            }
         if ((FLAGS_acq_test_num_meas > 0) and (FLAGS_acq_test_num_meas < aux2))
             {
                 num_of_measurements = static_cast<unsigned int>(FLAGS_acq_test_num_meas);


### PR DESCRIPTION
set the tolerance of the doppler error to Acquisition.doppler_step in the acquisition performance test
fix the calculation of the number of measurements of the acquisition performance test and take into account bit_transition_flag