### PR TITLE
correct name of SSE3 in Linux kernel for volk_profile SIMD detection

### DIFF
--- a/src/algorithms/libs/volk_gnsssdr_module/volk_gnsssdr/cpu_features/src/cpuinfo_x86.c
+++ b/src/algorithms/libs/volk_gnsssdr_module/volk_gnsssdr/cpu_features/src/cpuinfo_x86.c
@@ -1439,7 +1439,7 @@ static void ParseCpuId(const uint32_t max_cpuid_leaf, X86Info* info,
                             if (!CpuFeatures_StringView_IsEquals(key, str("flags"))) continue;
                             features->sse = CpuFeatures_StringView_HasWord(value, "sse", ' ');
                             features->sse2 = CpuFeatures_StringView_HasWord(value, "sse2", ' ');
-                            features->sse3 = CpuFeatures_StringView_HasWord(value, "sse3", ' ');
+                            features->sse3 = CpuFeatures_StringView_HasWord(value, "pni", ' ');
                             features->ssse3 = CpuFeatures_StringView_HasWord(value, "ssse3", ' ');
                             features->sse4_1 = CpuFeatures_StringView_HasWord(value, "sse4_1", ' ');
                             features->sse4_2 = CpuFeatures_StringView_HasWord(value, "sse4_2", ' ');


### PR DESCRIPTION
Correct name of SSE3 for using SIMD on volk-gnss. See https://github.com/google/cpu_features/pull/225

Signed-off-by: Jean-Michel Friedt <friedtj@free.fr>