### PR TITLE
Add missing #include <boost/exception/diagnostic_information.hpp>

### DIFF
--- a/src/algorithms/signal_source/adapters/limesdr_signal_source.cc
+++ b/src/algorithms/signal_source/adapters/limesdr_signal_source.cc
@@ -19,6 +19,7 @@
 #include "gnss_frequencies.h"
 #include "gnss_sdr_string_literals.h"
 #include "gnss_sdr_valve.h"
+#include <boost/exception/diagnostic_information.hpp>
 #include <glog/logging.h>
 #include <gnuradio/blocks/file_sink.h>
 #include <iostream>

--- a/src/algorithms/signal_source/adapters/osmosdr_signal_source.cc
+++ b/src/algorithms/signal_source/adapters/osmosdr_signal_source.cc
@@ -20,6 +20,7 @@
 #include "configuration_interface.h"
 #include "gnss_sdr_string_literals.h"
 #include "gnss_sdr_valve.h"
+#include <boost/exception/diagnostic_information.hpp>
 #include <glog/logging.h>
 #include <gnuradio/blocks/file_sink.h>
 #include <iostream>

--- a/src/algorithms/signal_source/adapters/rtl_tcp_signal_source.cc
+++ b/src/algorithms/signal_source/adapters/rtl_tcp_signal_source.cc
@@ -21,6 +21,7 @@
 #include "configuration_interface.h"
 #include "gnss_sdr_string_literals.h"
 #include "gnss_sdr_valve.h"
+#include <boost/exception/diagnostic_information.hpp>
 #include <glog/logging.h>
 #include <cstdint>
 #include <iostream>


### PR DESCRIPTION
This fixes the build failures at
https://buildd.debian.org/status/logs.php?pkg=gnss-sdr&ver=0.0.16-1%2Bb2
```
/<<PKGBUILDDIR>>/src/algorithms/signal_source/adapters/limesdr_signal_source.cc: In constructor ‘LimesdrSignalSource::LimesdrSignalSource(const ConfigurationInterface*, const string&, unsigned int, unsigned int, Concurrent_Queue<std::shared_ptr<pmt::pmt_base> >*)’:
/<<PKGBUILDDIR>>/src/algorithms/signal_source/adapters/limesdr_signal_source.cc:100:67: error: ‘diagnostic_information’ is not a member of ‘boost’
  100 |                     LOG(WARNING) << "Boost exception: " << boost::diagnostic_information(e);
      |                                                                   ^~~~~~~~~~~~~~~~~~~~~~
```
