### PR TITLE
Move duplicated files in asn-supl/ and asn-rrl/ to a new types/ subdir.

### DIFF
--- a/src/core/libs/supl/types/BIT_STRING.c
+++ b/src/core/libs/supl/types/BIT_STRING.c
@@ -1,0 +1,207 @@
+/*-
+ * SPDX-FileCopyrightText: (c) 2003, 2004 Lev Walkin <vlm@lionet.info>. All rights reserved.
+ * SPDX-License-Identifier: BSD-1-Clause
+ */
+#include <BIT_STRING.h>
+#include <asn_internal.h>
+
+/*
+ * BIT STRING basic type description.
+ */
+static ber_tlv_tag_t asn_DEF_BIT_STRING_tags[] = {
+    (ASN_TAG_CLASS_UNIVERSAL | (3 << 2))};
+static asn_OCTET_STRING_specifics_t asn_DEF_BIT_STRING_specs = {
+    sizeof(BIT_STRING_t), offsetof(BIT_STRING_t, _asn_ctx), ASN_OSUBV_BIT};
+asn_TYPE_descriptor_t asn_DEF_BIT_STRING = {
+    "BIT STRING",
+    "BIT_STRING",
+    OCTET_STRING_free, /* Implemented in terms of OCTET STRING */
+    BIT_STRING_print,
+    BIT_STRING_constraint,
+    OCTET_STRING_decode_ber, /* Implemented in terms of OCTET STRING */
+    OCTET_STRING_encode_der, /* Implemented in terms of OCTET STRING */
+    OCTET_STRING_decode_xer_binary,
+    BIT_STRING_encode_xer,
+    OCTET_STRING_decode_uper, /* Unaligned PER decoder */
+    OCTET_STRING_encode_uper, /* Unaligned PER encoder */
+    0,                        /* Use generic outmost tag fetcher */
+    asn_DEF_BIT_STRING_tags,
+    sizeof(asn_DEF_BIT_STRING_tags) / sizeof(asn_DEF_BIT_STRING_tags[0]),
+    asn_DEF_BIT_STRING_tags, /* Same as above */
+    sizeof(asn_DEF_BIT_STRING_tags) / sizeof(asn_DEF_BIT_STRING_tags[0]),
+    0, /* No PER visible constraints */
+    0,
+    0, /* No members */
+    &asn_DEF_BIT_STRING_specs};
+
+/*
+ * BIT STRING generic constraint.
+ */
+int BIT_STRING_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
+    asn_app_constraint_failed_f *ctfailcb, void *app_key)
+{
+    const BIT_STRING_t *st = (const BIT_STRING_t *)sptr;
+
+    if (st && st->buf)
+        {
+            if ((st->size == 0 && st->bits_unused) || st->bits_unused < 0 ||
+                st->bits_unused > 7)
+                {
+                    _ASN_CTFAIL(app_key, td, sptr,
+                        "%s: invalid padding byte (%s:%d)", td->name,
+                        __FILE__, __LINE__);
+                    return -1;
+                }
+        }
+    else
+        {
+            _ASN_CTFAIL(app_key, td, sptr, "%s: value not given (%s:%d)",
+                td->name, __FILE__, __LINE__);
+            return -1;
+        }
+
+    return 0;
+}
+
+static char *bit_pattern[16] = {"0000", "0001", "0010", "0011", "0100", "0101",
+    "0110", "0111", "1000", "1001", "1010", "1011",
+    "1100", "1101", "1110", "1111"};
+
+asn_enc_rval_t BIT_STRING_encode_xer(asn_TYPE_descriptor_t *td, void *sptr,
+    int ilevel, enum xer_encoder_flags_e flags,
+    asn_app_consume_bytes_f *cb, void *app_key)
+{
+    asn_enc_rval_t er;
+    char scratch[128];
+    char *p = scratch;
+    char *scend = scratch + (sizeof(scratch) - 10);
+    const BIT_STRING_t *st = (const BIT_STRING_t *)sptr;
+    int xcan = (flags & XER_F_CANONICAL);
+    uint8_t *buf;
+    uint8_t *end;
+
+    if (!st || !st->buf)
+        {
+            _ASN_ENCODE_FAILED;
+        }
+
+    er.encoded = 0;
+
+    buf = st->buf;
+    end = buf + st->size - 1; /* Last byte is special */
+
+    /*
+     * Binary dump
+     */
+    for (; buf < end; buf++)
+        {
+            int v = *buf;
+            int nline = xcan ? 0 : (((buf - st->buf) % 8) == 0);
+            if (p >= scend || nline)
+                {
+                    er.encoded += p - scratch;
+                    _ASN_CALLBACK(scratch, p - scratch);
+                    p = scratch;
+                    if (nline)
+                        {
+                            _i_ASN_TEXT_INDENT(1, ilevel);
+                        }
+                }
+            memcpy(p + 0, bit_pattern[v >> 4], 4);
+            memcpy(p + 4, bit_pattern[v & 0x0f], 4);
+            p += 8;
+        }
+
+    if (!xcan && ((buf - st->buf) % 8) == 0)
+        {
+            _i_ASN_TEXT_INDENT(1, ilevel);
+        }
+    er.encoded += p - scratch;
+    _ASN_CALLBACK(scratch, p - scratch);
+    p = scratch;
+
+    if (buf == end)
+        {
+            int v = *buf;
+            int ubits = st->bits_unused;
+            int i;
+            for (i = 7; i >= ubits; i--)
+                {
+                    *p++ = (v & (1 << i)) ? 0x31 : 0x30;
+                }
+            er.encoded += p - scratch;
+            _ASN_CALLBACK(scratch, p - scratch);
+        }
+
+    if (!xcan)
+        {
+            _i_ASN_TEXT_INDENT(1, ilevel - 1);
+        }
+
+    _ASN_ENCODED_OK(er);
+cb_failed:
+    _ASN_ENCODE_FAILED;
+}
+
+/*
+ * BIT STRING specific contents printer.
+ */
+int BIT_STRING_print(asn_TYPE_descriptor_t *td, const void *sptr, int ilevel,
+    asn_app_consume_bytes_f *cb, void *app_key)
+{
+    static const char *h2c = "0123456789ABCDEF";
+    char scratch[64];
+    const BIT_STRING_t *st = (const BIT_STRING_t *)sptr;
+    uint8_t *buf;
+    uint8_t *end;
+    char *p = scratch;
+
+    (void)td; /* Unused argument */
+
+    if (!st || !st->buf)
+        {
+            return (cb("<absent>", 8, app_key) < 0) ? -1 : 0;
+        }
+
+    ilevel++;
+    buf = st->buf;
+    end = buf + st->size;
+
+    /*
+     * Hexadecimal dump.
+     */
+    for (; buf < end; buf++)
+        {
+            if ((buf - st->buf) % 16 == 0 && (st->size > 16) && buf != st->buf)
+                {
+                    _i_INDENT(1);
+                    /* Dump the string */
+                    if (cb(scratch, p - scratch, app_key) < 0)
+                        {
+                            return -1;
+                        }
+                    p = scratch;
+                }
+            *p++ = h2c[*buf >> 4];
+            *p++ = h2c[*buf & 0x0F];
+            *p++ = 0x20;
+        }
+
+    if (p > scratch)
+        {
+            p--; /* Eat the tailing space */
+
+            if ((st->size > 16))
+                {
+                    _i_INDENT(1);
+                }
+
+            /* Dump the incomplete 16-bytes row */
+            if (cb(scratch, p - scratch, app_key) < 0)
+                {
+                    return -1;
+                }
+        }
+
+    return 0;
+}

--- a/src/core/libs/supl/types/BIT_STRING.h
+++ b/src/core/libs/supl/types/BIT_STRING.h
@@ -1,0 +1,35 @@
+/*-
+ * SPDX-FileCopyrightText: (c) 2003, 2004 Lev Walkin <vlm@lionet.info>. All rights reserved.
+ * SPDX-License-Identifier: BSD-1-Clause
+ */
+#ifndef _BIT_STRING_H
+#define _BIT_STRING_H
+
+#include <OCTET_STRING.h> /* Some help from OCTET STRING */
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+    typedef struct BIT_STRING_s
+    {
+        uint8_t *buf; /* BIT STRING body */
+        int size;     /* Size of the above buffer */
+
+        int bits_unused; /* Unused trailing bits in the last octet (0..7) */
+
+        asn_struct_ctx_t _asn_ctx; /* Parsing across buffer boundaries */
+    } BIT_STRING_t;
+
+    extern asn_TYPE_descriptor_t asn_DEF_BIT_STRING;
+
+    asn_struct_print_f BIT_STRING_print; /* Human-readable output */
+    asn_constr_check_f BIT_STRING_constraint;
+    xer_type_encoder_f BIT_STRING_encode_xer;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* _BIT_STRING_H_ */

--- a/src/core/libs/supl/types/BOOLEAN.c
+++ b/src/core/libs/supl/types/BOOLEAN.c
@@ -1,0 +1,330 @@
+/*-
+ * SPDX-FileCopyrightText: (c) 2003, 2004 Lev Walkin <vlm@lionet.info>. All rights reserved.
+ * SPDX-License-Identifier: BSD-1-Clause
+ */
+#include <BOOLEAN.h>
+#include <asn_codecs_prim.h>
+#include <asn_internal.h>
+
+/*
+ * BOOLEAN basic type description.
+ */
+static ber_tlv_tag_t asn_DEF_BOOLEAN_tags[] = {
+    (ASN_TAG_CLASS_UNIVERSAL | (1 << 2))};
+asn_TYPE_descriptor_t asn_DEF_BOOLEAN = {
+    "BOOLEAN",
+    "BOOLEAN",
+    BOOLEAN_free,
+    BOOLEAN_print,
+    asn_generic_no_constraint,
+    BOOLEAN_decode_ber,
+    BOOLEAN_encode_der,
+    BOOLEAN_decode_xer,
+    BOOLEAN_encode_xer,
+    BOOLEAN_decode_uper, /* Unaligned PER decoder */
+    BOOLEAN_encode_uper, /* Unaligned PER encoder */
+    0,                   /* Use generic outmost tag fetcher */
+    asn_DEF_BOOLEAN_tags,
+    sizeof(asn_DEF_BOOLEAN_tags) / sizeof(asn_DEF_BOOLEAN_tags[0]),
+    asn_DEF_BOOLEAN_tags, /* Same as above */
+    sizeof(asn_DEF_BOOLEAN_tags) / sizeof(asn_DEF_BOOLEAN_tags[0]),
+    0, /* No PER visible constraints */
+    0,
+    0, /* No members */
+    0  /* No specifics */
+};
+
+/*
+ * Decode BOOLEAN type.
+ */
+asn_dec_rval_t BOOLEAN_decode_ber(asn_codec_ctx_t *opt_codec_ctx,
+    asn_TYPE_descriptor_t *td, void **bool_value,
+    const void *buf_ptr, size_t size,
+    int tag_mode)
+{
+    BOOLEAN_t *st = (BOOLEAN_t *)*bool_value;
+    asn_dec_rval_t rval;
+    ber_tlv_len_t length;
+    ber_tlv_len_t lidx;
+
+    if (st == NULL)
+        {
+            st = (BOOLEAN_t *)(*bool_value = CALLOC(1, sizeof(*st)));
+            if (st == NULL)
+                {
+                    rval.code = RC_FAIL;
+                    rval.consumed = 0;
+                    return rval;
+                }
+        }
+
+    ASN_DEBUG("Decoding %s as BOOLEAN (tm=%d)", td->name, tag_mode);
+
+    /*
+     * Check tags.
+     */
+    rval = ber_check_tags(opt_codec_ctx, td, 0, buf_ptr, size, tag_mode, 0,
+        &length, 0);
+    if (rval.code != RC_OK)
+        {
+            return rval;
+        }
+
+    ASN_DEBUG("Boolean length is %d bytes", (int)length);
+
+    buf_ptr = ((const char *)buf_ptr) + rval.consumed;
+    size -= rval.consumed;
+    if (length > (ber_tlv_len_t)size)
+        {
+            rval.code = RC_WMORE;
+            rval.consumed = 0;
+            return rval;
+        }
+
+    /*
+     * Compute boolean value.
+     */
+    for (*st = 0, lidx = 0; (lidx < length) && *st == 0; lidx++)
+        {
+            /*
+             * Very simple approach: read bytes until the end or
+             * value is already TRUE.
+             * BOOLEAN is not supposed to contain meaningful data anyway.
+             */
+            *st |= ((const uint8_t *)buf_ptr)[lidx];
+        }
+
+    rval.code = RC_OK;
+    rval.consumed += length;
+
+    ASN_DEBUG("Took %ld/%ld bytes to encode %s, value=%d", (long)rval.consumed,
+        (long)length, td->name, *st);
+
+    return rval;
+}
+
+asn_enc_rval_t BOOLEAN_encode_der(asn_TYPE_descriptor_t *td, void *sptr,
+    int tag_mode, ber_tlv_tag_t tag,
+    asn_app_consume_bytes_f *cb, void *app_key)
+{
+    asn_enc_rval_t erval;
+    BOOLEAN_t *st = (BOOLEAN_t *)sptr;
+
+    erval.encoded = der_write_tags(td, 1, tag_mode, 0, tag, cb, app_key);
+    if (erval.encoded == -1)
+        {
+            erval.failed_type = td;
+            erval.structure_ptr = sptr;
+            return erval;
+        }
+
+    if (cb)
+        {
+            uint8_t bool_value;
+
+            bool_value = *st ? 0xff : 0; /* 0xff mandated by DER */
+
+            if (cb(&bool_value, 1, app_key) < 0)
+                {
+                    erval.encoded = -1;
+                    erval.failed_type = td;
+                    erval.structure_ptr = sptr;
+                    return erval;
+                }
+        }
+
+    erval.encoded += 1;
+
+    _ASN_ENCODED_OK(erval);
+}
+
+/*
+ * Decode the chunk of XML text encoding INTEGER.
+ */
+static enum xer_pbd_rval BOOLEAN__xer_body_decode(asn_TYPE_descriptor_t *td,
+    void *sptr,
+    const void *chunk_buf,
+    size_t chunk_size)
+{
+    BOOLEAN_t *st = (BOOLEAN_t *)sptr;
+    const char *p = (const char *)chunk_buf;
+
+    (void)td;
+
+    if (chunk_size && p[0] == 0x3c /* '<' */)
+        {
+            switch (xer_check_tag(chunk_buf, chunk_size, "false"))
+                {
+                case XCT_BOTH:
+                    /* "<false/>" */
+                    *st = 0;
+                    break;
+                case XCT_UNKNOWN_BO:
+                    if (xer_check_tag(chunk_buf, chunk_size, "true") !=
+                        XCT_BOTH)
+                        {
+                            return XPBD_BROKEN_ENCODING;
+                        }
+                    /* "<true/>" */
+                    *st = 1; /* Or 0xff as in DER?.. */
+                    break;
+                default:
+                    return XPBD_BROKEN_ENCODING;
+                }
+            return XPBD_BODY_CONSUMED;
+        }
+    else
+        {
+            if (xer_is_whitespace(chunk_buf, chunk_size))
+                {
+                    return XPBD_NOT_BODY_IGNORE;
+                }
+            else
+                {
+                    return XPBD_BROKEN_ENCODING;
+                }
+        }
+}
+
+asn_dec_rval_t BOOLEAN_decode_xer(asn_codec_ctx_t *opt_codec_ctx,
+    asn_TYPE_descriptor_t *td, void **sptr,
+    const char *opt_mname, const void *buf_ptr,
+    size_t size)
+{
+    return xer_decode_primitive(opt_codec_ctx, td, sptr, sizeof(BOOLEAN_t),
+        opt_mname, buf_ptr, size,
+        BOOLEAN__xer_body_decode);
+}
+
+asn_enc_rval_t BOOLEAN_encode_xer(asn_TYPE_descriptor_t *td, void *sptr,
+    int ilevel, enum xer_encoder_flags_e flags,
+    asn_app_consume_bytes_f *cb, void *app_key)
+{
+    const BOOLEAN_t *st = (const BOOLEAN_t *)sptr;
+    asn_enc_rval_t er;
+
+    (void)ilevel;
+    (void)flags;
+
+    if (!st)
+        {
+            _ASN_ENCODE_FAILED;
+        }
+
+    if (*st)
+        {
+            _ASN_CALLBACK("<true/>", 7);
+            er.encoded = 7;
+        }
+    else
+        {
+            _ASN_CALLBACK("<false/>", 8);
+            er.encoded = 8;
+        }
+
+    _ASN_ENCODED_OK(er);
+cb_failed:
+    _ASN_ENCODE_FAILED;
+}
+
+int BOOLEAN_print(asn_TYPE_descriptor_t *td, const void *sptr, int ilevel,
+    asn_app_consume_bytes_f *cb, void *app_key)
+{
+    const BOOLEAN_t *st = (const BOOLEAN_t *)sptr;
+    const char *buf;
+    size_t buflen;
+
+    (void)td;     /* Unused argument */
+    (void)ilevel; /* Unused argument */
+
+    if (st)
+        {
+            if (*st)
+                {
+                    buf = "TRUE";
+                    buflen = 4;
+                }
+            else
+                {
+                    buf = "FALSE";
+                    buflen = 5;
+                }
+        }
+    else
+        {
+            buf = "<absent>";
+            buflen = 8;
+        }
+
+    return (cb(buf, buflen, app_key) < 0) ? -1 : 0;
+}
+
+void BOOLEAN_free(asn_TYPE_descriptor_t *td, void *ptr, int contents_only)
+{
+    if (td && ptr && !contents_only)
+        {
+            FREEMEM(ptr);
+        }
+}
+
+asn_dec_rval_t BOOLEAN_decode_uper(asn_codec_ctx_t *opt_codec_ctx,
+    asn_TYPE_descriptor_t *td,
+    asn_per_constraints_t *constraints,
+    void **sptr, asn_per_data_t *pd)
+{
+    asn_dec_rval_t rv;
+    BOOLEAN_t *st = (BOOLEAN_t *)*sptr;
+
+    (void)opt_codec_ctx;
+    (void)constraints;
+
+    if (!st)
+        {
+            st = (BOOLEAN_t *)(*sptr = MALLOC(sizeof(*st)));
+            if (!st)
+                {
+                    _ASN_DECODE_FAILED;
+                }
+        }
+
+    /*
+     * Extract a single bit
+     */
+    switch (per_get_few_bits(pd, 1))
+        {
+        case 1:
+            *st = 1;
+            break;
+        case 0:
+            *st = 0;
+            break;
+        case -1:
+        default:
+            _ASN_DECODE_STARVED;
+        }
+
+    ASN_DEBUG("%s decoded as %s", td->name, *st ? "TRUE" : "FALSE");
+
+    rv.code = RC_OK;
+    rv.consumed = 1;
+    return rv;
+}
+
+asn_enc_rval_t BOOLEAN_encode_uper(asn_TYPE_descriptor_t *td,
+    asn_per_constraints_t *constraints,
+    void *sptr, asn_per_outp_t *po)
+{
+    const BOOLEAN_t *st = (const BOOLEAN_t *)sptr;
+    asn_enc_rval_t er;
+
+    (void)constraints;
+
+    if (!st)
+        {
+            _ASN_ENCODE_FAILED;
+        }
+
+    per_put_few_bits(po, *st ? 1 : 0, 1);
+
+    _ASN_ENCODED_OK(er);
+}

--- a/src/core/libs/supl/types/BOOLEAN.h
+++ b/src/core/libs/supl/types/BOOLEAN.h
@@ -1,0 +1,37 @@
+/*-
+ * SPDX-FileCopyrightText: (c) 2003, 2004 Lev Walkin <vlm@lionet.info>. All rights reserved.
+ * SPDX-License-Identifier: BSD-1-Clause
+ */
+#ifndef _BOOLEAN_H
+#define _BOOLEAN_H
+
+#include <asn_application.h>
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+    /*
+     * The underlying integer may contain various values, but everything
+     * non-zero is capped to 0xff by the DER encoder. The BER decoder may
+     * yield non-zero values different from 1, beware.
+     */
+    typedef int BOOLEAN_t;
+
+    extern asn_TYPE_descriptor_t asn_DEF_BOOLEAN;
+
+    asn_struct_free_f BOOLEAN_free;
+    asn_struct_print_f BOOLEAN_print;
+    ber_type_decoder_f BOOLEAN_decode_ber;
+    der_type_encoder_f BOOLEAN_encode_der;
+    xer_type_decoder_f BOOLEAN_decode_xer;
+    xer_type_encoder_f BOOLEAN_encode_xer;
+    per_type_decoder_f BOOLEAN_decode_uper;
+    per_type_encoder_f BOOLEAN_encode_uper;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* _BOOLEAN_H_ */

--- a/src/core/libs/supl/types/ENUMERATED.c
+++ b/src/core/libs/supl/types/ENUMERATED.c
@@ -1,0 +1,82 @@
+/*-
+ * SPDX-FileCopyrightText: (c) 2003, 2004 Lev Walkin <vlm@lionet.info>. All rights reserved.
+ * SPDX-License-Identifier: BSD-1-Clause
+ */
+#include <ENUMERATED.h>
+#include <NativeEnumerated.h>
+#include <asn_codecs_prim.h> /* Encoder and decoder of a primitive type */
+#include <asn_internal.h>
+
+/*
+ * ENUMERATED basic type description.
+ */
+static ber_tlv_tag_t asn_DEF_ENUMERATED_tags[] = {
+    (ASN_TAG_CLASS_UNIVERSAL | (10 << 2))};
+asn_TYPE_descriptor_t asn_DEF_ENUMERATED = {
+    "ENUMERATED",
+    "ENUMERATED",
+    ASN__PRIMITIVE_TYPE_free,
+    INTEGER_print, /* Implemented in terms of INTEGER */
+    asn_generic_no_constraint,
+    ber_decode_primitive,
+    INTEGER_encode_der, /* Implemented in terms of INTEGER */
+    INTEGER_decode_xer, /* This is temporary! */
+    INTEGER_encode_xer,
+    ENUMERATED_decode_uper, /* Unaligned PER decoder */
+    ENUMERATED_encode_uper, /* Unaligned PER encoder */
+    0,                      /* Use generic outmost tag fetcher */
+    asn_DEF_ENUMERATED_tags,
+    sizeof(asn_DEF_ENUMERATED_tags) / sizeof(asn_DEF_ENUMERATED_tags[0]),
+    asn_DEF_ENUMERATED_tags, /* Same as above */
+    sizeof(asn_DEF_ENUMERATED_tags) / sizeof(asn_DEF_ENUMERATED_tags[0]),
+    0, /* No PER visible constraints */
+    0,
+    0, /* No members */
+    0  /* No specifics */
+};
+
+asn_dec_rval_t ENUMERATED_decode_uper(asn_codec_ctx_t *opt_codec_ctx,
+    asn_TYPE_descriptor_t *td,
+    asn_per_constraints_t *constraints,
+    void **sptr, asn_per_data_t *pd)
+{
+    asn_dec_rval_t rval;
+    ENUMERATED_t *st = (ENUMERATED_t *)*sptr;
+    long value;
+    void *vptr = &value;
+
+    if (!st)
+        {
+            st = (ENUMERATED_t *)(*sptr = CALLOC(1, sizeof(*st)));
+            if (!st)
+                {
+                    _ASN_DECODE_FAILED;
+                }
+        }
+
+    rval =
+        NativeEnumerated_decode_uper(opt_codec_ctx, td, constraints, &vptr, pd);
+    if (rval.code == RC_OK)
+        {
+            if (asn_long2INTEGER(st, value))
+                {
+                    rval.code = RC_FAIL;
+                }
+        }
+    return rval;
+}
+
+asn_enc_rval_t ENUMERATED_encode_uper(asn_TYPE_descriptor_t *td,
+    asn_per_constraints_t *constraints,
+    void *sptr, asn_per_outp_t *po)
+{
+    ENUMERATED_t *st = (ENUMERATED_t *)sptr;
+    int64_t value;
+
+    if (asn_INTEGER2long(st, &value))
+        {
+            _ASN_ENCODE_FAILED;
+        }
+
+    return NativeEnumerated_encode_uper(td, constraints, &value, po);
+}

--- a/src/core/libs/supl/types/ENUMERATED.h
+++ b/src/core/libs/supl/types/ENUMERATED.h
@@ -1,0 +1,26 @@
+/*-
+ * SPDX-FileCopyrightText: (c) 2003, 2004 Lev Walkin <vlm@lionet.info>. All rights reserved.
+ * SPDX-License-Identifier: BSD-1-Clause
+ */
+#ifndef _ENUMERATED_H
+#define _ENUMERATED_H
+
+#include <INTEGER.h>
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+    typedef INTEGER_t ENUMERATED_t; /* Implemented via INTEGER */
+
+    extern asn_TYPE_descriptor_t asn_DEF_ENUMERATED;
+
+    per_type_decoder_f ENUMERATED_decode_uper;
+    per_type_encoder_f ENUMERATED_encode_uper;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* _ENUMERATED_H_ */

--- a/src/core/libs/supl/types/INTEGER.c
+++ b/src/core/libs/supl/types/INTEGER.c
@@ -1,0 +1,1265 @@
+/*-
+ * SPDX-FileCopyrightText: (c) 2003, 2004 Lev Walkin <vlm@lionet.info>. All rights reserved.
+ * SPDX-License-Identifier: BSD-1-Clause
+ */
+#include <INTEGER.h>
+#include <asn_codecs_prim.h> /* Encoder and decoder of a primitive type */
+#include <asn_internal.h>
+#include <errno.h>
+#include <inttypes.h>
+
+/*
+ * INTEGER basic type description.
+ */
+static ber_tlv_tag_t asn_DEF_INTEGER_tags[] = {
+    (ASN_TAG_CLASS_UNIVERSAL | (2 << 2))};
+asn_TYPE_descriptor_t asn_DEF_INTEGER = {
+    "INTEGER",
+    "INTEGER",
+    ASN__PRIMITIVE_TYPE_free,
+    INTEGER_print,
+    asn_generic_no_constraint,
+    ber_decode_primitive,
+    INTEGER_encode_der,
+    INTEGER_decode_xer,
+    INTEGER_encode_xer,
+    INTEGER_decode_uper, /* Unaligned PER decoder */
+    INTEGER_encode_uper, /* Unaligned PER encoder */
+    0,                   /* Use generic outmost tag fetcher */
+    asn_DEF_INTEGER_tags,
+    sizeof(asn_DEF_INTEGER_tags) / sizeof(asn_DEF_INTEGER_tags[0]),
+    asn_DEF_INTEGER_tags, /* Same as above */
+    sizeof(asn_DEF_INTEGER_tags) / sizeof(asn_DEF_INTEGER_tags[0]),
+    0, /* No PER visible constraints */
+    0,
+    0, /* No members */
+    0  /* No specifics */
+};
+
+/*
+ * Encode INTEGER type using DER.
+ */
+asn_enc_rval_t INTEGER_encode_der(asn_TYPE_descriptor_t *td, void *sptr,
+    int tag_mode, ber_tlv_tag_t tag,
+    asn_app_consume_bytes_f *cb, void *app_key)
+{
+    INTEGER_t *st = (INTEGER_t *)sptr;
+
+    ASN_DEBUG("%s %s as INTEGER (tm=%d)", cb ? "Encoding" : "Estimating",
+        td->name, tag_mode);
+
+    /*
+     * Canonicalize integer in the buffer.
+     * (Remove too int64_t sign extension, remove some first 0x00 bytes)
+     */
+    if (st->buf)
+        {
+            uint8_t *buf = st->buf;
+            uint8_t *end1 = buf + st->size - 1;
+            int shift;
+
+            /* Compute the number of superfluous leading bytes */
+            for (; buf < end1; buf++)
+                {
+                    /*
+                     * If the contents octets of an integer value encoding
+                     * consist of more than one octet, then the bits of the
+                     * first octet and bit 8 of the second octet:
+                     * a) shall not all be ones; and
+                     * b) shall not all be zero.
+                     */
+                    switch (*buf)
+                        {
+                        case 0x00:
+                            if ((buf[1] & 0x80) == 0)
+                                {
+                                    continue;
+                                }
+                            break;
+                        case 0xff:
+                            if ((buf[1] & 0x80))
+                                {
+                                    continue;
+                                }
+                            break;
+                        }
+                    break;
+                }
+
+            /* Remove leading superfluous bytes from the integer */
+            shift = buf - st->buf;
+            if (shift)
+                {
+                    uint8_t *nb = st->buf;
+                    uint8_t *end;
+
+                    st->size -= shift; /* New size, minus bad bytes */
+                    end = nb + st->size;
+
+                    for (; nb < end; nb++, buf++)
+                        {
+                            *nb = *buf;
+                        }
+                }
+
+        } /* if(1) */
+
+    return der_encode_primitive(td, sptr, tag_mode, tag, cb, app_key);
+}
+
+static const asn_INTEGER_enum_map_t *INTEGER_map_enum2value(
+    asn_INTEGER_specifics_t *specs, const char *lstart, const char *lstop);
+
+/*
+ * INTEGER specific human-readable output.
+ */
+static ssize_t INTEGER__dump(asn_TYPE_descriptor_t *td, const INTEGER_t *st,
+    asn_app_consume_bytes_f *cb, void *app_key,
+    int plainOrXER)
+{
+    asn_INTEGER_specifics_t *specs = (asn_INTEGER_specifics_t *)td->specifics;
+    char scratch[32]; /* Enough for 64-bit integer */
+    uint8_t *buf = st->buf;
+    uint8_t *buf_end = st->buf + st->size;
+    int64_t accum;
+    ssize_t wrote = 0;
+    char *p;
+    int ret;
+
+    /*
+     * Advance buf pointer until the start of the value's body.
+     * This will make us able to process large integers using simple case,
+     * when the actual value is small
+     * (0x0000000000abcdef would yield a fine 0x00abcdef)
+     */
+    /* Skip the insignificant leading bytes */
+    for (; buf < buf_end - 1; buf++)
+        {
+            switch (*buf)
+                {
+                case 0x00:
+                    if ((buf[1] & 0x80) == 0)
+                        {
+                            continue;
+                        }
+                    break;
+                case 0xff:
+                    if ((buf[1] & 0x80) != 0)
+                        {
+                            continue;
+                        }
+                    break;
+                }
+            break;
+        }
+
+    /* Simple case: the integer size is small */
+    if ((size_t)(buf_end - buf) <= sizeof(accum))
+        {
+            const asn_INTEGER_enum_map_t *el;
+            size_t scrsize;
+            char *scr;
+
+            if (buf == buf_end)
+                {
+                    accum = 0LL;
+                }
+            else
+                {
+                    accum = (*buf & 0x80) ? -1LL : 0LL;
+                    for (; buf < buf_end; buf++)
+                        {
+                            accum = (accum * 256) | *buf;
+                        }
+                }
+
+            el = INTEGER_map_value2enum(specs, accum);
+            if (el)
+                {
+                    scrsize = el->enum_len + 32;
+                    scr = (char *)alloca(scrsize);
+                    if (plainOrXER == 0)
+                        {
+                            ret = snprintf(scr, scrsize, "%+" PRId64 "(%s)", accum,
+                                el->enum_name);
+                        }
+                    else
+                        {
+                            ret = snprintf(scr, scrsize, "<%s/>", el->enum_name);
+                        }
+                }
+            else if (plainOrXER && specs && specs->strict_enumeration)
+                {
+                    ASN_DEBUG(
+                        "ASN.1 forbids dealing with "
+                        "unknown value of ENUMERATED type");
+                    errno = EPERM;
+                    return -1;
+                }
+            else
+                {
+                    scrsize = sizeof(scratch);
+                    scr = scratch;
+                    ret =
+                        snprintf(scr, scrsize,
+                            (specs && specs->field_unsigned) ? "%" PRIu64
+                                                             : "%+" PRId64,
+                            accum);
+                }
+            assert(ret > 0 && (size_t)ret < scrsize);
+            return (cb(scr, ret, app_key) < 0) ? -1 : ret;
+        }
+    else if (plainOrXER && specs && specs->strict_enumeration)
+        {
+            /*
+             * Here and earlier, we cannot encode the ENUMERATED values
+             * if there is no corresponding identifier.
+             */
+            ASN_DEBUG(
+                "ASN.1 forbids dealing with "
+                "unknown value of ENUMERATED type");
+            errno = EPERM;
+            return -1;
+        }
+
+    /* Output in the int64_t xx:yy:zz... format */
+    /* TODO: replace with generic algorithm (Knuth TAOCP Vol 2, 4.3.1) */
+    for (p = scratch; buf < buf_end; buf++)
+        {
+            static const char *h2c = "0123456789ABCDEF";
+            if ((p - scratch) >= (ssize_t)(sizeof(scratch) - 4))
+                {
+                    /* Flush buffer */
+                    if (cb(scratch, p - scratch, app_key) < 0)
+                        {
+                            return -1;
+                        }
+                    wrote += p - scratch;
+                    p = scratch;
+                }
+            *p++ = h2c[*buf >> 4];
+            *p++ = h2c[*buf & 0x0F];
+            *p++ = 0x3a; /* ":" */
+        }
+    if (p != scratch)
+        {
+            p--; /* Remove the last ":" */
+        }
+
+    wrote += p - scratch;
+    return (cb(scratch, p - scratch, app_key) < 0) ? -1 : wrote;
+}
+
+/*
+ * INTEGER specific human-readable output.
+ */
+int INTEGER_print(asn_TYPE_descriptor_t *td, const void *sptr, int ilevel,
+    asn_app_consume_bytes_f *cb, void *app_key)
+{
+    const INTEGER_t *st = (const INTEGER_t *)sptr;
+    ssize_t ret;
+
+    (void)td;
+    (void)ilevel;
+
+    if (!st || !st->buf)
+        {
+            ret = cb("<absent>", 8, app_key);
+        }
+    else
+        {
+            ret = INTEGER__dump(td, st, cb, app_key, 0);
+        }
+
+    return (ret < 0) ? -1 : 0;
+}
+
+struct e2v_key
+{
+    const char *start;
+    const char *stop;
+    asn_INTEGER_enum_map_t *vemap;
+    unsigned int *evmap;
+};
+static int INTEGER__compar_enum2value(const void *kp, const void *am)
+{
+    const struct e2v_key *key = (const struct e2v_key *)kp;
+    const asn_INTEGER_enum_map_t *el = (const asn_INTEGER_enum_map_t *)am;
+    const char *ptr;
+    const char *end;
+    const char *name;
+
+    /* Remap the element (sort by different criterion) */
+    el = key->vemap + key->evmap[el - key->vemap];
+
+    /* Compare strings */
+    for (ptr = key->start, end = key->stop, name = el->enum_name; ptr < end;
+         ptr++, name++)
+        {
+            if (*ptr != *name)
+                {
+                    return *(const unsigned char *)ptr -
+                           *(const unsigned char *)name;
+                }
+        }
+    return name[0] ? -1 : 0;
+}
+
+static const asn_INTEGER_enum_map_t *INTEGER_map_enum2value(
+    asn_INTEGER_specifics_t *specs, const char *lstart, const char *lstop)
+{
+    asn_INTEGER_enum_map_t *el_found;
+    int count = specs ? specs->map_count : 0;
+    struct e2v_key key;
+    const char *lp;
+
+    if (!count)
+        {
+            return NULL;
+        }
+
+    /* Guaranteed: assert(lstart < lstop); */
+    /* Figure out the tag name */
+    for (lstart++, lp = lstart; lp < lstop; lp++)
+        {
+            switch (*lp)
+                {
+                case 9:
+                case 10:
+                case 11:
+                case 12:
+                case 13:
+                case 32:   /* WSP */
+                case 0x2f: /* '/' */
+                case 0x3e: /* '>' */
+                    break;
+                default:
+                    continue;
+                }
+            break;
+        }
+    if (lp == lstop)
+        {
+            return NULL; /* No tag found */
+        }
+    lstop = lp;
+
+    key.start = lstart;
+    key.stop = lstop;
+    key.vemap = specs->value2enum;
+    key.evmap = specs->enum2value;
+    el_found = (asn_INTEGER_enum_map_t *)bsearch(&key, specs->value2enum, count,
+        sizeof(specs->value2enum[0]),
+        INTEGER__compar_enum2value);
+    if (el_found)
+        {
+            /* Remap enum2value into value2enum */
+            el_found = key.vemap + key.evmap[el_found - key.vemap];
+        }
+    return el_found;
+}
+
+static int INTEGER__compar_value2enum(const void *kp, const void *am)
+{
+    int64_t a = *(const int64_t *)kp;
+    const asn_INTEGER_enum_map_t *el = (const asn_INTEGER_enum_map_t *)am;
+    int64_t b = el->nat_value;
+    if (a < b)
+        {
+            return -1;
+        }
+    else if (a == b)
+        {
+            return 0;
+        }
+    else
+        {
+            return 1;
+        }
+}
+
+const asn_INTEGER_enum_map_t *INTEGER_map_value2enum(
+    asn_INTEGER_specifics_t *specs, int64_t value)
+{
+    int count = specs ? specs->map_count : 0;
+    if (!count)
+        {
+            return 0;
+        }
+    return (asn_INTEGER_enum_map_t *)bsearch(&value, specs->value2enum, count,
+        sizeof(specs->value2enum[0]),
+        INTEGER__compar_value2enum);
+}
+
+static int INTEGER_st_prealloc(INTEGER_t *st, int min_size)
+{
+    void *p = MALLOC(min_size + 1);
+    if (p)
+        {
+            void *b = st->buf;
+            st->size = 0;
+            st->buf = p;
+            FREEMEM(b);
+            return 0;
+        }
+    else
+        {
+            return -1;
+        }
+}
+
+/*
+ * Decode the chunk of XML text encoding INTEGER.
+ */
+static enum xer_pbd_rval INTEGER__xer_body_decode(asn_TYPE_descriptor_t *td,
+    void *sptr,
+    const void *chunk_buf,
+    size_t chunk_size)
+{
+    INTEGER_t *st = (INTEGER_t *)sptr;
+    int64_t sign = 1LL;
+    int64_t value;
+    const char *lp;
+    const char *lstart = (const char *)chunk_buf;
+    const char *lstop = lstart + chunk_size;
+    enum
+    {
+        ST_SKIPSPACE,
+        ST_SKIPSPHEX,
+        ST_WAITDIGITS,
+        ST_DIGITS,
+        ST_HEXDIGIT1,
+        ST_HEXDIGIT2,
+        ST_HEXCOLON,
+        ST_EXTRASTUFF
+    } state = ST_SKIPSPACE;
+
+    if (chunk_size)
+        {
+            ASN_DEBUG("INTEGER body %ld 0x%2x..0x%2x", (int64_t)chunk_size, *lstart,
+                lstop[-1]);
+        }
+
+    /*
+     * We may have received a tag here. It will be processed inline.
+     * Use strtoul()-like code and serialize the result.
+     */
+    for (value = 0, lp = lstart; lp < lstop; lp++)
+        {
+            int lv = *lp;
+            switch (lv)
+                {
+                case 0x09:
+                case 0x0a:
+                case 0x0d:
+                case 0x20:
+                    switch (state)
+                        {
+                        case ST_SKIPSPACE:
+                        case ST_SKIPSPHEX:
+                            continue;
+                        case ST_HEXCOLON:
+                            if (xer_is_whitespace(lp, lstop - lp))
+                                {
+                                    lp = lstop - 1;
+                                    continue;
+                                }
+                            break;
+                        default:
+                            break;
+                        }
+                    break;
+                case 0x2d: /* '-' */
+                    if (state == ST_SKIPSPACE)
+                        {
+                            sign = -1;
+                            state = ST_WAITDIGITS;
+                            continue;
+                        }
+                    break;
+                case 0x2b: /* '+' */
+                    if (state == ST_SKIPSPACE)
+                        {
+                            state = ST_WAITDIGITS;
+                            continue;
+                        }
+                    break;
+                case 0x30:
+                case 0x31:
+                case 0x32:
+                case 0x33:
+                case 0x34:
+                case 0x35:
+                case 0x36:
+                case 0x37:
+                case 0x38:
+                case 0x39:
+                    switch (state)
+                        {
+                        case ST_DIGITS:
+                            break;
+                        case ST_SKIPSPHEX: /* Fall through */
+                        case ST_HEXDIGIT1:
+                            value = (lv - 0x30) << 4;
+                            state = ST_HEXDIGIT2;
+                            continue;
+                        case ST_HEXDIGIT2:
+                            value += (lv - 0x30);
+                            state = ST_HEXCOLON;
+                            st->buf[st->size++] = (uint8_t)value;
+                            continue;
+                        case ST_HEXCOLON:
+                            return XPBD_BROKEN_ENCODING;
+                        default:
+                            state = ST_DIGITS;
+                            break;
+                        }
+
+                    {
+                        int64_t new_value = value * 10;
+
+                        if (new_value / 10 != value)
+                            { /* Overflow */
+                                return XPBD_DECODER_LIMIT;
+                            }
+
+                        value = new_value + (lv - 0x30);
+                        /* Check for two's complement overflow */
+                        if (value < 0)
+                            {
+                                /* Check whether it is a LONG_MIN */
+                                if (sign == -1 &&
+                                    (uint64_t)value == ~((uint64_t)-1 >> 1))
+                                    {
+                                        sign = 1;
+                                    }
+                                else
+                                    {
+                                        /* Overflow */
+                                        return XPBD_DECODER_LIMIT;
+                                    }
+                            }
+                    }
+                    continue;
+                case 0x3c: /* '<' */
+                    if (state == ST_SKIPSPACE)
+                        {
+                            const asn_INTEGER_enum_map_t *el;
+                            el = INTEGER_map_enum2value(
+                                (asn_INTEGER_specifics_t *)td->specifics,
+                                lstart, lstop);
+                            if (el)
+                                {
+                                    ASN_DEBUG("Found \"%s\" => %ld",
+                                        el->enum_name, el->nat_value);
+                                    state = ST_DIGITS;
+                                    value = el->nat_value;
+                                    lp = lstop - 1;
+                                    continue;
+                                }
+                            ASN_DEBUG("Unknown identifier for INTEGER");
+                        }
+                    return XPBD_BROKEN_ENCODING;
+                case 0x3a: /* ':' */
+                    if (state == ST_HEXCOLON)
+                        {
+                            /* This colon is expected */
+                            state = ST_HEXDIGIT1;
+                            continue;
+                        }
+                    else if (state == ST_DIGITS)
+                        {
+                            /* The colon here means that we have
+                             * decoded the first two hexadecimal
+                             * places as a decimal value.
+                             * Switch decoding mode. */
+                            ASN_DEBUG("INTEGER re-evaluate as hex form");
+                            if (INTEGER_st_prealloc(st,
+                                    (chunk_size / 3) + 1))
+                                {
+                                    return XPBD_SYSTEM_FAILURE;
+                                }
+                            state = ST_SKIPSPHEX;
+                            lp = lstart - 1;
+                            continue;
+                        }
+                    else
+                        {
+                            ASN_DEBUG("state %d at %d", state, lp - lstart);
+                            break;
+                        }
+                /* [A-Fa-f] */
+                case 0x41:
+                case 0x42:
+                case 0x43:
+                case 0x44:
+                case 0x45:
+                case 0x46:
+                case 0x61:
+                case 0x62:
+                case 0x63:
+                case 0x64:
+                case 0x65:
+                case 0x66:
+                    switch (state)
+                        {
+                        case ST_SKIPSPHEX:
+                        case ST_SKIPSPACE: /* Fall through */
+                        case ST_HEXDIGIT1:
+                            value = lv - ((lv < 0x61) ? 0x41 : 0x61);
+                            value += 10;
+                            value <<= 4;
+                            state = ST_HEXDIGIT2;
+                            continue;
+                        case ST_HEXDIGIT2:
+                            value += lv - ((lv < 0x61) ? 0x41 : 0x61);
+                            value += 10;
+                            st->buf[st->size++] = (uint8_t)value;
+                            state = ST_HEXCOLON;
+                            continue;
+                        case ST_DIGITS:
+                            ASN_DEBUG(
+                                "INTEGER re-evaluate as hex form");
+                            if (INTEGER_st_prealloc(
+                                    st, (chunk_size / 3) + 1))
+                                {
+                                    return XPBD_SYSTEM_FAILURE;
+                                }
+                            state = ST_SKIPSPHEX;
+                            lp = lstart - 1;
+                            continue;
+                        default:
+                            break;
+                        }
+                    break;
+                }
+
+            /* Found extra non-numeric stuff */
+            ASN_DEBUG("Found non-numeric 0x%2x at %d", lv, lp - lstart);
+            state = ST_EXTRASTUFF;
+            break;
+        }
+
+    switch (state)
+        {
+        case ST_DIGITS:
+            /* Everything is cool */
+            break;
+        case ST_HEXCOLON:
+            st->buf[st->size] = 0; /* Just in case termination */
+            return XPBD_BODY_CONSUMED;
+        case ST_HEXDIGIT1:
+        case ST_HEXDIGIT2:
+        case ST_SKIPSPHEX:
+            return XPBD_BROKEN_ENCODING;
+        default:
+            if (xer_is_whitespace(lp, lstop - lp))
+                {
+                    if (state != ST_EXTRASTUFF)
+                        {
+                            return XPBD_NOT_BODY_IGNORE;
+                        }
+                    break;
+                }
+            else
+                {
+                    ASN_DEBUG("INTEGER: No useful digits (state %d)",
+                        state);
+                    return XPBD_BROKEN_ENCODING; /* No digits */
+                }
+            break;
+        }
+
+    value *= sign; /* Change sign, if needed */
+
+    if (asn_long2INTEGER(st, value))
+        {
+            return XPBD_SYSTEM_FAILURE;
+        }
+
+    return XPBD_BODY_CONSUMED;
+}
+
+asn_dec_rval_t INTEGER_decode_xer(asn_codec_ctx_t *opt_codec_ctx,
+    asn_TYPE_descriptor_t *td, void **sptr,
+    const char *opt_mname, const void *buf_ptr,
+    size_t size)
+{
+    return xer_decode_primitive(opt_codec_ctx, td, sptr, sizeof(INTEGER_t),
+        opt_mname, buf_ptr, size,
+        INTEGER__xer_body_decode);
+}
+
+asn_enc_rval_t INTEGER_encode_xer(asn_TYPE_descriptor_t *td, void *sptr,
+    int ilevel, enum xer_encoder_flags_e flags,
+    asn_app_consume_bytes_f *cb, void *app_key)
+{
+    const INTEGER_t *st = (const INTEGER_t *)sptr;
+    asn_enc_rval_t er;
+
+    (void)ilevel;
+    (void)flags;
+
+    if (!st || !st->buf)
+        {
+            _ASN_ENCODE_FAILED;
+        }
+
+    er.encoded = INTEGER__dump(td, st, cb, app_key, 1);
+    if (er.encoded < 0)
+        {
+            _ASN_ENCODE_FAILED;
+        }
+
+    _ASN_ENCODED_OK(er);
+}
+
+asn_dec_rval_t INTEGER_decode_uper(asn_codec_ctx_t *opt_codec_ctx,
+    asn_TYPE_descriptor_t *td,
+    asn_per_constraints_t *constraints,
+    void **sptr, asn_per_data_t *pd)
+{
+    asn_INTEGER_specifics_t *specs = (asn_INTEGER_specifics_t *)td->specifics;
+    asn_dec_rval_t rval = {RC_OK, 0};
+    INTEGER_t *st = (INTEGER_t *)*sptr;
+    asn_per_constraint_t *ct;
+    int repeat;
+
+    (void)opt_codec_ctx;
+
+    if (!st)
+        {
+            st = (INTEGER_t *)(*sptr = CALLOC(1, sizeof(*st)));
+            if (!st)
+                {
+                    _ASN_DECODE_FAILED;
+                }
+        }
+
+    if (!constraints)
+        {
+            constraints = td->per_constraints;
+        }
+    ct = constraints ? &constraints->value : 0;
+
+    if (ct && ct->flags & APC_EXTENSIBLE)
+        {
+            int inext = per_get_few_bits(pd, 1);
+            if (inext < 0)
+                {
+                    _ASN_DECODE_STARVED;
+                }
+            if (inext)
+                {
+                    ct = 0;
+                }
+        }
+
+    FREEMEM(st->buf);
+    st->buf = 0;
+    st->size = 0;
+    if (ct)
+        {
+            if (ct->flags & APC_SEMI_CONSTRAINED)
+                {
+                    st->buf = (uint8_t *)CALLOC(1, 2);
+                    if (!st->buf)
+                        {
+                            _ASN_DECODE_FAILED;
+                        }
+                    st->size = 1;
+                }
+            else if (ct->flags & APC_CONSTRAINED && ct->range_bits >= 0)
+                {
+                    size_t size = (ct->range_bits + 7) >> 3;
+                    st->buf = (uint8_t *)MALLOC(1 + size + 1);
+                    if (!st->buf)
+                        {
+                            _ASN_DECODE_FAILED;
+                        }
+                    st->size = size;
+                }
+        }
+
+    /* X.691, #12.2.2 */
+    if (ct && ct->flags != APC_UNCONSTRAINED)
+        {
+            /* #10.5.6 */
+            ASN_DEBUG("Integer with range %d bits", ct->range_bits);
+            if (ct->range_bits >= 0)
+                {
+                    int64_t value;
+                    if (ct->range_bits == 32)
+                        {
+                            int64_t lhalf;
+                            value = per_get_few_bits(pd, 16);
+                            if (value < 0)
+                                {
+                                    _ASN_DECODE_STARVED;
+                                }
+                            lhalf = per_get_few_bits(pd, 16);
+                            if (lhalf < 0)
+                                {
+                                    _ASN_DECODE_STARVED;
+                                }
+                            value = (value << 16) | lhalf;
+                        }
+                    else
+                        {
+                            value = per_get_few_bits(pd, ct->range_bits);
+                            if (value < 0)
+                                {
+                                    _ASN_DECODE_STARVED;
+                                }
+                        }
+                    ASN_DEBUG("Got value %ld + low %ld", value,
+                        ct->lower_bound);
+                    value += ct->lower_bound;
+                    if ((specs && specs->field_unsigned)
+                            ? asn_ulong2INTEGER(st, value)
+                            : asn_long2INTEGER(st, value))
+                        {
+                            _ASN_DECODE_FAILED;
+                        }
+                    return rval;
+                }
+        }
+    else
+        {
+            ASN_DEBUG("Decoding unconstrained integer %s", td->name);
+        }
+
+    /* X.691, #12.2.3, #12.2.4 */
+    do
+        {
+            ssize_t len;
+            void *p;
+            int ret;
+
+            /* Get the PER length */
+            len = uper_get_length(pd, -1, &repeat);
+            if (len < 0)
+                {
+                    _ASN_DECODE_STARVED;
+                }
+
+            p = REALLOC(st->buf, st->size + len + 1);
+            if (!p)
+                {
+                    _ASN_DECODE_FAILED;
+                }
+            st->buf = (uint8_t *)p;
+
+            ret = per_get_many_bits(pd, &st->buf[st->size], 0, 8 * len);
+            if (ret < 0)
+                {
+                    _ASN_DECODE_STARVED;
+                }
+            st->size += len;
+        }
+    while (repeat);
+    st->buf[st->size] = 0; /* JIC */
+
+    /* #12.2.3 */
+    if (ct && ct->lower_bound)
+        {
+            /*
+             * TODO: replace by in-place arithmetics.
+             */
+            int64_t value;
+            if (asn_INTEGER2long(st, &value))
+                {
+                    _ASN_DECODE_FAILED;
+                }
+            if (asn_long2INTEGER(st, value + ct->lower_bound))
+                {
+                    _ASN_DECODE_FAILED;
+                }
+        }
+
+    return rval;
+}
+
+asn_enc_rval_t INTEGER_encode_uper(asn_TYPE_descriptor_t *td,
+    asn_per_constraints_t *constraints,
+    void *sptr, asn_per_outp_t *po)
+{
+    asn_INTEGER_specifics_t *specs = (asn_INTEGER_specifics_t *)td->specifics;
+    asn_enc_rval_t er;
+    INTEGER_t *st = (INTEGER_t *)sptr;
+    const uint8_t *buf;
+    const uint8_t *end;
+    asn_per_constraint_t *ct;
+    int64_t value = 0;
+
+    if (!st || st->size == 0)
+        {
+            _ASN_ENCODE_FAILED;
+        }
+
+    if (!constraints)
+        {
+            constraints = td->per_constraints;
+        }
+    ct = constraints ? &constraints->value : 0;
+
+    er.encoded = 0;
+
+    if (ct)
+        {
+            int inext = 0;
+            if (specs && specs->field_unsigned)
+                {
+                    uint64_t uval;
+                    if (asn_INTEGER2ulong(st, &uval))
+                        {
+                            _ASN_ENCODE_FAILED;
+                        }
+                    /* Check proper range */
+                    if (ct->flags & APC_SEMI_CONSTRAINED)
+                        {
+                            if (uval < (uint64_t)ct->lower_bound)
+                                {
+                                    inext = 1;
+                                }
+                        }
+                    else if (ct->range_bits >= 0)
+                        {
+                            if (uval < (uint64_t)ct->lower_bound ||
+                                uval > (uint64_t)ct->upper_bound)
+                                {
+                                    inext = 1;
+                                }
+                        }
+                    ASN_DEBUG("Value %lu (%02x/%d) lb %lu ub %lu %s", uval,
+                        st->buf[0], st->size, ct->lower_bound,
+                        ct->upper_bound, inext ? "ext" : "fix");
+                    value = uval;
+                }
+            else
+                {
+                    if (asn_INTEGER2long(st, &value))
+                        {
+                            _ASN_ENCODE_FAILED;
+                        }
+                    /* Check proper range */
+                    if (ct->flags & APC_SEMI_CONSTRAINED)
+                        {
+                            if (value < ct->lower_bound)
+                                {
+                                    inext = 1;
+                                }
+                        }
+                    else if (ct->range_bits >= 0)
+                        {
+                            if (value < ct->lower_bound ||
+                                value > ct->upper_bound)
+                                {
+                                    inext = 1;
+                                }
+                        }
+                    ASN_DEBUG("Value %ld (%02x/%d) lb %ld ub %ld %s", value,
+                        st->buf[0], st->size, ct->lower_bound,
+                        ct->upper_bound, inext ? "ext" : "fix");
+                }
+            if (ct->flags & APC_EXTENSIBLE)
+                {
+                    if (per_put_few_bits(po, inext, 1))
+                        {
+                            _ASN_ENCODE_FAILED;
+                        }
+                    if (inext)
+                        {
+                            ct = 0;
+                        }
+                }
+            else if (inext)
+                {
+                    _ASN_ENCODE_FAILED;
+                }
+        }
+
+    /* X.691, #12.2.2 */
+    if (ct && ct->range_bits >= 0)
+        {
+            /* #10.5.6 */
+            ASN_DEBUG("Encoding integer with range %d bits", ct->range_bits);
+            if (ct->range_bits == 32)
+                {
+                    /* TODO: extend to >32 bits */
+                    int64_t v = value - ct->lower_bound;
+                    if (per_put_few_bits(po, v >> 1, 31) ||
+                        per_put_few_bits(po, v, 1))
+                        {
+                            _ASN_ENCODE_FAILED;
+                        }
+                }
+            else
+                {
+                    if (per_put_few_bits(po, value - ct->lower_bound,
+                            ct->range_bits))
+                        {
+                            _ASN_ENCODE_FAILED;
+                        }
+                }
+            _ASN_ENCODED_OK(er);
+        }
+
+    if (ct && ct->lower_bound)
+        {
+            ASN_DEBUG("Adjust lower bound to %ld", ct->lower_bound);
+            /* TODO: adjust lower bound */
+            _ASN_ENCODE_FAILED;
+        }
+
+    for (buf = st->buf, end = st->buf + st->size; buf < end;)
+        {
+            ssize_t mayEncode = uper_put_length(po, end - buf);
+            if (mayEncode < 0)
+                {
+                    _ASN_ENCODE_FAILED;
+                }
+            if (per_put_many_bits(po, buf, 8 * mayEncode))
+                {
+                    _ASN_ENCODE_FAILED;
+                }
+            buf += mayEncode;
+        }
+
+    _ASN_ENCODED_OK(er);
+}
+
+int asn_INTEGER2long(const INTEGER_t *iptr, int64_t *lptr)
+{
+    uint8_t *b;
+    uint8_t *end;
+    size_t size;
+    int64_t l;
+
+    /* Sanity checking */
+    if (!iptr || !iptr->buf || !lptr)
+        {
+            errno = EINVAL;
+            return -1;
+        }
+
+    /* Cache the begin/end of the buffer */
+    b = iptr->buf; /* Start of the INTEGER buffer */
+    size = iptr->size;
+    end = b + size; /* Where to stop */
+
+    if (size > sizeof(int64_t))
+        {
+            uint8_t *end1 = end - 1;
+            /*
+             * Slightly more advanced processing,
+             * able to >sizeof(int64_t) bytes,
+             * when the actual value is small
+             * (0x0000000000abcdef would yield a fine 0x00abcdef)
+             */
+            /* Skip out the insignificant leading bytes */
+            for (; b < end1; b++)
+                {
+                    switch (*b)
+                        {
+                        case 0x00:
+                            if ((b[1] & 0x80) == 0)
+                                {
+                                    continue;
+                                }
+                            break;
+                        case 0xff:
+                            if ((b[1] & 0x80) != 0)
+                                {
+                                    continue;
+                                }
+                            break;
+                        }
+                    break;
+                }
+
+            size = end - b;
+            if (size > sizeof(int64_t))
+                {
+                    /* Still cannot fit the int64_t */
+                    errno = ERANGE;
+                    return -1;
+                }
+        }
+
+    /* Shortcut processing of a corner case */
+    if (end == b)
+        {
+            *lptr = 0;
+            return 0;
+        }
+
+    /* Perform the sign initialization */
+    /* Actually l = -(*b >> 7); gains nothing, yet unreadable! */
+    if ((*b >> 7))
+        {
+            l = -1;
+        }
+    else
+        {
+            l = 0;
+        }
+
+    /* Conversion engine */
+    for (; b < end; b++)
+        {
+            l = (l * 256) | *b;
+        }
+
+    *lptr = l;
+    return 0;
+}
+
+int asn_INTEGER2ulong(const INTEGER_t *iptr, uint64_t *lptr)
+{
+    uint8_t *b;
+    uint8_t *end;
+    uint64_t l;
+    size_t size;
+
+    if (!iptr || !iptr->buf || !lptr)
+        {
+            errno = EINVAL;
+            return -1;
+        }
+
+    b = iptr->buf;
+    size = iptr->size;
+    end = b + size;
+
+    /* If all extra leading bytes are zeroes, ignore them */
+    for (; size > sizeof(uint64_t); b++, size--)
+        {
+            if (*b)
+                {
+                    /* Value won't fit uint64_t */
+                    errno = ERANGE;
+                    return -1;
+                }
+        }
+
+    /* Conversion engine */
+    for (l = 0; b < end; b++)
+        {
+            l = (l << 8) | *b;
+        }
+
+    *lptr = l;
+    return 0;
+}
+
+int asn_ulong2INTEGER(INTEGER_t *st, uint64_t value)
+{
+    uint8_t *buf;
+    uint8_t *end;
+    uint8_t *b;
+    int shr;
+
+    if (value <= LONG_MAX)
+        {
+            return asn_long2INTEGER(st, value);
+        }
+
+    buf = (uint8_t *)MALLOC(1 + sizeof(value));
+    if (!buf)
+        {
+            return -1;
+        }
+
+    end = buf + (sizeof(value) + 1);
+    buf[0] = 0;
+    for (b = buf + 1, shr = (sizeof(int64_t) - 1) * 8; b < end; shr -= 8, b++)
+        {
+            *b = (uint8_t)(value >> shr);
+        }
+
+    if (st->buf)
+        {
+            FREEMEM(st->buf);
+        }
+    st->buf = buf;
+    st->size = 1 + sizeof(value);
+
+    return 0;
+}
+
+int asn_long2INTEGER(INTEGER_t *st, int64_t value)
+{
+    uint8_t *buf;
+    uint8_t *bp;
+    uint8_t *p;
+    uint8_t *pstart;
+    uint8_t *pend1;
+    int littleEndian = 1; /* Run-time detection */
+    int add;
+
+    if (!st)
+        {
+            errno = EINVAL;
+            return -1;
+        }
+
+    buf = (uint8_t *)MALLOC(16);
+    if (!buf)
+        {
+            return -1;
+        }
+
+    if (*(char *)&littleEndian)
+        {
+            pstart = (uint8_t *)&value + sizeof(value) - 1;
+            pend1 = (uint8_t *)&value;
+            add = -1;
+        }
+    else
+        {
+            pstart = (uint8_t *)&value;
+            pend1 = pstart + sizeof(value) - 1;
+            add = 1;
+        }
+
+    /*
+     * If the contents octet consists of more than one octet,
+     * then bits of the first octet and bit 8 of the second octet:
+     * a) shall not all be ones; and
+     * b) shall not all be zero.
+     */
+    for (p = pstart; p != pend1; p += add)
+        {
+            switch (*p)
+                {
+                case 0x00:
+                    if ((*(p + add) & 0x80) == 0)
+                        {
+                            continue;
+                        }
+                    break;
+                case 0xff:
+                    if ((*(p + add) & 0x80))
+                        {
+                            continue;
+                        }
+                    break;
+                }
+            break;
+        }
+    /* Copy the integer body */
+    for (pstart = p, bp = buf, pend1 += add; p != pend1; p += add)
+        {
+            *bp++ = *p;
+        }
+
+    if (st->buf)
+        {
+            FREEMEM(st->buf);
+        }
+    st->buf = buf;
+    st->size = bp - buf;
+
+    return 0;
+}

--- a/src/core/libs/supl/types/INTEGER.h
+++ b/src/core/libs/supl/types/INTEGER.h
@@ -1,0 +1,73 @@
+/*-
+ * SPDX-FileCopyrightText: (c) 2003, 2004 Lev Walkin <vlm@lionet.info>. All rights reserved.
+ * SPDX-License-Identifier: BSD-1-Clause
+ */
+#ifndef _INTEGER_H
+#define _INTEGER_H
+
+#include <asn_application.h>
+#include <asn_codecs_prim.h>
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+    typedef ASN__PRIMITIVE_TYPE_t INTEGER_t;
+
+    extern asn_TYPE_descriptor_t asn_DEF_INTEGER;
+
+    /* Map with <tag> to integer value association */
+    typedef struct asn_INTEGER_enum_map_s
+    {
+        int64_t nat_value;     /* associated native integer value */
+        size_t enum_len;       /* strlen("tag") */
+        const char *enum_name; /* "tag" */
+    } asn_INTEGER_enum_map_t;
+
+    /* This type describes an enumeration for INTEGER and ENUMERATED types */
+    typedef struct asn_INTEGER_specifics_s
+    {
+        asn_INTEGER_enum_map_t *value2enum; /* N -> "tag"; sorted by N */
+        unsigned int *enum2value;           /* "tag" => N; sorted by tag */
+        int map_count;                      /* Elements in either map */
+        int extension;                      /* This map is extensible */
+        int strict_enumeration;             /* Enumeration set is fixed */
+        int field_width;                    /* Size of native integer */
+        int field_unsigned;                 /* Signed=0, unsigned=1 */
+    } asn_INTEGER_specifics_t;
+
+    asn_struct_print_f INTEGER_print;
+    ber_type_decoder_f INTEGER_decode_ber;
+    der_type_encoder_f INTEGER_encode_der;
+    xer_type_decoder_f INTEGER_decode_xer;
+    xer_type_encoder_f INTEGER_encode_xer;
+    per_type_decoder_f INTEGER_decode_uper;
+    per_type_encoder_f INTEGER_encode_uper;
+
+    /***********************************
+     * Some handy conversion routines. *
+     ***********************************/
+
+    /*
+     * Returns 0 if it was possible to convert, -1 otherwise.
+     * -1/EINVAL: Mandatory argument missing
+     * -1/ERANGE: Value encoded is out of range for long representation
+     * -1/ENOMEM: Memory allocation failed (in asn_long2INTEGER()).
+     */
+    int asn_INTEGER2long(const INTEGER_t *i, int64_t *l);
+    int asn_INTEGER2ulong(const INTEGER_t *i, uint64_t *l);
+    int asn_long2INTEGER(INTEGER_t *st, int64_t value);
+    int asn_ulong2INTEGER(INTEGER_t *st, uint64_t value);
+
+    /*
+     * Convert the integer value into the corresponding enumeration map entry.
+     */
+    const asn_INTEGER_enum_map_t *INTEGER_map_value2enum(
+        asn_INTEGER_specifics_t *specs, int64_t value);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* _INTEGER_H_ */

--- a/src/core/libs/supl/types/NativeEnumerated.c
+++ b/src/core/libs/supl/types/NativeEnumerated.c
@@ -1,0 +1,302 @@
+/*-
+ * SPDX-FileCopyrightText: (c) 2003, 2004 Lev Walkin <vlm@lionet.info>. All rights reserved.
+ * SPDX-License-Identifier: BSD-1-Clause
+ */
+/*
+ * Read the NativeInteger.h for the explanation wrt. differences between
+ * INTEGER and NativeInteger.
+ * Basically, both are decoders and encoders of ASN.1 INTEGER type, but this
+ * implementation deals with the standard (machine-specific) representation
+ * of them instead of using the platform-independent buffer.
+ */
+#include <NativeEnumerated.h>
+#include <asn_internal.h>
+
+/*
+ * NativeEnumerated basic type description.
+ */
+static ber_tlv_tag_t asn_DEF_NativeEnumerated_tags[] = {
+    (ASN_TAG_CLASS_UNIVERSAL | (10 << 2))};
+asn_TYPE_descriptor_t asn_DEF_NativeEnumerated = {
+    "ENUMERATED", /* The ASN.1 type is still ENUMERATED */
+    "ENUMERATED",
+    NativeInteger_free,
+    NativeInteger_print,
+    asn_generic_no_constraint,
+    NativeInteger_decode_ber,
+    NativeInteger_encode_der,
+    NativeInteger_decode_xer,
+    NativeEnumerated_encode_xer,
+    NativeEnumerated_decode_uper,
+    NativeEnumerated_encode_uper,
+    0, /* Use generic outmost tag fetcher */
+    asn_DEF_NativeEnumerated_tags,
+    sizeof(asn_DEF_NativeEnumerated_tags) /
+        sizeof(asn_DEF_NativeEnumerated_tags[0]),
+    asn_DEF_NativeEnumerated_tags, /* Same as above */
+    sizeof(asn_DEF_NativeEnumerated_tags) /
+        sizeof(asn_DEF_NativeEnumerated_tags[0]),
+    0, /* No PER visible constraints */
+    0,
+    0, /* No members */
+    0  /* No specifics */
+};
+
+asn_enc_rval_t NativeEnumerated_encode_xer(asn_TYPE_descriptor_t *td,
+    void *sptr, int ilevel,
+    enum xer_encoder_flags_e flags,
+    asn_app_consume_bytes_f *cb,
+    void *app_key)
+{
+    asn_INTEGER_specifics_t *specs = (asn_INTEGER_specifics_t *)td->specifics;
+    asn_enc_rval_t er;
+    const long *native = (const long *)sptr;
+    const asn_INTEGER_enum_map_t *el;
+
+    (void)ilevel;
+    (void)flags;
+
+    if (!native)
+        {
+            _ASN_ENCODE_FAILED;
+        }
+
+    el = INTEGER_map_value2enum(specs, *native);
+    if (el)
+        {
+            size_t srcsize = el->enum_len + 5;
+            char *src = (char *)alloca(srcsize);
+
+            er.encoded = snprintf(src, srcsize, "<%s/>", el->enum_name);
+            assert(er.encoded > 0 && (size_t)er.encoded < srcsize);
+            if (cb(src, er.encoded, app_key) < 0)
+                {
+                    _ASN_ENCODE_FAILED;
+                }
+            _ASN_ENCODED_OK(er);
+        }
+    else
+        {
+            ASN_DEBUG(
+                "ASN.1 forbids dealing with "
+                "unknown value of ENUMERATED type");
+            _ASN_ENCODE_FAILED;
+        }
+}
+
+asn_dec_rval_t NativeEnumerated_decode_uper(asn_codec_ctx_t *opt_codec_ctx,
+    asn_TYPE_descriptor_t *td,
+    asn_per_constraints_t *constraints,
+    void **sptr, asn_per_data_t *pd)
+{
+    asn_INTEGER_specifics_t *specs = (asn_INTEGER_specifics_t *)td->specifics;
+    asn_dec_rval_t rval = {RC_OK, 0};
+    long *native = (long *)*sptr;
+    asn_per_constraint_t *ct;
+    long value;
+
+    (void)opt_codec_ctx;
+
+    if (constraints)
+        {
+            ct = &constraints->value;
+        }
+    else if (td->per_constraints)
+        {
+            ct = &td->per_constraints->value;
+        }
+    else
+        {
+            _ASN_DECODE_FAILED; /* Mandatory! */
+        }
+    if (!specs)
+        {
+            _ASN_DECODE_FAILED;
+        }
+
+    if (!native)
+        {
+            native = (long *)(*sptr = CALLOC(1, sizeof(*native)));
+            if (!native)
+                {
+                    _ASN_DECODE_FAILED;
+                }
+        }
+
+    ASN_DEBUG("Decoding %s as NativeEnumerated", td->name);
+
+    if (ct->flags & APC_EXTENSIBLE)
+        {
+            int inext = per_get_few_bits(pd, 1);
+            if (inext < 0)
+                {
+                    _ASN_DECODE_STARVED;
+                }
+            if (inext)
+                {
+                    ct = 0;
+                }
+        }
+
+    if (ct && ct->range_bits >= 0)
+        {
+            value = per_get_few_bits(pd, ct->range_bits);
+            if (value < 0)
+                {
+                    _ASN_DECODE_STARVED;
+                }
+            if (value >=
+                (specs->extension ? specs->extension - 1 : specs->map_count))
+                {
+                    _ASN_DECODE_FAILED;
+                }
+        }
+    else
+        {
+            if (!specs->extension)
+                {
+                    _ASN_DECODE_FAILED;
+                }
+            /*
+             * X.691, #10.6: normally small non-negative whole number;
+             */
+            value = uper_get_nsnnwn(pd);
+            if (value < 0)
+                {
+                    _ASN_DECODE_STARVED;
+                }
+            value += specs->extension - 1;
+            if (value >= specs->map_count)
+                {
+                    _ASN_DECODE_FAILED;
+                }
+        }
+
+    *native = specs->value2enum[value].nat_value;
+    ASN_DEBUG("Decoded %s = %ld", td->name, *native);
+
+    return rval;
+}
+
+static int NativeEnumerated__compar_value2enum(const void *ap, const void *bp)
+{
+    const asn_INTEGER_enum_map_t *a = ap;
+    const asn_INTEGER_enum_map_t *b = bp;
+    if (a->nat_value == b->nat_value)
+        {
+            return 0;
+        }
+    if (a->nat_value < b->nat_value)
+        {
+            return -1;
+        }
+    return 1;
+}
+
+asn_enc_rval_t NativeEnumerated_encode_uper(asn_TYPE_descriptor_t *td,
+    asn_per_constraints_t *constraints,
+    void *sptr, asn_per_outp_t *po)
+{
+    asn_INTEGER_specifics_t *specs = (asn_INTEGER_specifics_t *)td->specifics;
+    asn_enc_rval_t er;
+    long native;
+    long value;
+    asn_per_constraint_t *ct;
+    int inext = 0;
+    asn_INTEGER_enum_map_t key;
+    asn_INTEGER_enum_map_t *kf;
+
+    if (!sptr)
+        {
+            _ASN_ENCODE_FAILED;
+        }
+    if (!specs)
+        {
+            _ASN_ENCODE_FAILED;
+        }
+
+    if (constraints)
+        {
+            ct = &constraints->value;
+        }
+    else if (td->per_constraints)
+        {
+            ct = &td->per_constraints->value;
+        }
+    else
+        {
+            _ASN_ENCODE_FAILED; /* Mandatory! */
+        }
+
+    ASN_DEBUG("Encoding %s as NativeEnumerated", td->name);
+
+    er.encoded = 0;
+
+    native = *(long *)sptr;
+    if (native < 0)
+        {
+            _ASN_ENCODE_FAILED;
+        }
+
+    key.nat_value = native;
+    kf = bsearch(&key, specs->value2enum, specs->map_count, sizeof(key),
+        NativeEnumerated__compar_value2enum);
+    if (!kf)
+        {
+            ASN_DEBUG("No element corresponds to %ld", native);
+            _ASN_ENCODE_FAILED;
+        }
+    value = kf - specs->value2enum;
+
+    if (ct->range_bits >= 0)
+        {
+            int cmpWith =
+                specs->extension ? specs->extension - 1 : specs->map_count;
+            if (value >= cmpWith)
+                {
+                    inext = 1;
+                }
+        }
+    if (ct->flags & APC_EXTENSIBLE)
+        {
+            if (per_put_few_bits(po, inext, 1))
+                {
+                    _ASN_ENCODE_FAILED;
+                }
+            if (inext)
+                {
+                    ct = 0;
+                }
+        }
+    else if (inext)
+        {
+            _ASN_ENCODE_FAILED;
+        }
+
+    if (ct && ct->range_bits >= 0)
+        {
+            if (per_put_few_bits(po, value, ct->range_bits))
+                {
+                    _ASN_ENCODE_FAILED;
+                }
+            _ASN_ENCODED_OK(er);
+        }
+
+    if (!specs->extension)
+        {
+            _ASN_ENCODE_FAILED;
+        }
+
+    /*
+     * X.691, #10.6: normally small non-negative whole number;
+     */
+    ASN_DEBUG("value = %ld, ext = %d, inext = %d, res = %ld", value,
+        specs->extension, inext,
+        value - (inext ? (specs->extension - 1) : 0));
+    if (uper_put_nsnnwn(po, value - (inext ? (specs->extension - 1) : 0)))
+        {
+            _ASN_ENCODE_FAILED;
+        }
+
+    _ASN_ENCODED_OK(er);
+}

--- a/src/core/libs/supl/types/NativeEnumerated.h
+++ b/src/core/libs/supl/types/NativeEnumerated.h
@@ -1,0 +1,32 @@
+/*-
+ * SPDX-FileCopyrightText: (c) 2003, 2004 Lev Walkin <vlm@lionet.info>. All rights reserved.
+ * SPDX-License-Identifier: BSD-1-Clause
+ */
+/*
+ * This type differs from the standard ENUMERATED in that it is modelled using
+ * the fixed machine type (long, int, short), so it can hold only values of
+ * limited length. There is no type (i.e., NativeEnumerated_t, any integer type
+ * will do).
+ * This type may be used when integer range is limited by subtype constraints.
+ */
+#ifndef _NativeEnumerated_H
+#define _NativeEnumerated_H
+
+#include <NativeInteger.h>
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+    extern asn_TYPE_descriptor_t asn_DEF_NativeEnumerated;
+
+    xer_type_encoder_f NativeEnumerated_encode_xer;
+    per_type_decoder_f NativeEnumerated_decode_uper;
+    per_type_encoder_f NativeEnumerated_encode_uper;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* _NativeEnumerated_H_ */

--- a/src/core/libs/supl/types/NativeInteger.c
+++ b/src/core/libs/supl/types/NativeInteger.c
@@ -1,0 +1,377 @@
+/*-
+ * SPDX-FileCopyrightText: (c) 2003, 2004 Lev Walkin <vlm@lionet.info>. All rights reserved.
+ * SPDX-License-Identifier: BSD-1-Clause
+ */
+/*
+ * Read the NativeInteger.h for the explanation wrt. differences between
+ * INTEGER and NativeInteger.
+ * Basically, both are decoders and encoders of ASN.1 INTEGER type, but this
+ * implementation deals with the standard (machine-specific) representation
+ * of them instead of using the platform-independent buffer.
+ */
+#include <NativeInteger.h>
+#include <asn_internal.h>
+
+/*
+ * NativeInteger basic type description.
+ */
+static ber_tlv_tag_t asn_DEF_NativeInteger_tags[] = {
+    (ASN_TAG_CLASS_UNIVERSAL | (2 << 2))};
+asn_TYPE_descriptor_t asn_DEF_NativeInteger = {
+    "INTEGER", /* The ASN.1 type is still INTEGER */
+    "INTEGER",
+    NativeInteger_free,
+    NativeInteger_print,
+    asn_generic_no_constraint,
+    NativeInteger_decode_ber,
+    NativeInteger_encode_der,
+    NativeInteger_decode_xer,
+    NativeInteger_encode_xer,
+    NativeInteger_decode_uper, /* Unaligned PER decoder */
+    NativeInteger_encode_uper, /* Unaligned PER encoder */
+    0,                         /* Use generic outmost tag fetcher */
+    asn_DEF_NativeInteger_tags,
+    sizeof(asn_DEF_NativeInteger_tags) / sizeof(asn_DEF_NativeInteger_tags[0]),
+    asn_DEF_NativeInteger_tags, /* Same as above */
+    sizeof(asn_DEF_NativeInteger_tags) / sizeof(asn_DEF_NativeInteger_tags[0]),
+    0, /* No PER visible constraints */
+    0,
+    0, /* No members */
+    0  /* No specifics */
+};
+
+/*
+ * Decode INTEGER type.
+ */
+asn_dec_rval_t NativeInteger_decode_ber(asn_codec_ctx_t *opt_codec_ctx,
+    asn_TYPE_descriptor_t *td,
+    void **nint_ptr, const void *buf_ptr,
+    size_t size, int tag_mode)
+{
+    asn_INTEGER_specifics_t *specs = (asn_INTEGER_specifics_t *)td->specifics;
+    int64_t *native = (int64_t *)*nint_ptr;
+    asn_dec_rval_t rval;
+    ber_tlv_len_t length;
+
+    /*
+     * If the structure is not there, allocate it.
+     */
+    if (native == NULL)
+        {
+            native = (int64_t *)(*nint_ptr = CALLOC(1, sizeof(*native)));
+            if (native == NULL)
+                {
+                    rval.code = RC_FAIL;
+                    rval.consumed = 0;
+                    return rval;
+                }
+        }
+
+    ASN_DEBUG("Decoding %s as INTEGER (tm=%d)", td->name, tag_mode);
+
+    /*
+     * Check tags.
+     */
+    rval = ber_check_tags(opt_codec_ctx, td, 0, buf_ptr, size, tag_mode, 0,
+        &length, 0);
+    if (rval.code != RC_OK)
+        {
+            return rval;
+        }
+
+    ASN_DEBUG("%s length is %d bytes", td->name, (int)length);
+
+    /*
+     * Make sure we have this length.
+     */
+    buf_ptr = ((const char *)buf_ptr) + rval.consumed;
+    size -= rval.consumed;
+    if (length > (ber_tlv_len_t)size)
+        {
+            rval.code = RC_WMORE;
+            rval.consumed = 0;
+            return rval;
+        }
+
+    /*
+     * ASN.1 encoded INTEGER: buf_ptr, length
+     * Fill the native, at the same time checking for overflow.
+     * If overflow occurred, return with RC_FAIL.
+     */
+    {
+        INTEGER_t tmp;
+        union
+        {
+            const void *constbuf;
+            void *nonconstbuf;
+        } unconst_buf;
+        int64_t l;
+
+        unconst_buf.constbuf = buf_ptr;
+        tmp.buf = (uint8_t *)unconst_buf.nonconstbuf;
+        tmp.size = length;
+
+        if ((specs && specs->field_unsigned)
+                ? asn_INTEGER2ulong(&tmp, (uint64_t *)&l)
+                : asn_INTEGER2long(&tmp, &l))
+            {
+                rval.code = RC_FAIL;
+                rval.consumed = 0;
+                return rval;
+            }
+
+        *native = l;
+    }
+
+    rval.code = RC_OK;
+    rval.consumed += length;
+
+    ASN_DEBUG("Took %ld/%ld bytes to encode %s (%ld)", (long)rval.consumed,
+        (long)length, td->name, (long)*native);
+
+    return rval;
+}
+
+// clang-format off
+/*
+ * Encode the NativeInteger using the standard INTEGER type DER encoder.
+ */
+asn_enc_rval_t NativeInteger_encode_der(asn_TYPE_descriptor_t *sd, void *ptr,
+    int tag_mode, ber_tlv_tag_t tag,
+    asn_app_consume_bytes_f *cb,
+    void *app_key)
+{
+    uint64_t native = *(uint64_t *)ptr; /* Disable sign ext. */
+    asn_enc_rval_t erval;
+    INTEGER_t tmp;
+
+#ifdef WORDS_BIGENDIAN /* Opportunistic optimization */
+
+    tmp.buf = (uint8_t *)&native;
+    tmp.size = sizeof(native);
+
+#else  /* Works even if WORDS_BIGENDIAN is not set where should've been */
+    uint8_t buf[sizeof(native)];
+    uint8_t *p;
+
+    /* Prepare a fake INTEGER */
+    for (p = buf + sizeof(buf) - 1; p >= buf; p--, native >>= 8)
+        {
+            *p = (uint8_t)native;
+        }
+
+    tmp.buf = buf;
+    tmp.size = sizeof(buf);
+#endif /* WORDS_BIGENDIAN */
+
+    /* Encode fake INTEGER */
+    erval = INTEGER_encode_der(sd, &tmp, tag_mode, tag, cb, app_key);
+    if (erval.encoded == -1)
+        {
+            assert(erval.structure_ptr == &tmp);
+            erval.structure_ptr = ptr;
+        }
+    return erval;
+}
+// clang-format on
+
+/*
+ * Decode the chunk of XML text encoding INTEGER.
+ */
+asn_dec_rval_t NativeInteger_decode_xer(asn_codec_ctx_t *opt_codec_ctx,
+    asn_TYPE_descriptor_t *td, void **sptr,
+    const char *opt_mname,
+    const void *buf_ptr, size_t size)
+{
+    asn_INTEGER_specifics_t *specs = (asn_INTEGER_specifics_t *)td->specifics;
+    asn_dec_rval_t rval;
+    INTEGER_t st;
+    void *st_ptr = (void *)&st;
+    int64_t *native = (int64_t *)*sptr;
+
+    if (!native)
+        {
+            native = (int64_t *)(*sptr = CALLOC(1, sizeof(*native)));
+            if (!native)
+                {
+                    _ASN_DECODE_FAILED;
+                }
+        }
+
+    memset(&st, 0, sizeof(st));
+    rval = INTEGER_decode_xer(opt_codec_ctx, td, &st_ptr, opt_mname, buf_ptr,
+        size);
+    if (rval.code == RC_OK)
+        {
+            int64_t l;
+            if ((specs && specs->field_unsigned)
+                    ? asn_INTEGER2ulong(&st, (uint64_t *)&l)
+                    : asn_INTEGER2long(&st, &l))
+                {
+                    rval.code = RC_FAIL;
+                    rval.consumed = 0;
+                }
+            else
+                {
+                    *native = l;
+                }
+        }
+    else
+        {
+            /*
+             * Cannot restart from the middle;
+             * there is no place to save state in the native type.
+             * Request a continuation from the very beginning.
+             */
+            rval.consumed = 0;
+        }
+    ASN_STRUCT_FREE_CONTENTS_ONLY(asn_DEF_INTEGER, &st);
+    return rval;
+}
+
+asn_enc_rval_t NativeInteger_encode_xer(asn_TYPE_descriptor_t *td, void *sptr,
+    int ilevel,
+    enum xer_encoder_flags_e flags,
+    asn_app_consume_bytes_f *cb,
+    void *app_key)
+{
+    asn_INTEGER_specifics_t *specs = (asn_INTEGER_specifics_t *)td->specifics;
+    char scratch[32]; /* Enough for 64-bit int */
+    asn_enc_rval_t er;
+    const long *native = (const long *)sptr;
+
+    (void)ilevel;
+    (void)flags;
+
+    if (!native)
+        {
+            _ASN_ENCODE_FAILED;
+        }
+
+    er.encoded =
+        snprintf(scratch, sizeof(scratch),
+            (specs && specs->field_unsigned) ? "%lu" : "%ld", *native);
+    if (er.encoded <= 0 || (size_t)er.encoded >= sizeof(scratch) ||
+        cb(scratch, er.encoded, app_key) < 0)
+        {
+            _ASN_ENCODE_FAILED;
+        }
+
+    _ASN_ENCODED_OK(er);
+}
+
+asn_dec_rval_t NativeInteger_decode_uper(asn_codec_ctx_t *opt_codec_ctx,
+    asn_TYPE_descriptor_t *td,
+    asn_per_constraints_t *constraints,
+    void **sptr, asn_per_data_t *pd)
+{
+    asn_INTEGER_specifics_t *specs = (asn_INTEGER_specifics_t *)td->specifics;
+    asn_dec_rval_t rval;
+    int64_t *native = (int64_t *)*sptr;
+    INTEGER_t tmpint;
+    void *tmpintptr = &tmpint;
+
+    (void)opt_codec_ctx;
+    ASN_DEBUG("Decoding NativeInteger %s (UPER)", td->name);
+
+    if (!native)
+        {
+            native = (int64_t *)(*sptr = CALLOC(1, sizeof(*native)));
+            if (!native)
+                {
+                    _ASN_DECODE_FAILED;
+                }
+        }
+
+    memset(&tmpint, 0, sizeof tmpint);
+    rval = INTEGER_decode_uper(opt_codec_ctx, td, constraints, &tmpintptr, pd);
+    if (rval.code == RC_OK)
+        {
+            if ((specs && specs->field_unsigned)
+                    ? asn_INTEGER2ulong(&tmpint, (uint64_t *)native)
+                    : asn_INTEGER2long(&tmpint, native))
+                {
+                    rval.code = RC_FAIL;
+                }
+            else
+                {
+                    ASN_DEBUG("NativeInteger %s got value %ld", td->name, *native);
+                }
+        }
+    ASN_STRUCT_FREE_CONTENTS_ONLY(asn_DEF_INTEGER, &tmpint);
+
+    return rval;
+}
+
+asn_enc_rval_t NativeInteger_encode_uper(asn_TYPE_descriptor_t *td,
+    asn_per_constraints_t *constraints,
+    void *sptr, asn_per_outp_t *po)
+{
+    asn_INTEGER_specifics_t *specs = (asn_INTEGER_specifics_t *)td->specifics;
+    asn_enc_rval_t er;
+    long native;
+    INTEGER_t tmpint;
+
+    if (!sptr)
+        {
+            _ASN_ENCODE_FAILED;
+        }
+
+    native = *(long *)sptr;
+
+    ASN_DEBUG("Encoding NativeInteger %s %ld (UPER)", td->name, native);
+
+    memset(&tmpint, 0, sizeof(tmpint));
+    if ((specs && specs->field_unsigned) ? asn_ulong2INTEGER(&tmpint, native)
+                                         : asn_long2INTEGER(&tmpint, native))
+        {
+            _ASN_ENCODE_FAILED;
+        }
+    er = INTEGER_encode_uper(td, constraints, &tmpint, po);
+    ASN_STRUCT_FREE_CONTENTS_ONLY(asn_DEF_INTEGER, &tmpint);
+    return er;
+}
+
+/*
+ * INTEGER specific human-readable output.
+ */
+int NativeInteger_print(asn_TYPE_descriptor_t *td, const void *sptr, int ilevel,
+    asn_app_consume_bytes_f *cb, void *app_key)
+{
+    asn_INTEGER_specifics_t *specs = (asn_INTEGER_specifics_t *)td->specifics;
+    const long *native = (const long *)sptr;
+    char scratch[32]; /* Enough for 64-bit int */
+    int ret;
+
+    (void)td;     /* Unused argument */
+    (void)ilevel; /* Unused argument */
+
+    if (native)
+        {
+            ret = snprintf(scratch, sizeof(scratch),
+                (specs && specs->field_unsigned) ? "%lu" : "%ld",
+                *native);
+            assert(ret > 0 && (size_t)ret < sizeof(scratch));
+            return (cb(scratch, ret, app_key) < 0) ? -1 : 0;
+        }
+    else
+        {
+            return (cb("<absent>", 8, app_key) < 0) ? -1 : 0;
+        }
+}
+
+void NativeInteger_free(asn_TYPE_descriptor_t *td, void *ptr, int contents_only)
+{
+    if (!td || !ptr)
+        {
+            return;
+        }
+
+    ASN_DEBUG("Freeing %s as INTEGER (%d, %p, Native)", td->name, contents_only,
+        ptr);
+
+    if (!contents_only)
+        {
+            FREEMEM(ptr);
+        }
+}

--- a/src/core/libs/supl/types/NativeInteger.h
+++ b/src/core/libs/supl/types/NativeInteger.h
@@ -1,0 +1,38 @@
+/*-
+ * SPDX-FileCopyrightText: (c) 2003, 2004 Lev Walkin <vlm@lionet.info>. All rights reserved.
+ * SPDX-License-Identifier: BSD-1-Clause
+ */
+/*
+ * This type differs from the standard INTEGER in that it is modelled using
+ * the fixed machine type (long, int, short), so it can hold only values of
+ * limited length. There is no type (i.e., NativeInteger_t, any integer type
+ * will do).
+ * This type may be used when integer range is limited by subtype constraints.
+ */
+#ifndef _NativeInteger_H
+#define _NativeInteger_H
+
+#include <INTEGER.h>
+#include <asn_application.h>
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+    extern asn_TYPE_descriptor_t asn_DEF_NativeInteger;
+
+    asn_struct_free_f NativeInteger_free;
+    asn_struct_print_f NativeInteger_print;
+    ber_type_decoder_f NativeInteger_decode_ber;
+    der_type_encoder_f NativeInteger_encode_der;
+    xer_type_decoder_f NativeInteger_decode_xer;
+    xer_type_encoder_f NativeInteger_encode_xer;
+    per_type_decoder_f NativeInteger_decode_uper;
+    per_type_encoder_f NativeInteger_encode_uper;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* _NativeInteger_H_ */

--- a/src/core/libs/supl/types/OCTET_STRING.c
+++ b/src/core/libs/supl/types/OCTET_STRING.c
@@ -1,0 +1,2308 @@
+/*-
+ * SPDX-FileCopyrightText: (c) 2003, 2004 Lev Walkin <vlm@lionet.info>. All rights reserved.
+ * SPDX-License-Identifier: BSD-1-Clause
+ */
+#include <BIT_STRING.h> /* for .bits_unused member */
+#include <OCTET_STRING.h>
+#include <asn_internal.h>
+#include <errno.h>
+
+/*
+ * OCTET STRING basic type description.
+ */
+static ber_tlv_tag_t asn_DEF_OCTET_STRING_tags[] = {
+    (ASN_TAG_CLASS_UNIVERSAL | (4 << 2))};
+static asn_OCTET_STRING_specifics_t asn_DEF_OCTET_STRING_specs = {
+    sizeof(OCTET_STRING_t), offsetof(OCTET_STRING_t, _asn_ctx), ASN_OSUBV_STR};
+static asn_per_constraints_t ASN_DEF_OCTET_STRING_CONSTRAINTS = {
+    {APC_CONSTRAINED, 8, 8, 0, 255},
+    {APC_SEMI_CONSTRAINED, -1, -1, 0, 0},
+    0,
+    0};
+asn_TYPE_descriptor_t asn_DEF_OCTET_STRING = {
+    "OCTET STRING", /* Canonical name */
+    "OCTET_STRING", /* XML tag name */
+    OCTET_STRING_free,
+    OCTET_STRING_print, /* non-ascii stuff, generally */
+    asn_generic_no_constraint,
+    OCTET_STRING_decode_ber,
+    OCTET_STRING_encode_der,
+    OCTET_STRING_decode_xer_hex,
+    OCTET_STRING_encode_xer,
+    OCTET_STRING_decode_uper, /* Unaligned PER decoder */
+    OCTET_STRING_encode_uper, /* Unaligned PER encoder */
+    0,                        /* Use generic outmost tag fetcher */
+    asn_DEF_OCTET_STRING_tags,
+    sizeof(asn_DEF_OCTET_STRING_tags) / sizeof(asn_DEF_OCTET_STRING_tags[0]),
+    asn_DEF_OCTET_STRING_tags, /* Same as above */
+    sizeof(asn_DEF_OCTET_STRING_tags) / sizeof(asn_DEF_OCTET_STRING_tags[0]),
+    0, /* No PER visible constraints */
+    0,
+    0, /* No members */
+    &asn_DEF_OCTET_STRING_specs};
+
+#undef _CH_PHASE
+#undef NEXT_PHASE
+#undef PREV_PHASE
+#define _CH_PHASE(ctx, inc)                            \
+    do                                                 \
+        {                                              \
+            if ((ctx)->phase == 0) (ctx)->context = 0; \
+            (ctx)->phase += (inc);                     \
+        }                                              \
+    while (0)
+#define NEXT_PHASE(ctx) _CH_PHASE(ctx, +1)
+#define PREV_PHASE(ctx) _CH_PHASE(ctx, -1)
+
+#undef ADVANCE
+#define ADVANCE(num_bytes)                           \
+    do                                               \
+        {                                            \
+            size_t num = (num_bytes);                \
+            buf_ptr = ((const char *)buf_ptr) + num; \
+            size -= num;                             \
+            consumed_myself += num;                  \
+        }                                            \
+    while (0)
+
+#undef RETURN
+#define RETURN(_code)                           \
+    do                                          \
+        {                                       \
+            asn_dec_rval_t tmprval;             \
+            tmprval.code = _code;               \
+            tmprval.consumed = consumed_myself; \
+            return tmprval;                     \
+        }                                       \
+    while (0)
+
+#undef APPEND
+#define APPEND(bufptr, bufsize)                                     \
+    do                                                              \
+        {                                                           \
+            size_t _bs = (bufsize);      /* Append size */          \
+            size_t _ns = ctx->context;   /* Allocated now */        \
+            size_t _es = st->size + _bs; /* Expected size */        \
+            /* int is really a typeof(st->size): */                 \
+            if ((int)_es < 0) RETURN(RC_FAIL);                      \
+            if (_ns <= _es)                                         \
+                {                                                   \
+                    void *ptr;                                      \
+                    /* Be nice and round to the memory allocator */ \
+                    do                                              \
+                        {                                           \
+                            _ns = _ns ? _ns << 1 : 16;              \
+                        }                                           \
+                    while (_ns <= _es);                             \
+                    /* int is really a typeof(st->size): */         \
+                    if ((int)_ns < 0) RETURN(RC_FAIL);              \
+                    ptr = REALLOC(st->buf, _ns);                    \
+                    if (ptr)                                        \
+                        {                                           \
+                            st->buf = (uint8_t *)ptr;               \
+                            ctx->context = _ns;                     \
+                        }                                           \
+                    else                                            \
+                        {                                           \
+                            RETURN(RC_FAIL);                        \
+                        }                                           \
+                    ASN_DEBUG("Reallocating into %ld", (long)_ns);  \
+                }                                                   \
+            memcpy(st->buf + st->size, bufptr, _bs);                \
+            /* Convenient nul-termination */                        \
+            st->buf[_es] = '\0';                                    \
+            st->size = _es;                                         \
+        }                                                           \
+    while (0)
+
+/*
+ * The main reason why ASN.1 is still alive is that too much time and effort
+ * is necessary for learning it more or less adequately, thus creating a gut
+ * necessity to demonstrate that acquired skill everywhere afterwards.
+ * No, I am not going to explain what the following stuff is.
+ */
+struct stack_el
+{
+    ber_tlv_len_t left; /* What's left to read (or -1) */
+    ber_tlv_len_t got;  /* What was actually processed */
+    int cont_level;     /* Depth of subcontainment */
+    int want_nulls;     /* Want null "end of content" octets? */
+    int bits_chopped;   /* Flag in BIT STRING mode */
+    ber_tlv_tag_t tag;  /* For debugging purposes */
+    struct stack_el *prev;
+    struct stack_el *next;
+};
+struct stack
+{
+    struct stack_el *tail;
+    struct stack_el *cur_ptr;
+};
+
+static struct stack_el *OS__add_stack_el(struct stack *st)
+{
+    struct stack_el *nel;
+
+    /*
+     * Reuse the old stack frame or allocate a new one.
+     */
+    if (st->cur_ptr && st->cur_ptr->next)
+        {
+            nel = st->cur_ptr->next;
+            nel->bits_chopped = 0;
+            nel->got = 0;
+            /* Retain the nel->cont_level, it's correct. */
+        }
+    else
+        {
+            nel = (struct stack_el *)CALLOC(1, sizeof(struct stack_el));
+            if (nel == NULL)
+                {
+                    return NULL;
+                }
+
+            if (st->tail)
+                {
+                    /* Increase a subcontainment depth */
+                    nel->cont_level = st->tail->cont_level + 1;
+                    st->tail->next = nel;
+                }
+            nel->prev = st->tail;
+            st->tail = nel;
+        }
+
+    st->cur_ptr = nel;
+
+    return nel;
+}
+
+static struct stack *new_stack()
+{
+    return (struct stack *)CALLOC(1, sizeof(struct stack));
+}
+
+/*
+ * Decode OCTET STRING type.
+ */
+asn_dec_rval_t OCTET_STRING_decode_ber(asn_codec_ctx_t *opt_codec_ctx,
+    asn_TYPE_descriptor_t *td, void **sptr,
+    const void *buf_ptr, size_t size,
+    int tag_mode)
+{
+    asn_OCTET_STRING_specifics_t *specs =
+        td->specifics ? (asn_OCTET_STRING_specifics_t *)td->specifics
+                      : &asn_DEF_OCTET_STRING_specs;
+    BIT_STRING_t *st = (BIT_STRING_t *)*sptr;
+    asn_dec_rval_t rval;
+    asn_struct_ctx_t *ctx;
+    ssize_t consumed_myself = 0;
+    struct stack *stck;       /* Expectations stack structure */
+    struct stack_el *sel = 0; /* Stack element */
+    int tlv_constr;
+    enum asn_OS_Subvariant type_variant = specs->subvariant;
+
+    ASN_DEBUG(
+        "Decoding %s as %s (frame %ld)", td->name,
+        (type_variant == ASN_OSUBV_STR) ? "OCTET STRING" : "OS-SpecialCase",
+        (long)size);
+
+    /*
+     * Create the string if does not exist.
+     */
+    if (st == NULL)
+        {
+            st = (BIT_STRING_t *)(*sptr = CALLOC(1, specs->struct_size));
+            if (st == NULL)
+                {
+                    RETURN(RC_FAIL);
+                }
+        }
+
+    /* Restore parsing context */
+    ctx = (asn_struct_ctx_t *)((char *)st + specs->ctx_offset);
+
+    switch (ctx->phase)
+        {
+        case 0:
+            /*
+             * Check tags.
+             */
+            rval = ber_check_tags(opt_codec_ctx, td, ctx, buf_ptr, size,
+                tag_mode, -1, &ctx->left, &tlv_constr);
+            if (rval.code != RC_OK)
+                {
+                    return rval;
+                }
+
+            if (tlv_constr)
+                {
+                    /*
+                     * Complex operation, requires stack of expectations.
+                     */
+                    ctx->ptr = new_stack();
+                    if (ctx->ptr)
+                        {
+                            stck = (struct stack *)ctx->ptr;
+                        }
+                    else
+                        {
+                            RETURN(RC_FAIL);
+                        }
+                }
+            else
+                {
+                    /*
+                     * Jump into stackless primitive decoding.
+                     */
+                    _CH_PHASE(ctx, 3);
+                    if (type_variant == ASN_OSUBV_ANY && tag_mode != 1)
+                        {
+                            APPEND(buf_ptr, rval.consumed);
+                        }
+                    ADVANCE(rval.consumed);
+                    goto phase3;
+                }
+
+            NEXT_PHASE(ctx);
+            /* Fall through */
+        case 1:
+        phase1:
+            /*
+             * Fill the stack with expectations.
+             */
+            stck = (struct stack *)ctx->ptr;
+            sel = stck->cur_ptr;
+            do
+                {
+                    ber_tlv_tag_t tlv_tag;
+                    ber_tlv_len_t tlv_len;
+                    ber_tlv_tag_t expected_tag;
+                    ssize_t tl;
+                    ssize_t ll;
+                    ssize_t tlvl;
+                    /* This one works even if (sel->left == -1) */
+                    ssize_t Left =
+                        ((!sel || (size_t)sel->left >= size) ? (ssize_t)size
+                                                             : sel->left);
+
+                    ASN_DEBUG("%p, s->l=%ld, s->wn=%ld, s->g=%ld\n", sel,
+                        (sel ? sel->left : 0),
+                        (long)(sel ? sel->want_nulls : 0),
+                        (sel ? sel->got : 0));
+                    if (sel && sel->left <= 0 && sel->want_nulls == 0)
+                        {
+                            if (sel->prev)
+                                {
+                                    struct stack_el *prev = sel->prev;
+                                    if (prev->left != -1)
+                                        {
+                                            if (prev->left < sel->got)
+                                                {
+                                                    RETURN(RC_FAIL);
+                                                }
+                                            prev->left -= sel->got;
+                                        }
+                                    prev->got += sel->got;
+                                    sel = stck->cur_ptr = prev;
+                                    if (!sel)
+                                        {
+                                            break;
+                                        }
+                                    tlv_constr = 1;
+                                    continue;
+                                }
+                            else
+                                {
+                                    sel = stck->cur_ptr = 0;
+                                    break; /* Nothing to wait */
+                                }
+                        }
+
+                    tl = ber_fetch_tag(buf_ptr, Left, &tlv_tag);
+                    ASN_DEBUG(
+                        "fetch tag(size=%ld,L=%ld), %sstack, left=%ld, "
+                        "wn=%ld, "
+                        "tl=%ld",
+                        (long)size, (long)Left, sel ? "" : "!",
+                        (sel ? sel->left : 0),
+                        (long)(sel ? sel->want_nulls : 0), (long)tl);
+                    switch (tl)
+                        {
+                        case -1:
+                            RETURN(RC_FAIL);
+                        case 0:
+                            RETURN(RC_WMORE);
+                        }
+
+                    tlv_constr = BER_TLV_CONSTRUCTED(buf_ptr);
+
+                    ll = ber_fetch_length(tlv_constr,
+                        (const char *)buf_ptr + tl,
+                        Left - tl, &tlv_len);
+                    ASN_DEBUG(
+                        "Got tag=%s, tc=%d, left=%ld, tl=%ld, len=%ld, "
+                        "ll=%ld",
+                        ber_tlv_tag_string(tlv_tag), tlv_constr, (long)Left,
+                        (long)tl, (long)tlv_len, (long)ll);
+                    switch (ll)
+                        {
+                        case -1:
+                            RETURN(RC_FAIL);
+                        case 0:
+                            RETURN(RC_WMORE);
+                        }
+
+                    if (sel && sel->want_nulls &&
+                        ((const uint8_t *)buf_ptr)[0] == 0 &&
+                        ((const uint8_t *)buf_ptr)[1] == 0)
+                        {
+                            ASN_DEBUG("Eat EOC; wn=%d--", sel->want_nulls);
+
+                            if (type_variant == ASN_OSUBV_ANY &&
+                                (tag_mode != 1 || sel->cont_level))
+                                {
+                                    APPEND("\0\0", 2);
+                                }
+
+                            ADVANCE(2);
+                            sel->got += 2;
+                            if (sel->left != -1)
+                                {
+                                    sel->left -=
+                                        2; /* assert(sel->left >= 2) */
+                                }
+
+                            sel->want_nulls--;
+                            if (sel->want_nulls == 0)
+                                {
+                                    /* Move to the next expectation */
+                                    sel->left = 0;
+                                    tlv_constr = 1;
+                                }
+
+                            continue;
+                        }
+
+                    /*
+                     * Set up expected tags,
+                     * depending on ASN.1 type being decoded.
+                     */
+                    switch (type_variant)
+                        {
+                        case ASN_OSUBV_BIT:
+                            /* X.690: 8.6.4.1, NOTE 2 */
+                            /* Fall through */
+                        case ASN_OSUBV_STR:
+                        default:
+                            if (sel)
+                                {
+                                    int level = sel->cont_level;
+                                    if (level < td->all_tags_count)
+                                        {
+                                            expected_tag =
+                                                td->all_tags[level];
+                                            break;
+                                        }
+                                    else if (td->all_tags_count)
+                                        {
+                                            expected_tag =
+                                                td->all_tags
+                                                    [td->all_tags_count -
+                                                        1];
+                                            break;
+                                        }
+                                    /* else, Fall through */
+                                }
+                            /* Fall through */
+                        case ASN_OSUBV_ANY:
+                            expected_tag = tlv_tag;
+                            break;
+                        }
+
+                    if (tlv_tag != expected_tag)
+                        {
+                            char buf[2][32];
+                            ber_tlv_tag_snprint(tlv_tag, buf[0],
+                                sizeof(buf[0]));
+                            ber_tlv_tag_snprint(
+                                td->tags[td->tags_count - 1], buf[1],
+                                sizeof(buf[1]));
+                            ASN_DEBUG(
+                                "Tag does not match expectation: %s != %s",
+                                buf[0], buf[1]);
+                            RETURN(RC_FAIL);
+                        }
+
+                    tlvl =
+                        tl + ll; /* Combined length of T and L encoding */
+                    if ((tlv_len + tlvl) < 0)
+                        {
+                            /* tlv_len value is too big */
+                            ASN_DEBUG(
+                                "TLV encoding + length (%ld) is too big",
+                                (long)tlv_len);
+                            RETURN(RC_FAIL);
+                        }
+
+                    /*
+                     * Append a new expectation.
+                     */
+                    sel = OS__add_stack_el(stck);
+                    if (!sel)
+                        {
+                            RETURN(RC_FAIL);
+                        }
+
+                    sel->tag = tlv_tag;
+
+                    sel->want_nulls = (tlv_len == -1);
+                    if (sel->prev && sel->prev->left != -1)
+                        {
+                            /* Check that the parent frame is big enough */
+                            if (sel->prev->left <
+                                tlvl + (tlv_len == -1 ? 0 : tlv_len))
+                                {
+                                    RETURN(RC_FAIL);
+                                }
+                            if (tlv_len == -1)
+                                {
+                                    sel->left = sel->prev->left - tlvl;
+                                }
+                            else
+                                {
+                                    sel->left = tlv_len;
+                                }
+                        }
+                    else
+                        {
+                            sel->left = tlv_len;
+                        }
+                    if (type_variant == ASN_OSUBV_ANY &&
+                        (tag_mode != 1 || sel->cont_level))
+                        {
+                            APPEND(buf_ptr, tlvl);
+                        }
+                    sel->got += tlvl;
+                    ADVANCE(tlvl);
+
+                    ASN_DEBUG("+EXPECT2 got=%ld left=%ld, wn=%d, clvl=%d",
+                        (long)sel->got, (long)sel->left,
+                        sel->want_nulls, sel->cont_level);
+                }
+            while (tlv_constr);
+            if (sel == NULL)
+                {
+                    /* Finished operation, "phase out" */
+                    ASN_DEBUG("Phase out");
+                    _CH_PHASE(ctx, +3);
+                    break;
+                }
+
+            NEXT_PHASE(ctx);
+            /* Fall through */
+        case 2:
+            stck = (struct stack *)ctx->ptr;
+            sel = stck->cur_ptr;
+            ASN_DEBUG("Phase 2: Need %ld bytes, size=%ld, alrg=%ld, wn=%d",
+                (long)sel->left, (long)size, (long)sel->got,
+                sel->want_nulls);
+            {
+                ber_tlv_len_t len;
+
+                assert(sel->left >= 0);
+
+                len = ((ber_tlv_len_t)size < sel->left)
+                          ? (ber_tlv_len_t)size
+                          : sel->left;
+                if (len > 0)
+                    {
+                        if (type_variant == ASN_OSUBV_BIT &&
+                            sel->bits_chopped == 0)
+                            {
+                                /* Put the unused-bits-octet away */
+                                st->bits_unused = *(const uint8_t *)buf_ptr;
+                                APPEND(((const char *)buf_ptr + 1),
+                                    (len - 1));
+                                sel->bits_chopped = 1;
+                            }
+                        else
+                            {
+                                APPEND(buf_ptr, len);
+                            }
+                        ADVANCE(len);
+                        sel->left -= len;
+                        sel->got += len;
+                    }
+
+                if (sel->left)
+                    {
+                        ASN_DEBUG("OS left %ld, size = %ld, wn=%d\n",
+                            (long)sel->left, (long)size,
+                            sel->want_nulls);
+                        RETURN(RC_WMORE);
+                    }
+
+                PREV_PHASE(ctx);
+                goto phase1;
+            }
+            break;
+        case 3:
+        phase3:
+            /*
+             * Primitive form, no stack required.
+             */
+            assert(ctx->left >= 0);
+
+            if (size < (size_t)ctx->left)
+                {
+                    if (!size)
+                        {
+                            RETURN(RC_WMORE);
+                        }
+                    if (type_variant == ASN_OSUBV_BIT && !ctx->context)
+                        {
+                            st->bits_unused = *(const uint8_t *)buf_ptr;
+                            ctx->left--;
+                            ADVANCE(1);
+                        }
+                    APPEND(buf_ptr, size);
+                    assert(ctx->context > 0);
+                    ctx->left -= size;
+                    ADVANCE(size);
+                    RETURN(RC_WMORE);
+                }
+            else
+                {
+                    if (type_variant == ASN_OSUBV_BIT && !ctx->context &&
+                        ctx->left)
+                        {
+                            st->bits_unused = *(const uint8_t *)buf_ptr;
+                            ctx->left--;
+                            ADVANCE(1);
+                        }
+                    APPEND(buf_ptr, ctx->left);
+                    ADVANCE(ctx->left);
+                    ctx->left = 0;
+
+                    NEXT_PHASE(ctx);
+                }
+            break;
+        }
+
+    if (sel)
+        {
+            ASN_DEBUG("3sel p=%p, wn=%d, l=%ld, g=%ld, size=%ld", sel->prev,
+                sel->want_nulls, (long)sel->left, (long)sel->got,
+                (long)size);
+            if (sel->prev || sel->want_nulls > 1 || sel->left > 0)
+                {
+                    RETURN(RC_WMORE);
+                }
+        }
+
+    /*
+     * BIT STRING-specific processing.
+     */
+    if (type_variant == ASN_OSUBV_BIT && st->size)
+        {
+            /* Finalize BIT STRING: zero out unused bits. */
+            st->buf[st->size - 1] &= 0xff << st->bits_unused;
+        }
+
+    ASN_DEBUG("Took %ld bytes to encode %s: [%s]:%ld", (long)consumed_myself,
+        td->name,
+        (type_variant == ASN_OSUBV_STR) ? (char *)st->buf : "<data>",
+        (long)st->size);
+
+    RETURN(RC_OK);
+}
+
+/*
+ * Encode OCTET STRING type using DER.
+ */
+asn_enc_rval_t OCTET_STRING_encode_der(asn_TYPE_descriptor_t *td, void *sptr,
+    int tag_mode, ber_tlv_tag_t tag,
+    asn_app_consume_bytes_f *cb,
+    void *app_key)
+{
+    asn_enc_rval_t er;
+    asn_OCTET_STRING_specifics_t *specs =
+        td->specifics ? (asn_OCTET_STRING_specifics_t *)td->specifics
+                      : &asn_DEF_OCTET_STRING_specs;
+    BIT_STRING_t *st = (BIT_STRING_t *)sptr;
+    enum asn_OS_Subvariant type_variant = specs->subvariant;
+    int fix_last_byte = 0;
+
+    ASN_DEBUG("%s %s as OCTET STRING", cb ? "Estimating" : "Encoding",
+        td->name);
+
+    /*
+     * Write tags.
+     */
+    if (type_variant != ASN_OSUBV_ANY || tag_mode == 1)
+        {
+            er.encoded = der_write_tags(
+                td, (type_variant == ASN_OSUBV_BIT) + st->size, tag_mode,
+                type_variant == ASN_OSUBV_ANY, tag, cb, app_key);
+            if (er.encoded == -1)
+                {
+                    er.failed_type = td;
+                    er.structure_ptr = sptr;
+                    return er;
+                }
+        }
+    else
+        {
+            /* Disallow: [<tag>] IMPLICIT ANY */
+            assert(type_variant != ASN_OSUBV_ANY || tag_mode != -1);
+            er.encoded = 0;
+        }
+
+    if (!cb)
+        {
+            er.encoded += (type_variant == ASN_OSUBV_BIT) + st->size;
+            _ASN_ENCODED_OK(er);
+        }
+
+    /*
+     * Prepare to deal with the last octet of BIT STRING.
+     */
+    if (type_variant == ASN_OSUBV_BIT)
+        {
+            uint8_t b = st->bits_unused & 0x07;
+            if (b && st->size)
+                {
+                    fix_last_byte = 1;
+                }
+            _ASN_CALLBACK(&b, 1);
+            er.encoded++;
+        }
+
+    /* Invoke callback for the main part of the buffer */
+    _ASN_CALLBACK(st->buf, st->size - fix_last_byte);
+
+    /* The last octet should be stripped off the unused bits */
+    if (fix_last_byte)
+        {
+            uint8_t b = st->buf[st->size - 1] & (0xff << st->bits_unused);
+            _ASN_CALLBACK(&b, 1);
+        }
+
+    er.encoded += st->size;
+    _ASN_ENCODED_OK(er);
+cb_failed:
+    _ASN_ENCODE_FAILED;
+}
+
+asn_enc_rval_t OCTET_STRING_encode_xer(asn_TYPE_descriptor_t *td, void *sptr,
+    int ilevel,
+    enum xer_encoder_flags_e flags,
+    asn_app_consume_bytes_f *cb,
+    void *app_key)
+{
+    static const char *h2c = "0123456789ABCDEF";
+    const OCTET_STRING_t *st = (const OCTET_STRING_t *)sptr;
+    asn_enc_rval_t er;
+    char scratch[16 * 3 + 4];
+    char *p = scratch;
+    uint8_t *buf;
+    uint8_t *end;
+    size_t i;
+
+    if (!st || (!st->buf && st->size))
+        {
+            _ASN_ENCODE_FAILED;
+        }
+
+    er.encoded = 0;
+
+    /*
+     * Dump the contents of the buffer in hexadecimal.
+     */
+    buf = st->buf;
+    end = buf + st->size;
+    if (flags & XER_F_CANONICAL)
+        {
+            char *scend = scratch + (sizeof(scratch) - 2);
+            for (; buf < end; buf++)
+                {
+                    if (p >= scend)
+                        {
+                            _ASN_CALLBACK(scratch, p - scratch);
+                            er.encoded += p - scratch;
+                            p = scratch;
+                        }
+                    *p++ = h2c[(*buf >> 4) & 0x0F];
+                    *p++ = h2c[*buf & 0x0F];
+                }
+
+            _ASN_CALLBACK(scratch, p - scratch); /* Dump the rest */
+            er.encoded += p - scratch;
+        }
+    else
+        {
+            for (i = 0; buf < end; buf++, i++)
+                {
+                    if (!(i % 16) && (i || st->size > 16))
+                        {
+                            _ASN_CALLBACK(scratch, p - scratch);
+                            er.encoded += (p - scratch);
+                            p = scratch;
+                            _i_ASN_TEXT_INDENT(1, ilevel);
+                        }
+                    *p++ = h2c[(*buf >> 4) & 0x0F];
+                    *p++ = h2c[*buf & 0x0F];
+                    *p++ = 0x20;
+                }
+            if (p - scratch)
+                {
+                    p--;                                 /* Remove the tail space */
+                    _ASN_CALLBACK(scratch, p - scratch); /* Dump the rest */
+                    er.encoded += p - scratch;
+                    if (st->size > 16)
+                        {
+                            _i_ASN_TEXT_INDENT(1, ilevel - 1);
+                        }
+                }
+        }
+
+    _ASN_ENCODED_OK(er);
+cb_failed:
+    _ASN_ENCODE_FAILED;
+}
+
+static struct OCTET_STRING__xer_escape_table_s
+{
+    char *string;
+    int size;
+} OCTET_STRING__xer_escape_table[] = {
+#define OSXET(s)         \
+    {                    \
+        s, sizeof(s) - 1 \
+    }
+    OSXET("\074\156\165\154\057\076"), /* <nul/> */
+    OSXET("\074\163\157\150\057\076"), /* <soh/> */
+    OSXET("\074\163\164\170\057\076"), /* <stx/> */
+    OSXET("\074\145\164\170\057\076"), /* <etx/> */
+    OSXET("\074\145\157\164\057\076"), /* <eot/> */
+    OSXET("\074\145\156\161\057\076"), /* <enq/> */
+    OSXET("\074\141\143\153\057\076"), /* <ack/> */
+    OSXET("\074\142\145\154\057\076"), /* <bel/> */
+    OSXET("\074\142\163\057\076"),     /* <bs/> */
+    OSXET("\011"),                     /* \t */
+    OSXET("\012"),                     /* \n */
+    OSXET("\074\166\164\057\076"),     /* <vt/> */
+    OSXET("\074\146\146\057\076"),     /* <ff/> */
+    OSXET("\015"),                     /* \r */
+    OSXET("\074\163\157\057\076"),     /* <so/> */
+    OSXET("\074\163\151\057\076"),     /* <si/> */
+    OSXET("\074\144\154\145\057\076"), /* <dle/> */
+    OSXET("\074\144\143\061\057\076"), /* <de1/> */
+    OSXET("\074\144\143\062\057\076"), /* <de2/> */
+    OSXET("\074\144\143\063\057\076"), /* <de3/> */
+    OSXET("\074\144\143\064\057\076"), /* <de4/> */
+    OSXET("\074\156\141\153\057\076"), /* <nak/> */
+    OSXET("\074\163\171\156\057\076"), /* <syn/> */
+    OSXET("\074\145\164\142\057\076"), /* <etb/> */
+    OSXET("\074\143\141\156\057\076"), /* <can/> */
+    OSXET("\074\145\155\057\076"),     /* <em/> */
+    OSXET("\074\163\165\142\057\076"), /* <sub/> */
+    OSXET("\074\145\163\143\057\076"), /* <esc/> */
+    OSXET("\074\151\163\064\057\076"), /* <is4/> */
+    OSXET("\074\151\163\063\057\076"), /* <is3/> */
+    OSXET("\074\151\163\062\057\076"), /* <is2/> */
+    OSXET("\074\151\163\061\057\076"), /* <is1/> */
+    {0, 0},                            /* " " */
+    {0, 0},                            /* ! */
+    {0, 0},                            /* \" */
+    {0, 0},                            /* # */
+    {0, 0},                            /* $ */
+    {0, 0},                            /* % */
+    OSXET("\046\141\155\160\073"),     /* &amp; */
+    {0, 0},                            /* ' */
+    {0, 0},
+    {0, 0},
+    {0, 0},
+    {0, 0},
+    {0, 0},
+    {0, 0},
+    {0, 0},
+    {0, 0}, /* ()*+,-./ */
+    {0, 0},
+    {0, 0},
+    {0, 0},
+    {0, 0},
+    {0, 0},
+    {0, 0},
+    {0, 0},
+    {0, 0}, /* 01234567 */
+    {0, 0},
+    {0, 0},
+    {0, 0},
+    {0, 0},                    /* 89:; */
+    OSXET("\046\154\164\073"), /* &lt; */
+    {0, 0},                    /* = */
+    OSXET("\046\147\164\073"), /* &gt; */
+};
+
+static int OS__check_escaped_control_char(const void *buf, int size)
+{
+    size_t i;
+    /*
+     * Inefficient algorithm which translates the escape sequences
+     * defined above into characters. Returns -1 if not found.
+     * TODO: replace by a faster algorithm (bsearch(), hash or
+     * nested table lookups).
+     */
+    for (i = 0; i < 32 /* Don't spend time on the bottom half */; i++)
+        {
+            struct OCTET_STRING__xer_escape_table_s *el;
+            el = &OCTET_STRING__xer_escape_table[i];
+            if (el->size == size && memcmp(buf, el->string, size) == 0)
+                {
+                    return i;
+                }
+        }
+    return -1;
+}
+
+static int OCTET_STRING__handle_control_chars(void *struct_ptr,
+    const void *chunk_buf,
+    size_t chunk_size)
+{
+    /*
+     * This might be one of the escape sequences
+     * for control characters. Check it out.
+     * #11.15.5
+     */
+    int control_char = OS__check_escaped_control_char(chunk_buf, chunk_size);
+    if (control_char >= 0)
+        {
+            OCTET_STRING_t *st = (OCTET_STRING_t *)struct_ptr;
+            void *p = REALLOC(st->buf, st->size + 2);
+            if (p)
+                {
+                    st->buf = (uint8_t *)p;
+                    st->buf[st->size++] = control_char;
+                    st->buf[st->size] = '\0'; /* nul-termination */
+                    return 0;
+                }
+        }
+
+    return -1; /* No, it's not */
+}
+
+asn_enc_rval_t OCTET_STRING_encode_xer_utf8(asn_TYPE_descriptor_t *td,
+    void *sptr, int ilevel,
+    enum xer_encoder_flags_e flags,
+    asn_app_consume_bytes_f *cb,
+    void *app_key)
+{
+    const OCTET_STRING_t *st = (const OCTET_STRING_t *)sptr;
+    asn_enc_rval_t er;
+    uint8_t *buf;
+    uint8_t *end;
+    uint8_t *ss; /* Sequence start */
+    ssize_t encoded_len = 0;
+
+    (void)ilevel; /* Unused argument */
+    (void)flags;  /* Unused argument */
+
+    if (!st || (!st->buf && st->size))
+        {
+            _ASN_ENCODE_FAILED;
+        }
+
+    buf = st->buf;
+    end = buf + st->size;
+    for (ss = buf; buf < end; buf++)
+        {
+            unsigned int ch = *buf;
+            int s_len; /* Special encoding sequence length */
+
+            /*
+             * Escape certain characters: X.680/11.15
+             */
+            if (ch < sizeof(OCTET_STRING__xer_escape_table) /
+                         sizeof(OCTET_STRING__xer_escape_table[0]) &&
+                (s_len = OCTET_STRING__xer_escape_table[ch].size))
+                {
+                    if (((buf - ss) && cb(ss, buf - ss, app_key) < 0) ||
+                        cb(OCTET_STRING__xer_escape_table[ch].string, s_len,
+                            app_key) < 0)
+                        {
+                            _ASN_ENCODE_FAILED;
+                        }
+                    encoded_len += (buf - ss) + s_len;
+                    ss = buf + 1;
+                }
+        }
+
+    encoded_len += (buf - ss);
+    if ((buf - ss) && cb(ss, buf - ss, app_key) < 0)
+        {
+            _ASN_ENCODE_FAILED;
+        }
+
+    er.encoded = encoded_len;
+    _ASN_ENCODED_OK(er);
+}
+
+/*
+ * Convert from hexadecimal format (cstring): "AB CD EF"
+ */
+static ssize_t OCTET_STRING__convert_hexadecimal(void *sptr,
+    const void *chunk_buf,
+    size_t chunk_size,
+    int have_more)
+{
+    OCTET_STRING_t *st = (OCTET_STRING_t *)sptr;
+    const char *chunk_stop = (const char *)chunk_buf;
+    const char *p = chunk_stop;
+    const char *pend = p + chunk_size;
+    unsigned int clv = 0;
+    int half = 0; /* Half bit */
+    uint8_t *buf;
+
+    /* Reallocate buffer according to high cap estimation */
+    ssize_t _ns = st->size + (chunk_size + 1) / 2;
+    void *nptr = REALLOC(st->buf, _ns + 1);
+    if (!nptr)
+        {
+            return -1;
+        }
+    st->buf = (uint8_t *)nptr;
+    buf = st->buf + st->size;
+
+    /*
+     * If something like " a b c " appears here, the " a b":3 will be
+     * converted, and the rest skipped. That is, unless buf_size is greater
+     * than chunk_size, then it'll be equivalent to "ABC0".
+     */
+    for (; p < pend; p++)
+        {
+            int ch = *(const unsigned char *)p;
+            switch (ch)
+                {
+                case 0x09:
+                case 0x0a:
+                case 0x0c:
+                case 0x0d:
+                case 0x20:
+                    /* Ignore whitespace */
+                    continue;
+                case 0x30:
+                case 0x31:
+                case 0x32:
+                case 0x33:
+                case 0x34: /*01234*/
+                case 0x35:
+                case 0x36:
+                case 0x37:
+                case 0x38:
+                case 0x39: /*56789*/
+                    clv = (clv << 4) + (ch - 0x30);
+                    break;
+                case 0x41:
+                case 0x42:
+                case 0x43: /* ABC */
+                case 0x44:
+                case 0x45:
+                case 0x46: /* DEF */
+                    clv = (clv << 4) + (ch - 0x41 + 10);
+                    break;
+                case 0x61:
+                case 0x62:
+                case 0x63: /* abc */
+                case 0x64:
+                case 0x65:
+                case 0x66: /* def */
+                    clv = (clv << 4) + (ch - 0x61 + 10);
+                    break;
+                default:
+                    *buf = 0; /* JIC */
+                    return -1;
+                }
+            if (half++)
+                {
+                    half = 0;
+                    *buf++ = clv;
+                    chunk_stop = p + 1;
+                }
+        }
+
+    /*
+     * Check partial decoding.
+     */
+    if (half)
+        {
+            if (have_more)
+                {
+                    /*
+                     * Partial specification is fine,
+                     * because no more more PXER_TEXT data is available.
+                     */
+                    *buf++ = clv << 4;
+                    chunk_stop = p;
+                }
+        }
+    else
+        {
+            chunk_stop = p;
+        }
+
+    st->size = buf - st->buf; /* Adjust the buffer size */
+    assert(st->size <= _ns);
+    st->buf[st->size] = 0; /* Courtesy termination */
+
+    return (chunk_stop - (const char *)chunk_buf); /* Converted size */
+}
+
+/*
+ * Convert from binary format: "00101011101"
+ */
+static ssize_t OCTET_STRING__convert_binary(void *sptr, const void *chunk_buf,
+    size_t chunk_size, int have_more)
+{
+    BIT_STRING_t *st = (BIT_STRING_t *)sptr;
+    const char *p = (const char *)chunk_buf;
+    const char *pend = p + chunk_size;
+    int bits_unused = st->bits_unused & 0x7;
+    uint8_t *buf;
+
+    /* Reallocate buffer according to high cap estimation */
+    ssize_t _ns = st->size + (chunk_size + 7) / 8;
+    void *nptr = REALLOC(st->buf, _ns + 1);
+    if (!nptr)
+        {
+            return -1;
+        }
+    st->buf = (uint8_t *)nptr;
+    buf = st->buf + st->size;
+
+    (void)have_more;
+
+    if (bits_unused == 0)
+        {
+            bits_unused = 8;
+        }
+    else if (st->size)
+        {
+            buf--;
+        }
+
+    /*
+     * Convert series of 0 and 1 into the octet string.
+     */
+    for (; p < pend; p++)
+        {
+            int ch = *(const unsigned char *)p;
+            switch (ch)
+                {
+                case 0x09:
+                case 0x0a:
+                case 0x0c:
+                case 0x0d:
+                case 0x20:
+                    /* Ignore whitespace */
+                    break;
+                case 0x30:
+                case 0x31:
+                    if (bits_unused-- <= 0)
+                        {
+                            *++buf = 0; /* Clean the cell */
+                            bits_unused = 7;
+                        }
+                    *buf |= (ch & 1) << bits_unused;
+                    break;
+                default:
+                    st->bits_unused = bits_unused;
+                    return -1;
+                }
+        }
+
+    if (bits_unused == 8)
+        {
+            st->size = buf - st->buf;
+            st->bits_unused = 0;
+        }
+    else
+        {
+            st->size = buf - st->buf + 1;
+            st->bits_unused = bits_unused;
+        }
+
+    assert(st->size <= _ns);
+    st->buf[st->size] = 0; /* Courtesy termination */
+
+    return chunk_size; /* Converted in full */
+}
+
+/*
+ * Something like strtod(), but with stricter rules.
+ */
+static int OS__strtoent(int base, const char *buf, const char *end,
+    int32_t *ret_value)
+{
+    int32_t val = 0;
+    const char *p;
+
+    for (p = buf; p < end; p++)
+        {
+            int ch = *p;
+
+            /* Strange huge value */
+            if ((val * base + base) < 0)
+                {
+                    return -1;
+                }
+
+            switch (ch)
+                {
+                case 0x30:
+                case 0x31:
+                case 0x32:
+                case 0x33:
+                case 0x34: /*01234*/
+                case 0x35:
+                case 0x36:
+                case 0x37:
+                case 0x38:
+                case 0x39: /*56789*/
+                    val = val * base + (ch - 0x30);
+                    break;
+                case 0x41:
+                case 0x42:
+                case 0x43: /* ABC */
+                case 0x44:
+                case 0x45:
+                case 0x46: /* DEF */
+                    val = val * base + (ch - 0x41 + 10);
+                    break;
+                case 0x61:
+                case 0x62:
+                case 0x63: /* abc */
+                case 0x64:
+                case 0x65:
+                case 0x66: /* def */
+                    val = val * base + (ch - 0x61 + 10);
+                    break;
+                case 0x3b: /* ';' */
+                    *ret_value = val;
+                    return (p - buf) + 1;
+                default:
+                    return -1; /* Character set error */
+                }
+        }
+
+    *ret_value = -1;
+    return (p - buf);
+}
+
+/*
+ * Convert from the plain UTF-8 format, expanding entity references: "2 &lt; 3"
+ */
+static ssize_t OCTET_STRING__convert_entrefs(void *sptr, const void *chunk_buf,
+    size_t chunk_size, int have_more)
+{
+    OCTET_STRING_t *st = (OCTET_STRING_t *)sptr;
+    const char *p = (const char *)chunk_buf;
+    const char *pend = p + chunk_size;
+    uint8_t *buf;
+
+    /* Reallocate buffer */
+    ssize_t _ns = st->size + chunk_size;
+    void *nptr = REALLOC(st->buf, _ns + 1);
+    if (!nptr)
+        {
+            return -1;
+        }
+    st->buf = (uint8_t *)nptr;
+    buf = st->buf + st->size;
+
+    /*
+     * Convert series of 0 and 1 into the octet string.
+     */
+    for (; p < pend; p++)
+        {
+            int ch = *(const unsigned char *)p;
+            int len; /* Length of the rest of the chunk */
+
+            if (ch != 0x26 /* '&' */)
+                {
+                    *buf++ = ch;
+                    continue; /* That was easy... */
+                }
+
+            /*
+             * Process entity reference.
+             */
+            len = chunk_size - (p - (const char *)chunk_buf);
+            if (len == 1 /* "&" */)
+                {
+                    goto want_more;
+                }
+            if (p[1] == 0x23 /* '#' */)
+                {
+                    const char *pval; /* Pointer to start of digits */
+                    int32_t val = 0;  /* Entity reference value */
+                    int base;
+
+                    if (len == 2 /* "&#" */)
+                        {
+                            goto want_more;
+                        }
+                    if (p[2] == 0x78 /* 'x' */)
+                        {
+                            pval = p + 3, base = 16;
+                        }
+                    else
+                        {
+                            pval = p + 2, base = 10;
+                        }
+                    len = OS__strtoent(base, pval, p + len, &val);
+                    if (len == -1)
+                        {
+                            /* Invalid charset. Just copy verbatim. */
+                            *buf++ = ch;
+                            continue;
+                        }
+                    if (!len || pval[len - 1] != 0x3b)
+                        {
+                            goto want_more;
+                        }
+                    assert(val > 0);
+                    p += (pval - p) + len - 1; /* Advance past entref */
+
+                    if (val < 0x80)
+                        {
+                            *buf++ = (char)val;
+                        }
+                    else if (val < 0x800)
+                        {
+                            *buf++ = 0xc0 | ((val >> 6));
+                            *buf++ = 0x80 | ((val & 0x3f));
+                        }
+                    else if (val < 0x10000)
+                        {
+                            *buf++ = 0xe0 | ((val >> 12));
+                            *buf++ = 0x80 | ((val >> 6) & 0x3f);
+                            *buf++ = 0x80 | ((val & 0x3f));
+                        }
+                    else if (val < 0x200000)
+                        {
+                            *buf++ = 0xf0 | ((val >> 18));
+                            *buf++ = 0x80 | ((val >> 12) & 0x3f);
+                            *buf++ = 0x80 | ((val >> 6) & 0x3f);
+                            *buf++ = 0x80 | ((val & 0x3f));
+                        }
+                    else if (val < 0x4000000)
+                        {
+                            *buf++ = 0xf8 | ((val >> 24));
+                            *buf++ = 0x80 | ((val >> 18) & 0x3f);
+                            *buf++ = 0x80 | ((val >> 12) & 0x3f);
+                            *buf++ = 0x80 | ((val >> 6) & 0x3f);
+                            *buf++ = 0x80 | ((val & 0x3f));
+                        }
+                    else
+                        {
+                            *buf++ = 0xfc | ((val >> 30) & 0x1);
+                            *buf++ = 0x80 | ((val >> 24) & 0x3f);
+                            *buf++ = 0x80 | ((val >> 18) & 0x3f);
+                            *buf++ = 0x80 | ((val >> 12) & 0x3f);
+                            *buf++ = 0x80 | ((val >> 6) & 0x3f);
+                            *buf++ = 0x80 | ((val & 0x3f));
+                        }
+                }
+            else
+                {
+                    /*
+                     * Ugly, limited parsing of &amp; &gt; &lt;
+                     */
+                    char *sc = (char *)memchr(p, 0x3b, len > 5 ? 5 : len);
+                    if (!sc)
+                        {
+                            goto want_more;
+                        }
+                    if ((sc - p) == 4 && p[1] == 0x61 /* 'a' */
+                        && p[2] == 0x6d               /* 'm' */
+                        && p[3] == 0x70 /* 'p' */)
+                        {
+                            *buf++ = 0x26;
+                            p = sc;
+                            continue;
+                        }
+                    if ((sc - p) == 3)
+                        {
+                            if (p[1] == 0x6c)
+                                {
+                                    *buf = 0x3c; /* '<' */
+                                }
+                            else if (p[1] == 0x67)
+                                {
+                                    *buf = 0x3e; /* '>' */
+                                }
+                            else
+                                {
+                                    /* Unsupported entity reference */
+                                    *buf++ = ch;
+                                    continue;
+                                }
+                            if (p[2] != 0x74)
+                                {
+                                    /* Unsupported entity reference */
+                                    *buf++ = ch;
+                                    continue;
+                                }
+                            buf++;
+                            p = sc;
+                            continue;
+                        }
+                    /* Unsupported entity reference */
+                    *buf++ = ch;
+                }
+
+            continue;
+        want_more:
+            if (have_more)
+                {
+                    /*
+                     * We know that no more data (of the same type)
+                     * is coming. Copy the rest verbatim.
+                     */
+                    *buf++ = ch;
+                    continue;
+                }
+            chunk_size = (p - (const char *)chunk_buf);
+            /* Processing stalled: need more data */
+            break;
+        }
+
+    st->size = buf - st->buf;
+    assert(st->size <= _ns);
+    st->buf[st->size] = 0; /* Courtesy termination */
+
+    return chunk_size; /* Converted in full */
+}
+
+/*
+ * Decode OCTET STRING from the XML element's body.
+ */
+static asn_dec_rval_t OCTET_STRING__decode_xer(
+    asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td, void **sptr,
+    const char *opt_mname, const void *buf_ptr, size_t size,
+    int (*opt_unexpected_tag_decoder)(void *struct_ptr, const void *chunk_buf,
+        size_t chunk_size),
+    ssize_t (*body_receiver)(void *struct_ptr, const void *chunk_buf,
+        size_t chunk_size, int have_more))
+{
+    OCTET_STRING_t *st = (OCTET_STRING_t *)*sptr;
+    asn_OCTET_STRING_specifics_t *specs =
+        td->specifics ? (asn_OCTET_STRING_specifics_t *)td->specifics
+                      : &asn_DEF_OCTET_STRING_specs;
+    const char *xml_tag = opt_mname ? opt_mname : td->xml_tag;
+    asn_struct_ctx_t *ctx; /* Per-structure parser context */
+    asn_dec_rval_t rval;   /* Return value from the decoder */
+    int st_allocated;
+
+    /*
+     * Create the string if does not exist.
+     */
+    if (!st)
+        {
+            st = (OCTET_STRING_t *)CALLOC(1, specs->struct_size);
+            *sptr = (void *)st;
+            if (!st)
+                {
+                    goto sta_failed;
+                }
+            st_allocated = 1;
+        }
+    else
+        {
+            st_allocated = 0;
+        }
+    if (!st->buf)
+        {
+            /* This is separate from above section */
+            st->buf = (uint8_t *)CALLOC(1, 1);
+            if (!st->buf)
+                {
+                    if (st_allocated)
+                        {
+                            *sptr = 0;
+                            goto stb_failed;
+                        }
+                    else
+                        {
+                            goto sta_failed;
+                        }
+                }
+        }
+
+    /* Restore parsing context */
+    ctx = (asn_struct_ctx_t *)(((char *)*sptr) + specs->ctx_offset);
+
+    return xer_decode_general(opt_codec_ctx, ctx, *sptr, xml_tag, buf_ptr, size,
+        opt_unexpected_tag_decoder, body_receiver);
+
+stb_failed:
+    FREEMEM(st);
+sta_failed:
+    rval.code = RC_FAIL;
+    rval.consumed = 0;
+    return rval;
+}
+
+/*
+ * Decode OCTET STRING from the hexadecimal data.
+ */
+asn_dec_rval_t OCTET_STRING_decode_xer_hex(asn_codec_ctx_t *opt_codec_ctx,
+    asn_TYPE_descriptor_t *td,
+    void **sptr, const char *opt_mname,
+    const void *buf_ptr, size_t size)
+{
+    return OCTET_STRING__decode_xer(opt_codec_ctx, td, sptr, opt_mname, buf_ptr,
+        size, 0, OCTET_STRING__convert_hexadecimal);
+}
+
+/*
+ * Decode OCTET STRING from the binary (0/1) data.
+ */
+asn_dec_rval_t OCTET_STRING_decode_xer_binary(asn_codec_ctx_t *opt_codec_ctx,
+    asn_TYPE_descriptor_t *td,
+    void **sptr,
+    const char *opt_mname,
+    const void *buf_ptr, size_t size)
+{
+    return OCTET_STRING__decode_xer(opt_codec_ctx, td, sptr, opt_mname, buf_ptr,
+        size, 0, OCTET_STRING__convert_binary);
+}
+
+/*
+ * Decode OCTET STRING from the string (ASCII/UTF-8) data.
+ */
+asn_dec_rval_t OCTET_STRING_decode_xer_utf8(asn_codec_ctx_t *opt_codec_ctx,
+    asn_TYPE_descriptor_t *td,
+    void **sptr, const char *opt_mname,
+    const void *buf_ptr, size_t size)
+{
+    return OCTET_STRING__decode_xer(opt_codec_ctx, td, sptr, opt_mname, buf_ptr,
+        size, OCTET_STRING__handle_control_chars,
+        OCTET_STRING__convert_entrefs);
+}
+
+static int OCTET_STRING_per_get_characters(asn_per_data_t *po, uint8_t *buf,
+    size_t units, unsigned int bpc,
+    unsigned int unit_bits, long lb,
+    long ub, asn_per_constraints_t *pc)
+{
+    uint8_t *end = buf + units * bpc;
+
+    ASN_DEBUG("Expanding %d characters into (%ld..%ld):%d", (int)units, lb, ub,
+        unit_bits);
+
+    /* X.691: 27.5.4 */
+    if ((unsigned long)ub <= ((unsigned long)2 << (unit_bits - 1)))
+        {
+            /* Decode without translation */
+            lb = 0;
+        }
+    else if (pc && pc->code2value)
+        {
+            if (unit_bits > 16)
+                {
+                    return 1;
+                } /* FATAL: can't have constrained
+                   * UniversalString with more than
+                   * 16 million code points */
+            for (; buf < end; buf += bpc)
+                {
+                    int value;
+                    int code = per_get_few_bits(po, unit_bits);
+                    if (code < 0)
+                        {
+                            return -1; /* WMORE */
+                        }
+                    value = pc->code2value(code);
+                    if (value < 0)
+                        {
+                            ASN_DEBUG(
+                                "Code %d (0x%02x) is"
+                                " not in map (%ld..%ld)",
+                                code, code, lb, ub);
+                            return 1; /* FATAL */
+                        }
+                    switch (bpc)
+                        {
+                        case 1:
+                            *buf = value;
+                            break;
+                        case 2:
+                            buf[0] = value >> 8;
+                            buf[1] = value;
+                            break;
+                        case 4:
+                            buf[0] = value >> 24;
+                            buf[1] = value >> 16;
+                            buf[2] = value >> 8;
+                            buf[3] = value;
+                            break;
+                        }
+                }
+            return 0;
+        }
+
+    /* Shortcut the no-op copying to the aligned structure */
+    if (lb == 0 && (unit_bits == 8 * bpc))
+        {
+            return per_get_many_bits(po, buf, 0, unit_bits * units);
+        }
+
+    for (; buf < end; buf += bpc)
+        {
+            int code = per_get_few_bits(po, unit_bits);
+            int ch = code + lb;
+            if (code < 0)
+                {
+                    return -1; /* WMORE */
+                }
+            if (ch > ub)
+                {
+                    ASN_DEBUG("Code %d is out of range (%ld..%ld)", ch, lb, ub);
+                    return 1; /* FATAL */
+                }
+            switch (bpc)
+                {
+                case 1:
+                    *buf = ch;
+                    break;
+                case 2:
+                    buf[0] = ch >> 8;
+                    buf[1] = ch;
+                    break;
+                case 4:
+                    buf[0] = ch >> 24;
+                    buf[1] = ch >> 16;
+                    buf[2] = ch >> 8;
+                    buf[3] = ch;
+                    break;
+                }
+        }
+
+    return 0;
+}
+
+static int OCTET_STRING_per_put_characters(asn_per_outp_t *po,
+    const uint8_t *buf, size_t units,
+    unsigned int bpc,
+    unsigned int unit_bits, long lb,
+    long ub, asn_per_constraints_t *pc)
+{
+    const uint8_t *end = buf + units * bpc;
+
+    ASN_DEBUG("Squeezing %d characters into (%ld..%ld):%d (%d bpc)", (int)units,
+        lb, ub, unit_bits, bpc);
+
+    /* X.691: 27.5.4 */
+    if ((unsigned long)ub <= ((unsigned long)2 << (unit_bits - 1)))
+        {
+            /* Encode as is */
+            lb = 0;
+        }
+    else if (pc && pc->value2code)
+        {
+            for (; buf < end; buf += bpc)
+                {
+                    int code;
+                    uint32_t value;
+                    switch (bpc)
+                        {
+                        case 1:
+                            value = *buf;
+                            break;
+                        case 2:
+                            value = (buf[0] << 8) | buf[1];
+                            break;
+                        case 4:
+                            value = (buf[0] << 24) | (buf[1] << 16) |
+                                    (buf[2] << 8) | buf[3];
+                            break;
+                        default:
+                            return -1;
+                        }
+                    code = pc->value2code(value);
+                    if (code < 0)
+                        {
+                            ASN_DEBUG(
+                                "Character %d (0x%02x) is"
+                                " not in map (%ld..%ld)",
+                                *buf, *buf, lb, ub);
+                            return -1;
+                        }
+                    if (per_put_few_bits(po, code, unit_bits))
+                        {
+                            return -1;
+                        }
+                }
+        }
+
+    /* Shortcut the no-op copying to the aligned structure */
+    if (lb == 0 && (unit_bits == 8 * bpc))
+        {
+            return per_put_many_bits(po, buf, unit_bits * units);
+        }
+
+    for (ub -= lb; buf < end; buf += bpc)
+        {
+            int ch;
+            uint32_t value;
+            switch (bpc)
+                {
+                case 1:
+                    value = *buf;
+                    break;
+                case 2:
+                    value = (buf[0] << 8) | buf[1];
+                    break;
+                case 4:
+                    value = (buf[0] << 24) | (buf[1] << 16) |
+                            (buf[2] << 8) | buf[3];
+                    break;
+                default:
+                    return -1;
+                }
+            ch = value - lb;
+            if (ch < 0 || ch > ub)
+                {
+                    ASN_DEBUG(
+                        "Character %d (0x%02x)"
+                        " is out of range (%ld..%ld)",
+                        *buf, *buf, lb, ub + lb);
+                    return -1;
+                }
+            if (per_put_few_bits(po, ch, unit_bits))
+                {
+                    return -1;
+                }
+        }
+
+    return 0;
+}
+
+asn_dec_rval_t OCTET_STRING_decode_uper(asn_codec_ctx_t *opt_codec_ctx,
+    asn_TYPE_descriptor_t *td,
+    asn_per_constraints_t *constraints,
+    void **sptr, asn_per_data_t *pd)
+{
+    asn_OCTET_STRING_specifics_t *specs =
+        td->specifics ? (asn_OCTET_STRING_specifics_t *)td->specifics
+                      : &asn_DEF_OCTET_STRING_specs;
+    asn_per_constraints_t *pc = constraints ? constraints : td->per_constraints;
+    asn_per_constraint_t *cval;
+    asn_per_constraint_t *csiz;
+    asn_dec_rval_t rval = {RC_OK, 0};
+    BIT_STRING_t *st = (BIT_STRING_t *)*sptr;
+    ssize_t consumed_myself = 0;
+    int repeat;
+    enum
+    {
+        OS__BPC_BIT = 0,
+        OS__BPC_CHAR = 1,
+        OS__BPC_U16 = 2,
+        OS__BPC_U32 = 4
+    } bpc; /* Bytes per character */
+    unsigned int unit_bits;
+    unsigned int canonical_unit_bits;
+
+    (void)opt_codec_ctx;
+
+    if (pc)
+        {
+            cval = &pc->value;
+            csiz = &pc->size;
+        }
+    else
+        {
+            cval = &ASN_DEF_OCTET_STRING_CONSTRAINTS.value;
+            csiz = &ASN_DEF_OCTET_STRING_CONSTRAINTS.size;
+        }
+
+    switch (specs->subvariant)
+        {
+        default:
+        case ASN_OSUBV_ANY:
+            ASN_DEBUG("Unrecognized subvariant %d", specs->subvariant);
+            RETURN(RC_FAIL);
+        case ASN_OSUBV_BIT:
+            canonical_unit_bits = unit_bits = 1;
+            bpc = OS__BPC_BIT;
+            break;
+        case ASN_OSUBV_STR:
+            canonical_unit_bits = unit_bits = 8;
+            if (cval->flags & APC_CONSTRAINED)
+                {
+                    unit_bits = cval->range_bits;
+                }
+            bpc = OS__BPC_CHAR;
+            break;
+        case ASN_OSUBV_U16:
+            canonical_unit_bits = unit_bits = 16;
+            if (cval->flags & APC_CONSTRAINED)
+                {
+                    unit_bits = cval->range_bits;
+                }
+            bpc = OS__BPC_U16;
+            break;
+        case ASN_OSUBV_U32:
+            canonical_unit_bits = unit_bits = 32;
+            if (cval->flags & APC_CONSTRAINED)
+                {
+                    unit_bits = cval->range_bits;
+                }
+            bpc = OS__BPC_U32;
+            break;
+        }
+
+    /*
+     * Allocate the string.
+     */
+    if (!st)
+        {
+            st = (BIT_STRING_t *)(*sptr = CALLOC(1, specs->struct_size));
+            if (!st)
+                {
+                    RETURN(RC_FAIL);
+                }
+        }
+
+    ASN_DEBUG("PER Decoding %s size %ld .. %ld bits %d",
+        csiz->flags & APC_EXTENSIBLE ? "extensible" : "non-extensible",
+        csiz->lower_bound, csiz->upper_bound, csiz->effective_bits);
+
+    if (csiz->flags & APC_EXTENSIBLE)
+        {
+            int inext = per_get_few_bits(pd, 1);
+            if (inext < 0)
+                {
+                    RETURN(RC_WMORE);
+                }
+            if (inext)
+                {
+                    csiz = &ASN_DEF_OCTET_STRING_CONSTRAINTS.size;
+                    cval = &ASN_DEF_OCTET_STRING_CONSTRAINTS.value;
+                    unit_bits = canonical_unit_bits;
+                }
+        }
+
+    if (csiz->effective_bits >= 0)
+        {
+            FREEMEM(st->buf);
+            if (bpc)
+                {
+                    st->size = csiz->upper_bound * bpc;
+                }
+            else
+                {
+                    st->size = (csiz->upper_bound + 7) >> 3;
+                }
+            st->buf = (uint8_t *)MALLOC(st->size + 1);
+            if (!st->buf)
+                {
+                    st->size = 0;
+                    RETURN(RC_FAIL);
+                }
+        }
+
+    /* X.691, #16.5: zero-length encoding */
+    /* X.691, #16.6: short fixed length encoding (up to 2 octets) */
+    /* X.691, #16.7: long fixed length encoding (up to 64K octets) */
+    if (csiz->effective_bits == 0)
+        {
+            int ret;
+            if (bpc)
+                {
+                    ASN_DEBUG("Encoding OCTET STRING size %ld",
+                        csiz->upper_bound);
+                    ret = OCTET_STRING_per_get_characters(
+                        pd, st->buf, csiz->upper_bound, bpc, unit_bits,
+                        cval->lower_bound, cval->upper_bound, pc);
+                    if (ret > 0)
+                        {
+                            RETURN(RC_FAIL);
+                        }
+                }
+            else
+                {
+                    ASN_DEBUG("Encoding BIT STRING size %ld",
+                        csiz->upper_bound);
+                    ret = per_get_many_bits(pd, st->buf, 0,
+                        unit_bits * csiz->upper_bound);
+                }
+            if (ret < 0)
+                {
+                    RETURN(RC_WMORE);
+                }
+            consumed_myself += unit_bits * csiz->upper_bound;
+            st->buf[st->size] = 0;
+            if (bpc == 0)
+                {
+                    int ubs = (csiz->upper_bound & 0x7);
+                    st->bits_unused = ubs ? 8 - ubs : 0;
+                }
+            RETURN(RC_OK);
+        }
+
+    st->size = 0;
+    do
+        {
+            ssize_t raw_len;
+            ssize_t len_bytes;
+            ssize_t len_bits;
+            void *p;
+            int ret;
+
+            /* Get the PER length */
+            raw_len = uper_get_length(pd, csiz->effective_bits, &repeat);
+            if (raw_len < 0)
+                {
+                    RETURN(RC_WMORE);
+                }
+            raw_len += csiz->lower_bound;
+
+            ASN_DEBUG("Got PER length eb %ld, len %ld, %s (%s)",
+                (long)csiz->effective_bits, (long)raw_len,
+                repeat ? "repeat" : "once", td->name);
+            if (bpc)
+                {
+                    len_bytes = raw_len * bpc;
+                    len_bits = len_bytes * unit_bits;
+                }
+            else
+                {
+                    len_bits = raw_len;
+                    len_bytes = (len_bits + 7) >> 3;
+                    if (len_bits & 0x7)
+                        {
+                            st->bits_unused = 8 - (len_bits & 0x7);
+                        }
+                    /* len_bits be multiple of 16K if repeat is set */
+                }
+            p = REALLOC(st->buf, st->size + len_bytes + 1);
+            if (!p)
+                {
+                    RETURN(RC_FAIL);
+                }
+            st->buf = (uint8_t *)p;
+
+            if (bpc)
+                {
+                    ret = OCTET_STRING_per_get_characters(
+                        pd, &st->buf[st->size], raw_len, bpc, unit_bits,
+                        cval->lower_bound, cval->upper_bound, pc);
+                    if (ret > 0)
+                        {
+                            RETURN(RC_FAIL);
+                        }
+                }
+            else
+                {
+                    ret =
+                        per_get_many_bits(pd, &st->buf[st->size], 0, len_bits);
+                }
+            if (ret < 0)
+                {
+                    RETURN(RC_WMORE);
+                }
+            st->size += len_bytes;
+        }
+    while (repeat);
+    st->buf[st->size] = 0; /* nul-terminate */
+
+    return rval;
+}
+
+asn_enc_rval_t OCTET_STRING_encode_uper(asn_TYPE_descriptor_t *td,
+    asn_per_constraints_t *constraints,
+    void *sptr, asn_per_outp_t *po)
+{
+    asn_OCTET_STRING_specifics_t *specs =
+        td->specifics ? (asn_OCTET_STRING_specifics_t *)td->specifics
+                      : &asn_DEF_OCTET_STRING_specs;
+    asn_per_constraints_t *pc = constraints ? constraints : td->per_constraints;
+    asn_per_constraint_t *cval;
+    asn_per_constraint_t *csiz;
+    const BIT_STRING_t *st = (const BIT_STRING_t *)sptr;
+    asn_enc_rval_t er = {0, 0, 0};
+    int inext = 0; /* Lies not within extension root */
+    unsigned int unit_bits;
+    unsigned int canonical_unit_bits;
+    unsigned int sizeinunits;
+    const uint8_t *buf;
+    int ret;
+    enum
+    {
+        OS__BPC_BIT = 0,
+        OS__BPC_CHAR = 1,
+        OS__BPC_U16 = 2,
+        OS__BPC_U32 = 4
+    } bpc; /* Bytes per character */
+    int ct_extensible;
+
+    if (!st || (!st->buf && st->size))
+        {
+            _ASN_ENCODE_FAILED;
+        }
+
+    if (pc)
+        {
+            cval = &pc->value;
+            csiz = &pc->size;
+        }
+    else
+        {
+            cval = &ASN_DEF_OCTET_STRING_CONSTRAINTS.value;
+            csiz = &ASN_DEF_OCTET_STRING_CONSTRAINTS.size;
+        }
+    ct_extensible = csiz->flags & APC_EXTENSIBLE;
+
+    switch (specs->subvariant)
+        {
+        default:
+        case ASN_OSUBV_ANY:
+            _ASN_ENCODE_FAILED;
+        case ASN_OSUBV_BIT:
+            canonical_unit_bits = unit_bits = 1;
+            bpc = OS__BPC_BIT;
+            sizeinunits = st->size * 8 - (st->bits_unused & 0x07);
+            ASN_DEBUG("BIT STRING of %d bytes, %d bits unused", sizeinunits,
+                st->bits_unused);
+            break;
+        case ASN_OSUBV_STR:
+            canonical_unit_bits = unit_bits = 8;
+            if (cval->flags & APC_CONSTRAINED)
+                {
+                    unit_bits = cval->range_bits;
+                }
+            bpc = OS__BPC_CHAR;
+            sizeinunits = st->size;
+            break;
+        case ASN_OSUBV_U16:
+            canonical_unit_bits = unit_bits = 16;
+            if (cval->flags & APC_CONSTRAINED)
+                {
+                    unit_bits = cval->range_bits;
+                }
+            bpc = OS__BPC_U16;
+            sizeinunits = st->size / 2;
+            break;
+        case ASN_OSUBV_U32:
+            canonical_unit_bits = unit_bits = 32;
+            if (cval->flags & APC_CONSTRAINED)
+                {
+                    unit_bits = cval->range_bits;
+                }
+            bpc = OS__BPC_U32;
+            sizeinunits = st->size / 4;
+            break;
+        }
+
+    ASN_DEBUG(
+        "Encoding %s into %d units of %d bits"
+        " (%ld..%ld, effective %d)%s",
+        td->name, sizeinunits, unit_bits, csiz->lower_bound, csiz->upper_bound,
+        csiz->effective_bits, ct_extensible ? " EXT" : "");
+
+    /* Figure out whether size lies within PER visible constraint */
+
+    if (csiz->effective_bits >= 0)
+        {
+            if ((int)sizeinunits < csiz->lower_bound ||
+                (int)sizeinunits > csiz->upper_bound)
+                {
+                    if (ct_extensible)
+                        {
+                            cval = &ASN_DEF_OCTET_STRING_CONSTRAINTS.value;
+                            csiz = &ASN_DEF_OCTET_STRING_CONSTRAINTS.size;
+                            unit_bits = canonical_unit_bits;
+                            inext = 1;
+                        }
+                    else
+                        {
+                            _ASN_ENCODE_FAILED;
+                        }
+                }
+        }
+    else
+        {
+            inext = 0;
+        }
+
+    if (ct_extensible)
+        {
+            /* Declare whether length is [not] within extension root */
+            if (per_put_few_bits(po, inext, 1))
+                {
+                    _ASN_ENCODE_FAILED;
+                }
+        }
+
+    /* X.691, #16.5: zero-length encoding */
+    /* X.691, #16.6: short fixed length encoding (up to 2 octets) */
+    /* X.691, #16.7: long fixed length encoding (up to 64K octets) */
+    if (csiz->effective_bits >= 0)
+        {
+            ASN_DEBUG("Encoding %d bytes (%ld), length in %d bits", st->size,
+                sizeinunits - csiz->lower_bound, csiz->effective_bits);
+            ret = per_put_few_bits(po, sizeinunits - csiz->lower_bound,
+                csiz->effective_bits);
+            if (ret)
+                {
+                    _ASN_ENCODE_FAILED;
+                }
+            if (bpc)
+                {
+                    ret = OCTET_STRING_per_put_characters(
+                        po, st->buf, sizeinunits, bpc, unit_bits,
+                        cval->lower_bound, cval->upper_bound, pc);
+                }
+            else
+                {
+                    ret =
+                        per_put_many_bits(po, st->buf, sizeinunits * unit_bits);
+                }
+            if (ret)
+                {
+                    _ASN_ENCODE_FAILED;
+                }
+            _ASN_ENCODED_OK(er);
+        }
+
+    ASN_DEBUG("Encoding %d bytes", st->size);
+
+    if (sizeinunits == 0)
+        {
+            if (uper_put_length(po, 0))
+                {
+                    _ASN_ENCODE_FAILED;
+                }
+            _ASN_ENCODED_OK(er);
+        }
+
+    buf = st->buf;
+    while (sizeinunits)
+        {
+            ssize_t maySave = uper_put_length(po, sizeinunits);
+            if (maySave < 0)
+                {
+                    _ASN_ENCODE_FAILED;
+                }
+
+            ASN_DEBUG("Encoding %ld of %ld", (long)maySave, (long)sizeinunits);
+
+            if (bpc)
+                {
+                    ret = OCTET_STRING_per_put_characters(
+                        po, buf, maySave, bpc, unit_bits, cval->lower_bound,
+                        cval->upper_bound, pc);
+                }
+            else
+                {
+                    ret = per_put_many_bits(po, buf, maySave * unit_bits);
+                }
+            if (ret)
+                {
+                    _ASN_ENCODE_FAILED;
+                }
+
+            if (bpc)
+                {
+                    buf += maySave * bpc;
+                }
+            else
+                {
+                    buf += maySave >> 3;
+                }
+            sizeinunits -= maySave;
+            assert(!(maySave & 0x07) || !sizeinunits);
+        }
+
+    _ASN_ENCODED_OK(er);
+}
+
+int OCTET_STRING_print(asn_TYPE_descriptor_t *td, const void *sptr, int ilevel,
+    asn_app_consume_bytes_f *cb, void *app_key)
+{
+    static const char *h2c = "0123456789ABCDEF";
+    const OCTET_STRING_t *st = (const OCTET_STRING_t *)sptr;
+    char scratch[16 * 3 + 4];
+    char *p = scratch;
+    uint8_t *buf;
+    uint8_t *end;
+    size_t i;
+
+    (void)td; /* Unused argument */
+
+    if (!st || (!st->buf && st->size))
+        {
+            return (cb("<absent>", 8, app_key) < 0) ? -1 : 0;
+        }
+
+    /*
+     * Dump the contents of the buffer in hexadecimal.
+     */
+    buf = st->buf;
+    end = buf + st->size;
+    for (i = 0; buf < end; buf++, i++)
+        {
+            if (!(i % 16) && (i || st->size > 16))
+                {
+                    if (cb(scratch, p - scratch, app_key) < 0)
+                        {
+                            return -1;
+                        }
+                    _i_INDENT(1);
+                    p = scratch;
+                }
+            *p++ = h2c[(*buf >> 4) & 0x0F];
+            *p++ = h2c[*buf & 0x0F];
+            *p++ = 0x20;
+        }
+
+    if (p > scratch)
+        {
+            p--; /* Remove the tail space */
+            if (cb(scratch, p - scratch, app_key) < 0)
+                {
+                    return -1;
+                }
+        }
+
+    return 0;
+}
+
+int OCTET_STRING_print_utf8(asn_TYPE_descriptor_t *td, const void *sptr,
+    int ilevel, asn_app_consume_bytes_f *cb,
+    void *app_key)
+{
+    const OCTET_STRING_t *st = (const OCTET_STRING_t *)sptr;
+
+    (void)td;     /* Unused argument */
+    (void)ilevel; /* Unused argument */
+
+    if (st && (st->buf || !st->size))
+        {
+            return (cb(st->buf, st->size, app_key) < 0) ? -1 : 0;
+        }
+    else
+        {
+            return (cb("<absent>", 8, app_key) < 0) ? -1 : 0;
+        }
+}
+
+void OCTET_STRING_free(asn_TYPE_descriptor_t *td, void *sptr, int contents_only)
+{
+    OCTET_STRING_t *st = (OCTET_STRING_t *)sptr;
+    asn_OCTET_STRING_specifics_t *specs =
+        td->specifics ? (asn_OCTET_STRING_specifics_t *)td->specifics
+                      : &asn_DEF_OCTET_STRING_specs;
+    asn_struct_ctx_t *ctx =
+        (asn_struct_ctx_t *)((char *)st + specs->ctx_offset);
+    struct stack *stck;
+
+    if (!td || !st)
+        {
+            return;
+        }
+
+    ASN_DEBUG("Freeing %s as OCTET STRING", td->name);
+
+    if (st->buf)
+        {
+            FREEMEM(st->buf);
+            st->buf = 0;
+        }
+
+    /*
+     * Remove decode-time stack.
+     */
+    stck = (struct stack *)ctx->ptr;
+    if (stck)
+        {
+            while (stck->tail)
+                {
+                    struct stack_el *sel = stck->tail;
+                    stck->tail = sel->prev;
+                    FREEMEM(sel);
+                }
+            FREEMEM(stck);
+        }
+
+    if (!contents_only)
+        {
+            FREEMEM(st);
+        }
+}
+
+/*
+ * Conversion routines.
+ */
+int OCTET_STRING_fromBuf(OCTET_STRING_t *st, const char *str, int len)
+{
+    void *buf;
+
+    if (st == 0 || (str == 0 && len))
+        {
+            errno = EINVAL;
+            return -1;
+        }
+
+    /*
+     * Clear the OCTET STRING.
+     */
+    if (str == NULL)
+        {
+            FREEMEM(st->buf);
+            st->buf = 0;
+            st->size = 0;
+            return 0;
+        }
+
+    /* Determine the original string size, if not explicitly given */
+    if (len < 0)
+        {
+            len = strlen(str);
+        }
+
+    /* Allocate and fill the memory */
+    buf = MALLOC(len + 1);
+    if (buf == NULL)
+        {
+            return -1;
+        }
+
+    memcpy(buf, str, len);
+    ((uint8_t *)buf)[len] = '\0'; /* Couldn't use memcpy(len+1)! */
+    FREEMEM(st->buf);
+    st->buf = (uint8_t *)buf;
+    st->size = len;
+
+    return 0;
+}
+
+OCTET_STRING_t *OCTET_STRING_new_fromBuf(asn_TYPE_descriptor_t *td,
+    const char *str, int len)
+{
+    asn_OCTET_STRING_specifics_t *specs =
+        td->specifics ? (asn_OCTET_STRING_specifics_t *)td->specifics
+                      : &asn_DEF_OCTET_STRING_specs;
+    OCTET_STRING_t *st;
+
+    st = (OCTET_STRING_t *)CALLOC(1, specs->struct_size);
+    if (st && str && OCTET_STRING_fromBuf(st, str, len))
+        {
+            FREEMEM(st);
+            st = NULL;
+        }
+
+    return st;
+}

--- a/src/core/libs/supl/types/OCTET_STRING.h
+++ b/src/core/libs/supl/types/OCTET_STRING.h
@@ -1,0 +1,90 @@
+/*-
+ * SPDX-FileCopyrightText: (c) 2003, 2004 Lev Walkin <vlm@lionet.info>. All rights reserved.
+ * SPDX-License-Identifier: BSD-1-Clause
+ */
+#ifndef _OCTET_STRING_H
+#define _OCTET_STRING_H
+
+#include <asn_application.h>
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+    typedef struct OCTET_STRING
+    {
+        uint8_t *buf; /* Buffer with consecutive OCTET_STRING bits */
+        int size;     /* Size of the buffer */
+
+        asn_struct_ctx_t _asn_ctx; /* Parsing across buffer boundaries */
+    } OCTET_STRING_t;
+
+    extern asn_TYPE_descriptor_t asn_DEF_OCTET_STRING;
+
+    asn_struct_free_f OCTET_STRING_free;
+    asn_struct_print_f OCTET_STRING_print;
+    asn_struct_print_f OCTET_STRING_print_utf8;
+    ber_type_decoder_f OCTET_STRING_decode_ber;
+    der_type_encoder_f OCTET_STRING_encode_der;
+    xer_type_decoder_f OCTET_STRING_decode_xer_hex;    /* Hexadecimal */
+    xer_type_decoder_f OCTET_STRING_decode_xer_binary; /* 01010111010 */
+    xer_type_decoder_f OCTET_STRING_decode_xer_utf8;   /* ASCII/UTF-8 */
+    xer_type_encoder_f OCTET_STRING_encode_xer;
+    xer_type_encoder_f OCTET_STRING_encode_xer_utf8;
+    per_type_decoder_f OCTET_STRING_decode_uper;
+    per_type_encoder_f OCTET_STRING_encode_uper;
+
+    /******************************
+     * Handy conversion routines. *
+     ******************************/
+
+    /*
+     * This function clears the previous value of the OCTET STRING (if any)
+     * and then allocates a new memory with the specified content (str/size).
+     * If size = -1, the size of the original string will be determined
+     * using strlen(str).
+     * If str equals to NULL, the function will silently clear the
+     * current contents of the OCTET STRING.
+     * Returns 0 if it was possible to perform operation, -1 otherwise.
+     */
+    int OCTET_STRING_fromBuf(OCTET_STRING_t *s, const char *str, int len);
+
+/* Handy conversion from the C string into the OCTET STRING. */
+#define OCTET_STRING_fromString(s, str) OCTET_STRING_fromBuf(s, str, -1)
+
+    /*
+     * Allocate and fill the new OCTET STRING and return a pointer to the newly
+     * allocated object. NULL is permitted in str: the function will just
+     * allocate empty OCTET STRING.
+     */
+    OCTET_STRING_t *OCTET_STRING_new_fromBuf(asn_TYPE_descriptor_t *td,
+        const char *str, int len);
+
+    /****************************
+     * Internally useful stuff. *
+     ****************************/
+
+    typedef struct asn_OCTET_STRING_specifics_s
+    {
+        /*
+         * Target structure description.
+         */
+        int struct_size; /* Size of the structure */
+        int ctx_offset;  /* Offset of the asn_struct_ctx_t member */
+
+        enum asn_OS_Subvariant
+        {
+            ASN_OSUBV_ANY, /* The open type (ANY) */
+            ASN_OSUBV_BIT, /* BIT STRING */
+            ASN_OSUBV_STR, /* String types, not {BMP,Universal}String  */
+            ASN_OSUBV_U16, /* 16-bit character (BMPString) */
+            ASN_OSUBV_U32  /* 32-bit character (UniversalString) */
+        } subvariant;
+    } asn_OCTET_STRING_specifics_t;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* _OCTET_STRING_H_ */

--- a/src/core/libs/supl/types/asn_SEQUENCE_OF.c
+++ b/src/core/libs/supl/types/asn_SEQUENCE_OF.c
@@ -1,0 +1,51 @@
+/*-
+ * SPDX-FileCopyrightText: (c) 2003, 2004 Lev Walkin <vlm@lionet.info>. All rights reserved.
+ * SPDX-License-Identifier: BSD-1-Clause
+ */
+#include <asn_SEQUENCE_OF.h>
+#include <asn_internal.h>
+
+typedef A_SEQUENCE_OF(void) asn_sequence;
+
+void asn_sequence_del(void *asn_sequence_of_x, int number, int _do_free)
+{
+    asn_sequence *as = (asn_sequence *)asn_sequence_of_x;
+
+    if (as)
+        {
+            void *ptr;
+            int n;
+
+            if (number < 0 || number >= as->count)
+                {
+                    return; /* Nothing to delete */
+                }
+
+            if (_do_free && as->free)
+                {
+                    ptr = as->array[number];
+                }
+            else
+                {
+                    ptr = 0;
+                }
+
+            /*
+             * Shift all elements to the left to hide the gap.
+             */
+            --as->count;
+            for (n = number; n < as->count; n++)
+                {
+                    as->array[n] = as->array[n + 1];
+                }
+
+            /*
+             * Invoke the third-party function only when the state
+             * of the parent structure is consistent.
+             */
+            if (ptr)
+                {
+                    as->free(ptr);
+                }
+        }
+}

--- a/src/core/libs/supl/types/asn_SEQUENCE_OF.h
+++ b/src/core/libs/supl/types/asn_SEQUENCE_OF.h
@@ -1,0 +1,52 @@
+/*-
+ * SPDX-FileCopyrightText: (c) 2003, 2004 Lev Walkin <vlm@lionet.info>. All rights reserved.
+ * SPDX-License-Identifier: BSD-1-Clause
+ */
+#ifndef ASN_SEQUENCE_OF_H
+#define ASN_SEQUENCE_OF_H
+
+#include <asn_SET_OF.h>
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+/*
+ * SEQUENCE OF is the same as SET OF with a tiny difference:
+ * the delete operation preserves the initial order of elements
+ * and thus MAY operate in non-constant time.
+ */
+#define A_SEQUENCE_OF(type) A_SET_OF(type)
+
+#define ASN_SEQUENCE_ADD(headptr, ptr) asn_sequence_add((headptr), (ptr))
+
+    /***********************************************
+     * Implementation of the SEQUENCE OF structure.
+     */
+
+#define asn_sequence_add asn_set_add
+#define asn_sequence_empty asn_set_empty
+
+    /*
+     * Delete the element from the set by its number (base 0).
+     * This is NOT a constant-time operation.
+     * The order of elements is preserved.
+     * If _do_free is given AND the (*free) is initialized, the element
+     * will be freed using the custom (*free) function as well.
+     */
+    void asn_sequence_del(void *asn_sequence_of_x, int number, int _do_free);
+
+    /*
+     * Cope with different conversions requirements to/from void in C and C++.
+     * This is mostly useful for support library.
+     */
+    typedef A_SEQUENCE_OF(void) asn_anonymous_sequence_;
+#define _A_SEQUENCE_FROM_VOID(ptr) ((asn_anonymous_sequence_ *)(ptr))
+#define _A_CSEQUENCE_FROM_VOID(ptr) ((const asn_anonymous_sequence_ *)(ptr))
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ASN_SEQUENCE_OF_H */

--- a/src/core/libs/supl/types/asn_SET_OF.c
+++ b/src/core/libs/supl/types/asn_SET_OF.c
@@ -1,0 +1,105 @@
+/*-
+ * SPDX-FileCopyrightText: (c) 2003, 2004 Lev Walkin <vlm@lionet.info>. All rights reserved.
+ * SPDX-License-Identifier: BSD-1-Clause
+ */
+#include <asn_SET_OF.h>
+#include <asn_internal.h>
+#include <errno.h>
+
+/*
+ * Add another element into the set.
+ */
+int asn_set_add(void *asn_set_of_x, void *ptr)
+{
+    asn_anonymous_set_ *as = _A_SET_FROM_VOID(asn_set_of_x);
+
+    if (as == 0 || ptr == 0)
+        {
+            errno = EINVAL; /* Invalid arguments */
+            return -1;
+        }
+
+    /*
+     * Make sure there's enough space to insert an element.
+     */
+    if (as->count == as->size)
+        {
+            int _newsize = as->size ? (as->size << 1) : 4;
+            void *_new_arr;
+            _new_arr = REALLOC(as->array, _newsize * sizeof(as->array[0]));
+            if (_new_arr)
+                {
+                    as->array = (void **)_new_arr;
+                    as->size = _newsize;
+                }
+            else
+                {
+                    /* ENOMEM */
+                    return -1;
+                }
+        }
+
+    as->array[as->count++] = ptr;
+
+    return 0;
+}
+
+void asn_set_del(void *asn_set_of_x, int number, int _do_free)
+{
+    asn_anonymous_set_ *as = _A_SET_FROM_VOID(asn_set_of_x);
+
+    if (as)
+        {
+            void *ptr;
+            if (number < 0 || number >= as->count)
+                {
+                    return;
+                }
+
+            if (_do_free && as->free)
+                {
+                    ptr = as->array[number];
+                }
+            else
+                {
+                    ptr = 0;
+                }
+
+            as->array[number] = as->array[--as->count];
+
+            /*
+             * Invoke the third-party function only when the state
+             * of the parent structure is consistent.
+             */
+            if (ptr)
+                {
+                    as->free(ptr);
+                }
+        }
+}
+
+/*
+ * Free the contents of the set, do not free the set itself.
+ */
+void asn_set_empty(void *asn_set_of_x)
+{
+    asn_anonymous_set_ *as = _A_SET_FROM_VOID(asn_set_of_x);
+
+    if (as)
+        {
+            if (as->array)
+                {
+                    if (as->free)
+                        {
+                            while (as->count--)
+                                {
+                                    as->free(as->array[as->count]);
+                                }
+                        }
+                    FREEMEM(as->array);
+                    as->array = 0;
+                }
+            as->count = 0;
+            as->size = 0;
+        }
+}

--- a/src/core/libs/supl/types/asn_SET_OF.h
+++ b/src/core/libs/supl/types/asn_SET_OF.h
@@ -1,0 +1,63 @@
+/*-
+ * SPDX-FileCopyrightText: (c) 2003, 2004 Lev Walkin <vlm@lionet.info>. All rights reserved.
+ * SPDX-License-Identifier: BSD-1-Clause
+ */
+#ifndef ASN_SET_OF_H
+#define ASN_SET_OF_H
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+#define A_SET_OF(type)                   \
+    struct                               \
+    {                                    \
+        type **array;                    \
+        int count; /* Meaningful size */ \
+        int size;  /* Allocated size */  \
+        void (*free)(type *);            \
+    }
+
+#define ASN_SET_ADD(headptr, ptr) asn_set_add((headptr), (ptr))
+
+    /*******************************************
+     * Implementation of the SET OF structure.
+     */
+
+    /*
+     * Add another structure into the set by its pointer.
+     * RETURN VALUES:
+     * 0 for success and -1/errno for failure.
+     */
+    int asn_set_add(void *asn_set_of_x, void *ptr);
+
+    /*
+     * Delete the element from the set by its number (base 0).
+     * This is a constant-time operation. The order of elements before the
+     * deleted ones is guaranteed, the order of elements after the deleted
+     * one is NOT guaranteed.
+     * If _do_free is given AND the (*free) is initialized, the element
+     * will be freed using the custom (*free) function as well.
+     */
+    void asn_set_del(void *asn_set_of_x, int number, int _do_free);
+
+    /*
+     * Empty the contents of the set. Will free the elements, if (*free) is
+     * given. Will NOT free the set itself.
+     */
+    void asn_set_empty(void *asn_set_of_x);
+
+    /*
+     * Cope with different conversions requirements to/from void in C and C++.
+     * This is mostly useful for support library.
+     */
+    typedef A_SET_OF(void) asn_anonymous_set_;
+#define _A_SET_FROM_VOID(ptr) ((asn_anonymous_set_ *)(ptr))
+#define _A_CSET_FROM_VOID(ptr) ((const asn_anonymous_set_ *)(ptr))
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ASN_SET_OF_H */

--- a/src/core/libs/supl/types/asn_application.h
+++ b/src/core/libs/supl/types/asn_application.h
@@ -1,0 +1,51 @@
+/*-
+ * SPDX-FileCopyrightText: (c) 2003, 2004 Lev Walkin <vlm@lionet.info>. All rights reserved.
+ * SPDX-License-Identifier: BSD-1-Clause
+ */
+/*
+ * Application-level ASN.1 callbacks.
+ */
+#ifndef _ASN_APPLICATION_H
+#define _ASN_APPLICATION_H
+
+// clang-format off
+#include "asn_system.h" /* for platform-dependent types */
+#include "asn_codecs.h" /* for ASN.1 codecs specifics */
+// clang-format on
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+    /*
+     * Generic type of an application-defined callback to return various
+     * types of data to the application.
+     * EXPECTED RETURN VALUES:
+     *  -1: Failed to consume bytes. Abort the mission.
+     * Non-negative return values indicate success, and ignored.
+     */
+    typedef int(asn_app_consume_bytes_f)(const void *buffer, size_t size,
+        void *application_specific_key);
+
+    /*
+     * A callback of this type is called whenever constraint validation fails
+     * on some ASN.1 type. See "constraints.h" for more details on constraint
+     * validation.
+     * This callback specifies a descriptor of the ASN.1 type which failed
+     * the constraint check, as well as human readable message on what
+     * particular constraint has failed.
+     */
+    typedef void(asn_app_constraint_failed_f)(
+        void *application_specific_key,
+        struct asn_TYPE_descriptor_s *type_descriptor_which_failed,
+        const void *structure_which_failed_ptr,
+        const char *error_message_format, ...) GCC_PRINTFLIKE(4, 5);
+
+#ifdef __cplusplus
+}
+#endif
+
+#include "constr_TYPE.h" /* for asn_TYPE_descriptor_t */
+
+#endif /* _ASN_APPLICATION_H_ */

--- a/src/core/libs/supl/types/asn_codecs.h
+++ b/src/core/libs/supl/types/asn_codecs.h
@@ -1,0 +1,127 @@
+/*-
+ * SPDX-FileCopyrightText: (c) 2003, 2004 Lev Walkin <vlm@lionet.info>. All rights reserved.
+ * SPDX-License-Identifier: BSD-1-Clause
+ */
+#ifndef _ASN_CODECS_H
+#define _ASN_CODECS_H
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+    struct asn_TYPE_descriptor_s; /* Forward declaration */
+
+    /*
+     * This structure defines a set of parameters that may be passed
+     * to every ASN.1 encoder or decoder function.
+     * WARNING: if max_stack_size member is set, and you are calling the
+     *   function pointers of the asn_TYPE_descriptor_t directly,
+     *   this structure must be ALLOCATED ON THE STACK!
+     *   If you can't always satisfy this requirement, use ber_decode(),
+     *   xer_decode() and uper_decode() functions instead.
+     */
+    typedef struct asn_codec_ctx_s
+    {
+        /*
+         * Limit the decoder routines to use no (much) more stack than a given
+         * number of bytes. Most of decoders are stack-based, and this
+         * would protect against stack overflows if the number of nested
+         * encodings is high.
+         * The OCTET STRING, BIT STRING and ANY BER decoders are heap-based,
+         * and are safe from this kind of overflow.
+         * A value from getrlimit(RLIMIT_STACK) may be used to initialize
+         * this variable. Be careful in multithreaded environments, as the
+         * stack size is rather limited.
+         */
+        size_t max_stack_size; /* 0 disables stack bounds checking */
+    } asn_codec_ctx_t;
+
+    /*
+     * Type of the return value of the encoding functions (der_encode,
+     * xer_encode).
+     */
+    typedef struct asn_enc_rval_s
+    {
+        /*
+         * Number of bytes encoded.
+         * -1 indicates failure to encode the structure.
+         * In this case, the members below this one are meaningful.
+         */
+        ssize_t encoded;
+
+        /*
+         * Members meaningful when (encoded == -1), for post mortem analysis.
+         */
+
+        /* Type which cannot be encoded */
+        struct asn_TYPE_descriptor_s *failed_type;
+
+        /* Pointer to the structure of that type */
+        void *structure_ptr;
+    } asn_enc_rval_t;
+#define _ASN_ENCODE_FAILED                                      \
+    do                                                          \
+        {                                                       \
+            asn_enc_rval_t tmp_error;                           \
+            tmp_error.encoded = -1;                             \
+            tmp_error.failed_type = td;                         \
+            tmp_error.structure_ptr = sptr;                     \
+            ASN_DEBUG("Failed to encode element %s", td->name); \
+            return tmp_error;                                   \
+        }                                                       \
+    while (0)
+#define _ASN_ENCODED_OK(rval)       \
+    do                              \
+        {                           \
+            rval.structure_ptr = 0; \
+            rval.failed_type = 0;   \
+            return rval;            \
+        }                           \
+    while (0)
+
+    /*
+     * Type of the return value of the decoding functions (ber_decode,
+     * xer_decode)
+     *
+     * Please note that the number of consumed bytes is ALWAYS meaningful,
+     * even if code==RC_FAIL. This is to indicate the number of successfully
+     * decoded bytes, hence providing a possibility to fail with more
+     * diagnostics (i.e., print the offending remainder of the buffer).
+     */
+    enum asn_dec_rval_code_e
+    {
+        RC_OK,    /* Decoded successfully */
+        RC_WMORE, /* More data expected, call again */
+        RC_FAIL   /* Failure to decode data */
+    };
+    typedef struct asn_dec_rval_s
+    {
+        enum asn_dec_rval_code_e code; /* Result code */
+        size_t consumed;               /* Number of bytes consumed */
+    } asn_dec_rval_t;
+#define _ASN_DECODE_FAILED                                      \
+    do                                                          \
+        {                                                       \
+            asn_dec_rval_t tmp_error;                           \
+            tmp_error.code = RC_FAIL;                           \
+            tmp_error.consumed = 0;                             \
+            ASN_DEBUG("Failed to decode element %s", td->name); \
+            return tmp_error;                                   \
+        }                                                       \
+    while (0)
+#define _ASN_DECODE_STARVED            \
+    do                                 \
+        {                              \
+            asn_dec_rval_t tmp_error;  \
+            tmp_error.code = RC_WMORE; \
+            tmp_error.consumed = 0;    \
+            return tmp_error;          \
+        }                              \
+    while (0)
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* _ASN_CODECS_H_ */

--- a/src/core/libs/supl/types/asn_codecs_prim.c
+++ b/src/core/libs/supl/types/asn_codecs_prim.c
@@ -1,0 +1,327 @@
+/*-
+ * SPDX-FileCopyrightText: (c) 2003, 2004 Lev Walkin <vlm@lionet.info>. All rights reserved.
+ * SPDX-License-Identifier: BSD-1-Clause
+ */
+#include <asn_codecs_prim.h>
+#include <asn_internal.h>
+#include <errno.h>
+
+/*
+ * Decode an always-primitive type.
+ */
+asn_dec_rval_t ber_decode_primitive(asn_codec_ctx_t *opt_codec_ctx,
+    asn_TYPE_descriptor_t *td, void **sptr,
+    const void *buf_ptr, size_t size,
+    int tag_mode)
+{
+    ASN__PRIMITIVE_TYPE_t *st = (ASN__PRIMITIVE_TYPE_t *)*sptr;
+    asn_dec_rval_t rval;
+    ber_tlv_len_t length;
+
+    /*
+     * If the structure is not there, allocate it.
+     */
+    if (st == NULL)
+        {
+            st = (ASN__PRIMITIVE_TYPE_t *)CALLOC(1, sizeof(*st));
+            if (st == NULL)
+                {
+                    _ASN_DECODE_FAILED;
+                }
+            *sptr = (void *)st;
+        }
+
+    ASN_DEBUG("Decoding %s as plain primitive (tm=%d)", td->name, tag_mode);
+
+    /*
+     * Check tags and extract value length.
+     */
+    rval = ber_check_tags(opt_codec_ctx, td, 0, buf_ptr, size, tag_mode, 0,
+        &length, 0);
+    if (rval.code != RC_OK)
+        {
+            return rval;
+        }
+
+    ASN_DEBUG("%s length is %d bytes", td->name, (int)length);
+
+    /*
+     * Make sure we have this length.
+     */
+    buf_ptr = ((const char *)buf_ptr) + rval.consumed;
+    size -= rval.consumed;
+    if (length > (ber_tlv_len_t)size)
+        {
+            rval.code = RC_WMORE;
+            rval.consumed = 0;
+            return rval;
+        }
+
+    st->size = (int)length;
+    /* The following better be optimized away. */
+    if (sizeof(st->size) != sizeof(length) && (ber_tlv_len_t)st->size != length)
+        {
+            st->size = 0;
+            _ASN_DECODE_FAILED;
+        }
+
+    st->buf = (uint8_t *)MALLOC(length + 1);
+    if (!st->buf)
+        {
+            st->size = 0;
+            _ASN_DECODE_FAILED;
+        }
+
+    memcpy(st->buf, buf_ptr, length);
+    st->buf[length] = '\0'; /* Just in case */
+
+    rval.code = RC_OK;
+    rval.consumed += length;
+
+    ASN_DEBUG("Took %ld/%ld bytes to encode %s", (long)rval.consumed,
+        (long)length, td->name);
+
+    return rval;
+}
+
+/*
+ * Encode an always-primitive type using DER.
+ */
+asn_enc_rval_t der_encode_primitive(asn_TYPE_descriptor_t *td, void *sptr,
+    int tag_mode, ber_tlv_tag_t tag,
+    asn_app_consume_bytes_f *cb, void *app_key)
+{
+    asn_enc_rval_t erval;
+    ASN__PRIMITIVE_TYPE_t *st = (ASN__PRIMITIVE_TYPE_t *)sptr;
+
+    ASN_DEBUG("%s %s as a primitive type (tm=%d)",
+        cb ? "Encoding" : "Estimating", td->name, tag_mode);
+
+    erval.encoded = der_write_tags(td, st->size, tag_mode, 0, tag, cb, app_key);
+    ASN_DEBUG("%s wrote tags %d", td->name, (int)erval.encoded);
+    if (erval.encoded == -1)
+        {
+            erval.failed_type = td;
+            erval.structure_ptr = sptr;
+            return erval;
+        }
+
+    if (cb && st->buf)
+        {
+            if (cb(st->buf, st->size, app_key) < 0)
+                {
+                    erval.encoded = -1;
+                    erval.failed_type = td;
+                    erval.structure_ptr = sptr;
+                    return erval;
+                }
+        }
+    else
+        {
+            assert(st->buf || st->size == 0);
+        }
+
+    erval.encoded += st->size;
+    _ASN_ENCODED_OK(erval);
+}
+
+void ASN__PRIMITIVE_TYPE_free(asn_TYPE_descriptor_t *td, void *sptr,
+    int contents_only)
+{
+    ASN__PRIMITIVE_TYPE_t *st = (ASN__PRIMITIVE_TYPE_t *)sptr;
+
+    if (!td || !sptr)
+        {
+            return;
+        }
+
+    ASN_DEBUG("Freeing %s as a primitive type", td->name);
+
+    if (st->buf)
+        {
+            FREEMEM(st->buf);
+        }
+
+    if (!contents_only)
+        {
+            FREEMEM(st);
+        }
+}
+
+/*
+ * Local internal type passed around as an argument.
+ */
+struct xdp_arg_s
+{
+    asn_TYPE_descriptor_t *type_descriptor;
+    void *struct_key;
+    xer_primitive_body_decoder_f *prim_body_decoder;
+    int decoded_something;
+    int want_more;
+};
+
+static int xer_decode__unexpected_tag(void *key, const void *chunk_buf,
+    size_t chunk_size)
+{
+    struct xdp_arg_s *arg = (struct xdp_arg_s *)key;
+    enum xer_pbd_rval bret;
+
+    if (arg->decoded_something)
+        {
+            if (xer_is_whitespace(chunk_buf, chunk_size))
+                {
+                    return 0; /* Skip it. */
+                }
+            /*
+             * Decoding was done once already. Prohibit doing it again.
+             */
+            return -1;
+        }
+
+    bret = arg->prim_body_decoder(arg->type_descriptor, arg->struct_key,
+        chunk_buf, chunk_size);
+    switch (bret)
+        {
+        case XPBD_SYSTEM_FAILURE:
+        case XPBD_DECODER_LIMIT:
+        case XPBD_BROKEN_ENCODING:
+            break;
+        case XPBD_BODY_CONSUMED:
+            /* Tag decoded successfully */
+            arg->decoded_something = 1;
+            /* Fall through */
+        case XPBD_NOT_BODY_IGNORE: /* Safe to proceed further */
+            return 0;
+        }
+
+    return -1;
+}
+
+static ssize_t xer_decode__body(void *key, const void *chunk_buf,
+    size_t chunk_size, int have_more)
+{
+    struct xdp_arg_s *arg = (struct xdp_arg_s *)key;
+    enum xer_pbd_rval bret;
+
+    if (arg->decoded_something)
+        {
+            if (xer_is_whitespace(chunk_buf, chunk_size))
+                {
+                    return chunk_size;
+                }
+            /*
+             * Decoding was done once already. Prohibit doing it again.
+             */
+            return -1;
+        }
+
+    if (!have_more)
+        {
+            /*
+             * If we've received something like "1", we can't really
+             * tell whether it is really `1` or `123`, until we know
+             * that there is no more data coming.
+             * The have_more argument will be set to 1 once something
+             * like this is available to the caller of this callback:
+             * "1<tag_start..."
+             */
+            arg->want_more = 1;
+            return -1;
+        }
+
+    bret = arg->prim_body_decoder(arg->type_descriptor, arg->struct_key,
+        chunk_buf, chunk_size);
+    switch (bret)
+        {
+        case XPBD_SYSTEM_FAILURE:
+        case XPBD_DECODER_LIMIT:
+        case XPBD_BROKEN_ENCODING:
+            break;
+        case XPBD_BODY_CONSUMED:
+            /* Tag decoded successfully */
+            arg->decoded_something = 1;
+            /* Fall through */
+        case XPBD_NOT_BODY_IGNORE: /* Safe to proceed further */
+            return chunk_size;
+        }
+
+    return -1;
+}
+
+asn_dec_rval_t xer_decode_primitive(
+    asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td, void **sptr,
+    size_t struct_size, const char *opt_mname, const void *buf_ptr, size_t size,
+    xer_primitive_body_decoder_f *prim_body_decoder)
+{
+    const char *xml_tag = opt_mname ? opt_mname : td->xml_tag;
+    asn_struct_ctx_t s_ctx;
+    struct xdp_arg_s s_arg;
+    asn_dec_rval_t rc;
+
+    /*
+     * Create the structure if does not exist.
+     */
+    if (!*sptr)
+        {
+            *sptr = CALLOC(1, struct_size);
+            if (!*sptr)
+                {
+                    _ASN_DECODE_FAILED;
+                }
+        }
+
+    memset(&s_ctx, 0, sizeof(s_ctx));
+    s_arg.type_descriptor = td;
+    s_arg.struct_key = *sptr;
+    s_arg.prim_body_decoder = prim_body_decoder;
+    s_arg.decoded_something = 0;
+    s_arg.want_more = 0;
+
+    rc = xer_decode_general(opt_codec_ctx, &s_ctx, &s_arg, xml_tag, buf_ptr,
+        size, xer_decode__unexpected_tag, xer_decode__body);
+    switch (rc.code)
+        {
+        case RC_OK:
+            if (!s_arg.decoded_something)
+                {
+                    char ch;
+                    ASN_DEBUG(
+                        "Primitive body is not recognized, "
+                        "supplying empty one");
+                    /*
+                     * Decoding opportunity has come and gone.
+                     * Where's the result?
+                     * Try to feed with empty body, see if it eats it.
+                     */
+                    if (prim_body_decoder(s_arg.type_descriptor,
+                            s_arg.struct_key, &ch,
+                            0) != XPBD_BODY_CONSUMED)
+                        {
+                            /*
+                             * This decoder does not like empty stuff.
+                             */
+                            _ASN_DECODE_FAILED;
+                        }
+                }
+            break;
+        case RC_WMORE:
+            /*
+             * Redo the whole thing later.
+             * We don't have a context to save intermediate parsing state.
+             */
+            rc.consumed = 0;
+            break;
+        case RC_FAIL:
+            rc.consumed = 0;
+            if (s_arg.want_more)
+                {
+                    rc.code = RC_WMORE;
+                }
+            else
+                {
+                    _ASN_DECODE_FAILED;
+                }
+            break;
+        }
+    return rc;
+}

--- a/src/core/libs/supl/types/asn_codecs_prim.h
+++ b/src/core/libs/supl/types/asn_codecs_prim.h
@@ -1,0 +1,53 @@
+/*-
+ * SPDX-FileCopyrightText: (c) 2003, 2004 Lev Walkin <vlm@lionet.info>. All rights reserved.
+ * SPDX-License-Identifier: BSD-1-Clause
+ */
+#ifndef ASN_CODECS_PRIM_H
+#define ASN_CODECS_PRIM_H
+
+#include <asn_application.h>
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+    typedef struct ASN__PRIMITIVE_TYPE_s
+    {
+        uint8_t *buf;        /* Buffer with consecutive primitive encoding bytes */
+        int size;            /* Size of the buffer */
+    } ASN__PRIMITIVE_TYPE_t; /* Do not use this type directly! */
+
+    asn_struct_free_f ASN__PRIMITIVE_TYPE_free;
+    ber_type_decoder_f ber_decode_primitive;
+    der_type_encoder_f der_encode_primitive;
+
+    /*
+     * A callback specification for the xer_decode_primitive() function below.
+     */
+    enum xer_pbd_rval
+    {
+        XPBD_SYSTEM_FAILURE,  /* System failure (memory shortage, etc) */
+        XPBD_DECODER_LIMIT,   /* Hit some decoder limitation or deficiency */
+        XPBD_BROKEN_ENCODING, /* Encoding of a primitive body is broken */
+        XPBD_NOT_BODY_IGNORE, /* Not a body format, but safe to ignore */
+        XPBD_BODY_CONSUMED    /* Body is recognized and consumed */
+    };
+    typedef enum xer_pbd_rval(xer_primitive_body_decoder_f)(
+        asn_TYPE_descriptor_t *td, void *struct_ptr, const void *chunk_buf,
+        size_t chunk_size);
+
+    /*
+     * Specific function to decode simple primitive types.
+     * Also see xer_decode_general() in xer_decoder.h
+     */
+    asn_dec_rval_t xer_decode_primitive(
+        asn_codec_ctx_t *opt_codec_ctx, asn_TYPE_descriptor_t *td, void **sptr,
+        size_t struct_size, const char *opt_mname, const void *buf_ptr,
+        size_t size, xer_primitive_body_decoder_f *prim_body_decoder);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ASN_CODECS_PRIM_H */

--- a/src/core/libs/supl/types/asn_internal.h
+++ b/src/core/libs/supl/types/asn_internal.h
@@ -1,0 +1,133 @@
+/*-
+ * SPDX-FileCopyrightText: (c) 2003, 2004 Lev Walkin <vlm@lionet.info>. All rights reserved.
+ * SPDX-License-Identifier: BSD-1-Clause
+ */
+/*
+ * Declarations internally useful for the ASN.1 support code.
+ */
+#ifndef _ASN_INTERNAL_H
+#define _ASN_INTERNAL_H
+
+#include "asn_application.h" /* Application-visible API */
+
+#ifndef __NO_ASSERT_H__ /* Include assert.h only for internal use. */
+#include <assert.h>     /* for assert() macro */
+#endif
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+// clang-format off
+/* Environment version might be used to avoid running with the old library */
+#define ASN1C_ENVIRONMENT_VERSION 922        /* Compile-time version */
+    int get_asn1c_environment_version(void); /* Run-time version */
+
+#define CALLOC(nmemb, size) calloc(nmemb, size)
+#define MALLOC(size) malloc(size)
+#define REALLOC(oldptr, size) realloc(oldptr, size)
+#define FREEMEM(ptr) free(ptr)
+
+/*
+ * A macro for debugging the ASN.1 internals.
+ * You may enable or override it.
+ */
+#ifndef ASN_DEBUG       /* If debugging code is not defined elsewhere... */
+#if EMIT_ASN_DEBUG == 1 /* And it was asked to emit this code... */
+#ifdef __GNUC__
+#ifdef ASN_THREAD_SAFE
+#define asn_debug_indent 0
+#else  /* !ASN_THREAD_SAFE */
+    int asn_debug_indent;
+#endif /* ASN_THREAD_SAFE */
+#define ASN_DEBUG(fmt, args...)                                \
+    do                                                         \
+        {                                                      \
+            int adi = asn_debug_indent;                        \
+            while (adi--) fprintf(stderr, " ");                \
+            fprintf(stderr, fmt, ##args);                      \
+            fprintf(stderr, " (%s:%d)\n", __FILE__, __LINE__); \
+        }                                                      \
+    while (0)
+#else /* !__GNUC__ */
+    void ASN_DEBUG_f(const char *fmt, ...);
+#define ASN_DEBUG ASN_DEBUG_f
+#endif /* __GNUC__ */
+#else  /* EMIT_ASN_DEBUG != 1 */
+    static inline void ASN_DEBUG(const char *fmt, ...)
+    {
+        (void)fmt;
+    }
+#endif /* EMIT_ASN_DEBUG */
+#endif /* ASN_DEBUG */
+// clang-format on
+
+/*
+ * Invoke the application-supplied callback and fail, if something is wrong.
+ */
+#define __ASN_E_cbc(buf, size) (cb((buf), (size), app_key) < 0)
+#define _ASN_E_CALLBACK(foo)         \
+    do                               \
+        {                            \
+            if (foo) goto cb_failed; \
+        }                            \
+    while (0)
+#define _ASN_CALLBACK(buf, size) _ASN_E_CALLBACK(__ASN_E_cbc(buf, size))
+#define _ASN_CALLBACK2(buf1, size1, buf2, size2) \
+    _ASN_E_CALLBACK(__ASN_E_cbc(buf1, size1) || __ASN_E_cbc(buf2, size2))
+#define _ASN_CALLBACK3(buf1, size1, buf2, size2, buf3, size3)               \
+    _ASN_E_CALLBACK(__ASN_E_cbc(buf1, size1) || __ASN_E_cbc(buf2, size2) || \
+                    __ASN_E_cbc(buf3, size3))
+
+#define _i_ASN_TEXT_INDENT(nl, level)                                     \
+    do                                                                    \
+        {                                                                 \
+            int __level = (level);                                        \
+            int __nl = ((nl) != 0);                                       \
+            int __i;                                                      \
+            if (__nl) _ASN_CALLBACK("\n", 1);                             \
+            if (__level < 0) __level = 0;                                 \
+            for (__i = 0; __i < __level; __i++) _ASN_CALLBACK("    ", 4); \
+            er.encoded += __nl + 4 * __level;                             \
+        }                                                                 \
+    while (0)
+
+#define _i_INDENT(nl)                                        \
+    do                                                       \
+        {                                                    \
+            int __i;                                         \
+            if ((nl) && cb("\n", 1, app_key) < 0) return -1; \
+            for (__i = 0; __i < ilevel; __i++)               \
+                if (cb("    ", 4, app_key) < 0) return -1;   \
+        }                                                    \
+    while (0)
+
+/*
+ * Check stack against overflow, if limit is set.
+ */
+#define _ASN_DEFAULT_STACK_MAX (30000)
+    static inline int _ASN_STACK_OVERFLOW_CHECK(asn_codec_ctx_t *ctx)
+    {
+        if (ctx && ctx->max_stack_size)
+            {
+                /* ctx MUST be allocated on the stack */
+                ptrdiff_t usedstack = ((char *)ctx - (char *)&ctx);
+                if (usedstack > 0) usedstack = -usedstack; /* grows up! */
+
+                /* double negative required to avoid int wrap-around */
+                if (usedstack < -(ptrdiff_t)ctx->max_stack_size)
+                    {
+                        ASN_DEBUG("Stack limit %ld reached",
+                            (long)ctx->max_stack_size);
+                        return -1;
+                    }
+            }
+        return 0;
+    }
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* _ASN_INTERNAL_H_ */

--- a/src/core/libs/supl/types/asn_system.h
+++ b/src/core/libs/supl/types/asn_system.h
@@ -1,0 +1,133 @@
+/*-
+ * SPDX-FileCopyrightText: (c) 2003, 2004 Lev Walkin <vlm@lionet.info>. All rights reserved.
+ * SPDX-License-Identifier: BSD-1-Clause
+ */
+/*
+ * Miscellaneous system-dependent types.
+ */
+#ifndef _ASN_SYSTEM_H
+#define _ASN_SYSTEM_H
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <limits.h>    /* For LONG_MAX */
+#include <stdarg.h>    /* For va_start */
+#include <stddef.h>    /* for offsetof and ptrdiff_t */
+#include <stdio.h>     /* For snprintf(3) */
+#include <stdlib.h>    /* For *alloc(3) */
+#include <string.h>    /* For memcpy(3) */
+#include <sys/types.h> /* For size_t */
+
+#ifdef WIN32
+
+#include <malloc.h>
+#define snprintf _snprintf
+#define vsnprintf _vsnprintf
+
+/* To avoid linking with ws2_32.lib, here's the definition of ntohl() */
+#define sys_ntohl(l)                                         \
+    ((((l) << 24) & 0xff000000) | (((l) << 16) & 0xff0000) | \
+        (((l) << 8) & 0xff00) | ((l)&0xff))
+
+#ifdef _MSC_VER /* MSVS.Net */
+#ifndef __cplusplus
+#define inline __inline
+#endif
+#ifndef ASSUMESTDTYPES /* Standard types have been defined elsewhere */
+#define ssize_t SSIZE_T
+typedef char int8_t;
+typedef short int16_t;
+typedef int int32_t;
+typedef unsigned char uint8_t;
+typedef unsigned short uint16_t;
+typedef unsigned int uint32_t;
+#endif /* ASSUMESTDTYPES */
+#define WIN32_LEAN_AND_MEAN
+#include <float.h>
+#include <windows.h>
+#define isnan _isnan
+#define finite _finite
+#define copysign _copysign
+#define ilogb _logb
+#else /* !_MSC_VER */
+#include <stdint.h>
+#endif /* _MSC_VER */
+
+#else /* !WIN32 */
+
+#if defined(__vxworks)
+#include <types/vxTypes.h>
+#else /* !defined(__vxworks) */
+
+// clang-format off
+#include <inttypes.h> /* C99 specifies this file */
+/*
+ * 1. Earlier FreeBSD version didn't have <stdint.h>,
+ * but <inttypes.h> was present.
+ * 2. Sun Solaris requires <alloca.h> for alloca(3),
+ * but does not have <stdint.h>.
+ */
+#if (!defined(__FreeBSD__) || !defined(_SYS_INTTYPES_H_))
+#if defined(sun)
+#include <alloca.h> /* For alloca(3) */
+#include <ieeefp.h> /* for finite(3) */
+#elif defined(__hpux)
+#ifdef __GNUC__
+#include <alloca.h> /* For alloca(3) */
+#else               /* !__GNUC__ */
+#define inline
+#endif /* __GNUC__ */
+#else
+#include <stdint.h> /* SUSv2+ and C99 specify this file, for uintXX_t */
+#endif              /* defined(sun) */
+#endif
+
+#include <netinet/in.h> /* for ntohl() */
+#define sys_ntohl(foo) ntohl(foo)
+
+#endif /* defined(__vxworks) */
+
+#endif /* WIN32 */
+
+#if __GNUC__ >= 3
+#ifndef GCC_PRINTFLIKE
+#define GCC_PRINTFLIKE(fmt, var) __attribute__((format(printf, fmt, var)))
+#endif
+#ifndef GCC_NOTUSED
+#define GCC_NOTUSED __attribute__((unused))
+#endif
+#else
+#ifndef GCC_PRINTFLIKE
+#define GCC_PRINTFLIKE(fmt, var) /* nothing */
+#endif
+#ifndef GCC_NOTUSED
+#define GCC_NOTUSED
+#endif
+#endif
+
+/* Figure out if thread safety is requested */
+#if !defined(ASN_THREAD_SAFE) && (defined(THREAD_SAFE) || defined(_REENTRANT))
+#define ASN_THREAD_SAFE
+#endif /* Thread safety */
+
+#ifndef offsetof /* If not defined by <stddef.h> */
+#define offsetof(s, m) ((ptrdiff_t) & (((s *)0)->m) - (ptrdiff_t)((s *)0))
+#endif /* offsetof */
+
+#ifndef MIN /* Suitable for comparing primitive types (integers) */
+#if defined(__GNUC__)
+#define MIN(a, b)                    \
+    ({                               \
+        __typeof a _a = a;           \
+        __typeof b _b = b;           \
+        ((_a) < (_b) ? (_a) : (_b)); \
+    })
+#else                                     /* !__GNUC__ */
+#define MIN(a, b) ((a) < (b) ? (a) : (b)) /* Unsafe variant */
+#endif                                    /* __GNUC__ */
+#endif                                    /* MIN */
+// clang-format on
+
+#endif /* _ASN_SYSTEM_H_ */

--- a/src/core/libs/supl/types/ber_decoder.c
+++ b/src/core/libs/supl/types/ber_decoder.c
@@ -1,0 +1,337 @@
+/*-
+ * SPDX-FileCopyrightText: (c) 2003, 2004 Lev Walkin <vlm@lionet.info>. All rights reserved.
+ * SPDX-License-Identifier: BSD-1-Clause
+ */
+#include <asn_internal.h>
+
+#undef ADVANCE
+#define ADVANCE(num_bytes)                   \
+    do                                       \
+        {                                    \
+            size_t num = num_bytes;          \
+            ptr = ((const char *)ptr) + num; \
+            size -= num;                     \
+            consumed_myself += num;          \
+        }                                    \
+    while (0)
+#undef RETURN
+#define RETURN(_code)                                             \
+    do                                                            \
+        {                                                         \
+            asn_dec_rval_t rval;                                  \
+            rval.code = _code;                                    \
+            if (opt_ctx) opt_ctx->step = step; /* Save context */ \
+            if ((_code) == RC_OK || opt_ctx)                      \
+                rval.consumed = consumed_myself;                  \
+            else                                                  \
+                rval.consumed = 0; /* Context-free */             \
+            return rval;                                          \
+        }                                                         \
+    while (0)
+
+/*
+ * The BER decoder of any type.
+ */
+asn_dec_rval_t ber_decode(asn_codec_ctx_t *opt_codec_ctx,
+    asn_TYPE_descriptor_t *type_descriptor,
+    void **struct_ptr, const void *ptr, size_t size)
+{
+    asn_codec_ctx_t s_codec_ctx;
+
+    /*
+     * Stack checker requires that the codec context
+     * must be allocated on the stack.
+     */
+    if (opt_codec_ctx)
+        {
+            if (opt_codec_ctx->max_stack_size)
+                {
+                    s_codec_ctx = *opt_codec_ctx;
+                    opt_codec_ctx = &s_codec_ctx;
+                }
+        }
+    else
+        {
+            /* If context is not given, be security-conscious anyway */
+            memset(&s_codec_ctx, 0, sizeof(s_codec_ctx));
+            s_codec_ctx.max_stack_size = _ASN_DEFAULT_STACK_MAX;
+            opt_codec_ctx = &s_codec_ctx;
+        }
+
+    /*
+     * Invoke type-specific decoder.
+     */
+    return type_descriptor->ber_decoder(
+        opt_codec_ctx, type_descriptor,
+        struct_ptr, /* Pointer to the destination structure */
+        ptr, size,  /* Buffer and its size */
+        0           /* Default tag mode is 0 */
+    );
+}
+
+/*
+ * Check the set of <TL<TL<TL...>>> tags matches the definition.
+ */
+asn_dec_rval_t ber_check_tags(asn_codec_ctx_t *opt_codec_ctx,
+    asn_TYPE_descriptor_t *td,
+    asn_struct_ctx_t *opt_ctx, const void *ptr,
+    size_t size, int tag_mode, int last_tag_form,
+    ber_tlv_len_t *last_length, int *opt_tlv_form)
+{
+    ssize_t consumed_myself = 0;
+    ssize_t tag_len;
+    ssize_t len_len;
+    ber_tlv_tag_t tlv_tag;
+    ber_tlv_len_t tlv_len;
+    ber_tlv_len_t limit_len = -1;
+    int expect_00_terminators = 0;
+    int tlv_constr = -1;                    /* If CHOICE, opt_tlv_form is not given */
+    int step = opt_ctx ? opt_ctx->step : 0; /* Where we left previously */
+    int tagno;
+
+    /*
+     * Make sure we didn't exceed the maximum stack size.
+     */
+    if (_ASN_STACK_OVERFLOW_CHECK(opt_codec_ctx))
+        {
+            RETURN(RC_FAIL);
+        }
+
+    /*
+     * So what does all this implicit skip stuff mean?
+     * Imagine two types,
+     *     A ::= [5] IMPLICIT    T
+     *     B ::= [2] EXPLICIT    T
+     * Where T is defined as
+     *    T ::= [4] IMPLICIT SEQUENCE { ... }
+     *
+     * Let's say, we are starting to decode type A, given the
+     * following TLV stream: <5> <0>. What does this mean?
+     * It means that the type A contains type T which is,
+     * in turn, empty.
+     * Remember though, that we are still in A. We cannot
+     * just pass control to the type T decoder. Why? Because
+     * the type T decoder expects <4> <0>, not <5> <0>.
+     * So, we must make sure we are going to receive <5> while
+     * still in A, then pass control to the T decoder, indicating
+     * that the tag <4> was implicitly skipped. The decoder of T
+     * hence will be prepared to treat <4> as valid tag, and decode
+     * it appropriately.
+     */
+
+    tagno = step /* Continuing where left previously */
+            + (tag_mode == 1 ? -1 : 0);
+    ASN_DEBUG("ber_check_tags(%s, size=%ld, tm=%d, step=%d, tagno=%d)",
+        td->name, (long)size, tag_mode, step, tagno);
+    /* assert(td->tags_count >= 1) May not be the case for CHOICE or ANY */
+
+    if (tag_mode == 0 && tagno == td->tags_count)
+        {
+            /*
+             * This must be the _untagged_ ANY type,
+             * which outermost tag isn't known in advance.
+             * Fetch the tag and length separately.
+             */
+            tag_len = ber_fetch_tag(ptr, size, &tlv_tag);
+            switch (tag_len)
+                {
+                case -1:
+                    RETURN(RC_FAIL);
+                case 0:
+                    RETURN(RC_WMORE);
+                }
+            tlv_constr = BER_TLV_CONSTRUCTED(ptr);
+            len_len = ber_fetch_length(tlv_constr, (const char *)ptr + tag_len,
+                size - tag_len, &tlv_len);
+            switch (len_len)
+                {
+                case -1:
+                    RETURN(RC_FAIL);
+                case 0:
+                    RETURN(RC_WMORE);
+                }
+            ASN_DEBUG("Advancing %ld in ANY case", (tag_len + len_len));
+            ADVANCE(tag_len + len_len);
+        }
+    else
+        {
+            assert(tagno < td->tags_count); /* At least one loop */
+        }
+    for ((void)tagno; tagno < td->tags_count; tagno++, step++)
+        {
+            /*
+             * Fetch and process T from TLV.
+             */
+            tag_len = ber_fetch_tag(ptr, size, &tlv_tag);
+            ASN_DEBUG(
+                "Fetching tag from {%p,%ld}: "
+                "len %ld, step %d, tagno %d got %s",
+                ptr, (long)size, (long)tag_len, step, tagno,
+                ber_tlv_tag_string(tlv_tag));
+            switch (tag_len)
+                {
+                case -1:
+                    RETURN(RC_FAIL);
+                case 0:
+                    RETURN(RC_WMORE);
+                }
+
+            tlv_constr = BER_TLV_CONSTRUCTED(ptr);
+
+            /*
+             * If {I}, don't check anything.
+             * If {I,B,C}, check B and C unless we're at I.
+             */
+            if (tag_mode != 0 && step == 0)
+                {
+                    /*
+                     * We don't expect tag to match here.
+                     * It's just because we don't know how the tag
+                     * is supposed to look like.
+                     */
+                }
+            else
+                {
+                    assert(tagno >= 0); /* Guaranteed by the code above */
+                    if (tlv_tag != td->tags[tagno])
+                        {
+                            /*
+                             * Unexpected tag. Too bad.
+                             */
+                            ASN_DEBUG(
+                                "Expected: %s, "
+                                "expectation failed (tn=%d, tm=%d)",
+                                ber_tlv_tag_string(td->tags[tagno]), tagno,
+                                tag_mode);
+                            RETURN(RC_FAIL);
+                        }
+                }
+
+            /*
+             * Attention: if there are more tags expected,
+             * ensure that the current tag is presented
+             * in constructed form (it contains other tags!).
+             * If this one is the last one, check that the tag form
+             * matches the one given in descriptor.
+             */
+            if (tagno < (td->tags_count - 1))
+                {
+                    if (tlv_constr == 0)
+                        {
+                            ASN_DEBUG("tlv_constr = %d, expfail", tlv_constr);
+                            RETURN(RC_FAIL);
+                        }
+                }
+            else
+                {
+                    if (last_tag_form != tlv_constr && last_tag_form != -1)
+                        {
+                            ASN_DEBUG("last_tag_form %d != %d", last_tag_form,
+                                tlv_constr);
+                            RETURN(RC_FAIL);
+                        }
+                }
+
+            /*
+             * Fetch and process L from TLV.
+             */
+            len_len = ber_fetch_length(tlv_constr, (const char *)ptr + tag_len,
+                size - tag_len, &tlv_len);
+            ASN_DEBUG("Fetchinig len = %ld", (long)len_len);
+            switch (len_len)
+                {
+                case -1:
+                    RETURN(RC_FAIL);
+                case 0:
+                    RETURN(RC_WMORE);
+                }
+
+            /*
+             * FIXME
+             * As of today, the chain of tags
+             * must either contain several indefinite length TLVs,
+             * or several definite length ones.
+             * No mixing is allowed.
+             */
+            if (tlv_len == -1)
+                {
+                    /*
+                     * Indefinite length.
+                     */
+                    if (limit_len == -1)
+                        {
+                            expect_00_terminators++;
+                        }
+                    else
+                        {
+                            ASN_DEBUG(
+                                "Unexpected indefinite length "
+                                "in a chain of definite lengths");
+                            RETURN(RC_FAIL);
+                        }
+                    ADVANCE(tag_len + len_len);
+                    continue;
+                }
+            else
+                {
+                    if (expect_00_terminators)
+                        {
+                            ASN_DEBUG(
+                                "Unexpected definite length "
+                                "in a chain of indefinite lengths");
+                            RETURN(RC_FAIL);
+                        }
+                }
+
+            /*
+             * Check that multiple TLVs specify ever decreasing length,
+             * which is consistent.
+             */
+            if (limit_len == -1)
+                {
+                    limit_len = tlv_len + tag_len + len_len;
+                    if (limit_len < 0)
+                        {
+                            /* Too great tlv_len value? */
+                            RETURN(RC_FAIL);
+                        }
+                }
+            else if (limit_len != tlv_len + tag_len + len_len)
+                {
+                    /*
+                     * Inner TLV specifies length which is inconsistent
+                     * with the outer TLV's length value.
+                     */
+                    ASN_DEBUG("Outer TLV is %ld and inner is %ld",
+                        (long)limit_len, (long)tlv_len);
+                    RETURN(RC_FAIL);
+                }
+
+            ADVANCE(tag_len + len_len);
+
+            limit_len -= (tag_len + len_len);
+            if ((ssize_t)size > limit_len)
+                {
+                    /*
+                     * Make sure that we won't consume more bytes
+                     * from the parent frame than the inferred limit.
+                     */
+                    size = limit_len;
+                }
+        }
+
+    if (opt_tlv_form)
+        {
+            *opt_tlv_form = tlv_constr;
+        }
+    if (expect_00_terminators)
+        {
+            *last_length = -expect_00_terminators;
+        }
+    else
+        {
+            *last_length = tlv_len;
+        }
+
+    RETURN(RC_OK);
+}

--- a/src/core/libs/supl/types/ber_decoder.h
+++ b/src/core/libs/supl/types/ber_decoder.h
@@ -1,0 +1,65 @@
+/*-
+ * SPDX-FileCopyrightText: (c) 2003, 2004 Lev Walkin <vlm@lionet.info>. All rights reserved.
+ * SPDX-License-Identifier: BSD-1-Clause
+ */
+#ifndef _BER_DECODER_H
+#define _BER_DECODER_H
+
+#include <asn_application.h>
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+    struct asn_TYPE_descriptor_s; /* Forward declaration */
+    struct asn_codec_ctx_s;       /* Forward declaration */
+
+    /*
+     * The BER decoder of any type.
+     * This function may be invoked directly from the application.
+     * The der_encode() function (der_encoder.h) is an opposite to ber_decode().
+     */
+    asn_dec_rval_t ber_decode(
+        struct asn_codec_ctx_s *opt_codec_ctx,
+        struct asn_TYPE_descriptor_s *type_descriptor,
+        void **struct_ptr, /* Pointer to a target structure's pointer */
+        const void *ptr,   /* Data to be decoded */
+        size_t size        /* Size of that buffer */
+    );
+
+    /*
+     * Type of generic function which decodes the byte stream into the
+     * structure.
+     */
+    typedef asn_dec_rval_t(ber_type_decoder_f)(
+        struct asn_codec_ctx_s *opt_codec_ctx,
+        struct asn_TYPE_descriptor_s *type_descriptor, void **struct_ptr,
+        const void *buf_ptr, size_t size, int tag_mode);
+
+    /*******************************
+     * INTERNALLY USEFUL FUNCTIONS *
+     *******************************/
+
+    /*
+     * Check that all tags correspond to the type definition (as given in head).
+     * On return, last_length would contain either a non-negative length of the
+     * value part of the last TLV, or the negative number of expected
+     * "end of content" sequences. The number may only be negative if the
+     * head->last_tag_form is non-zero.
+     */
+    asn_dec_rval_t ber_check_tags(
+        struct asn_codec_ctx_s *opt_codec_ctx, /* codec options */
+        struct asn_TYPE_descriptor_s *td,
+        asn_struct_ctx_t *opt_ctx, /* saved decoding context */
+        const void *ptr, size_t size,
+        int tag_mode,                                 /* {-1,0,1}: IMPLICIT, no, EXPLICIT */
+        int last_tag_form,                            /* {-1,0:1}: any, primitive, constr */
+        ber_tlv_len_t *last_length, int *opt_tlv_form /* optional tag form */
+    );
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* _BER_DECODER_H_ */

--- a/src/core/libs/supl/types/ber_tlv_length.c
+++ b/src/core/libs/supl/types/ber_tlv_length.c
@@ -1,0 +1,214 @@
+/*-
+ * SPDX-FileCopyrightText: (c) 2003, 2004 Lev Walkin <vlm@lionet.info>. All rights reserved.
+ * SPDX-License-Identifier: BSD-1-Clause
+ */
+#include <asn_internal.h>
+#include <ber_tlv_length.h>
+#include <ber_tlv_tag.h>
+
+ssize_t ber_fetch_length(int _is_constructed, const void *bufptr, size_t size,
+    ber_tlv_len_t *len_r)
+{
+    const uint8_t *buf = (const uint8_t *)bufptr;
+    unsigned oct;
+
+    if (size == 0)
+        {
+            return 0; /* Want more */
+        }
+
+    oct = *buf;
+    if ((oct & 0x80) == 0)
+        {
+            /*
+             * Short definite length.
+             */
+            *len_r = oct; /* & 0x7F */
+            return 1;
+        }
+    else
+        {
+            ber_tlv_len_t len;
+            size_t skipped;
+
+            if (_is_constructed && oct == 0x80)
+                {
+                    *len_r = -1; /* Indefinite length */
+                    return 1;
+                }
+
+            if (oct == 0xff)
+                {
+                    /* Reserved in standard for future use. */
+                    return -1;
+                }
+
+            oct &= 0x7F; /* Leave only the 7 LS bits */
+            for (len = 0, buf++, skipped = 1; oct && (++skipped <= size);
+                 buf++, oct--)
+                {
+                    len = (len << 8) | *buf;
+                    if (len < 0 || (len >> ((8 * sizeof(len)) - 8) && oct > 1))
+                        {
+                            /*
+                             * Too large length value.
+                             */
+                            return -1;
+                        }
+                }
+
+            if (oct == 0)
+                {
+                    ber_tlv_len_t lenplusepsilon = (size_t)len + 1024;
+                    /*
+                     * Here length may be very close or equal to 2G.
+                     * However, the arithmetics used in some decoders
+                     * may add some (small) quantities to the length,
+                     * to check the resulting value against some limits.
+                     * This may result in integer wrap-around, which
+                     * we try to avoid by checking it earlier here.
+                     */
+                    if (lenplusepsilon < 0)
+                        {
+                            /* Too large length value */
+                            return -1;
+                        }
+
+                    *len_r = len;
+                    return skipped;
+                }
+
+            return 0; /* Want more */
+        }
+}
+
+ssize_t ber_skip_length(asn_codec_ctx_t *opt_codec_ctx, int _is_constructed,
+    const void *ptr, size_t size)
+{
+    ber_tlv_len_t vlen; /* Length of V in TLV */
+    ssize_t tl;         /* Length of L in TLV */
+    ssize_t ll;         /* Length of L in TLV */
+    size_t skip;
+
+    /*
+     * Make sure we didn't exceed the maximum stack size.
+     */
+    if (_ASN_STACK_OVERFLOW_CHECK(opt_codec_ctx))
+        {
+            return -1;
+        }
+
+    /*
+     * Determine the size of L in TLV.
+     */
+    ll = ber_fetch_length(_is_constructed, ptr, size, &vlen);
+    if (ll <= 0)
+        {
+            return ll;
+        }
+
+    /*
+     * Definite length.
+     */
+    if (vlen >= 0)
+        {
+            skip = ll + vlen;
+            if (skip > size)
+                {
+                    return 0; /* Want more */
+                }
+            return skip;
+        }
+
+    /*
+     * Indefinite length!
+     */
+    ASN_DEBUG("Skipping indefinite length");
+    for (skip = ll, ptr = ((const char *)ptr) + ll, size -= ll;;)
+        {
+            ber_tlv_tag_t tag;
+
+            /* Fetch the tag */
+            tl = ber_fetch_tag(ptr, size, &tag);
+            if (tl <= 0)
+                {
+                    return tl;
+                }
+
+            ll = ber_skip_length(opt_codec_ctx, BER_TLV_CONSTRUCTED(ptr),
+                ((const char *)ptr) + tl, size - tl);
+            if (ll <= 0)
+                {
+                    return ll;
+                }
+
+            skip += tl + ll;
+
+            /*
+             * This may be the end of the indefinite length structure,
+             * two consecutive 0 octets.
+             * Check if it is true.
+             */
+            if (((const uint8_t *)ptr)[0] == 0 &&
+                ((const uint8_t *)ptr)[1] == 0)
+                {
+                    return skip;
+                }
+
+            ptr = ((const char *)ptr) + tl + ll;
+            size -= tl + ll;
+        }
+
+    /* UNREACHABLE */
+}
+
+size_t der_tlv_length_serialize(ber_tlv_len_t len, void *bufp, size_t size)
+{
+    size_t required_size; /* Size of len encoding */
+    uint8_t *buf = (uint8_t *)bufp;
+    uint8_t *end;
+    size_t i;
+
+    if (len <= 127)
+        {
+            /* Encoded in 1 octet */
+            if (size)
+                {
+                    *buf = (uint8_t)len;
+                }
+            return 1;
+        }
+
+    /*
+     * Compute the size of the subsequent bytes.
+     */
+    for (required_size = 1, i = 8; i < 8 * sizeof(len); i += 8)
+        {
+            if (len >> i)
+                {
+                    required_size++;
+                }
+            else
+                {
+                    break;
+                }
+        }
+
+    if (size <= required_size)
+        {
+            return required_size + 1;
+        }
+
+    *buf++ = (uint8_t)(0x80 | required_size); /* Length of the encoding */
+
+    /*
+     * Produce the len encoding, space permitting.
+     */
+    end = buf + required_size;
+    for (i -= 8; buf < end; i -= 8, buf++)
+        {
+            *buf = (uint8_t)(len >> i);
+        }
+
+    return required_size + 1;
+}

--- a/src/core/libs/supl/types/ber_tlv_length.h
+++ b/src/core/libs/supl/types/ber_tlv_length.h
@@ -1,0 +1,52 @@
+/*-
+ * SPDX-FileCopyrightText: (c) 2003, 2004 Lev Walkin <vlm@lionet.info>. All rights reserved.
+ * SPDX-License-Identifier: BSD-1-Clause
+ */
+#ifndef _BER_TLV_LENGTH_H
+#define _BER_TLV_LENGTH_H
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+    typedef ssize_t ber_tlv_len_t;
+
+    /*
+     * This function tries to fetch the length of the BER TLV value and place it
+     * in *len_r.
+     * RETURN VALUES:
+     *     0:    More data expected than bufptr contains.
+     *    -1:    Fatal error deciphering length.
+     *    >0:    Number of bytes used from bufptr.
+     * On return with >0, len_r is constrained as -1..MAX, where -1 mean
+     * that the value is of indefinite length.
+     */
+    ssize_t ber_fetch_length(int _is_constructed, const void *bufptr,
+        size_t size, ber_tlv_len_t *len_r);
+
+    /*
+     * This function expects bufptr to be positioned over L in TLV.
+     * It returns number of bytes occupied by L and V together, suitable
+     * for skipping. The function properly handles indefinite length.
+     * RETURN VALUES:
+     *     Standard {-1,0,>0} convention.
+     */
+    ssize_t ber_skip_length(
+        struct asn_codec_ctx_s *opt_codec_ctx, /* optional context */
+        int _is_constructed, const void *bufptr, size_t size);
+
+    /*
+     * This function serializes the length (L from TLV) in DER format.
+     * It always returns number of bytes necessary to represent the length,
+     * it is a caller's responsibility to check the return value
+     * against the supplied buffer's size.
+     */
+    size_t der_tlv_length_serialize(ber_tlv_len_t len, void *bufptr,
+        size_t size);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* _BER_TLV_LENGTH_H_ */

--- a/src/core/libs/supl/types/ber_tlv_tag.c
+++ b/src/core/libs/supl/types/ber_tlv_tag.c
@@ -1,0 +1,176 @@
+/*-
+ * SPDX-FileCopyrightText: (c) 2003, 2004 Lev Walkin <vlm@lionet.info>. All rights reserved.
+ * SPDX-License-Identifier: BSD-1-Clause
+ */
+#include <asn_internal.h>
+#include <ber_tlv_tag.h>
+#include <errno.h>
+
+ssize_t ber_fetch_tag(const void *ptr, size_t size, ber_tlv_tag_t *tag_r)
+{
+    ber_tlv_tag_t val;
+    ber_tlv_tag_t tclass;
+    size_t skipped;
+
+    if (size == 0)
+        {
+            return 0;
+        }
+
+    val = *(const uint8_t *)ptr;
+    tclass = (val >> 6);
+    if ((val &= 0x1F) != 0x1F)
+        {
+            /*
+             * Simple form: everything encoded in a single octet.
+             * Tag Class is encoded using two least significant bits.
+             */
+            *tag_r = (val << 2) | tclass;
+            return 1;
+        }
+
+    /*
+     * Each octet contains 7 bits of useful information.
+     * The MSB is 0 if it is the last octet of the tag.
+     */
+    for (val = 0, ptr = ((const char *)ptr) + 1, skipped = 2; skipped <= size;
+         ptr = ((const char *)ptr) + 1, skipped++)
+        {
+            unsigned int oct = *(const uint8_t *)ptr;
+            if (oct & 0x80)
+                {
+                    val = (val << 7) | (oct & 0x7F);
+                    /*
+                     * Make sure there are at least 9 bits spare
+                     * at the MS side of a value.
+                     */
+                    if (val >> ((8 * sizeof(val)) - 9))
+                        {
+                            /*
+                             * We would not be able to accommodate
+                             * any more tag bits.
+                             */
+                            return -1;
+                        }
+                }
+            else
+                {
+                    val = (val << 7) | oct;
+                    *tag_r = (val << 2) | tclass;
+                    return skipped;
+                }
+        }
+
+    return 0; /* Want more */
+}
+
+ssize_t ber_tlv_tag_fwrite(ber_tlv_tag_t tag, FILE *f)
+{
+    char buf[sizeof("[APPLICATION ]") + 32];
+    ssize_t ret;
+
+    ret = ber_tlv_tag_snprint(tag, buf, sizeof(buf));
+    if (ret >= (ssize_t)sizeof(buf) || ret < 2)
+        {
+            errno = EPERM;
+            return -1;
+        }
+
+    return fwrite(buf, 1, ret, f);
+}
+
+ssize_t ber_tlv_tag_snprint(ber_tlv_tag_t tag, char *buf, size_t size)
+{
+    char *type = 0;
+    int ret;
+
+    switch (tag & 0x3)
+        {
+        case ASN_TAG_CLASS_UNIVERSAL:
+            type = "UNIVERSAL ";
+            break;
+        case ASN_TAG_CLASS_APPLICATION:
+            type = "APPLICATION ";
+            break;
+        case ASN_TAG_CLASS_CONTEXT:
+            type = "";
+            break;
+        case ASN_TAG_CLASS_PRIVATE:
+            type = "PRIVATE ";
+            break;
+        }
+
+    ret = snprintf(buf, size, "[%s%u]", type, ((unsigned)tag) >> 2);
+    if (ret <= 0 && size)
+        {
+            buf[0] = '\0'; /* against broken libc's */
+        }
+
+    return ret;
+}
+
+char *ber_tlv_tag_string(ber_tlv_tag_t tag)
+{
+    static char buf[sizeof("[APPLICATION ]") + 32];
+
+    (void)ber_tlv_tag_snprint(tag, buf, sizeof(buf));
+
+    return buf;
+}
+
+size_t ber_tlv_tag_serialize(ber_tlv_tag_t tag, void *bufp, size_t size)
+{
+    int tclass = BER_TAG_CLASS(tag);
+    ber_tlv_tag_t tval = BER_TAG_VALUE(tag);
+    uint8_t *buf = (uint8_t *)bufp;
+    uint8_t *end;
+    size_t required_size;
+    size_t i;
+
+    if (tval <= 30)
+        {
+            /* Encoded in 1 octet */
+            if (size)
+                {
+                    buf[0] = (tclass << 6) | tval;
+                }
+            return 1;
+        }
+    else if (size)
+        {
+            *buf++ = (tclass << 6) | 0x1F;
+            size--;
+        }
+
+    /*
+     * Compute the size of the subsequent bytes.
+     */
+    for (required_size = 1, i = 7; i < 8 * sizeof(tval); i += 7)
+        {
+            if (tval >> i)
+                {
+                    required_size++;
+                }
+            else
+                {
+                    break;
+                }
+        }
+
+    if (size < required_size)
+        {
+            return required_size + 1;
+        }
+
+    /*
+     * Fill in the buffer, space permitting.
+     */
+    end = buf + required_size - 1;
+    for (i -= 7; buf < end; i -= 7, buf++)
+        {
+            *buf = 0x80 | ((tval >> i) & 0x7F);
+        }
+    *buf = (tval & 0x7F); /* Last octet without high bit */
+
+    return required_size + 1;
+}

--- a/src/core/libs/supl/types/ber_tlv_tag.h
+++ b/src/core/libs/supl/types/ber_tlv_tag.h
@@ -1,0 +1,63 @@
+/*-
+ * SPDX-FileCopyrightText: (c) 2003, 2004 Lev Walkin <vlm@lionet.info>. All rights reserved.
+ * SPDX-License-Identifier: BSD-1-Clause
+ */
+#ifndef _BER_TLV_TAG_H
+#define _BER_TLV_TAG_H
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+    enum asn_tag_class
+    {
+        ASN_TAG_CLASS_UNIVERSAL = 0,   /* 0b00 */
+        ASN_TAG_CLASS_APPLICATION = 1, /* 0b01 */
+        ASN_TAG_CLASS_CONTEXT = 2,     /* 0b10 */
+        ASN_TAG_CLASS_PRIVATE = 3      /* 0b11 */
+    };
+    typedef unsigned ber_tlv_tag_t; /* BER TAG from Tag-Length-Value */
+
+/*
+ * Tag class is encoded together with tag value for optimization purposes.
+ */
+#define BER_TAG_CLASS(tag) ((tag)&0x3)
+#define BER_TAG_VALUE(tag) ((tag) >> 2)
+#define BER_TLV_CONSTRUCTED(tagptr) \
+    (((*(const uint8_t *)tagptr) & 0x20) ? 1 : 0)
+
+#define BER_TAGS_EQUAL(tag1, tag2) ((tag1) == (tag2))
+
+    /*
+     * Several functions for printing the TAG in the canonical form
+     * (i.e. "[PRIVATE 0]").
+     * Return values correspond to their libc counterparts (if any).
+     */
+    ssize_t ber_tlv_tag_snprint(ber_tlv_tag_t tag, char *buf, size_t size);
+    ssize_t ber_tlv_tag_fwrite(ber_tlv_tag_t tag, FILE * /*f*/);
+    char *ber_tlv_tag_string(ber_tlv_tag_t tag);
+
+    /*
+     * This function tries to fetch the tag from the input stream.
+     * RETURN VALUES:
+     *      0:    More data expected than bufptr contains.
+     *     -1:    Fatal error deciphering tag.
+     *     >0:    Number of bytes used from bufptr. tag_r will contain the tag.
+     */
+    ssize_t ber_fetch_tag(const void *bufptr, size_t size,
+        ber_tlv_tag_t *tag_r);
+
+    /*
+     * This function serializes the tag (T from TLV) in BER format.
+     * It always returns number of bytes necessary to represent the tag,
+     * it is a caller's responsibility to check the return value
+     * against the supplied buffer's size.
+     */
+    size_t ber_tlv_tag_serialize(ber_tlv_tag_t tag, void *bufptr, size_t size);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* _BER_TLV_TAG_H_ */

--- a/src/core/libs/supl/types/constr_CHOICE.c
+++ b/src/core/libs/supl/types/constr_CHOICE.c
@@ -1,0 +1,1419 @@
+/*
+ * SPDX-FileCopyrightText: (c) 2003, 2004 Lev Walkin <vlm@lionet.info>. All rights reserved.
+ * SPDX-License-Identifier: BSD-1-Clause
+ */
+#include <asn_internal.h>
+#include <constr_CHOICE.h>
+#include <per_opentype.h>
+
+/*
+ * Number of bytes left for this structure.
+ * (ctx->left) indicates the number of bytes _transferred_ for the structure.
+ * (size) contains the number of bytes in the buffer passed.
+ */
+#define LEFT ((size < (size_t)ctx->left) ? size : (size_t)ctx->left)
+
+/*
+ * If the subprocessor function returns with an indication that it wants
+ * more data, it may well be a fatal decoding problem, because the
+ * size is constrained by the <TLV>'s L, even if the buffer size allows
+ * reading more data.
+ * For example, consider the buffer containing the following TLVs:
+ * <T:5><L:1><V> <T:6>...
+ * The TLV length clearly indicates that one byte is expected in V, but
+ * if the V processor returns with "want more data" even if the buffer
+ * contains way more data than the V processor have seen.
+ */
+#define SIZE_VIOLATION (ctx->left >= 0 && (size_t)ctx->left <= size)
+
+/*
+ * This macro "eats" the part of the buffer which is definitely "consumed",
+ * i.e. was correctly converted into local representation or rightfully skipped.
+ */
+#undef ADVANCE
+#define ADVANCE(num_bytes)                        \
+    do                                            \
+        {                                         \
+            size_t num = num_bytes;               \
+            ptr = ((const char *)ptr) + num;      \
+            size -= num;                          \
+            if (ctx->left >= 0) ctx->left -= num; \
+            consumed_myself += num;               \
+        }                                         \
+    while (0)
+
+/*
+ * Switch to the next phase of parsing.
+ */
+#undef NEXT_PHASE
+#define NEXT_PHASE(ctx)      \
+    do                       \
+        {                    \
+            (ctx)->phase++;  \
+            (ctx)->step = 0; \
+        }                    \
+    while (0)
+
+/*
+ * Return a standardized complex structure.
+ */
+#undef RETURN
+#define RETURN(_code)                        \
+    do                                       \
+        {                                    \
+            rval.code = _code;               \
+            rval.consumed = consumed_myself; \
+            return rval;                     \
+        }                                    \
+    while (0)
+
+/*
+ * See the definitions.
+ */
+static int fetch_present_idx(const void *struct_ptr, int pres_offset,
+    int size);
+static void set_present_idx(void *struct_ptr, int offset, int size, int pres);
+
+/*
+ * Tags are canonically sorted in the tag to member table.
+ */
+static int search4tag(const void *ap, const void *bp)
+{
+    const asn_TYPE_tag2member_t *a = (const asn_TYPE_tag2member_t *)ap;
+    const asn_TYPE_tag2member_t *b = (const asn_TYPE_tag2member_t *)bp;
+
+    int a_class = BER_TAG_CLASS(a->el_tag);
+    int b_class = BER_TAG_CLASS(b->el_tag);
+
+    if (a_class == b_class)
+        {
+            ber_tlv_tag_t a_value = BER_TAG_VALUE(a->el_tag);
+            ber_tlv_tag_t b_value = BER_TAG_VALUE(b->el_tag);
+
+            if (a_value == b_value)
+                {
+                    return 0;
+                }
+            else if (a_value < b_value)
+                {
+                    return -1;
+                }
+            else
+                {
+                    return 1;
+                }
+        }
+    else if (a_class < b_class)
+        {
+            return -1;
+        }
+    else
+        {
+            return 1;
+        }
+}
+
+/*
+ * The decoder of the CHOICE type.
+ */
+asn_dec_rval_t CHOICE_decode_ber(asn_codec_ctx_t *opt_codec_ctx,
+    asn_TYPE_descriptor_t *td, void **struct_ptr,
+    const void *ptr, size_t size, int tag_mode)
+{
+    /*
+     * Bring closer parts of structure description.
+     */
+    asn_CHOICE_specifics_t *specs = (asn_CHOICE_specifics_t *)td->specifics;
+    asn_TYPE_member_t *elements = td->elements;
+
+    /*
+     * Parts of the structure being constructed.
+     */
+    void *st = *struct_ptr; /* Target structure. */
+    asn_struct_ctx_t *ctx;  /* Decoder context */
+
+    ber_tlv_tag_t tlv_tag; /* T from TLV */
+    ssize_t tag_len;       /* Length of TLV's T */
+    asn_dec_rval_t rval;   /* Return code from subparsers */
+
+    ssize_t consumed_myself = 0; /* Consumed bytes from ptr */
+
+    ASN_DEBUG("Decoding %s as CHOICE", td->name);
+
+    /*
+     * Create the target structure if it is not present already.
+     */
+    if (st == 0)
+        {
+            st = *struct_ptr = CALLOC(1, specs->struct_size);
+            if (st == 0)
+                {
+                    RETURN(RC_FAIL);
+                }
+        }
+
+    /*
+     * Restore parsing context.
+     */
+    ctx = (asn_struct_ctx_t *)((char *)st + specs->ctx_offset);
+
+    /*
+     * Start to parse where left previously
+     */
+    switch (ctx->phase)
+        {
+        case 0:
+            /*
+             * PHASE 0.
+             * Check that the set of tags associated with given structure
+             * perfectly fits our expectations.
+             */
+
+            if (tag_mode || td->tags_count)
+                {
+                    rval = ber_check_tags(opt_codec_ctx, td, ctx, ptr, size,
+                        tag_mode, -1, &ctx->left, 0);
+                    if (rval.code != RC_OK)
+                        {
+                            ASN_DEBUG("%s tagging check failed: %d",
+                                td->name, rval.code);
+                            return rval;
+                        }
+
+                    if (ctx->left >= 0)
+                        {
+                            /* ?Subtracted below! */
+                            ctx->left += rval.consumed;
+                        }
+                    ADVANCE(rval.consumed);
+                }
+            else
+                {
+                    ctx->left = -1;
+                }
+
+            NEXT_PHASE(ctx);
+
+            ASN_DEBUG("Structure consumes %ld bytes, buffer %ld",
+                (long)ctx->left, (long)size);
+
+            /* Fall through */
+        case 1:
+            /*
+             * Fetch the T from TLV.
+             */
+            tag_len = ber_fetch_tag(ptr, LEFT, &tlv_tag);
+            ASN_DEBUG("In %s CHOICE tag length %d", td->name, (int)tag_len);
+            switch (tag_len)
+                {
+                case 0:
+                    if (!SIZE_VIOLATION)
+                        {
+                            RETURN(RC_WMORE);
+                        }
+                    /* Fall through */
+                case -1:
+                    RETURN(RC_FAIL);
+                }
+
+            do
+                {
+                    asn_TYPE_tag2member_t *t2m;
+                    asn_TYPE_tag2member_t key;
+
+                    key.el_tag = tlv_tag;
+                    t2m = (asn_TYPE_tag2member_t *)bsearch(
+                        &key, specs->tag2el, specs->tag2el_count,
+                        sizeof(specs->tag2el[0]), search4tag);
+                    if (t2m)
+                        {
+                            /*
+                             * Found the element corresponding to the tag.
+                             */
+                            NEXT_PHASE(ctx);
+                            ctx->step = t2m->el_no;
+                            break;
+                        }
+                    else if (specs->ext_start == -1)
+                        {
+                            ASN_DEBUG(
+                                "Unexpected tag %s "
+                                "in non-extensible CHOICE %s",
+                                ber_tlv_tag_string(tlv_tag), td->name);
+                            RETURN(RC_FAIL);
+                        }
+                    else
+                        {
+                            /* Skip this tag */
+                            ssize_t skip;
+
+                            ASN_DEBUG("Skipping unknown tag %s",
+                                ber_tlv_tag_string(tlv_tag));
+
+                            skip = ber_skip_length(
+                                opt_codec_ctx, BER_TLV_CONSTRUCTED(ptr),
+                                (const char *)ptr + tag_len,
+                                LEFT - tag_len);
+
+                            switch (skip)
+                                {
+                                case 0:
+                                    if (!SIZE_VIOLATION)
+                                        {
+                                            RETURN(RC_WMORE);
+                                        }
+                                    /* Fall through */
+                                case -1:
+                                    RETURN(RC_FAIL);
+                                }
+
+                            ADVANCE(skip + tag_len);
+                            RETURN(RC_OK);
+                        }
+                }
+            while (0);
+
+        case 2:
+            /*
+             * PHASE 2.
+             * Read in the element.
+             */
+            do
+                {
+                    asn_TYPE_member_t *elm; /* CHOICE's element */
+                    void *memb_ptr;         /* Pointer to the member */
+                    void **memb_ptr2;       /* Pointer to that pointer */
+
+                    elm = &elements[ctx->step];
+
+                    /*
+                     * Compute the position of the member inside a
+                     * structure, and also a type of containment (it may be
+                     * contained as pointer or using inline inclusion).
+                     */
+                    if (elm->flags & ATF_POINTER)
+                        {
+                            /* Member is a pointer to another structure */
+                            memb_ptr2 =
+                                (void **)((char *)st + elm->memb_offset);
+                        }
+                    else
+                        {
+                            /*
+                             * A pointer to a pointer
+                             * holding the start of the structure
+                             */
+                            memb_ptr = (char *)st + elm->memb_offset;
+                            memb_ptr2 = &memb_ptr;
+                        }
+                    /* Set presence to be able to free it properly at any
+                     * time */
+                    set_present_idx(st, specs->pres_offset,
+                        specs->pres_size, ctx->step + 1);
+                    /*
+                     * Invoke the member fetch routine according to member's
+                     * type
+                     */
+                    rval = elm->type->ber_decoder(opt_codec_ctx, elm->type,
+                        memb_ptr2, ptr, LEFT,
+                        elm->tag_mode);
+                    switch (rval.code)
+                        {
+                        case RC_OK:
+                            break;
+                        case RC_WMORE: /* More data expected */
+                            if (!SIZE_VIOLATION)
+                                {
+                                    ADVANCE(rval.consumed);
+                                    RETURN(RC_WMORE);
+                                }
+                            RETURN(RC_FAIL);
+                        case RC_FAIL: /* Fatal error */
+                            RETURN(rval.code);
+                        } /* switch(rval) */
+
+                    ADVANCE(rval.consumed);
+                }
+            while (0);
+
+            NEXT_PHASE(ctx);
+
+            /* Fall through */
+        case 3:
+            ASN_DEBUG("CHOICE %s Leftover: %ld, size = %ld, tm=%d, tc=%d",
+                td->name, (long)ctx->left, (long)size, tag_mode,
+                td->tags_count);
+
+            if (ctx->left > 0)
+                {
+                    /*
+                     * The type must be fully decoded
+                     * by the CHOICE member-specific decoder.
+                     */
+                    RETURN(RC_FAIL);
+                }
+
+            if (ctx->left == -1 && !(tag_mode || td->tags_count))
+                {
+                    /*
+                     * This is an untagged CHOICE.
+                     * It doesn't contain nothing
+                     * except for the member itself, including all its tags.
+                     * The decoding is completed.
+                     */
+                    NEXT_PHASE(ctx);
+                    break;
+                }
+
+            /*
+             * Read in the "end of data chunks"'s.
+             */
+            while (ctx->left < 0)
+                {
+                    ssize_t tl;
+
+                    tl = ber_fetch_tag(ptr, LEFT, &tlv_tag);
+                    switch (tl)
+                        {
+                        case 0:
+                            if (!SIZE_VIOLATION)
+                                {
+                                    RETURN(RC_WMORE);
+                                }
+                            /* Fall through */
+                        case -1:
+                            RETURN(RC_FAIL);
+                        }
+
+                    /*
+                     * Expected <0><0>...
+                     */
+                    if (((const uint8_t *)ptr)[0] == 0)
+                        {
+                            if (LEFT < 2)
+                                {
+                                    if (SIZE_VIOLATION)
+                                        {
+                                            RETURN(RC_FAIL);
+                                        }
+                                    else
+                                        {
+                                            RETURN(RC_WMORE);
+                                        }
+                                }
+                            else if (((const uint8_t *)ptr)[1] == 0)
+                                {
+                                    /*
+                                     * Correctly finished with <0><0>.
+                                     */
+                                    ADVANCE(2);
+                                    ctx->left++;
+                                    continue;
+                                }
+                        }
+                    else
+                        {
+                            ASN_DEBUG("Unexpected continuation in %s",
+                                td->name);
+                            RETURN(RC_FAIL);
+                        }
+
+                    /* UNREACHABLE */
+                }
+
+            NEXT_PHASE(ctx);
+        case 4:
+            /* No meaningful work here */
+            break;
+        }
+
+    RETURN(RC_OK);
+}
+
+asn_enc_rval_t CHOICE_encode_der(asn_TYPE_descriptor_t *td, void *sptr,
+    int tag_mode, ber_tlv_tag_t tag,
+    asn_app_consume_bytes_f *cb, void *app_key)
+{
+    asn_CHOICE_specifics_t *specs = (asn_CHOICE_specifics_t *)td->specifics;
+    asn_TYPE_member_t *elm; /* CHOICE element */
+    asn_enc_rval_t erval;
+    void *memb_ptr;
+    size_t computed_size = 0;
+    int present;
+
+    if (!sptr)
+        {
+            _ASN_ENCODE_FAILED;
+        }
+
+    ASN_DEBUG("%s %s as CHOICE", cb ? "Encoding" : "Estimating", td->name);
+
+    present = fetch_present_idx(sptr, specs->pres_offset, specs->pres_size);
+
+    /*
+     * If the structure was not initialized, it cannot be encoded:
+     * can't deduce what to encode in the choice type.
+     */
+    if (present <= 0 || present > td->elements_count)
+        {
+            if (present == 0 && td->elements_count == 0)
+                {
+                    /* The CHOICE is empty?! */
+                    erval.encoded = 0;
+                    _ASN_ENCODED_OK(erval);
+                }
+            _ASN_ENCODE_FAILED;
+        }
+
+    /*
+     * Seek over the present member of the structure.
+     */
+    elm = &td->elements[present - 1];
+    if (elm->flags & ATF_POINTER)
+        {
+            memb_ptr = *(void **)((char *)sptr + elm->memb_offset);
+            if (memb_ptr == 0)
+                {
+                    if (elm->optional)
+                        {
+                            erval.encoded = 0;
+                            _ASN_ENCODED_OK(erval);
+                        }
+                    /* Mandatory element absent */
+                    _ASN_ENCODE_FAILED;
+                }
+        }
+    else
+        {
+            memb_ptr = (void *)((char *)sptr + elm->memb_offset);
+        }
+
+    /*
+     * If the CHOICE itself is tagged EXPLICIT:
+     * T ::= [2] EXPLICIT CHOICE { ... }
+     * Then emit the appropriate tags.
+     */
+    if (tag_mode == 1 || td->tags_count)
+        {
+            /*
+             * For this, we need to pre-compute the member.
+             */
+            ssize_t ret;
+
+            /* Encode member with its tag */
+            erval = elm->type->der_encoder(elm->type, memb_ptr, elm->tag_mode,
+                elm->tag, 0, 0);
+            if (erval.encoded == -1)
+                {
+                    return erval;
+                }
+
+            /* Encode CHOICE with parent or my own tag */
+            ret = der_write_tags(td, erval.encoded, tag_mode, 1, tag, cb,
+                app_key);
+            if (ret == -1)
+                {
+                    _ASN_ENCODE_FAILED;
+                }
+            computed_size += ret;
+        }
+
+    /*
+     * Encode the single underlying member.
+     */
+    erval = elm->type->der_encoder(elm->type, memb_ptr, elm->tag_mode, elm->tag,
+        cb, app_key);
+    if (erval.encoded == -1)
+        {
+            return erval;
+        }
+
+    ASN_DEBUG("Encoded CHOICE member in %ld bytes (+%ld)", (long)erval.encoded,
+        (long)computed_size);
+
+    erval.encoded += computed_size;
+
+    return erval;
+}
+
+ber_tlv_tag_t CHOICE_outmost_tag(asn_TYPE_descriptor_t *td, const void *ptr,
+    int tag_mode, ber_tlv_tag_t tag)
+{
+    asn_CHOICE_specifics_t *specs = (asn_CHOICE_specifics_t *)td->specifics;
+    int present;
+
+    assert(tag_mode == 0);
+    (void)tag_mode;
+    assert(tag == 0);
+    (void)tag;
+
+    /*
+     * Figure out which CHOICE element is encoded.
+     */
+    present = fetch_present_idx(ptr, specs->pres_offset, specs->pres_size);
+
+    if (present > 0 || present <= td->elements_count)
+        {
+            asn_TYPE_member_t *elm = &td->elements[present - 1];
+            const void *memb_ptr;
+
+            if (elm->flags & ATF_POINTER)
+                {
+                    memb_ptr = *(const void *const *)((const char *)ptr +
+                                                      elm->memb_offset);
+                }
+            else
+                {
+                    memb_ptr =
+                        (const void *)((const char *)ptr + elm->memb_offset);
+                }
+
+            return asn_TYPE_outmost_tag(elm->type, memb_ptr, elm->tag_mode,
+                elm->tag);
+        }
+    else
+        {
+            return (ber_tlv_tag_t)-1;
+        }
+}
+
+int CHOICE_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
+    asn_app_constraint_failed_f *ctfailcb, void *app_key)
+{
+    asn_CHOICE_specifics_t *specs = (asn_CHOICE_specifics_t *)td->specifics;
+    int present;
+
+    if (!sptr)
+        {
+            _ASN_CTFAIL(app_key, td, sptr, "%s: value not given (%s:%d)",
+                td->name, __FILE__, __LINE__);
+            return -1;
+        }
+
+    /*
+     * Figure out which CHOICE element is encoded.
+     */
+    present = fetch_present_idx(sptr, specs->pres_offset, specs->pres_size);
+    if (present > 0 && present <= td->elements_count)
+        {
+            asn_TYPE_member_t *elm = &td->elements[present - 1];
+            const void *memb_ptr;
+
+            if (elm->flags & ATF_POINTER)
+                {
+                    memb_ptr = *(const void *const *)((const char *)sptr +
+                                                      elm->memb_offset);
+                    if (!memb_ptr)
+                        {
+                            if (elm->optional)
+                                {
+                                    return 0;
+                                }
+                            _ASN_CTFAIL(app_key, td, sptr,
+                                "%s: mandatory CHOICE element %s "
+                                "absent (%s:%d)",
+                                td->name, elm->name, __FILE__,
+                                __LINE__);
+                            return -1;
+                        }
+                }
+            else
+                {
+                    memb_ptr =
+                        (const void *)((const char *)sptr + elm->memb_offset);
+                }
+
+            if (elm->memb_constraints)
+                {
+                    return elm->memb_constraints(elm->type, memb_ptr, ctfailcb,
+                        app_key);
+                }
+            else
+                {
+                    int ret = elm->type->check_constraints(elm->type, memb_ptr,
+                        ctfailcb, app_key);
+                    /*
+                     * Cannot inherit it eralier:
+                     * need to make sure we get the updated version.
+                     */
+                    elm->memb_constraints = elm->type->check_constraints;
+                    return ret;
+                }
+        }
+    else
+        {
+            _ASN_CTFAIL(app_key, td, sptr,
+                "%s: no CHOICE element given (%s:%d)", td->name,
+                __FILE__, __LINE__);
+            return -1;
+        }
+}
+
+#undef XER_ADVANCE
+#define XER_ADVANCE(num_bytes)                       \
+    do                                               \
+        {                                            \
+            size_t num = num_bytes;                  \
+            buf_ptr = ((const char *)buf_ptr) + num; \
+            size -= num;                             \
+            consumed_myself += num;                  \
+        }                                            \
+    while (0)
+
+/*
+ * Decode the XER (XML) data.
+ */
+asn_dec_rval_t CHOICE_decode_xer(asn_codec_ctx_t *opt_codec_ctx,
+    asn_TYPE_descriptor_t *td, void **struct_ptr,
+    const char *opt_mname, const void *buf_ptr,
+    size_t size)
+{
+    /*
+     * Bring closer parts of structure description.
+     */
+    asn_CHOICE_specifics_t *specs = (asn_CHOICE_specifics_t *)td->specifics;
+    const char *xml_tag = opt_mname ? opt_mname : td->xml_tag;
+
+    /*
+     * Parts of the structure being constructed.
+     */
+    void *st = *struct_ptr; /* Target structure. */
+    asn_struct_ctx_t *ctx;  /* Decoder context */
+
+    asn_dec_rval_t rval;         /* Return value of a decoder */
+    ssize_t consumed_myself = 0; /* Consumed bytes from ptr */
+    int edx;                     /* Element index */
+
+    /*
+     * Create the target structure if it is not present already.
+     */
+    if (st == 0)
+        {
+            st = *struct_ptr = CALLOC(1, specs->struct_size);
+            if (st == 0)
+                {
+                    RETURN(RC_FAIL);
+                }
+        }
+
+    /*
+     * Restore parsing context.
+     */
+    ctx = (asn_struct_ctx_t *)((char *)st + specs->ctx_offset);
+    if (ctx->phase == 0 && !*xml_tag)
+        {
+            ctx->phase = 1; /* Skip the outer tag checking phase */
+        }
+
+    /*
+     * Phases of XER/XML processing:
+     * Phase 0: Check that the opening tag matches our expectations.
+     * Phase 1: Processing body and reacting on closing tag.
+     * Phase 2: Processing inner type.
+     * Phase 3: Only waiting for closing tag.
+     * Phase 4: Skipping unknown extensions.
+     * Phase 5: PHASED OUT
+     */
+    for (edx = ctx->step; ctx->phase <= 4;)
+        {
+            pxer_chunk_type_e ch_type; /* XER chunk type */
+            ssize_t ch_size;           /* Chunk size */
+            xer_check_tag_e tcv;       /* Tag check value */
+            asn_TYPE_member_t *elm;
+
+            /*
+             * Go inside the member.
+             */
+            if (ctx->phase == 2)
+                {
+                    asn_dec_rval_t tmprval;
+                    void *memb_ptr;   /* Pointer to the member */
+                    void **memb_ptr2; /* Pointer to that pointer */
+
+                    elm = &td->elements[edx];
+
+                    if (elm->flags & ATF_POINTER)
+                        {
+                            /* Member is a pointer to another structure */
+                            memb_ptr2 =
+                                (void **)((char *)st + elm->memb_offset);
+                        }
+                    else
+                        {
+                            memb_ptr = (char *)st + elm->memb_offset;
+                            memb_ptr2 = &memb_ptr;
+                        }
+
+                    /* Start/Continue decoding the inner member */
+                    tmprval = elm->type->xer_decoder(opt_codec_ctx, elm->type,
+                        memb_ptr2, elm->name,
+                        buf_ptr, size);
+                    XER_ADVANCE(tmprval.consumed);
+                    ASN_DEBUG("XER/CHOICE: itdf: [%s] code=%d", elm->type->name,
+                        tmprval.code);
+                    if (tmprval.code != RC_OK)
+                        {
+                            RETURN(tmprval.code);
+                        }
+                    assert(fetch_present_idx(st, specs->pres_offset,
+                               specs->pres_size) == 0);
+                    /* Record what we've got */
+                    set_present_idx(st, specs->pres_offset, specs->pres_size,
+                        edx + 1);
+                    ctx->phase = 3;
+                    /* Fall through */
+                }
+
+            /* No need to wait for closing tag; special mode. */
+            if (ctx->phase == 3 && !*xml_tag)
+                {
+                    ctx->phase = 5; /* Phase out */
+                    RETURN(RC_OK);
+                }
+
+            /*
+             * Get the next part of the XML stream.
+             */
+            ch_size = xer_next_token(&ctx->context, buf_ptr, size, &ch_type);
+            switch (ch_size)
+                {
+                case -1:
+                    RETURN(RC_FAIL);
+                case 0:
+                    RETURN(RC_WMORE);
+                default:
+                    switch (ch_type)
+                        {
+                        case PXER_COMMENT:        /* Got XML comment */
+                        case PXER_TEXT:           /* Ignore free-standing text */
+                            XER_ADVANCE(ch_size); /* Skip silently */
+                            continue;
+                        case PXER_TAG:
+                            break; /* Check the rest down there */
+                        }
+                }
+
+            tcv = xer_check_tag(buf_ptr, ch_size, xml_tag);
+            ASN_DEBUG("XER/CHOICE checked [%c%c%c%c] vs [%s], tcv=%d",
+                ch_size > 0 ? ((const uint8_t *)buf_ptr)[0] : '?',
+                ch_size > 1 ? ((const uint8_t *)buf_ptr)[1] : '?',
+                ch_size > 2 ? ((const uint8_t *)buf_ptr)[2] : '?',
+                ch_size > 3 ? ((const uint8_t *)buf_ptr)[3] : '?',
+                xml_tag, tcv);
+
+            /* Skip the extensions section */
+            if (ctx->phase == 4)
+                {
+                    ASN_DEBUG("skip_unknown(%d, %ld)", tcv, (long)ctx->left);
+                    switch (xer_skip_unknown(tcv, &ctx->left))
+                        {
+                        case -1:
+                            ctx->phase = 5;
+                            RETURN(RC_FAIL);
+                            continue;
+                        case 1:
+                            ctx->phase = 3;
+                            /* Fall through */
+                        case 0:
+                            XER_ADVANCE(ch_size);
+                            continue;
+                        case 2:
+                            ctx->phase = 3;
+                            break;
+                        }
+                }
+
+            switch (tcv)
+                {
+                case XCT_BOTH:
+                    break; /* No CHOICE? */
+                case XCT_CLOSING:
+                    if (ctx->phase != 3)
+                        {
+                            break;
+                        }
+                    XER_ADVANCE(ch_size);
+                    ctx->phase = 5; /* Phase out */
+                    RETURN(RC_OK);
+                case XCT_OPENING:
+                    if (ctx->phase == 0)
+                        {
+                            XER_ADVANCE(ch_size);
+                            ctx->phase = 1; /* Processing body phase */
+                            continue;
+                        }
+                    /* Fall through */
+                case XCT_UNKNOWN_OP:
+                case XCT_UNKNOWN_BO:
+
+                    if (ctx->phase != 1)
+                        {
+                            break; /* Really unexpected */
+                        }
+
+                    /*
+                     * Search which inner member corresponds to this tag.
+                     */
+                    for (edx = 0; edx < td->elements_count; edx++)
+                        {
+                            elm = &td->elements[edx];
+                            tcv =
+                                xer_check_tag(buf_ptr, ch_size, elm->name);
+                            switch (tcv)
+                                {
+                                case XCT_BOTH:
+                                case XCT_OPENING:
+                                    /*
+                                     * Process this member.
+                                     */
+                                    ctx->step = edx;
+                                    ctx->phase = 2;
+                                    break;
+                                case XCT_UNKNOWN_OP:
+                                case XCT_UNKNOWN_BO:
+                                    continue;
+                                default:
+                                    edx = td->elements_count;
+                                    break; /* Phase out */
+                                }
+                            break;
+                        }
+                    if (edx != td->elements_count)
+                        {
+                            continue;
+                        }
+
+                    /* It is expected extension */
+                    if (specs->ext_start != -1)
+                        {
+                            ASN_DEBUG("Got anticipated extension");
+                            /*
+                             * Check for (XCT_BOTH or XCT_UNKNOWN_BO)
+                             * By using a mask. Only record a pure
+                             * <opening> tags.
+                             */
+                            if (tcv & XCT_CLOSING)
+                                {
+                                    /* Found </extension> without body */
+                                    ctx->phase = 3; /* Terminating */
+                                }
+                            else
+                                {
+                                    ctx->left = 1;
+                                    ctx->phase = 4; /* Skip ...'s */
+                                }
+                            XER_ADVANCE(ch_size);
+                            continue;
+                        }
+
+                    /* Fall through */
+                default:
+                    break;
+                }
+
+            ASN_DEBUG(
+                "Unexpected XML tag [%c%c%c%c] in CHOICE [%s]"
+                " (ph=%d, tag=%s)",
+                ch_size > 0 ? ((const uint8_t *)buf_ptr)[0] : '?',
+                ch_size > 1 ? ((const uint8_t *)buf_ptr)[1] : '?',
+                ch_size > 2 ? ((const uint8_t *)buf_ptr)[2] : '?',
+                ch_size > 3 ? ((const uint8_t *)buf_ptr)[3] : '?', td->name,
+                ctx->phase, xml_tag);
+            break;
+        }
+
+    ctx->phase = 5; /* Phase out, just in case */
+    RETURN(RC_FAIL);
+}
+
+asn_enc_rval_t CHOICE_encode_xer(asn_TYPE_descriptor_t *td, void *sptr,
+    int ilevel, enum xer_encoder_flags_e flags,
+    asn_app_consume_bytes_f *cb, void *app_key)
+{
+    asn_CHOICE_specifics_t *specs = (asn_CHOICE_specifics_t *)td->specifics;
+    asn_enc_rval_t er;
+    int present;
+
+    if (!sptr)
+        {
+            _ASN_ENCODE_FAILED;
+        }
+
+    /*
+     * Figure out which CHOICE element is encoded.
+     */
+    present = fetch_present_idx(sptr, specs->pres_offset, specs->pres_size);
+
+    if (present <= 0 || present > td->elements_count)
+        {
+            _ASN_ENCODE_FAILED;
+        }
+    else
+        {
+            asn_enc_rval_t tmper;
+            asn_TYPE_member_t *elm = &td->elements[present - 1];
+            void *memb_ptr;
+            const char *mname = elm->name;
+            unsigned int mlen = strlen(mname);
+
+            if (elm->flags & ATF_POINTER)
+                {
+                    memb_ptr = *(void **)((char *)sptr + elm->memb_offset);
+                    if (!memb_ptr)
+                        {
+                            _ASN_ENCODE_FAILED;
+                        }
+                }
+            else
+                {
+                    memb_ptr = (void *)((char *)sptr + elm->memb_offset);
+                }
+
+            er.encoded = 0;
+
+            if (!(flags & XER_F_CANONICAL))
+                {
+                    _i_ASN_TEXT_INDENT(1, ilevel);
+                }
+            _ASN_CALLBACK3("<", 1, mname, mlen, ">", 1);
+
+            tmper = elm->type->xer_encoder(elm->type, memb_ptr, ilevel + 1,
+                flags, cb, app_key);
+            if (tmper.encoded == -1)
+                {
+                    return tmper;
+                }
+
+            _ASN_CALLBACK3("</", 2, mname, mlen, ">", 1);
+
+            er.encoded += 5 + (2 * mlen) + tmper.encoded;
+        }
+
+    if (!(flags & XER_F_CANONICAL))
+        {
+            _i_ASN_TEXT_INDENT(1, ilevel - 1);
+        }
+
+    _ASN_ENCODED_OK(er);
+cb_failed:
+    _ASN_ENCODE_FAILED;
+}
+
+asn_dec_rval_t CHOICE_decode_uper(asn_codec_ctx_t *opt_codec_ctx,
+    asn_TYPE_descriptor_t *td,
+    asn_per_constraints_t *constraints,
+    void **sptr, asn_per_data_t *pd)
+{
+    asn_CHOICE_specifics_t *specs = (asn_CHOICE_specifics_t *)td->specifics;
+    asn_dec_rval_t rv;
+    asn_per_constraint_t *ct;
+    asn_TYPE_member_t *elm; /* CHOICE's element */
+    void *memb_ptr;
+    void **memb_ptr2;
+    void *st = *sptr;
+    int value;
+
+    if (_ASN_STACK_OVERFLOW_CHECK(opt_codec_ctx))
+        {
+            _ASN_DECODE_FAILED;
+        }
+
+    /*
+     * Create the target structure if it is not present already.
+     */
+    if (!st)
+        {
+            st = *sptr = CALLOC(1, specs->struct_size);
+            if (!st)
+                {
+                    _ASN_DECODE_FAILED;
+                }
+        }
+
+    if (constraints)
+        {
+            ct = &constraints->value;
+        }
+    else if (td->per_constraints)
+        {
+            ct = &td->per_constraints->value;
+        }
+    else
+        {
+            ct = 0;
+        }
+
+    if (ct && ct->flags & APC_EXTENSIBLE)
+        {
+            value = per_get_few_bits(pd, 1);
+            if (value < 0)
+                {
+                    _ASN_DECODE_STARVED;
+                }
+            if (value)
+                {
+                    ct = 0; /* Not restricted */
+                }
+        }
+
+    if (ct && ct->range_bits >= 0)
+        {
+            value = per_get_few_bits(pd, ct->range_bits);
+            if (value < 0)
+                {
+                    _ASN_DECODE_STARVED;
+                }
+            ASN_DEBUG("CHOICE %s got index %d in range %d", td->name, value,
+                ct->range_bits);
+            if (value > ct->upper_bound)
+                {
+                    _ASN_DECODE_FAILED;
+                }
+        }
+    else
+        {
+            if (specs->ext_start == -1)
+                {
+                    _ASN_DECODE_FAILED;
+                }
+            value = uper_get_nsnnwn(pd);
+            if (value < 0)
+                {
+                    _ASN_DECODE_STARVED;
+                }
+            value += specs->ext_start;
+            if (value >= td->elements_count)
+                {
+                    _ASN_DECODE_FAILED;
+                }
+        }
+
+    /* Adjust if canonical order is different from natural order */
+    if (specs->canonical_order)
+        {
+            value = specs->canonical_order[value];
+        }
+
+    /* Set presence to be able to free it later */
+    set_present_idx(st, specs->pres_offset, specs->pres_size, value + 1);
+
+    elm = &td->elements[value];
+    if (elm->flags & ATF_POINTER)
+        {
+            /* Member is a pointer to another structure */
+            memb_ptr2 = (void **)((char *)st + elm->memb_offset);
+        }
+    else
+        {
+            memb_ptr = (char *)st + elm->memb_offset;
+            memb_ptr2 = &memb_ptr;
+        }
+    ASN_DEBUG("Discovered CHOICE %s encodes %s", td->name, elm->name);
+
+    if (ct && ct->range_bits >= 0)
+        {
+            rv = elm->type->uper_decoder(opt_codec_ctx, elm->type,
+                elm->per_constraints, memb_ptr2, pd);
+        }
+    else
+        {
+            rv = uper_open_type_get(opt_codec_ctx, elm->type,
+                elm->per_constraints, memb_ptr2, pd);
+        }
+
+    if (rv.code != RC_OK)
+        {
+            ASN_DEBUG("Failed to decode %s in %s (CHOICE) %d", elm->name, td->name,
+                rv.code);
+        }
+    return rv;
+}
+
+asn_enc_rval_t CHOICE_encode_uper(asn_TYPE_descriptor_t *td,
+    asn_per_constraints_t *constraints,
+    void *sptr, asn_per_outp_t *po)
+{
+    asn_CHOICE_specifics_t *specs = (asn_CHOICE_specifics_t *)td->specifics;
+    asn_TYPE_member_t *elm; /* CHOICE's element */
+    asn_per_constraint_t *ct;
+    void *memb_ptr;
+    int present;
+
+    if (!sptr)
+        {
+            _ASN_ENCODE_FAILED;
+        }
+
+    ASN_DEBUG("Encoding %s as CHOICE", td->name);
+
+    if (constraints)
+        {
+            ct = &constraints->value;
+        }
+    else if (td->per_constraints)
+        {
+            ct = &td->per_constraints->value;
+        }
+    else
+        {
+            ct = 0;
+        }
+
+    present = fetch_present_idx(sptr, specs->pres_offset, specs->pres_size);
+
+    /*
+     * If the structure was not initialized properly, it cannot be encoded:
+     * can't deduce what to encode in the choice type.
+     */
+    if (present <= 0 || present > td->elements_count)
+        {
+            _ASN_ENCODE_FAILED;
+        }
+    else
+        {
+            present--;
+        }
+
+    /* Adjust if canonical order is different from natural order */
+    if (specs->canonical_order)
+        {
+            present = specs->canonical_order[present];
+        }
+
+    ASN_DEBUG("Encoding %s CHOICE element %d", td->name, present);
+
+    if (ct && ct->range_bits >= 0)
+        {
+            if (present < ct->lower_bound || present > ct->upper_bound)
+                {
+                    if (ct->flags & APC_EXTENSIBLE)
+                        {
+                            if (per_put_few_bits(po, 1, 1))
+                                {
+                                    _ASN_ENCODE_FAILED;
+                                }
+                        }
+                    else
+                        {
+                            _ASN_ENCODE_FAILED;
+                        }
+                    ct = 0;
+                }
+        }
+    if (ct && ct->flags & APC_EXTENSIBLE)
+        {
+            if (per_put_few_bits(po, 0, 1))
+                {
+                    _ASN_ENCODE_FAILED;
+                }
+        }
+
+    elm = &td->elements[present];
+    if (elm->flags & ATF_POINTER)
+        {
+            /* Member is a pointer to another structure */
+            memb_ptr = *(void **)((char *)sptr + elm->memb_offset);
+            if (!memb_ptr)
+                {
+                    _ASN_ENCODE_FAILED;
+                }
+        }
+    else
+        {
+            memb_ptr = (char *)sptr + elm->memb_offset;
+        }
+
+    if (ct && ct->range_bits >= 0)
+        {
+            if (per_put_few_bits(po, present, ct->range_bits))
+                {
+                    _ASN_ENCODE_FAILED;
+                }
+
+            return elm->type->uper_encoder(elm->type, elm->per_constraints,
+                memb_ptr, po);
+        }
+    else
+        {
+            asn_enc_rval_t rval;
+            if (specs->ext_start == -1)
+                {
+                    _ASN_ENCODE_FAILED;
+                }
+            if (uper_put_nsnnwn(po, present - specs->ext_start))
+                {
+                    _ASN_ENCODE_FAILED;
+                }
+            if (uper_open_type_put(elm->type, elm->per_constraints, memb_ptr,
+                    po))
+                {
+                    _ASN_ENCODE_FAILED;
+                }
+            rval.encoded = 0;
+            _ASN_ENCODED_OK(rval);
+        }
+}
+
+int CHOICE_print(asn_TYPE_descriptor_t *td, const void *sptr, int ilevel,
+    asn_app_consume_bytes_f *cb, void *app_key)
+{
+    asn_CHOICE_specifics_t *specs = (asn_CHOICE_specifics_t *)td->specifics;
+    int present;
+
+    if (!sptr)
+        {
+            return (cb("<absent>", 8, app_key) < 0) ? -1 : 0;
+        }
+
+    /*
+     * Figure out which CHOICE element is encoded.
+     */
+    present = fetch_present_idx(sptr, specs->pres_offset, specs->pres_size);
+
+    /*
+     * Print that element.
+     */
+    if (present > 0 && present <= td->elements_count)
+        {
+            asn_TYPE_member_t *elm = &td->elements[present - 1];
+            const void *memb_ptr;
+
+            if (elm->flags & ATF_POINTER)
+                {
+                    memb_ptr = *(const void *const *)((const char *)sptr +
+                                                      elm->memb_offset);
+                    if (!memb_ptr)
+                        {
+                            return (cb("<absent>", 8, app_key) < 0) ? -1 : 0;
+                        }
+                }
+            else
+                {
+                    memb_ptr =
+                        (const void *)((const char *)sptr + elm->memb_offset);
+                }
+
+            /* Print member's name and stuff */
+            if (0)
+                {
+                    if (cb(elm->name, strlen(elm->name), app_key) < 0 ||
+                        cb(": ", 2, app_key) < 0)
+                        {
+                            return -1;
+                        }
+                }
+
+            return elm->type->print_struct(elm->type, memb_ptr, ilevel, cb,
+                app_key);
+        }
+    else
+        {
+            return (cb("<absent>", 8, app_key) < 0) ? -1 : 0;
+        }
+}
+
+void CHOICE_free(asn_TYPE_descriptor_t *td, void *ptr, int contents_only)
+{
+    asn_CHOICE_specifics_t *specs = (asn_CHOICE_specifics_t *)td->specifics;
+    int present;
+
+    if (!td || !ptr)
+        {
+            return;
+        }
+
+    ASN_DEBUG("Freeing %s as CHOICE", td->name);
+
+    /*
+     * Figure out which CHOICE element is encoded.
+     */
+    present = fetch_present_idx(ptr, specs->pres_offset, specs->pres_size);
+
+    /*
+     * Free that element.
+     */
+    if (present > 0 && present <= td->elements_count)
+        {
+            asn_TYPE_member_t *elm = &td->elements[present - 1];
+            void *memb_ptr;
+
+            if (elm->flags & ATF_POINTER)
+                {
+                    memb_ptr = *(void **)((char *)ptr + elm->memb_offset);
+                    if (memb_ptr)
+                        {
+                            ASN_STRUCT_FREE(*elm->type, memb_ptr);
+                        }
+                }
+            else
+                {
+                    memb_ptr = (void *)((char *)ptr + elm->memb_offset);
+                    ASN_STRUCT_FREE_CONTENTS_ONLY(*elm->type, memb_ptr);
+                }
+        }
+
+    if (!contents_only)
+        {
+            FREEMEM(ptr);
+        }
+}
+
+/*
+ * The following functions functions offer protection against -fshort-enums,
+ * compatible with little- and big-endian machines.
+ * If assertion is triggered, either disable -fshort-enums, or add an entry
+ * here with the ->pres_size of your target stracture.
+ * Unless the target structure is packed, the ".present" member
+ * is guaranteed to be aligned properly. ASN.1 compiler itself does not
+ * produce packed code.
+ */
+static int fetch_present_idx(const void *struct_ptr, int pres_offset,
+    int pres_size)
+{
+    const void *present_ptr;
+    int present;
+
+    present_ptr = ((const char *)struct_ptr) + pres_offset;
+
+    switch (pres_size)
+        {
+        case sizeof(int):
+            present = *(const int *)present_ptr;
+            break;
+        case sizeof(short):
+            present = *(const short *)present_ptr;
+            break;
+        case sizeof(char):
+            present = *(const char *)present_ptr;
+            break;
+        default:
+            /* ANSI C mandates enum to be equivalent to integer */
+            assert(pres_size != sizeof(int));
+            return 0; /* If not aborted, pass back safe value */
+        }
+
+    return present;
+}
+
+static void set_present_idx(void *struct_ptr, int pres_offset, int pres_size,
+    int present)
+{
+    void *present_ptr;
+    present_ptr = ((char *)struct_ptr) + pres_offset;
+
+    switch (pres_size)
+        {
+        case sizeof(int):
+            *(int *)present_ptr = present;
+            break;
+        case sizeof(short):
+            *(short *)present_ptr = present;
+            break;
+        case sizeof(char):
+            *(char *)present_ptr = present;
+            break;
+        default:
+            /* ANSI C mandates enum to be equivalent to integer */
+            assert(pres_size != sizeof(int));
+        }
+}

--- a/src/core/libs/supl/types/constr_CHOICE.h
+++ b/src/core/libs/supl/types/constr_CHOICE.h
@@ -1,0 +1,58 @@
+/*-
+ * SPDX-FileCopyrightText: (c) 2003, 2004 Lev Walkin <vlm@lionet.info>. All rights reserved.
+ * SPDX-License-Identifier: BSD-1-Clause
+ */
+#ifndef _CONSTR_CHOICE_H
+#define _CONSTR_CHOICE_H
+
+#include <asn_application.h>
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+    typedef struct asn_CHOICE_specifics_s
+    {
+        /*
+         * Target structure description.
+         */
+        int struct_size; /* Size of the target structure. */
+        int ctx_offset;  /* Offset of the asn_codec_ctx_t member */
+        int pres_offset; /* Identifier of the present member */
+        int pres_size;   /* Size of the identifier (enum) */
+
+        /*
+         * Tags to members mapping table.
+         */
+        asn_TYPE_tag2member_t *tag2el;
+        int tag2el_count;
+
+        /* Canonical ordering of CHOICE elements, for PER */
+        int *canonical_order;
+
+        /*
+         * Extensions-related stuff.
+         */
+        int ext_start; /* First member of extensions, or -1 */
+    } asn_CHOICE_specifics_t;
+
+    /*
+     * A set specialized functions dealing with the CHOICE type.
+     */
+    asn_struct_free_f CHOICE_free;
+    asn_struct_print_f CHOICE_print;
+    asn_constr_check_f CHOICE_constraint;
+    ber_type_decoder_f CHOICE_decode_ber;
+    der_type_encoder_f CHOICE_encode_der;
+    xer_type_decoder_f CHOICE_decode_xer;
+    xer_type_encoder_f CHOICE_encode_xer;
+    per_type_decoder_f CHOICE_decode_uper;
+    per_type_encoder_f CHOICE_encode_uper;
+    asn_outmost_tag_f CHOICE_outmost_tag;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* _CONSTR_CHOICE_H_ */

--- a/src/core/libs/supl/types/constr_SEQUENCE.c
+++ b/src/core/libs/supl/types/constr_SEQUENCE.c
@@ -1,0 +1,1782 @@
+/*-
+ * SPDX-FileCopyrightText: (c) 2003, 2004 Lev Walkin <vlm@lionet.info>. All rights reserved.
+ * SPDX-License-Identifier: BSD-1-Clause
+ */
+#include <asn_internal.h>
+#include <constr_SEQUENCE.h>
+#include <per_opentype.h>
+
+/*
+ * Number of bytes left for this structure.
+ * (ctx->left) indicates the number of bytes _transferred_ for the structure.
+ * (size) contains the number of bytes in the buffer passed.
+ */
+#define LEFT ((size < (size_t)ctx->left) ? size : (size_t)ctx->left)
+
+/*
+ * If the subprocessor function returns with an indication that it wants
+ * more data, it may well be a fatal decoding problem, because the
+ * size is constrained by the <TLV>'s L, even if the buffer size allows
+ * reading more data.
+ * For example, consider the buffer containing the following TLVs:
+ * <T:5><L:1><V> <T:6>...
+ * The TLV length clearly indicates that one byte is expected in V, but
+ * if the V processor returns with "want more data" even if the buffer
+ * contains way more data than the V processor have seen.
+ */
+#define SIZE_VIOLATION (ctx->left >= 0 && (size_t)ctx->left <= size)
+
+/*
+ * This macro "eats" the part of the buffer which is definitely "consumed",
+ * i.e. was correctly converted into local representation or rightfully skipped.
+ */
+#undef ADVANCE
+#define ADVANCE(num_bytes)                        \
+    do                                            \
+        {                                         \
+            size_t num = num_bytes;               \
+            ptr = ((const char *)ptr) + num;      \
+            size -= num;                          \
+            if (ctx->left >= 0) ctx->left -= num; \
+            consumed_myself += num;               \
+        }                                         \
+    while (0)
+
+/*
+ * Switch to the next phase of parsing.
+ */
+#undef NEXT_PHASE
+#undef PHASE_OUT
+#define NEXT_PHASE(ctx)      \
+    do                       \
+        {                    \
+            (ctx)->phase++;  \
+            (ctx)->step = 0; \
+        }                    \
+    while (0)
+#define PHASE_OUT(ctx)         \
+    do                         \
+        {                      \
+            (ctx)->phase = 10; \
+        }                      \
+    while (0)
+
+/*
+ * Return a standardized complex structure.
+ */
+#undef RETURN
+#define RETURN(_code)                        \
+    do                                       \
+        {                                    \
+            rval.code = _code;               \
+            rval.consumed = consumed_myself; \
+            return rval;                     \
+        }                                    \
+    while (0)
+
+/*
+ * Check whether we are inside the extensions group.
+ */
+#define IN_EXTENSION_GROUP(specs, memb_idx) \
+    (((memb_idx) > (specs)->ext_after) && ((memb_idx) < (specs)->ext_before))
+
+/*
+ * Tags are canonically sorted in the tag2element map.
+ */
+static int t2e_cmp(const void *ap, const void *bp)
+{
+    const asn_TYPE_tag2member_t *a = (const asn_TYPE_tag2member_t *)ap;
+    const asn_TYPE_tag2member_t *b = (const asn_TYPE_tag2member_t *)bp;
+
+    int a_class = BER_TAG_CLASS(a->el_tag);
+    int b_class = BER_TAG_CLASS(b->el_tag);
+
+    if (a_class == b_class)
+        {
+            ber_tlv_tag_t a_value = BER_TAG_VALUE(a->el_tag);
+            ber_tlv_tag_t b_value = BER_TAG_VALUE(b->el_tag);
+
+            if (a_value == b_value)
+                {
+                    if (a->el_no > b->el_no)
+                        {
+                            return 1;
+                        }
+                    /*
+                     * Important: we do not check
+                     * for a->el_no <= b->el_no!
+                     */
+                    return 0;
+                }
+            else if (a_value < b_value)
+                {
+                    return -1;
+                }
+            else
+                {
+                    return 1;
+                }
+        }
+    else if (a_class < b_class)
+        {
+            return -1;
+        }
+    else
+        {
+            return 1;
+        }
+}
+
+/*
+ * The decoder of the SEQUENCE type.
+ */
+asn_dec_rval_t SEQUENCE_decode_ber(asn_codec_ctx_t *opt_codec_ctx,
+    asn_TYPE_descriptor_t *td, void **struct_ptr,
+    const void *ptr, size_t size, int tag_mode)
+{
+    /*
+     * Bring closer parts of structure description.
+     */
+    asn_SEQUENCE_specifics_t *specs = (asn_SEQUENCE_specifics_t *)td->specifics;
+    asn_TYPE_member_t *elements = td->elements;
+
+    /*
+     * Parts of the structure being constructed.
+     */
+    void *st = *struct_ptr; /* Target structure. */
+    asn_struct_ctx_t *ctx;  /* Decoder context */
+
+    ber_tlv_tag_t tlv_tag; /* T from TLV */
+    asn_dec_rval_t rval;   /* Return code from subparsers */
+
+    ssize_t consumed_myself = 0; /* Consumed bytes from ptr */
+    int edx;                     /* SEQUENCE element's index */
+
+    ASN_DEBUG("Decoding %s as SEQUENCE", td->name);
+
+    /*
+     * Create the target structure if it is not present already.
+     */
+    if (st == 0)
+        {
+            st = *struct_ptr = CALLOC(1, specs->struct_size);
+            if (st == 0)
+                {
+                    RETURN(RC_FAIL);
+                }
+        }
+
+    /*
+     * Restore parsing context.
+     */
+    ctx = (asn_struct_ctx_t *)((char *)st + specs->ctx_offset);
+
+    /*
+     * Start to parse where left previously
+     */
+    switch (ctx->phase)
+        {
+        case 0:
+            /*
+             * PHASE 0.
+             * Check that the set of tags associated with given structure
+             * perfectly fits our expectations.
+             */
+
+            rval = ber_check_tags(opt_codec_ctx, td, ctx, ptr, size,
+                tag_mode, 1, &ctx->left, 0);
+            if (rval.code != RC_OK)
+                {
+                    ASN_DEBUG("%s tagging check failed: %d", td->name,
+                        rval.code);
+                    return rval;
+                }
+
+            if (ctx->left >= 0)
+                {
+                    ctx->left += rval.consumed; /* ?Subtracted below! */
+                }
+            ADVANCE(rval.consumed);
+
+            NEXT_PHASE(ctx);
+
+            ASN_DEBUG("Structure consumes %ld bytes, buffer %ld",
+                (long)ctx->left, (long)size);
+
+            /* Fall through */
+        case 1:
+            /*
+             * PHASE 1.
+             * From the place where we've left it previously,
+             * try to decode the next member from the list of
+             * this structure's elements.
+             * (ctx->step) stores the member being processed
+             * between invocations and the microphase {0,1} of parsing
+             * that member:
+             *     step = (<member_number> * 2 + <microphase>).
+             */
+            for (edx = (ctx->step >> 1); edx < td->elements_count;
+                 edx++, ctx->step = (ctx->step & ~1) + 2)
+                {
+                    void *memb_ptr;   /* Pointer to the member */
+                    void **memb_ptr2; /* Pointer to that pointer */
+                    ssize_t tag_len;  /* Length of TLV's T */
+                    int opt_edx_end;  /* Next non-optional element */
+                    int use_bsearch;
+                    int n;
+
+                    if (ctx->step & 1)
+                        {
+                            goto microphase2;
+                        }
+
+                    /*
+                     * MICROPHASE 1: Synchronize decoding.
+                     */
+                    ASN_DEBUG(
+                        "In %s SEQUENCE left %d, edx=%d flags=%d"
+                        " opt=%d ec=%d",
+                        td->name, (int)ctx->left, edx, elements[edx].flags,
+                        elements[edx].optional, td->elements_count);
+
+                    if (ctx->left == 0 /* No more stuff is expected */
+                        && (
+                               /* Explicit OPTIONAL specification reaches
+                                      the end */
+                               (edx + elements[edx].optional ==
+                                   td->elements_count) ||
+                               /* All extensions are optional */
+                               (IN_EXTENSION_GROUP(specs, edx) &&
+                                   specs->ext_before > td->elements_count)))
+                        {
+                            ASN_DEBUG("End of SEQUENCE %s", td->name);
+                            /*
+                             * Found the legitimate end of the structure.
+                             */
+                            PHASE_OUT(ctx);
+                            RETURN(RC_OK);
+                        }
+
+                    /*
+                     * Fetch the T from TLV.
+                     */
+                    tag_len = ber_fetch_tag(ptr, LEFT, &tlv_tag);
+                    ASN_DEBUG(
+                        "Current tag in %s SEQUENCE for element %d "
+                        "(%s) is %s encoded in %d bytes, of frame %ld",
+                        td->name, edx, elements[edx].name,
+                        ber_tlv_tag_string(tlv_tag), (int)tag_len,
+                        (long)LEFT);
+                    switch (tag_len)
+                        {
+                        case 0:
+                            if (!SIZE_VIOLATION)
+                                {
+                                    RETURN(RC_WMORE);
+                                }
+                            /* Fall through */
+                        case -1:
+                            RETURN(RC_FAIL);
+                        }
+
+                    if (ctx->left < 0 && ((const uint8_t *)ptr)[0] == 0)
+                        {
+                            if (LEFT < 2)
+                                {
+                                    if (SIZE_VIOLATION)
+                                        {
+                                            RETURN(RC_FAIL);
+                                        }
+                                    else
+                                        {
+                                            RETURN(RC_WMORE);
+                                        }
+                                }
+                            else if (((const uint8_t *)ptr)[1] == 0)
+                                {
+                                    ASN_DEBUG("edx = %d, opt = %d, ec=%d",
+                                        edx, elements[edx].optional,
+                                        td->elements_count);
+                                    if ((edx + elements[edx].optional ==
+                                            td->elements_count) ||
+                                        (IN_EXTENSION_GROUP(specs, edx) &&
+                                            specs->ext_before >
+                                                td->elements_count))
+                                        {
+                                            /*
+                                             * Yeah, baby! Found the
+                                             * terminator of the indefinite
+                                             * length structure.
+                                             */
+                                            /*
+                                             * Proceed to the canonical
+                                             * finalization function.
+                                             * No advancing is necessary.
+                                             */
+                                            goto phase3;
+                                        }
+                                }
+                        }
+
+                    /*
+                     * Find the next available type with this tag.
+                     */
+                    use_bsearch = 0;
+                    opt_edx_end = edx + elements[edx].optional + 1;
+                    if (opt_edx_end > td->elements_count)
+                        {
+                            opt_edx_end = td->elements_count; /* Cap */
+                        }
+                    else if (opt_edx_end - edx > 8)
+                        {
+                            /* Limit the scope of linear search... */
+                            opt_edx_end = edx + 8;
+                            use_bsearch = 1;
+                            /* ... and resort to bsearch() */
+                        }
+                    for (n = edx; n < opt_edx_end; n++)
+                        {
+                            if (BER_TAGS_EQUAL(tlv_tag, elements[n].tag))
+                                {
+                                    /*
+                                     * Found element corresponding to the
+                                     * tag being looked at. Reposition over
+                                     * the right element.
+                                     */
+                                    edx = n;
+                                    ctx->step = 1 + 2 * edx; /* Remember! */
+                                    goto microphase2;
+                                }
+                            else if (elements[n].flags & ATF_OPEN_TYPE)
+                                {
+                                    /*
+                                     * This is the ANY type, which may bear
+                                     * any flag whatsoever.
+                                     */
+                                    edx = n;
+                                    ctx->step = 1 + 2 * edx; /* Remember! */
+                                    goto microphase2;
+                                }
+                            else if (elements[n].tag == (ber_tlv_tag_t)-1)
+                                {
+                                    use_bsearch = 1;
+                                    break;
+                                }
+                        }
+                    if (use_bsearch)
+                        {
+                            /*
+                             * Resort to a binary search over
+                             * sorted array of tags.
+                             */
+                            asn_TYPE_tag2member_t *t2m;
+                            asn_TYPE_tag2member_t key;
+                            key.el_tag = tlv_tag;
+                            key.el_no = edx;
+                            t2m = (asn_TYPE_tag2member_t *)bsearch(
+                                &key, specs->tag2el, specs->tag2el_count,
+                                sizeof(specs->tag2el[0]), t2e_cmp);
+                            if (t2m)
+                                {
+                                    asn_TYPE_tag2member_t *best = 0;
+                                    asn_TYPE_tag2member_t *t2m_f;
+                                    asn_TYPE_tag2member_t *t2m_l;
+                                    int edx_max =
+                                        edx + elements[edx].optional;
+                                    /*
+                                     * Rewind to the first element with that
+                                     * tag, `cause bsearch() does not
+                                     * guarantee order.
+                                     */
+                                    t2m_f = t2m + t2m->toff_first;
+                                    t2m_l = t2m + t2m->toff_last;
+                                    for (t2m = t2m_f; t2m <= t2m_l; t2m++)
+                                        {
+                                            if (t2m->el_no > edx_max)
+                                                {
+                                                    break;
+                                                }
+                                            if (t2m->el_no < edx)
+                                                {
+                                                    continue;
+                                                }
+                                            best = t2m;
+                                        }
+                                    if (best)
+                                        {
+                                            edx = best->el_no;
+                                            ctx->step = 1 + 2 * edx;
+                                            goto microphase2;
+                                        }
+                                }
+                            n = opt_edx_end;
+                        }
+                    if (n == opt_edx_end)
+                        {
+                            /*
+                             * If tag is unknown, it may be either
+                             * an unknown (thus, incorrect) tag,
+                             * or an extension (...),
+                             * or an end of the indefinite-length structure.
+                             */
+                            if (!IN_EXTENSION_GROUP(
+                                    specs, edx + elements[edx].optional))
+                                {
+                                    ASN_DEBUG("Unexpected tag %s (at %d)",
+                                        ber_tlv_tag_string(tlv_tag),
+                                        edx);
+                                    ASN_DEBUG("Expected tag %s (%s)%s",
+                                        ber_tlv_tag_string(
+                                            elements[edx].tag),
+                                        elements[edx].name,
+                                        elements[edx].optional
+                                            ? " or alternatives"
+                                            : "");
+                                    RETURN(RC_FAIL);
+                                }
+                            else
+                                {
+                                    /* Skip this tag */
+                                    ssize_t skip;
+                                    edx += elements[edx].optional;
+
+                                    ASN_DEBUG(
+                                        "Skipping unexpected %s (at %d)",
+                                        ber_tlv_tag_string(tlv_tag), edx);
+                                    skip = ber_skip_length(
+                                        opt_codec_ctx,
+                                        BER_TLV_CONSTRUCTED(ptr),
+                                        (const char *)ptr + tag_len,
+                                        LEFT - tag_len);
+                                    ASN_DEBUG("Skip length %d in %s",
+                                        (int)skip, td->name);
+                                    switch (skip)
+                                        {
+                                        case 0:
+                                            if (!SIZE_VIOLATION)
+                                                {
+                                                    RETURN(RC_WMORE);
+                                                }
+                                            /* Fall through */
+                                        case -1:
+                                            RETURN(RC_FAIL);
+                                        }
+
+                                    ADVANCE(skip + tag_len);
+                                    ctx->step -= 2;
+                                    edx--;
+                                    continue; /* Try again with the next tag
+                                               */
+                                }
+                        }
+
+                    /*
+                     * MICROPHASE 2: Invoke the member-specific decoder.
+                     */
+                    ctx->step |= 1; /* Confirm entering next microphase */
+                microphase2:
+                    ASN_DEBUG("Inside SEQUENCE %s MF2", td->name);
+
+                    /*
+                     * Compute the position of the member inside a
+                     * structure, and also a type of containment (it may be
+                     * contained as pointer or using inline inclusion).
+                     */
+                    if (elements[edx].flags & ATF_POINTER)
+                        {
+                            /* Member is a pointer to another structure */
+                            memb_ptr2 =
+                                (void **)((char *)st +
+                                          elements[edx].memb_offset);
+                        }
+                    else
+                        {
+                            /*
+                             * A pointer to a pointer
+                             * holding the start of the structure
+                             */
+                            memb_ptr =
+                                (char *)st + elements[edx].memb_offset;
+                            memb_ptr2 = &memb_ptr;
+                        }
+                    /*
+                     * Invoke the member fetch routine according to member's
+                     * type
+                     */
+                    rval = elements[edx].type->ber_decoder(
+                        opt_codec_ctx, elements[edx].type, memb_ptr2, ptr,
+                        LEFT, elements[edx].tag_mode);
+                    ASN_DEBUG(
+                        "In %s SEQUENCE decoded %d %s of %d "
+                        "in %d bytes rval.code %d, size=%d",
+                        td->name, edx, elements[edx].type->name, (int)LEFT,
+                        (int)rval.consumed, rval.code, (int)size);
+                    switch (rval.code)
+                        {
+                        case RC_OK:
+                            break;
+                        case RC_WMORE: /* More data expected */
+                            if (!SIZE_VIOLATION)
+                                {
+                                    ADVANCE(rval.consumed);
+                                    RETURN(RC_WMORE);
+                                }
+                            ASN_DEBUG(
+                                "Size violation (c->l=%ld <= s=%ld)",
+                                (long)ctx->left, (long)size);
+                            /* Fall through */
+                        case RC_FAIL: /* Fatal error */
+                            RETURN(RC_FAIL);
+                        } /* switch(rval) */
+
+                    ADVANCE(rval.consumed);
+                } /* for(all structure members) */
+
+        phase3:
+            ctx->phase = 3;
+        case 3: /* 00 and other tags expected */
+        case 4: /* only 00's expected */
+
+            ASN_DEBUG("SEQUENCE %s Leftover: %ld, size = %ld", td->name,
+                (long)ctx->left, (long)size);
+
+            /*
+             * Skip everything until the end of the SEQUENCE.
+             */
+            while (ctx->left)
+                {
+                    ssize_t tl;
+                    ssize_t ll;
+
+                    tl = ber_fetch_tag(ptr, LEFT, &tlv_tag);
+                    switch (tl)
+                        {
+                        case 0:
+                            if (!SIZE_VIOLATION)
+                                {
+                                    RETURN(RC_WMORE);
+                                }
+                            /* Fall through */
+                        case -1:
+                            RETURN(RC_FAIL);
+                        }
+
+                    /*
+                     * If expected <0><0>...
+                     */
+                    if (ctx->left < 0 && ((const uint8_t *)ptr)[0] == 0)
+                        {
+                            if (LEFT < 2)
+                                {
+                                    if (SIZE_VIOLATION)
+                                        {
+                                            RETURN(RC_FAIL);
+                                        }
+                                    else
+                                        {
+                                            RETURN(RC_WMORE);
+                                        }
+                                }
+                            else if (((const uint8_t *)ptr)[1] == 0)
+                                {
+                                    /*
+                                     * Correctly finished with <0><0>.
+                                     */
+                                    ADVANCE(2);
+                                    ctx->left++;
+                                    ctx->phase = 4;
+                                    continue;
+                                }
+                        }
+
+                    if (!IN_EXTENSION_GROUP(specs, td->elements_count) ||
+                        ctx->phase == 4)
+                        {
+                            ASN_DEBUG(
+                                "Unexpected continuation "
+                                "of a non-extensible type "
+                                "%s (SEQUENCE): %s",
+                                td->name, ber_tlv_tag_string(tlv_tag));
+                            RETURN(RC_FAIL);
+                        }
+
+                    ll = ber_skip_length(opt_codec_ctx,
+                        BER_TLV_CONSTRUCTED(ptr),
+                        (const char *)ptr + tl, LEFT - tl);
+                    switch (ll)
+                        {
+                        case 0:
+                            if (!SIZE_VIOLATION)
+                                {
+                                    RETURN(RC_WMORE);
+                                }
+                            /* Fall through */
+                        case -1:
+                            RETURN(RC_FAIL);
+                        }
+
+                    ADVANCE(tl + ll);
+                }
+
+            PHASE_OUT(ctx);
+        }
+
+    RETURN(RC_OK);
+}
+
+/*
+ * The DER encoder of the SEQUENCE type.
+ */
+asn_enc_rval_t SEQUENCE_encode_der(asn_TYPE_descriptor_t *td, void *sptr,
+    int tag_mode, ber_tlv_tag_t tag,
+    asn_app_consume_bytes_f *cb, void *app_key)
+{
+    size_t computed_size = 0;
+    asn_enc_rval_t erval;
+    ssize_t ret;
+    int edx;
+
+    ASN_DEBUG("%s %s as SEQUENCE", cb ? "Encoding" : "Estimating", td->name);
+
+    /*
+     * Gather the length of the underlying members sequence.
+     */
+    for (edx = 0; edx < td->elements_count; edx++)
+        {
+            asn_TYPE_member_t *elm = &td->elements[edx];
+            void *memb_ptr;
+            if (elm->flags & ATF_POINTER)
+                {
+                    memb_ptr = *(void **)((char *)sptr + elm->memb_offset);
+                    if (!memb_ptr)
+                        {
+                            if (elm->optional)
+                                {
+                                    continue;
+                                }
+                            /* Mandatory element is missing */
+                            _ASN_ENCODE_FAILED;
+                        }
+                }
+            else
+                {
+                    memb_ptr = (void *)((char *)sptr + elm->memb_offset);
+                }
+            erval = elm->type->der_encoder(elm->type, memb_ptr, elm->tag_mode,
+                elm->tag, 0, 0);
+            if (erval.encoded == -1)
+                {
+                    return erval;
+                }
+            computed_size += erval.encoded;
+            ASN_DEBUG("Member %d %s estimated %ld bytes", edx, elm->name,
+                (long)erval.encoded);
+        }
+
+    /*
+     * Encode the TLV for the sequence itself.
+     */
+    ret = der_write_tags(td, computed_size, tag_mode, 1, tag, cb, app_key);
+    ASN_DEBUG("Wrote tags: %ld (+%ld)", (long)ret, (long)computed_size);
+    if (ret == -1)
+        {
+            _ASN_ENCODE_FAILED;
+        }
+    erval.encoded = computed_size + ret;
+
+    if (!cb)
+        {
+            _ASN_ENCODED_OK(erval);
+        }
+
+    /*
+     * Encode all members.
+     */
+    for (edx = 0; edx < td->elements_count; edx++)
+        {
+            asn_TYPE_member_t *elm = &td->elements[edx];
+            asn_enc_rval_t tmperval;
+            void *memb_ptr;
+
+            if (elm->flags & ATF_POINTER)
+                {
+                    memb_ptr = *(void **)((char *)sptr + elm->memb_offset);
+                    if (!memb_ptr)
+                        {
+                            continue;
+                        }
+                }
+            else
+                {
+                    memb_ptr = (void *)((char *)sptr + elm->memb_offset);
+                }
+            tmperval = elm->type->der_encoder(
+                elm->type, memb_ptr, elm->tag_mode, elm->tag, cb, app_key);
+            if (tmperval.encoded == -1)
+                {
+                    return tmperval;
+                }
+            computed_size -= tmperval.encoded;
+            ASN_DEBUG("Member %d %s of SEQUENCE %s encoded in %ld bytes", edx,
+                elm->name, td->name, (long)tmperval.encoded);
+        }
+
+    if (computed_size != 0)
+        {
+            /*
+             * Encoded size is not equal to the computed size.
+             */
+            _ASN_ENCODE_FAILED;
+        }
+
+    _ASN_ENCODED_OK(erval);
+}
+
+#undef XER_ADVANCE
+#define XER_ADVANCE(num_bytes)                       \
+    do                                               \
+        {                                            \
+            size_t num = num_bytes;                  \
+            buf_ptr = ((const char *)buf_ptr) + num; \
+            size -= num;                             \
+            consumed_myself += num;                  \
+        }                                            \
+    while (0)
+
+/*
+ * Decode the XER (XML) data.
+ */
+asn_dec_rval_t SEQUENCE_decode_xer(asn_codec_ctx_t *opt_codec_ctx,
+    asn_TYPE_descriptor_t *td, void **struct_ptr,
+    const char *opt_mname, const void *buf_ptr,
+    size_t size)
+{
+    /*
+     * Bring closer parts of structure description.
+     */
+    asn_SEQUENCE_specifics_t *specs = (asn_SEQUENCE_specifics_t *)td->specifics;
+    asn_TYPE_member_t *elements = td->elements;
+    const char *xml_tag = opt_mname ? opt_mname : td->xml_tag;
+
+    /*
+     * ... and parts of the structure being constructed.
+     */
+    void *st = *struct_ptr; /* Target structure. */
+    asn_struct_ctx_t *ctx;  /* Decoder context */
+
+    asn_dec_rval_t rval;         /* Return value from a decoder */
+    ssize_t consumed_myself = 0; /* Consumed bytes from ptr */
+    int edx;                     /* Element index */
+    int edx_end;
+
+    /*
+     * Create the target structure if it is not present already.
+     */
+    if (st == 0)
+        {
+            st = *struct_ptr = CALLOC(1, specs->struct_size);
+            if (st == 0)
+                {
+                    RETURN(RC_FAIL);
+                }
+        }
+
+    /*
+     * Restore parsing context.
+     */
+    ctx = (asn_struct_ctx_t *)((char *)st + specs->ctx_offset);
+
+    /*
+     * Phases of XER/XML processing:
+     * Phase 0: Check that the opening tag matches our expectations.
+     * Phase 1: Processing body and reacting on closing tag.
+     * Phase 2: Processing inner type.
+     * Phase 3: Skipping unknown extensions.
+     * Phase 4: PHASED OUT
+     */
+    for (edx = ctx->step; ctx->phase <= 3;)
+        {
+            pxer_chunk_type_e ch_type; /* XER chunk type */
+            ssize_t ch_size;           /* Chunk size */
+            xer_check_tag_e tcv;       /* Tag check value */
+            asn_TYPE_member_t *elm;
+            int n;
+
+            /*
+             * Go inside the inner member of a sequence.
+             */
+            if (ctx->phase == 2)
+                {
+                    asn_dec_rval_t tmprval;
+                    void *memb_ptr;   /* Pointer to the member */
+                    void **memb_ptr2; /* Pointer to that pointer */
+
+                    elm = &td->elements[edx];
+
+                    if (elm->flags & ATF_POINTER)
+                        {
+                            /* Member is a pointer to another structure */
+                            memb_ptr2 =
+                                (void **)((char *)st + elm->memb_offset);
+                        }
+                    else
+                        {
+                            memb_ptr = (char *)st + elm->memb_offset;
+                            memb_ptr2 = &memb_ptr;
+                        }
+
+                    /* Invoke the inner type decoder, m.b. multiple times */
+                    tmprval = elm->type->xer_decoder(opt_codec_ctx, elm->type,
+                        memb_ptr2, elm->name,
+                        buf_ptr, size);
+                    XER_ADVANCE(tmprval.consumed);
+                    if (tmprval.code != RC_OK)
+                        {
+                            RETURN(tmprval.code);
+                        }
+                    ctx->phase = 1; /* Back to body processing */
+                    ctx->step = ++edx;
+                    ASN_DEBUG("XER/SEQUENCE phase => %d, step => %d",
+                        ctx->phase, ctx->step);
+                    /* Fall through */
+                }
+
+            /*
+             * Get the next part of the XML stream.
+             */
+            ch_size = xer_next_token(&ctx->context, buf_ptr, size, &ch_type);
+            switch (ch_size)
+                {
+                case -1:
+                    RETURN(RC_FAIL);
+                case 0:
+                    RETURN(RC_WMORE);
+                default:
+                    switch (ch_type)
+                        {
+                        case PXER_COMMENT:        /* Got XML comment */
+                        case PXER_TEXT:           /* Ignore free-standing text */
+                            XER_ADVANCE(ch_size); /* Skip silently */
+                            continue;
+                        case PXER_TAG:
+                            break; /* Check the rest down there */
+                        }
+                }
+
+            tcv = xer_check_tag(buf_ptr, ch_size, xml_tag);
+            ASN_DEBUG("XER/SEQUENCE: tcv = %d, ph=%d [%s]", tcv, ctx->phase,
+                xml_tag);
+
+            /* Skip the extensions section */
+            if (ctx->phase == 3)
+                {
+                    switch (xer_skip_unknown(tcv, &ctx->left))
+                        {
+                        case -1:
+                            ctx->phase = 4;
+                            RETURN(RC_FAIL);
+                        case 0:
+                            XER_ADVANCE(ch_size);
+                            continue;
+                        case 1:
+                            XER_ADVANCE(ch_size);
+                            ctx->phase = 1;
+                            continue;
+                        case 2:
+                            ctx->phase = 1;
+                            break;
+                        }
+                }
+
+            switch (tcv)
+                {
+                case XCT_CLOSING:
+                    if (ctx->phase == 0)
+                        {
+                            break;
+                        }
+                    ctx->phase = 0;
+                    /* Fall through */
+                case XCT_BOTH:
+                    if (ctx->phase == 0)
+                        {
+                            if (edx >= td->elements_count ||
+                                /* Explicit OPTIONAL specs reaches the end
+                                 */
+                                (edx + elements[edx].optional ==
+                                    td->elements_count) ||
+                                /* All extensions are optional */
+                                (IN_EXTENSION_GROUP(specs, edx) &&
+                                    specs->ext_before > td->elements_count))
+                                {
+                                    XER_ADVANCE(ch_size);
+                                    ctx->phase = 4; /* Phase out */
+                                    RETURN(RC_OK);
+                                }
+                            else
+                                {
+                                    ASN_DEBUG(
+                                        "Premature end of XER SEQUENCE");
+                                    RETURN(RC_FAIL);
+                                }
+                        }
+                    /* Fall through */
+                case XCT_OPENING:
+                    if (ctx->phase == 0)
+                        {
+                            XER_ADVANCE(ch_size);
+                            ctx->phase = 1; /* Processing body phase */
+                            continue;
+                        }
+                    /* Fall through */
+                case XCT_UNKNOWN_OP:
+                case XCT_UNKNOWN_BO:
+
+                    ASN_DEBUG("XER/SEQUENCE: tcv=%d, ph=%d, edx=%d", tcv,
+                        ctx->phase, edx);
+                    if (ctx->phase != 1)
+                        {
+                            break; /* Really unexpected */
+                        }
+
+                    if (edx < td->elements_count)
+                        {
+                            /*
+                             * Search which member corresponds to this tag.
+                             */
+                            edx_end = edx + elements[edx].optional + 1;
+                            if (edx_end > td->elements_count)
+                                {
+                                    edx_end = td->elements_count;
+                                }
+                            for (n = edx; n < edx_end; n++)
+                                {
+                                    elm = &td->elements[n];
+                                    tcv = xer_check_tag(buf_ptr, ch_size,
+                                        elm->name);
+                                    switch (tcv)
+                                        {
+                                        case XCT_BOTH:
+                                        case XCT_OPENING:
+                                            /*
+                                             * Process this member.
+                                             */
+                                            ctx->step = edx = n;
+                                            ctx->phase = 2;
+                                            break;
+                                        case XCT_UNKNOWN_OP:
+                                        case XCT_UNKNOWN_BO:
+                                            continue;
+                                        default:
+                                            n = edx_end;
+                                            break; /* Phase out */
+                                        }
+                                    break;
+                                }
+                            if (n != edx_end)
+                                {
+                                    continue;
+                                }
+                        }
+                    else
+                        {
+                            ASN_DEBUG("Out of defined members: %d/%d", edx,
+                                td->elements_count);
+                        }
+
+                    /* It is expected extension */
+                    if (IN_EXTENSION_GROUP(
+                            specs, edx + (edx < td->elements_count
+                                                 ? elements[edx].optional
+                                                 : 0)))
+                        {
+                            ASN_DEBUG("Got anticipated extension at %d",
+                                edx);
+                            /*
+                             * Check for (XCT_BOTH or XCT_UNKNOWN_BO)
+                             * By using a mask. Only record a pure
+                             * <opening> tags.
+                             */
+                            if (tcv & XCT_CLOSING)
+                                {
+                                    /* Found </extension> without body */
+                                }
+                            else
+                                {
+                                    ctx->left = 1;
+                                    ctx->phase = 3; /* Skip ...'s */
+                                }
+                            XER_ADVANCE(ch_size);
+                            continue;
+                        }
+
+                    /* Fall through */
+                default:
+                    break;
+                }
+
+            ASN_DEBUG("Unexpected XML tag in SEQUENCE [%c%c%c%c%c%c]",
+                size > 0 ? ((const char *)buf_ptr)[0] : '.',
+                size > 1 ? ((const char *)buf_ptr)[1] : '.',
+                size > 2 ? ((const char *)buf_ptr)[2] : '.',
+                size > 3 ? ((const char *)buf_ptr)[3] : '.',
+                size > 4 ? ((const char *)buf_ptr)[4] : '.',
+                size > 5 ? ((const char *)buf_ptr)[5] : '.');
+            break;
+        }
+
+    ctx->phase = 4; /* "Phase out" on hard failure */
+    RETURN(RC_FAIL);
+}
+
+asn_enc_rval_t SEQUENCE_encode_xer(asn_TYPE_descriptor_t *td, void *sptr,
+    int ilevel, enum xer_encoder_flags_e flags,
+    asn_app_consume_bytes_f *cb, void *app_key)
+{
+    asn_enc_rval_t er;
+    int xcan = (flags & XER_F_CANONICAL);
+    int edx;
+
+    if (!sptr)
+        {
+            _ASN_ENCODE_FAILED;
+        }
+
+    er.encoded = 0;
+
+    for (edx = 0; edx < td->elements_count; edx++)
+        {
+            asn_enc_rval_t tmper;
+            asn_TYPE_member_t *elm = &td->elements[edx];
+            void *memb_ptr;
+            const char *mname = elm->name;
+            unsigned int mlen = strlen(mname);
+
+            if (elm->flags & ATF_POINTER)
+                {
+                    memb_ptr = *(void **)((char *)sptr + elm->memb_offset);
+                    if (!memb_ptr)
+                        {
+                            if (elm->optional)
+                                {
+                                    continue;
+                                }
+                            /* Mandatory element is missing */
+                            _ASN_ENCODE_FAILED;
+                        }
+                }
+            else
+                {
+                    memb_ptr = (void *)((char *)sptr + elm->memb_offset);
+                }
+
+            if (!xcan)
+                {
+                    _i_ASN_TEXT_INDENT(1, ilevel);
+                }
+            _ASN_CALLBACK3("<", 1, mname, mlen, ">", 1);
+
+            /* Print the member itself */
+            tmper = elm->type->xer_encoder(elm->type, memb_ptr, ilevel + 1,
+                flags, cb, app_key);
+            if (tmper.encoded == -1)
+                {
+                    return tmper;
+                }
+
+            _ASN_CALLBACK3("</", 2, mname, mlen, ">", 1);
+            er.encoded += 5 + (2 * mlen) + tmper.encoded;
+        }
+
+    if (!xcan)
+        {
+            _i_ASN_TEXT_INDENT(1, ilevel - 1);
+        }
+
+    _ASN_ENCODED_OK(er);
+cb_failed:
+    _ASN_ENCODE_FAILED;
+}
+
+int SEQUENCE_print(asn_TYPE_descriptor_t *td, const void *sptr, int ilevel,
+    asn_app_consume_bytes_f *cb, void *app_key)
+{
+    int edx;
+    int ret;
+
+    if (!sptr)
+        {
+            return (cb("<absent>", 8, app_key) < 0) ? -1 : 0;
+        }
+
+    /* Dump preamble */
+    if (cb(td->name, strlen(td->name), app_key) < 0 ||
+        cb(" ::= {", 6, app_key) < 0)
+        {
+            return -1;
+        }
+
+    for (edx = 0; edx < td->elements_count; edx++)
+        {
+            asn_TYPE_member_t *elm = &td->elements[edx];
+            const void *memb_ptr;
+
+            if (elm->flags & ATF_POINTER)
+                {
+                    memb_ptr = *(const void *const *)((const char *)sptr +
+                                                      elm->memb_offset);
+                    if (!memb_ptr)
+                        {
+                            if (elm->optional)
+                                {
+                                    continue;
+                                }
+                            /* Print <absent> line */
+                            /* Fall through */
+                        }
+                }
+            else
+                {
+                    memb_ptr =
+                        (const void *)((const char *)sptr + elm->memb_offset);
+                }
+
+            /* Indentation */
+            _i_INDENT(1);
+
+            /* Print the member's name and stuff */
+            if (cb(elm->name, strlen(elm->name), app_key) < 0 ||
+                cb(": ", 2, app_key) < 0)
+                {
+                    return -1;
+                }
+
+            /* Print the member itself */
+            ret = elm->type->print_struct(elm->type, memb_ptr, ilevel + 1, cb,
+                app_key);
+            if (ret)
+                {
+                    return ret;
+                }
+        }
+
+    ilevel--;
+    _i_INDENT(1);
+
+    return (cb("}", 1, app_key) < 0) ? -1 : 0;
+}
+
+void SEQUENCE_free(asn_TYPE_descriptor_t *td, void *sptr, int contents_only)
+{
+    int edx;
+
+    if (!td || !sptr)
+        {
+            return;
+        }
+
+    ASN_DEBUG("Freeing %s as SEQUENCE", td->name);
+
+    for (edx = 0; edx < td->elements_count; edx++)
+        {
+            asn_TYPE_member_t *elm = &td->elements[edx];
+            void *memb_ptr;
+            if (elm->flags & ATF_POINTER)
+                {
+                    memb_ptr = *(void **)((char *)sptr + elm->memb_offset);
+                    if (memb_ptr)
+                        {
+                            ASN_STRUCT_FREE(*elm->type, memb_ptr);
+                        }
+                }
+            else
+                {
+                    memb_ptr = (void *)((char *)sptr + elm->memb_offset);
+                    ASN_STRUCT_FREE_CONTENTS_ONLY(*elm->type, memb_ptr);
+                }
+        }
+
+    if (!contents_only)
+        {
+            FREEMEM(sptr);
+        }
+}
+
+int SEQUENCE_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
+    asn_app_constraint_failed_f *ctfailcb, void *app_key)
+{
+    int edx;
+
+    if (!sptr)
+        {
+            _ASN_CTFAIL(app_key, td, sptr, "%s: value not given (%s:%d)",
+                td->name, __FILE__, __LINE__);
+            return -1;
+        }
+
+    /*
+     * Iterate over structure members and check their validity.
+     */
+    for (edx = 0; edx < td->elements_count; edx++)
+        {
+            asn_TYPE_member_t *elm = &td->elements[edx];
+            const void *memb_ptr;
+
+            if (elm->flags & ATF_POINTER)
+                {
+                    memb_ptr = *(const void *const *)((const char *)sptr +
+                                                      elm->memb_offset);
+                    if (!memb_ptr)
+                        {
+                            if (elm->optional)
+                                {
+                                    continue;
+                                }
+                            _ASN_CTFAIL(
+                                app_key, td, sptr,
+                                "%s: mandatory element %s absent (%s:%d)",
+                                td->name, elm->name, __FILE__, __LINE__);
+                            return -1;
+                        }
+                }
+            else
+                {
+                    memb_ptr =
+                        (const void *)((const char *)sptr + elm->memb_offset);
+                }
+
+            if (elm->memb_constraints)
+                {
+                    int ret = elm->memb_constraints(elm->type, memb_ptr,
+                        ctfailcb, app_key);
+                    if (ret)
+                        {
+                            return ret;
+                        }
+                }
+            else
+                {
+                    int ret = elm->type->check_constraints(elm->type, memb_ptr,
+                        ctfailcb, app_key);
+                    if (ret)
+                        {
+                            return ret;
+                        }
+                    /*
+                     * Cannot inherit it earlier:
+                     * need to make sure we get the updated version.
+                     */
+                    elm->memb_constraints = elm->type->check_constraints;
+                }
+        }
+
+    return 0;
+}
+
+asn_dec_rval_t SEQUENCE_decode_uper(asn_codec_ctx_t *opt_codec_ctx,
+    asn_TYPE_descriptor_t *td,
+    asn_per_constraints_t *constraints,
+    void **sptr, asn_per_data_t *pd)
+{
+    asn_SEQUENCE_specifics_t *specs = (asn_SEQUENCE_specifics_t *)td->specifics;
+    void *st = *sptr; /* Target structure. */
+    int extpresent;   /* Extension additions are present */
+    uint8_t *opres;   /* Presence of optional root members */
+    asn_per_data_t opmd;
+    asn_dec_rval_t rv;
+    int edx;
+
+    (void)constraints;
+
+    if (_ASN_STACK_OVERFLOW_CHECK(opt_codec_ctx))
+        {
+            _ASN_DECODE_FAILED;
+        }
+
+    if (!st)
+        {
+            st = *sptr = CALLOC(1, specs->struct_size);
+            if (!st)
+                {
+                    _ASN_DECODE_FAILED;
+                }
+        }
+
+    ASN_DEBUG("Decoding %s as SEQUENCE (UPER)", td->name);
+
+    /* Handle extensions */
+    if (specs->ext_before >= 0)
+        {
+            extpresent = per_get_few_bits(pd, 1);
+            if (extpresent < 0)
+                {
+                    _ASN_DECODE_STARVED;
+                }
+        }
+    else
+        {
+            extpresent = 0;
+        }
+
+    /* Prepare a place and read-in the presence bitmap */
+    memset(&opmd, 0, sizeof(opmd));
+    if (specs->roms_count)
+        {
+            opres = (uint8_t *)MALLOC(((specs->roms_count + 7) >> 3) + 1);
+            if (!opres)
+                {
+                    _ASN_DECODE_FAILED;
+                }
+            /* Get the presence map */
+            if (per_get_many_bits(pd, opres, 0, specs->roms_count))
+                {
+                    FREEMEM(opres);
+                    _ASN_DECODE_STARVED;
+                }
+            opmd.buffer = opres;
+            opmd.nbits = specs->roms_count;
+            ASN_DEBUG("Read in presence bitmap for %s of %d bits (%x..)",
+                td->name, specs->roms_count, *opres);
+        }
+    else
+        {
+            opres = 0;
+        }
+
+    /*
+     * Get the sequence ROOT elements.
+     */
+    for (edx = 0; edx < td->elements_count; edx++)
+        {
+            asn_TYPE_member_t *elm = &td->elements[edx];
+            void *memb_ptr;   /* Pointer to the member */
+            void **memb_ptr2; /* Pointer to that pointer */
+
+            if (IN_EXTENSION_GROUP(specs, edx))
+                {
+                    continue;
+                }
+
+            /* Fetch the pointer to this member */
+            if (elm->flags & ATF_POINTER)
+                {
+                    memb_ptr2 = (void **)((char *)st + elm->memb_offset);
+                }
+            else
+                {
+                    memb_ptr = (char *)st + elm->memb_offset;
+                    memb_ptr2 = &memb_ptr;
+                }
+
+            /* Deal with optionality */
+            if (elm->optional)
+                {
+                    int present = per_get_few_bits(&opmd, 1);
+                    ASN_DEBUG("Member %s->%s is optional, p=%d (%d->%d)",
+                        td->name, elm->name, present, (int)opmd.nboff,
+                        (int)opmd.nbits);
+                    if (present == 0)
+                        {
+                            /* This element is not present */
+                            if (elm->default_value)
+                                {
+                                    /* Fill-in DEFAULT */
+                                    if (elm->default_value(1, memb_ptr2))
+                                        {
+                                            FREEMEM(opres);
+                                            _ASN_DECODE_FAILED;
+                                        }
+                                    ASN_DEBUG("Filled-in default");
+                                }
+                            /* The member is just not present */
+                            continue;
+                        }
+                    /* Fall through */
+                }
+
+            /* Fetch the member from the stream */
+            ASN_DEBUG("Decoding member %s in %s", elm->name, td->name);
+            rv = elm->type->uper_decoder(opt_codec_ctx, elm->type,
+                elm->per_constraints, memb_ptr2, pd);
+            if (rv.code != RC_OK)
+                {
+                    ASN_DEBUG("Failed decode %s in %s", elm->name, td->name);
+                    FREEMEM(opres);
+                    return rv;
+                }
+        }
+
+    /* Optionality map is not needed anymore */
+    FREEMEM(opres);
+
+    /*
+     * Deal with extensions.
+     */
+    if (extpresent)
+        {
+            ssize_t bmlength;
+            uint8_t *epres; /* Presence of extension members */
+            asn_per_data_t epmd;
+
+            bmlength = uper_get_nslength(pd);
+            if (bmlength < 0)
+                {
+                    _ASN_DECODE_STARVED;
+                }
+
+            ASN_DEBUG("Extensions %d present in %s", bmlength, td->name);
+
+            epres = (uint8_t *)MALLOC((bmlength + 15) >> 3);
+            if (!epres)
+                {
+                    _ASN_DECODE_STARVED;
+                }
+
+            /* Get the extensions map */
+            if (per_get_many_bits(pd, epres, 0, bmlength))
+                {
+                    FREEMEM(epres);
+                    _ASN_DECODE_STARVED;
+                }
+            memset(&epmd, 0, sizeof(epmd));
+            epmd.buffer = epres;
+            epmd.nbits = bmlength;
+            ASN_DEBUG("Read in extensions bitmap for %s of %d bits (%x..)",
+                td->name, bmlength, *epres);
+
+            /* Go over extensions and read them in */
+            for (edx = specs->ext_after + 1; edx < td->elements_count; edx++)
+                {
+                    asn_TYPE_member_t *elm = &td->elements[edx];
+                    void *memb_ptr;   /* Pointer to the member */
+                    void **memb_ptr2; /* Pointer to that pointer */
+                    int present;
+
+                    if (!IN_EXTENSION_GROUP(specs, edx))
+                        {
+                            ASN_DEBUG("%d is not extension", edx);
+                            continue;
+                        }
+
+                    /* Fetch the pointer to this member */
+                    if (elm->flags & ATF_POINTER)
+                        {
+                            memb_ptr2 =
+                                (void **)((char *)st + elm->memb_offset);
+                        }
+                    else
+                        {
+                            memb_ptr = (void *)((char *)st + elm->memb_offset);
+                            memb_ptr2 = &memb_ptr;
+                        }
+
+                    present = per_get_few_bits(&epmd, 1);
+                    if (present <= 0)
+                        {
+                            if (present < 0)
+                                {
+                                    break; /* No more extensions */
+                                }
+                            continue;
+                        }
+
+                    ASN_DEBUG("Decoding member %s in %s %p", elm->name,
+                        td->name, *memb_ptr2);
+                    rv =
+                        uper_open_type_get(opt_codec_ctx, elm->type,
+                            elm->per_constraints, memb_ptr2, pd);
+                    if (rv.code != RC_OK)
+                        {
+                            FREEMEM(epres);
+                            return rv;
+                        }
+                }
+
+            /* Skip over overflow extensions which aren't present
+             * in this system's version of the protocol */
+            for (;;)
+                {
+                    ASN_DEBUG("Getting overflow extensions");
+                    switch (per_get_few_bits(&epmd, 1))
+                        {
+                        case -1:
+                            break;
+                        case 0:
+                            continue;
+                        default:
+                            if (uper_open_type_skip(opt_codec_ctx, pd))
+                                {
+                                    FREEMEM(epres);
+                                    _ASN_DECODE_STARVED;
+                                }
+                        }
+                    break;
+                }
+
+            FREEMEM(epres);
+        }
+
+    /* Fill DEFAULT members in extensions */
+    for (edx = specs->roms_count; edx < specs->roms_count + specs->aoms_count;
+         edx++)
+        {
+            asn_TYPE_member_t *elm = &td->elements[edx];
+            void **memb_ptr2; /* Pointer to member pointer */
+
+            if (!elm->default_value)
+                {
+                    continue;
+                }
+
+            /* Fetch the pointer to this member */
+            if (elm->flags & ATF_POINTER)
+                {
+                    memb_ptr2 = (void **)((char *)st + elm->memb_offset);
+                    if (*memb_ptr2)
+                        {
+                            continue;
+                        }
+                }
+            else
+                {
+                    continue; /* Extensions are all optionals */
+                }
+
+            /* Set default value */
+            if (elm->default_value(1, memb_ptr2))
+                {
+                    _ASN_DECODE_FAILED;
+                }
+        }
+
+    rv.consumed = 0;
+    rv.code = RC_OK;
+    return rv;
+}
+
+static int SEQUENCE_handle_extensions(asn_TYPE_descriptor_t *td, void *sptr,
+    asn_per_outp_t *po1, asn_per_outp_t *po2)
+{
+    asn_SEQUENCE_specifics_t *specs = (asn_SEQUENCE_specifics_t *)td->specifics;
+    int exts_present = 0;
+    int exts_count = 0;
+    int edx;
+
+    if (specs->ext_before < 0)
+        {
+            return 0;
+        }
+
+    /* Find out which extensions are present */
+    for (edx = specs->ext_after + 1; edx < td->elements_count; edx++)
+        {
+            asn_TYPE_member_t *elm = &td->elements[edx];
+            void *memb_ptr;   /* Pointer to the member */
+            void **memb_ptr2; /* Pointer to that pointer */
+            int present;
+
+            if (!IN_EXTENSION_GROUP(specs, edx))
+                {
+                    ASN_DEBUG("%s (@%d) is not extension", elm->type->name,
+                        edx);
+                    continue;
+                }
+
+            /* Fetch the pointer to this member */
+            if (elm->flags & ATF_POINTER)
+                {
+                    memb_ptr2 = (void **)((char *)sptr + elm->memb_offset);
+                    present = (*memb_ptr2 != 0);
+                }
+            else
+                {
+                    memb_ptr = (void *)((char *)sptr + elm->memb_offset);
+                    memb_ptr2 = &memb_ptr;
+                    present = 1;
+                }
+
+            ASN_DEBUG("checking %s (@%d) present => %d", elm->type->name, edx,
+                present);
+            exts_count++;
+            exts_present += present;
+
+            /* Encode as presence marker */
+            if (po1 && per_put_few_bits(po1, present, 1))
+                {
+                    return -1;
+                }
+            /* Encode as open type field */
+            if (po2 && present &&
+                uper_open_type_put(elm->type, elm->per_constraints, *memb_ptr2,
+                    po2))
+                {
+                    return -1;
+                }
+        }
+
+    return exts_present ? exts_count : 0;
+}
+
+asn_enc_rval_t SEQUENCE_encode_uper(asn_TYPE_descriptor_t *td,
+    asn_per_constraints_t *constraints,
+    void *sptr, asn_per_outp_t *po)
+{
+    asn_SEQUENCE_specifics_t *specs = (asn_SEQUENCE_specifics_t *)td->specifics;
+    asn_enc_rval_t er;
+    int n_extensions;
+    int edx;
+    int i;
+
+    (void)constraints;
+
+    if (!sptr)
+        {
+            _ASN_ENCODE_FAILED;
+        }
+
+    er.encoded = 0;
+
+    ASN_DEBUG("Encoding %s as SEQUENCE (UPER)", td->name);
+
+    /*
+     * X.691#18.1 Whether structure is extensible
+     * and whether to encode extensions
+     */
+    if (specs->ext_before >= 0)
+        {
+            n_extensions = SEQUENCE_handle_extensions(td, sptr, 0, 0);
+            per_put_few_bits(po, n_extensions ? 1 : 0, 1);
+        }
+    else
+        {
+            n_extensions = 0; /* There are no extensions to encode */
+        }
+
+    /* Encode a presence bitmap */
+    for (i = 0; i < specs->roms_count; i++)
+        {
+            asn_TYPE_member_t *elm;
+            void *memb_ptr;   /* Pointer to the member */
+            void **memb_ptr2; /* Pointer to that pointer */
+            int present;
+
+            edx = specs->oms[i];
+            elm = &td->elements[edx];
+
+            /* Fetch the pointer to this member */
+            if (elm->flags & ATF_POINTER)
+                {
+                    memb_ptr2 = (void **)((char *)sptr + elm->memb_offset);
+                    present = (*memb_ptr2 != 0);
+                }
+            else
+                {
+                    memb_ptr = (void *)((char *)sptr + elm->memb_offset);
+                    memb_ptr2 = &memb_ptr;
+                    present = 1;
+                }
+
+            /* Eliminate default values */
+            if (present && elm->default_value &&
+                elm->default_value(0, memb_ptr2) == 1)
+                {
+                    present = 0;
+                }
+
+            ASN_DEBUG("Element %s %s %s->%s is %s",
+                elm->flags & ATF_POINTER ? "ptr" : "inline",
+                elm->default_value ? "def" : "wtv", td->name, elm->name,
+                present ? "present" : "absent");
+            if (per_put_few_bits(po, present, 1))
+                {
+                    _ASN_ENCODE_FAILED;
+                }
+        }
+
+    /*
+     * Encode the sequence ROOT elements.
+     */
+    ASN_DEBUG("ext_after = %d, ec = %d, eb = %d", specs->ext_after,
+        td->elements_count, specs->ext_before);
+    for (edx = 0; edx < ((specs->ext_after < 0) ? td->elements_count
+                                                : specs->ext_before - 1);
+         edx++)
+        {
+            asn_TYPE_member_t *elm = &td->elements[edx];
+            void *memb_ptr;   /* Pointer to the member */
+            void **memb_ptr2; /* Pointer to that pointer */
+
+            if (IN_EXTENSION_GROUP(specs, edx))
+                {
+                    continue;
+                }
+
+            ASN_DEBUG("About to encode %s", elm->type->name);
+
+            /* Fetch the pointer to this member */
+            if (elm->flags & ATF_POINTER)
+                {
+                    memb_ptr2 = (void **)((char *)sptr + elm->memb_offset);
+                    if (!*memb_ptr2)
+                        {
+                            ASN_DEBUG("Element %s %d not present", elm->name,
+                                edx);
+                            if (elm->optional)
+                                {
+                                    continue;
+                                }
+                            /* Mandatory element is missing */
+                            _ASN_ENCODE_FAILED;
+                        }
+                }
+            else
+                {
+                    memb_ptr = (void *)((char *)sptr + elm->memb_offset);
+                    memb_ptr2 = &memb_ptr;
+                }
+
+            /* Eliminate default values */
+            if (elm->default_value && elm->default_value(0, memb_ptr2) == 1)
+                {
+                    continue;
+                }
+
+            ASN_DEBUG("Encoding %s->%s", td->name, elm->name);
+            er = elm->type->uper_encoder(elm->type, elm->per_constraints,
+                *memb_ptr2, po);
+            if (er.encoded == -1)
+                {
+                    return er;
+                }
+        }
+
+    /* No extensions to encode */
+    if (!n_extensions)
+        {
+            _ASN_ENCODED_OK(er);
+        }
+
+    ASN_DEBUG("Length of %d bit-map", n_extensions);
+    /* #18.8. Write down the presence bit-map length. */
+    if (uper_put_nslength(po, n_extensions))
+        {
+            _ASN_ENCODE_FAILED;
+        }
+
+    ASN_DEBUG("Bit-map of %d elements", n_extensions);
+    /* #18.7. Encoding the extensions presence bit-map. */
+    /* TODO: act upon NOTE in #18.7 for canonical PER */
+    if (SEQUENCE_handle_extensions(td, sptr, po, 0) != n_extensions)
+        {
+            _ASN_ENCODE_FAILED;
+        }
+
+    ASN_DEBUG("Writing %d extensions", n_extensions);
+    /* #18.9. Encode extensions as open type fields. */
+    if (SEQUENCE_handle_extensions(td, sptr, 0, po) != n_extensions)
+        {
+            _ASN_ENCODE_FAILED;
+        }
+
+    _ASN_ENCODED_OK(er);
+}

--- a/src/core/libs/supl/types/constr_SEQUENCE.h
+++ b/src/core/libs/supl/types/constr_SEQUENCE.h
@@ -1,0 +1,61 @@
+/*-
+ * SPDX-FileCopyrightText: (c) 2003, 2004 Lev Walkin <vlm@lionet.info>. All rights reserved.
+ * SPDX-License-Identifier: BSD-1-Clause
+ */
+#ifndef _CONSTR_SEQUENCE_H
+#define _CONSTR_SEQUENCE_H
+
+#include <asn_application.h>
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+    typedef struct asn_SEQUENCE_specifics_s
+    {
+        /*
+         * Target structure description.
+         */
+        int struct_size; /* Size of the target structure. */
+        int ctx_offset;  /* Offset of the asn_struct_ctx_t member */
+
+        /*
+         * Tags to members mapping table (sorted).
+         */
+        asn_TYPE_tag2member_t *tag2el;
+        int tag2el_count;
+
+        /*
+         * Optional members of the extensions root (roms) or additions (aoms).
+         * Meaningful for PER.
+         */
+        int *oms;       /* Optional MemberS */
+        int roms_count; /* Root optional members count */
+        int aoms_count; /* Additions optional members count */
+
+        /*
+         * Description of an extensions group.
+         */
+        int ext_after;  /* Extensions start after this member */
+        int ext_before; /* Extensions stop before this member */
+    } asn_SEQUENCE_specifics_t;
+
+    /*
+     * A set specialized functions dealing with the SEQUENCE type.
+     */
+    asn_struct_free_f SEQUENCE_free;
+    asn_struct_print_f SEQUENCE_print;
+    asn_constr_check_f SEQUENCE_constraint;
+    ber_type_decoder_f SEQUENCE_decode_ber;
+    der_type_encoder_f SEQUENCE_encode_der;
+    xer_type_decoder_f SEQUENCE_decode_xer;
+    xer_type_encoder_f SEQUENCE_encode_xer;
+    per_type_decoder_f SEQUENCE_decode_uper;
+    per_type_encoder_f SEQUENCE_encode_uper;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* _CONSTR_SEQUENCE_H_ */

--- a/src/core/libs/supl/types/constr_SEQUENCE_OF.c
+++ b/src/core/libs/supl/types/constr_SEQUENCE_OF.c
@@ -1,0 +1,288 @@
+/*-
+ * SPDX-FileCopyrightText: (c) 2003, 2004 Lev Walkin <vlm@lionet.info>. All rights reserved.
+ * SPDX-License-Identifier: BSD-1-Clause
+ */
+#include <asn_SEQUENCE_OF.h>
+#include <asn_internal.h>
+#include <constr_SEQUENCE_OF.h>
+
+/*
+ * The DER encoder of the SEQUENCE OF type.
+ */
+asn_enc_rval_t SEQUENCE_OF_encode_der(asn_TYPE_descriptor_t *td, void *ptr,
+    int tag_mode, ber_tlv_tag_t tag,
+    asn_app_consume_bytes_f *cb,
+    void *app_key)
+{
+    asn_TYPE_member_t *elm = td->elements;
+    asn_anonymous_sequence_ *list = _A_SEQUENCE_FROM_VOID(ptr);
+    size_t computed_size = 0;
+    ssize_t encoding_size = 0;
+    asn_enc_rval_t erval;
+    int edx;
+
+    ASN_DEBUG("Estimating size of SEQUENCE OF %s", td->name);
+
+    /*
+     * Gather the length of the underlying members sequence.
+     */
+    for (edx = 0; edx < list->count; edx++)
+        {
+            void *memb_ptr = list->array[edx];
+            if (!memb_ptr)
+                {
+                    continue;
+                }
+            erval =
+                elm->type->der_encoder(elm->type, memb_ptr, 0, elm->tag, 0, 0);
+            if (erval.encoded == -1)
+                {
+                    return erval;
+                }
+            computed_size += erval.encoded;
+        }
+
+    /*
+     * Encode the TLV for the sequence itself.
+     */
+    encoding_size =
+        der_write_tags(td, computed_size, tag_mode, 1, tag, cb, app_key);
+    if (encoding_size == -1)
+        {
+            erval.encoded = -1;
+            erval.failed_type = td;
+            erval.structure_ptr = ptr;
+            return erval;
+        }
+
+    computed_size += encoding_size;
+    if (!cb)
+        {
+            erval.encoded = computed_size;
+            _ASN_ENCODED_OK(erval);
+        }
+
+    ASN_DEBUG("Encoding members of SEQUENCE OF %s", td->name);
+
+    /*
+     * Encode all members.
+     */
+    for (edx = 0; edx < list->count; edx++)
+        {
+            void *memb_ptr = list->array[edx];
+            if (!memb_ptr)
+                {
+                    continue;
+                }
+            erval = elm->type->der_encoder(elm->type, memb_ptr, 0, elm->tag, cb,
+                app_key);
+            if (erval.encoded == -1)
+                {
+                    return erval;
+                }
+            encoding_size += erval.encoded;
+        }
+
+    if (computed_size != (size_t)encoding_size)
+        {
+            /*
+             * Encoded size is not equal to the computed size.
+             */
+            erval.encoded = -1;
+            erval.failed_type = td;
+            erval.structure_ptr = ptr;
+        }
+    else
+        {
+            erval.encoded = computed_size;
+            erval.structure_ptr = 0;
+            erval.failed_type = 0;
+        }
+
+    return erval;
+}
+
+asn_enc_rval_t SEQUENCE_OF_encode_xer(asn_TYPE_descriptor_t *td, void *sptr,
+    int ilevel,
+    enum xer_encoder_flags_e flags,
+    asn_app_consume_bytes_f *cb,
+    void *app_key)
+{
+    asn_enc_rval_t er;
+    asn_SET_OF_specifics_t *specs = (asn_SET_OF_specifics_t *)td->specifics;
+    asn_TYPE_member_t *elm = td->elements;
+    asn_anonymous_sequence_ *list = _A_SEQUENCE_FROM_VOID(sptr);
+    const char *mname = specs->as_XMLValueList
+                            ? 0
+                            : ((*elm->name) ? elm->name : elm->type->xml_tag);
+    unsigned int mlen = mname ? strlen(mname) : 0;
+    int xcan = (flags & XER_F_CANONICAL);
+    int i;
+
+    if (!sptr)
+        {
+            _ASN_ENCODE_FAILED;
+        }
+
+    er.encoded = 0;
+
+    for (i = 0; i < list->count; i++)
+        {
+            asn_enc_rval_t tmper;
+            void *memb_ptr = list->array[i];
+            if (!memb_ptr)
+                {
+                    continue;
+                }
+
+            if (mname)
+                {
+                    if (!xcan)
+                        {
+                            _i_ASN_TEXT_INDENT(1, ilevel);
+                        }
+                    _ASN_CALLBACK3("<", 1, mname, mlen, ">", 1);
+                }
+
+            tmper = elm->type->xer_encoder(elm->type, memb_ptr, ilevel + 1,
+                flags, cb, app_key);
+            if (tmper.encoded == -1)
+                {
+                    return tmper;
+                }
+            if (tmper.encoded == 0 && specs->as_XMLValueList)
+                {
+                    const char *name = elm->type->xml_tag;
+                    size_t len = strlen(name);
+                    if (!xcan)
+                        {
+                            _i_ASN_TEXT_INDENT(1, ilevel + 1);
+                        }
+                    _ASN_CALLBACK3("<", 1, name, len, "/>", 2);
+                }
+
+            if (mname)
+                {
+                    _ASN_CALLBACK3("</", 2, mname, mlen, ">", 1);
+                    er.encoded += 5;
+                }
+
+            er.encoded += (2 * mlen) + tmper.encoded;
+        }
+
+    if (!xcan)
+        {
+            _i_ASN_TEXT_INDENT(1, ilevel - 1);
+        }
+
+    _ASN_ENCODED_OK(er);
+cb_failed:
+    _ASN_ENCODE_FAILED;
+}
+
+asn_enc_rval_t SEQUENCE_OF_encode_uper(asn_TYPE_descriptor_t *td,
+    asn_per_constraints_t *constraints,
+    void *sptr, asn_per_outp_t *po)
+{
+    asn_anonymous_sequence_ *list;
+    asn_per_constraint_t *ct;
+    asn_enc_rval_t er;
+    asn_TYPE_member_t *elm = td->elements;
+    int seq;
+
+    if (!sptr)
+        {
+            _ASN_ENCODE_FAILED;
+        }
+    list = _A_SEQUENCE_FROM_VOID(sptr);
+
+    er.encoded = 0;
+
+    ASN_DEBUG("Encoding %s as SEQUENCE OF (%d)", td->name, list->count);
+
+    if (constraints)
+        {
+            ct = &constraints->size;
+        }
+    else if (td->per_constraints)
+        {
+            ct = &td->per_constraints->size;
+        }
+    else
+        {
+            ct = 0;
+        }
+
+    /* If extensible constraint, check if size is in root */
+    if (ct)
+        {
+            int not_in_root = (list->count < ct->lower_bound ||
+                               list->count > ct->upper_bound);
+            ASN_DEBUG("lb %ld ub %ld %s", ct->lower_bound, ct->upper_bound,
+                ct->flags & APC_EXTENSIBLE ? "ext" : "fix");
+            if (ct->flags & APC_EXTENSIBLE)
+                {
+                    /* Declare whether size is in extension root */
+                    if (per_put_few_bits(po, not_in_root, 1))
+                        {
+                            _ASN_ENCODE_FAILED;
+                        }
+                    if (not_in_root)
+                        {
+                            ct = 0;
+                        }
+                }
+            else if (not_in_root && ct->effective_bits >= 0)
+                {
+                    _ASN_ENCODE_FAILED;
+                }
+        }
+
+    if (ct && ct->effective_bits >= 0)
+        {
+            /* X.691, #19.5: No length determinant */
+            if (per_put_few_bits(po, list->count - ct->lower_bound,
+                    ct->effective_bits))
+                {
+                    _ASN_ENCODE_FAILED;
+                }
+        }
+
+    for (seq = -1; seq < list->count;)
+        {
+            ssize_t mayEncode;
+            if (seq < 0)
+                {
+                    seq = 0;
+                }
+            if (ct && ct->effective_bits >= 0)
+                {
+                    mayEncode = list->count;
+                }
+            else
+                {
+                    mayEncode = uper_put_length(po, list->count - seq);
+                    if (mayEncode < 0)
+                        {
+                            _ASN_ENCODE_FAILED;
+                        }
+                }
+
+            while (mayEncode--)
+                {
+                    void *memb_ptr = list->array[seq++];
+                    if (!memb_ptr)
+                        {
+                            _ASN_ENCODE_FAILED;
+                        }
+                    er = elm->type->uper_encoder(
+                        elm->type, elm->per_constraints, memb_ptr, po);
+                    if (er.encoded == -1)
+                        {
+                            _ASN_ENCODE_FAILED;
+                        }
+                }
+        }
+
+    _ASN_ENCODED_OK(er);
+}

--- a/src/core/libs/supl/types/constr_SEQUENCE_OF.h
+++ b/src/core/libs/supl/types/constr_SEQUENCE_OF.h
@@ -1,0 +1,34 @@
+/*-
+ * SPDX-FileCopyrightText: (c) 2003, 2004 Lev Walkin <vlm@lionet.info>. All rights reserved.
+ * SPDX-License-Identifier: BSD-1-Clause
+ */
+#ifndef _CONSTR_SEQUENCE_OF_H
+#define _CONSTR_SEQUENCE_OF_H
+
+#include <asn_application.h>
+#include <constr_SET_OF.h> /* Implemented using SET OF */
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+/*
+ * A set specialized functions dealing with the SEQUENCE OF type.
+ * Generally implemented using SET OF.
+ */
+#define SEQUENCE_OF_free SET_OF_free
+#define SEQUENCE_OF_print SET_OF_print
+#define SEQUENCE_OF_constraint SET_OF_constraint
+#define SEQUENCE_OF_decode_ber SET_OF_decode_ber
+#define SEQUENCE_OF_decode_xer SET_OF_decode_xer
+#define SEQUENCE_OF_decode_uper SET_OF_decode_uper
+    der_type_encoder_f SEQUENCE_OF_encode_der;
+    xer_type_encoder_f SEQUENCE_OF_encode_xer;
+    per_type_encoder_f SEQUENCE_OF_encode_uper;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* _CONSTR_SET_OF_H_ */

--- a/src/core/libs/supl/types/constr_SET_OF.c
+++ b/src/core/libs/supl/types/constr_SET_OF.c
@@ -1,0 +1,1205 @@
+/*-
+ * SPDX-FileCopyrightText: (c) 2003, 2004 Lev Walkin <vlm@lionet.info>. All rights reserved.
+ * SPDX-License-Identifier: BSD-1-Clause
+ */
+#include <asn_SET_OF.h>
+#include <asn_internal.h>
+#include <constr_SET_OF.h>
+
+/*
+ * Number of bytes left for this structure.
+ * (ctx->left) indicates the number of bytes _transferred_ for the structure.
+ * (size) contains the number of bytes in the buffer passed.
+ */
+#define LEFT ((size < (size_t)ctx->left) ? size : (size_t)ctx->left)
+
+/*
+ * If the subprocessor function returns with an indication that it wants
+ * more data, it may well be a fatal decoding problem, because the
+ * size is constrained by the <TLV>'s L, even if the buffer size allows
+ * reading more data.
+ * For example, consider the buffer containing the following TLVs:
+ * <T:5><L:1><V> <T:6>...
+ * The TLV length clearly indicates that one byte is expected in V, but
+ * if the V processor returns with "want more data" even if the buffer
+ * contains way more data than the V processor have seen.
+ */
+#define SIZE_VIOLATION (ctx->left >= 0 && (size_t)ctx->left <= size)
+
+/*
+ * This macro "eats" the part of the buffer which is definitely "consumed",
+ * i.e. was correctly converted into local representation or rightfully skipped.
+ */
+#undef ADVANCE
+#define ADVANCE(num_bytes)                        \
+    do                                            \
+        {                                         \
+            size_t num = num_bytes;               \
+            ptr = ((const char *)ptr) + num;      \
+            size -= num;                          \
+            if (ctx->left >= 0) ctx->left -= num; \
+            consumed_myself += num;               \
+        }                                         \
+    while (0)
+
+/*
+ * Switch to the next phase of parsing.
+ */
+#undef NEXT_PHASE
+#undef PHASE_OUT
+#define NEXT_PHASE(ctx)      \
+    do                       \
+        {                    \
+            (ctx)->phase++;  \
+            (ctx)->step = 0; \
+        }                    \
+    while (0)
+#define PHASE_OUT(ctx)         \
+    do                         \
+        {                      \
+            (ctx)->phase = 10; \
+        }                      \
+    while (0)
+
+/*
+ * Return a standardized complex structure.
+ */
+#undef RETURN
+#define RETURN(_code)                        \
+    do                                       \
+        {                                    \
+            rval.code = _code;               \
+            rval.consumed = consumed_myself; \
+            return rval;                     \
+        }                                    \
+    while (0)
+
+/*
+ * The decoder of the SET OF type.
+ */
+asn_dec_rval_t SET_OF_decode_ber(asn_codec_ctx_t *opt_codec_ctx,
+    asn_TYPE_descriptor_t *td, void **struct_ptr,
+    const void *ptr, size_t size, int tag_mode)
+{
+    /*
+     * Bring closer parts of structure description.
+     */
+    asn_SET_OF_specifics_t *specs = (asn_SET_OF_specifics_t *)td->specifics;
+    asn_TYPE_member_t *elm = td->elements; /* Single one */
+
+    /*
+     * Parts of the structure being constructed.
+     */
+    void *st = *struct_ptr; /* Target structure. */
+    asn_struct_ctx_t *ctx;  /* Decoder context */
+
+    ber_tlv_tag_t tlv_tag; /* T from TLV */
+    asn_dec_rval_t rval;   /* Return code from subparsers */
+
+    ssize_t consumed_myself = 0; /* Consumed bytes from ptr */
+
+    ASN_DEBUG("Decoding %s as SET OF", td->name);
+
+    /*
+     * Create the target structure if it is not present already.
+     */
+    if (st == 0)
+        {
+            st = *struct_ptr = CALLOC(1, specs->struct_size);
+            if (st == 0)
+                {
+                    RETURN(RC_FAIL);
+                }
+        }
+
+    /*
+     * Restore parsing context.
+     */
+    ctx = (asn_struct_ctx_t *)((char *)st + specs->ctx_offset);
+
+    /*
+     * Start to parse where left previously
+     */
+    switch (ctx->phase)
+        {
+        case 0:
+            /*
+             * PHASE 0.
+             * Check that the set of tags associated with given structure
+             * perfectly fits our expectations.
+             */
+
+            rval = ber_check_tags(opt_codec_ctx, td, ctx, ptr, size,
+                tag_mode, 1, &ctx->left, 0);
+            if (rval.code != RC_OK)
+                {
+                    ASN_DEBUG("%s tagging check failed: %d", td->name,
+                        rval.code);
+                    return rval;
+                }
+
+            if (ctx->left >= 0)
+                {
+                    ctx->left += rval.consumed; /* ?Subtracted below! */
+                }
+            ADVANCE(rval.consumed);
+
+            ASN_DEBUG(
+                "Structure consumes %ld bytes, "
+                "buffer %ld",
+                (long)ctx->left, (long)size);
+
+            NEXT_PHASE(ctx);
+            /* Fall through */
+        case 1:
+            /*
+             * PHASE 1.
+             * From the place where we've left it previously,
+             * try to decode the next item.
+             */
+            for (;; ctx->step = 0)
+                {
+                    ssize_t tag_len; /* Length of TLV's T */
+
+                    if (ctx->step & 1)
+                        {
+                            goto microphase2;
+                        }
+
+                    /*
+                     * MICROPHASE 1: Synchronize decoding.
+                     */
+
+                    if (ctx->left == 0)
+                        {
+                            ASN_DEBUG("End of SET OF %s", td->name);
+                            /*
+                             * No more things to decode.
+                             * Exit out of here.
+                             */
+                            PHASE_OUT(ctx);
+                            RETURN(RC_OK);
+                        }
+
+                    /*
+                     * Fetch the T from TLV.
+                     */
+                    tag_len = ber_fetch_tag(ptr, LEFT, &tlv_tag);
+                    switch (tag_len)
+                        {
+                        case 0:
+                            if (!SIZE_VIOLATION)
+                                {
+                                    RETURN(RC_WMORE);
+                                }
+                            /* Fall through */
+                        case -1:
+                            RETURN(RC_FAIL);
+                        }
+
+                    if (ctx->left < 0 && ((const uint8_t *)ptr)[0] == 0)
+                        {
+                            if (LEFT < 2)
+                                {
+                                    if (SIZE_VIOLATION)
+                                        {
+                                            RETURN(RC_FAIL);
+                                        }
+                                    else
+                                        {
+                                            RETURN(RC_WMORE);
+                                        }
+                                }
+                            else if (((const uint8_t *)ptr)[1] == 0)
+                                {
+                                    /*
+                                     * Found the terminator of the
+                                     * indefinite length structure.
+                                     */
+                                    break;
+                                }
+                        }
+
+                    /* Outmost tag may be unknown and cannot be
+                     * fetched/compared */
+                    if (elm->tag != (ber_tlv_tag_t)-1)
+                        {
+                            if (BER_TAGS_EQUAL(tlv_tag, elm->tag))
+                                {
+                                    /*
+                                     * The new list member of expected type
+                                     * has arrived.
+                                     */
+                                }
+                            else
+                                {
+                                    ASN_DEBUG(
+                                        "Unexpected tag %s fixed SET OF %s",
+                                        ber_tlv_tag_string(tlv_tag),
+                                        td->name);
+                                    ASN_DEBUG("%s SET OF has tag %s",
+                                        td->name,
+                                        ber_tlv_tag_string(elm->tag));
+                                    RETURN(RC_FAIL);
+                                }
+                        }
+
+                    /*
+                     * MICROPHASE 2: Invoke the member-specific decoder.
+                     */
+                    ctx->step |= 1; /* Confirm entering next microphase */
+                microphase2:
+
+                    /*
+                     * Invoke the member fetch routine according to member's
+                     * type
+                     */
+                    rval = elm->type->ber_decoder(opt_codec_ctx, elm->type,
+                        &ctx->ptr, ptr, LEFT, 0);
+                    ASN_DEBUG("In %s SET OF %s code %d consumed %d",
+                        td->name, elm->type->name, rval.code,
+                        (int)rval.consumed);
+                    switch (rval.code)
+                        {
+                        case RC_OK:
+                            {
+                                asn_anonymous_set_ *list =
+                                    _A_SET_FROM_VOID(st);
+                                if (ASN_SET_ADD(list, ctx->ptr) != 0)
+                                    {
+                                        RETURN(RC_FAIL);
+                                    }
+                                else
+                                    {
+                                        ctx->ptr = 0;
+                                    }
+                            }
+                            break;
+                        case RC_WMORE: /* More data expected */
+                            if (!SIZE_VIOLATION)
+                                {
+                                    ADVANCE(rval.consumed);
+                                    RETURN(RC_WMORE);
+                                }
+                            /* Fall through */
+                        case RC_FAIL: /* Fatal error */
+                            ASN_STRUCT_FREE(*elm->type, ctx->ptr);
+                            ctx->ptr = 0;
+                            RETURN(RC_FAIL);
+                        } /* switch(rval) */
+
+                    ADVANCE(rval.consumed);
+                } /* for(all list members) */
+
+            NEXT_PHASE(ctx);
+        case 2:
+            /*
+             * Read in all "end of content" TLVs.
+             */
+            while (ctx->left < 0)
+                {
+                    if (LEFT < 2)
+                        {
+                            if (LEFT > 0 && ((const char *)ptr)[0] != 0)
+                                {
+                                    /* Unexpected tag */
+                                    RETURN(RC_FAIL);
+                                }
+                            else
+                                {
+                                    RETURN(RC_WMORE);
+                                }
+                        }
+                    if (((const char *)ptr)[0] == 0 &&
+                        ((const char *)ptr)[1] == 0)
+                        {
+                            ADVANCE(2);
+                            ctx->left++;
+                        }
+                    else
+                        {
+                            RETURN(RC_FAIL);
+                        }
+                }
+
+            PHASE_OUT(ctx);
+        }
+
+    RETURN(RC_OK);
+}
+
+/*
+ * Internally visible buffer holding a single encoded element.
+ */
+struct el_buffer
+{
+    uint8_t *buf;
+    size_t length;
+    size_t size;
+};
+/* Append bytes to the above structure */
+static int el_addbytes(const void *buffer, size_t size, void *el_buf_ptr)
+{
+    struct el_buffer *el_buf = (struct el_buffer *)el_buf_ptr;
+
+    if (el_buf->length + size > el_buf->size)
+        {
+            return -1;
+        }
+
+    memcpy(el_buf->buf + el_buf->length, buffer, size);
+
+    el_buf->length += size;
+    return 0;
+}
+static int el_buf_cmp(const void *ap, const void *bp)
+{
+    const struct el_buffer *a = (const struct el_buffer *)ap;
+    const struct el_buffer *b = (const struct el_buffer *)bp;
+    int ret;
+    size_t common_len;
+
+    if (a->length < b->length)
+        {
+            common_len = a->length;
+        }
+    else
+        {
+            common_len = b->length;
+        }
+
+    ret = memcmp(a->buf, b->buf, common_len);
+    if (ret == 0)
+        {
+            if (a->length < b->length)
+                {
+                    ret = -1;
+                }
+            else if (a->length > b->length)
+                {
+                    ret = 1;
+                }
+        }
+
+    return ret;
+}
+
+/*
+ * The DER encoder of the SET OF type.
+ */
+asn_enc_rval_t SET_OF_encode_der(asn_TYPE_descriptor_t *td, void *ptr,
+    int tag_mode, ber_tlv_tag_t tag,
+    asn_app_consume_bytes_f *cb, void *app_key)
+{
+    asn_TYPE_member_t *elm = td->elements;
+    asn_TYPE_descriptor_t *elm_type = elm->type;
+    der_type_encoder_f *der_encoder = elm_type->der_encoder;
+    asn_anonymous_set_ *list = _A_SET_FROM_VOID(ptr);
+    size_t computed_size = 0;
+    ssize_t encoding_size = 0;
+    struct el_buffer *encoded_els;
+    ssize_t eels_count = 0;
+    size_t max_encoded_len = 1;
+    asn_enc_rval_t erval;
+    int ret;
+    ssize_t edx;
+
+    ASN_DEBUG("Estimating size for SET OF %s", td->name);
+
+    /*
+     * Gather the length of the underlying members sequence.
+     */
+    for (edx = 0; edx < list->count; edx++)
+        {
+            void *memb_ptr = list->array[edx];
+            if (!memb_ptr)
+                {
+                    continue;
+                }
+            erval = der_encoder(elm_type, memb_ptr, 0, elm->tag, 0, 0);
+            if (erval.encoded == -1)
+                {
+                    return erval;
+                }
+            computed_size += erval.encoded;
+
+            /* Compute maximum encoding's size */
+            if (max_encoded_len < (size_t)erval.encoded)
+                {
+                    max_encoded_len = erval.encoded;
+                }
+        }
+
+    /*
+     * Encode the TLV for the sequence itself.
+     */
+    encoding_size =
+        der_write_tags(td, computed_size, tag_mode, 1, tag, cb, app_key);
+    if (encoding_size == -1)
+        {
+            erval.encoded = -1;
+            erval.failed_type = td;
+            erval.structure_ptr = ptr;
+            return erval;
+        }
+    computed_size += encoding_size;
+
+    if (!cb || list->count == 0)
+        {
+            erval.encoded = computed_size;
+            _ASN_ENCODED_OK(erval);
+        }
+
+    /*
+     * DER mandates dynamic sorting of the SET OF elements
+     * according to their encodings. Build an array of the
+     * encoded elements.
+     */
+    encoded_els =
+        (struct el_buffer *)MALLOC(list->count * sizeof(encoded_els[0]));
+    if (encoded_els == NULL)
+        {
+            erval.encoded = -1;
+            erval.failed_type = td;
+            erval.structure_ptr = ptr;
+            return erval;
+        }
+
+    ASN_DEBUG("Encoding members of %s SET OF", td->name);
+
+    /*
+     * Encode all members.
+     */
+    for (edx = 0; edx < list->count; edx++)
+        {
+            void *memb_ptr = list->array[edx];
+            struct el_buffer *encoded_el = &encoded_els[eels_count];
+
+            if (!memb_ptr)
+                {
+                    continue;
+                }
+
+            /*
+             * Prepare space for encoding.
+             */
+            encoded_el->buf = (uint8_t *)MALLOC(max_encoded_len);
+            if (encoded_el->buf)
+                {
+                    encoded_el->length = 0;
+                    encoded_el->size = max_encoded_len;
+                }
+            else
+                {
+                    for (edx--; edx >= 0; edx--)
+                        {
+                            FREEMEM(encoded_els[edx].buf);
+                        }
+                    FREEMEM(encoded_els);
+                    erval.encoded = -1;
+                    erval.failed_type = td;
+                    erval.structure_ptr = ptr;
+                    return erval;
+                }
+
+            /*
+             * Encode the member into the prepared space.
+             */
+            erval = der_encoder(elm_type, memb_ptr, 0, elm->tag, el_addbytes,
+                encoded_el);
+            if (erval.encoded == -1)
+                {
+                    for (; edx >= 0; edx--)
+                        {
+                            FREEMEM(encoded_els[edx].buf);
+                        }
+                    FREEMEM(encoded_els);
+                    return erval;
+                }
+            encoding_size += erval.encoded;
+            eels_count++;
+        }
+
+    /*
+     * Sort the encoded elements according to their encoding.
+     */
+    qsort(encoded_els, eels_count, sizeof(encoded_els[0]), el_buf_cmp);
+
+    /*
+     * Report encoded elements to the application.
+     * Dispose of temporary sorted members table.
+     */
+    ret = 0;
+    for (edx = 0; edx < eels_count; edx++)
+        {
+            struct el_buffer *encoded_el = &encoded_els[edx];
+            /* Report encoded chunks to the application */
+            if (ret == 0 &&
+                cb(encoded_el->buf, encoded_el->length, app_key) < 0)
+                {
+                    ret = -1;
+                }
+            FREEMEM(encoded_el->buf);
+        }
+    FREEMEM(encoded_els);
+
+    if (ret || computed_size != (size_t)encoding_size)
+        {
+            /*
+             * Standard callback failed, or
+             * encoded size is not equal to the computed size.
+             */
+            erval.encoded = -1;
+            erval.failed_type = td;
+            erval.structure_ptr = ptr;
+        }
+    else
+        {
+            erval.encoded = computed_size;
+        }
+
+    _ASN_ENCODED_OK(erval);
+}
+
+#undef XER_ADVANCE
+#define XER_ADVANCE(num_bytes)                       \
+    do                                               \
+        {                                            \
+            size_t num = num_bytes;                  \
+            buf_ptr = ((const char *)buf_ptr) + num; \
+            size -= num;                             \
+            consumed_myself += num;                  \
+        }                                            \
+    while (0)
+
+/*
+ * Decode the XER (XML) data.
+ */
+asn_dec_rval_t SET_OF_decode_xer(asn_codec_ctx_t *opt_codec_ctx,
+    asn_TYPE_descriptor_t *td, void **struct_ptr,
+    const char *opt_mname, const void *buf_ptr,
+    size_t size)
+{
+    /*
+     * Bring closer parts of structure description.
+     */
+    asn_SET_OF_specifics_t *specs = (asn_SET_OF_specifics_t *)td->specifics;
+    asn_TYPE_member_t *element = td->elements;
+    const char *elm_tag;
+    const char *xml_tag = opt_mname ? opt_mname : td->xml_tag;
+
+    /*
+     * ... and parts of the structure being constructed.
+     */
+    void *st = *struct_ptr; /* Target structure. */
+    asn_struct_ctx_t *ctx;  /* Decoder context */
+
+    asn_dec_rval_t rval;         /* Return value from a decoder */
+    ssize_t consumed_myself = 0; /* Consumed bytes from ptr */
+
+    /*
+     * Create the target structure if it is not present already.
+     */
+    if (st == 0)
+        {
+            st = *struct_ptr = CALLOC(1, specs->struct_size);
+            if (st == 0)
+                {
+                    RETURN(RC_FAIL);
+                }
+        }
+
+    /* Which tag is expected for the downstream */
+    if (specs->as_XMLValueList)
+        {
+            elm_tag = (specs->as_XMLValueList == 1) ? 0 : "";
+        }
+    else
+        {
+            elm_tag = (*element->name) ? element->name : element->type->xml_tag;
+        }
+
+    /*
+     * Restore parsing context.
+     */
+    ctx = (asn_struct_ctx_t *)((char *)st + specs->ctx_offset);
+
+    /*
+     * Phases of XER/XML processing:
+     * Phase 0: Check that the opening tag matches our expectations.
+     * Phase 1: Processing body and reacting on closing tag.
+     * Phase 2: Processing inner type.
+     */
+    for (; ctx->phase <= 2;)
+        {
+            pxer_chunk_type_e ch_type; /* XER chunk type */
+            ssize_t ch_size;           /* Chunk size */
+            xer_check_tag_e tcv;       /* Tag check value */
+
+            /*
+             * Go inside the inner member of a set.
+             */
+            if (ctx->phase == 2)
+                {
+                    asn_dec_rval_t tmprval;
+
+                    /* Invoke the inner type decoder, m.b. multiple times */
+                    ASN_DEBUG("XER/SET OF element [%s]", elm_tag);
+                    tmprval = element->type->xer_decoder(
+                        opt_codec_ctx, element->type, &ctx->ptr, elm_tag,
+                        buf_ptr, size);
+                    if (tmprval.code == RC_OK)
+                        {
+                            asn_anonymous_set_ *list = _A_SET_FROM_VOID(st);
+                            if (ASN_SET_ADD(list, ctx->ptr) != 0)
+                                {
+                                    RETURN(RC_FAIL);
+                                }
+                            ctx->ptr = 0;
+                            XER_ADVANCE(tmprval.consumed);
+                        }
+                    else
+                        {
+                            XER_ADVANCE(tmprval.consumed);
+                            RETURN(tmprval.code);
+                        }
+                    ctx->phase = 1; /* Back to body processing */
+                    ASN_DEBUG("XER/SET OF phase => %d", ctx->phase);
+                    /* Fall through */
+                }
+
+            /*
+             * Get the next part of the XML stream.
+             */
+            ch_size = xer_next_token(&ctx->context, buf_ptr, size, &ch_type);
+            switch (ch_size)
+                {
+                case -1:
+                    RETURN(RC_FAIL);
+                case 0:
+                    RETURN(RC_WMORE);
+                default:
+                    switch (ch_type)
+                        {
+                        case PXER_COMMENT:        /* Got XML comment */
+                        case PXER_TEXT:           /* Ignore free-standing text */
+                            XER_ADVANCE(ch_size); /* Skip silently */
+                            continue;
+                        case PXER_TAG:
+                            break; /* Check the rest down there */
+                        }
+                }
+
+            tcv = xer_check_tag(buf_ptr, ch_size, xml_tag);
+            ASN_DEBUG("XER/SET OF: tcv = %d, ph=%d t=%s", tcv, ctx->phase,
+                xml_tag);
+            switch (tcv)
+                {
+                case XCT_CLOSING:
+                    if (ctx->phase == 0)
+                        {
+                            break;
+                        }
+                    ctx->phase = 0;
+                    /* Fall through */
+                case XCT_BOTH:
+                    if (ctx->phase == 0)
+                        {
+                            /* No more things to decode */
+                            XER_ADVANCE(ch_size);
+                            ctx->phase = 3; /* Phase out */
+                            RETURN(RC_OK);
+                        }
+                    /* Fall through */
+                case XCT_OPENING:
+                    if (ctx->phase == 0)
+                        {
+                            XER_ADVANCE(ch_size);
+                            ctx->phase = 1; /* Processing body phase */
+                            continue;
+                        }
+                    /* Fall through */
+                case XCT_UNKNOWN_OP:
+                case XCT_UNKNOWN_BO:
+
+                    ASN_DEBUG("XER/SET OF: tcv=%d, ph=%d", tcv, ctx->phase);
+                    if (ctx->phase == 1)
+                        {
+                            /*
+                             * Process a single possible member.
+                             */
+                            ctx->phase = 2;
+                            continue;
+                        }
+                    /* Fall through */
+                default:
+                    break;
+                }
+
+            ASN_DEBUG("Unexpected XML tag in SET OF");
+            break;
+        }
+
+    ctx->phase = 3; /* "Phase out" on hard failure */
+    RETURN(RC_FAIL);
+}
+
+typedef struct xer_tmp_enc_s
+{
+    void *buffer;
+    size_t offset;
+    size_t size;
+} xer_tmp_enc_t;
+static int SET_OF_encode_xer_callback(const void *buffer, size_t size,
+    void *key)
+{
+    xer_tmp_enc_t *t = (xer_tmp_enc_t *)key;
+    if (t->offset + size >= t->size)
+        {
+            size_t newsize = (t->size << 2) + size;
+            void *p = REALLOC(t->buffer, newsize);
+            if (!p)
+                {
+                    return -1;
+                }
+            t->buffer = p;
+            t->size = newsize;
+        }
+    memcpy((char *)t->buffer + t->offset, buffer, size);
+    t->offset += size;
+    return 0;
+}
+static int SET_OF_xer_order(const void *aptr, const void *bptr)
+{
+    const xer_tmp_enc_t *a = (const xer_tmp_enc_t *)aptr;
+    const xer_tmp_enc_t *b = (const xer_tmp_enc_t *)bptr;
+    size_t minlen = a->offset;
+    int ret;
+    if (b->offset < minlen)
+        {
+            minlen = b->offset;
+        }
+    /* Well-formed UTF-8 has this nice lexicographical property... */
+    ret = memcmp(a->buffer, b->buffer, minlen);
+    if (ret != 0)
+        {
+            return ret;
+        }
+    if (a->offset == b->offset)
+        {
+            return 0;
+        }
+    if (a->offset == minlen)
+        {
+            return -1;
+        }
+    return 1;
+}
+
+asn_enc_rval_t SET_OF_encode_xer(asn_TYPE_descriptor_t *td, void *sptr,
+    int ilevel, enum xer_encoder_flags_e flags,
+    asn_app_consume_bytes_f *cb, void *app_key)
+{
+    asn_enc_rval_t er;
+    asn_SET_OF_specifics_t *specs = (asn_SET_OF_specifics_t *)td->specifics;
+    asn_TYPE_member_t *elm = td->elements;
+    asn_anonymous_set_ *list = _A_SET_FROM_VOID(sptr);
+    const char *mname = specs->as_XMLValueList
+                            ? 0
+                            : ((*elm->name) ? elm->name : elm->type->xml_tag);
+    size_t mlen = mname ? strlen(mname) : 0;
+    int xcan = (flags & XER_F_CANONICAL);
+    xer_tmp_enc_t *encs = 0;
+    size_t encs_count = 0;
+    void *original_app_key = app_key;
+    asn_app_consume_bytes_f *original_cb = cb;
+    int i;
+
+    if (!sptr)
+        {
+            _ASN_ENCODE_FAILED;
+        }
+
+    if (xcan)
+        {
+            encs = (xer_tmp_enc_t *)MALLOC(list->count * sizeof(encs[0]));
+            if (!encs)
+                {
+                    _ASN_ENCODE_FAILED;
+                }
+            cb = SET_OF_encode_xer_callback;
+        }
+
+    er.encoded = 0;
+
+    for (i = 0; i < list->count; i++)
+        {
+            asn_enc_rval_t tmper;
+
+            void *memb_ptr = list->array[i];
+            if (!memb_ptr)
+                {
+                    continue;
+                }
+
+            if (encs)
+                {
+                    memset(&encs[encs_count], 0, sizeof(encs[0]));
+                    app_key = &encs[encs_count];
+                    encs_count++;
+                }
+
+            if (mname)
+                {
+                    if (!xcan)
+                        {
+                            _i_ASN_TEXT_INDENT(1, ilevel);
+                        }
+                    _ASN_CALLBACK3("<", 1, mname, mlen, ">", 1);
+                }
+
+            if (!xcan && specs->as_XMLValueList == 1)
+                {
+                    _i_ASN_TEXT_INDENT(1, ilevel + 1);
+                }
+            tmper = elm->type->xer_encoder(
+                elm->type, memb_ptr, ilevel + (specs->as_XMLValueList != 2),
+                flags, cb, app_key);
+            if (tmper.encoded == -1)
+                {
+                    td = tmper.failed_type;
+                    sptr = tmper.structure_ptr;
+                    goto cb_failed;
+                }
+            if (tmper.encoded == 0 && specs->as_XMLValueList)
+                {
+                    const char *name = elm->type->xml_tag;
+                    size_t len = strlen(name);
+                    _ASN_CALLBACK3("<", 1, name, len, "/>", 2);
+                }
+
+            if (mname)
+                {
+                    _ASN_CALLBACK3("</", 2, mname, mlen, ">", 1);
+                    er.encoded += 5;
+                }
+
+            er.encoded += (2 * mlen) + tmper.encoded;
+        }
+
+    if (!xcan)
+        {
+            _i_ASN_TEXT_INDENT(1, ilevel - 1);
+        }
+
+    if (encs)
+        {
+            xer_tmp_enc_t *enc = encs;
+            xer_tmp_enc_t *end = encs + encs_count;
+            ssize_t control_size = 0;
+
+            cb = original_cb;
+            app_key = original_app_key;
+            qsort(encs, encs_count, sizeof(encs[0]), SET_OF_xer_order);
+
+            for (; enc < end; enc++)
+                {
+                    _ASN_CALLBACK(enc->buffer, enc->offset);
+                    FREEMEM(enc->buffer);
+                    enc->buffer = 0;
+                    control_size += enc->offset;
+                }
+            assert(control_size == er.encoded);
+        }
+
+    goto cleanup;
+cb_failed:
+    er.encoded = -1;
+    er.failed_type = td;
+    er.structure_ptr = sptr;
+cleanup:
+    if (encs)
+        {
+            while (encs_count-- > 0)
+                {
+                    if (encs[encs_count].buffer)
+                        {
+                            FREEMEM(encs[encs_count].buffer);
+                        }
+                }
+            FREEMEM(encs);
+        }
+    _ASN_ENCODED_OK(er);
+}
+
+int SET_OF_print(asn_TYPE_descriptor_t *td, const void *sptr, int ilevel,
+    asn_app_consume_bytes_f *cb, void *app_key)
+{
+    asn_TYPE_member_t *elm = td->elements;
+    const asn_anonymous_set_ *list = _A_CSET_FROM_VOID(sptr);
+    int ret;
+    int i;
+
+    if (!sptr)
+        {
+            return (cb("<absent>", 8, app_key) < 0) ? -1 : 0;
+        }
+
+    /* Dump preamble */
+    if (cb(td->name, strlen(td->name), app_key) < 0 ||
+        cb(" ::= {", 6, app_key) < 0)
+        {
+            return -1;
+        }
+
+    for (i = 0; i < list->count; i++)
+        {
+            const void *memb_ptr = list->array[i];
+            if (!memb_ptr)
+                {
+                    continue;
+                }
+
+            _i_INDENT(1);
+
+            ret = elm->type->print_struct(elm->type, memb_ptr, ilevel + 1, cb,
+                app_key);
+            if (ret)
+                {
+                    return ret;
+                }
+        }
+
+    ilevel--;
+    _i_INDENT(1);
+
+    return (cb("}", 1, app_key) < 0) ? -1 : 0;
+}
+
+void SET_OF_free(asn_TYPE_descriptor_t *td, void *ptr, int contents_only)
+{
+    if (td && ptr)
+        {
+            asn_SET_OF_specifics_t *specs;
+            asn_TYPE_member_t *elm = td->elements;
+            asn_anonymous_set_ *list = _A_SET_FROM_VOID(ptr);
+            asn_struct_ctx_t *ctx; /* Decoder context */
+            int i;
+
+            /*
+             * Could not use set_of_empty() because of (*free)
+             * incompatibility.
+             */
+            for (i = 0; i < list->count; i++)
+                {
+                    void *memb_ptr = list->array[i];
+                    if (memb_ptr)
+                        {
+                            ASN_STRUCT_FREE(*elm->type, memb_ptr);
+                        }
+                }
+            list->count = 0; /* No meaningful elements left */
+
+            asn_set_empty(list); /* Remove (list->array) */
+
+            specs = (asn_SET_OF_specifics_t *)td->specifics;
+            ctx = (asn_struct_ctx_t *)((char *)ptr + specs->ctx_offset);
+            if (ctx->ptr)
+                {
+                    ASN_STRUCT_FREE(*elm->type, ctx->ptr);
+                    ctx->ptr = 0;
+                }
+
+            if (!contents_only)
+                {
+                    FREEMEM(ptr);
+                }
+        }
+}
+
+int SET_OF_constraint(asn_TYPE_descriptor_t *td, const void *sptr,
+    asn_app_constraint_failed_f *ctfailcb, void *app_key)
+{
+    asn_TYPE_member_t *elm = td->elements;
+    asn_constr_check_f *constr;
+    const asn_anonymous_set_ *list = _A_CSET_FROM_VOID(sptr);
+    int i;
+
+    if (!sptr)
+        {
+            _ASN_CTFAIL(app_key, td, sptr, "%s: value not given (%s:%d)",
+                td->name, __FILE__, __LINE__);
+            return -1;
+        }
+
+    constr = elm->memb_constraints;
+    if (!constr)
+        {
+            constr = elm->type->check_constraints;
+        }
+
+    /*
+     * Iterate over the members of an array.
+     * Validate each in turn, until one fails.
+     */
+    for (i = 0; i < list->count; i++)
+        {
+            const void *memb_ptr = list->array[i];
+            int ret;
+
+            if (!memb_ptr)
+                {
+                    continue;
+                }
+
+            ret = constr(elm->type, memb_ptr, ctfailcb, app_key);
+            if (ret)
+                {
+                    return ret;
+                }
+        }
+
+    /*
+     * Cannot inherit it eralier:
+     * need to make sure we get the updated version.
+     */
+    if (!elm->memb_constraints)
+        {
+            elm->memb_constraints = elm->type->check_constraints;
+        }
+
+    return 0;
+}
+
+asn_dec_rval_t SET_OF_decode_uper(asn_codec_ctx_t *opt_codec_ctx,
+    asn_TYPE_descriptor_t *td,
+    asn_per_constraints_t *constraints,
+    void **sptr, asn_per_data_t *pd)
+{
+    asn_dec_rval_t rv;
+    asn_SET_OF_specifics_t *specs = (asn_SET_OF_specifics_t *)td->specifics;
+    asn_TYPE_member_t *elm = td->elements; /* Single one */
+    void *st = *sptr;
+    asn_anonymous_set_ *list;
+    asn_per_constraint_t *ct;
+    int repeat = 0;
+    ssize_t nelems;
+
+    if (_ASN_STACK_OVERFLOW_CHECK(opt_codec_ctx))
+        {
+            _ASN_DECODE_FAILED;
+        }
+
+    /*
+     * Create the target structure if it is not present already.
+     */
+    if (!st)
+        {
+            st = *sptr = CALLOC(1, specs->struct_size);
+            if (!st)
+                {
+                    _ASN_DECODE_FAILED;
+                }
+        }
+    list = _A_SET_FROM_VOID(st);
+
+    /* Figure out which constraints to use */
+    if (constraints)
+        {
+            ct = &constraints->size;
+        }
+    else if (td->per_constraints)
+        {
+            ct = &td->per_constraints->size;
+        }
+    else
+        {
+            ct = 0;
+        }
+
+    if (ct && ct->flags & APC_EXTENSIBLE)
+        {
+            int value = per_get_few_bits(pd, 1);
+            if (value < 0)
+                {
+                    _ASN_DECODE_STARVED;
+                }
+            if (value)
+                {
+                    ct = 0; /* Not restricted! */
+                }
+        }
+
+    if (ct && ct->effective_bits >= 0)
+        {
+            /* X.691, #19.5: No length determinant */
+            nelems = per_get_few_bits(pd, ct->effective_bits);
+            ASN_DEBUG("Preparing to fetch %ld+%ld elements from %s",
+                (long)nelems, ct->lower_bound, td->name);
+            if (nelems < 0)
+                {
+                    _ASN_DECODE_STARVED;
+                }
+            nelems += ct->lower_bound;
+        }
+    else
+        {
+            nelems = -1;
+        }
+
+    do
+        {
+            if (nelems < 0)
+                {
+                    nelems = uper_get_length(pd, ct ? ct->effective_bits : -1,
+                        &repeat);
+                    ASN_DEBUG("Got to decode %d elements (eff %d)", (int)nelems,
+                        (long)ct ? ct->effective_bits : -1);
+                    if (nelems < 0)
+                        {
+                            _ASN_DECODE_STARVED;
+                        }
+                }
+
+            for (ssize_t k = 0; k < nelems; k++)
+                {
+                    void *ptr = 0;
+                    ASN_DEBUG("SET OF %s decoding", elm->type->name);
+                    rv =
+                        elm->type->uper_decoder(opt_codec_ctx, elm->type,
+                            elm->per_constraints, &ptr, pd);
+                    ASN_DEBUG("%s SET OF %s decoded %d, %p", td->name,
+                        elm->type->name, rv.code, ptr);
+                    if (rv.code == RC_OK)
+                        {
+                            if (ASN_SET_ADD(list, ptr) == 0)
+                                {
+                                    continue;
+                                }
+                            ASN_DEBUG("Failed to add element into %s",
+                                td->name);
+                            /* Fall through */
+                            rv.code = RC_FAIL;
+                        }
+                    else
+                        {
+                            ASN_DEBUG("Failed decoding %s of %s (SET OF)",
+                                elm->type->name, td->name);
+                        }
+                    if (ptr)
+                        {
+                            ASN_STRUCT_FREE(*elm->type, ptr);
+                        }
+                    return rv;
+                }
+
+            nelems = -1; /* Allow uper_get_length() */
+        }
+    while (repeat);
+
+    ASN_DEBUG("Decoded %s as SET OF", td->name);
+
+    rv.code = RC_OK;
+    rv.consumed = 0;
+    return rv;
+}

--- a/src/core/libs/supl/types/constr_SET_OF.h
+++ b/src/core/libs/supl/types/constr_SET_OF.h
@@ -1,0 +1,44 @@
+/*-
+ * SPDX-FileCopyrightText: (c) 2003, 2004 Lev Walkin <vlm@lionet.info>. All rights reserved.
+ * SPDX-License-Identifier: BSD-1-Clause
+ */
+#ifndef _CONSTR_SET_OF_H
+#define _CONSTR_SET_OF_H
+
+#include <asn_application.h>
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+    typedef struct asn_SET_OF_specifics_s
+    {
+        /*
+         * Target structure description.
+         */
+        int struct_size; /* Size of the target structure. */
+        int ctx_offset;  /* Offset of the asn_struct_ctx_t member */
+
+        /* XER-specific stuff */
+        int as_XMLValueList; /* The member type must be encoded like this */
+    } asn_SET_OF_specifics_t;
+
+    /*
+     * A set specialized functions dealing with the SET OF type.
+     */
+    asn_struct_free_f SET_OF_free;
+    asn_struct_print_f SET_OF_print;
+    asn_constr_check_f SET_OF_constraint;
+    ber_type_decoder_f SET_OF_decode_ber;
+    der_type_encoder_f SET_OF_encode_der;
+    xer_type_decoder_f SET_OF_decode_xer;
+    xer_type_encoder_f SET_OF_encode_xer;
+    per_type_decoder_f SET_OF_decode_uper;
+    per_type_encoder_f SET_OF_encode_uper;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* _CONSTR_SET_OF_H_ */

--- a/src/core/libs/supl/types/constr_TYPE.c
+++ b/src/core/libs/supl/types/constr_TYPE.c
@@ -1,0 +1,91 @@
+/*-
+ * SPDX-FileCopyrightText: (c) 2003, 2004 Lev Walkin <vlm@lionet.info>. All rights reserved.
+ * SPDX-License-Identifier: BSD-1-Clause
+ */
+#include <asn_internal.h>
+#include <constr_TYPE.h>
+#include <errno.h>
+
+/*
+ * Version of the ASN.1 infrastructure shipped with compiler.
+ */
+int get_asn1c_environment_version() { return ASN1C_ENVIRONMENT_VERSION; }
+
+static asn_app_consume_bytes_f print2fp;
+
+/*
+ * Return the outmost tag of the type.
+ */
+ber_tlv_tag_t asn_TYPE_outmost_tag(asn_TYPE_descriptor_t *type_descriptor,
+    const void *struct_ptr, int tag_mode,
+    ber_tlv_tag_t tag)
+{
+    if (tag_mode)
+        {
+            return tag;
+        }
+
+    if (type_descriptor->tags_count)
+        {
+            return type_descriptor->tags[0];
+        }
+
+    return type_descriptor->outmost_tag(type_descriptor, struct_ptr, 0, 0);
+}
+
+/*
+ * Print the target language's structure in human readable form.
+ */
+int asn_fprint(FILE *stream, asn_TYPE_descriptor_t *td, const void *struct_ptr)
+{
+    if (!stream)
+        {
+            stream = stdout;
+        }
+    if (!td || !struct_ptr)
+        {
+            errno = EINVAL;
+            return -1;
+        }
+
+    /* Invoke type-specific printer */
+    if (td->print_struct(td, struct_ptr, 1, print2fp, stream))
+        {
+            return -1;
+        }
+
+    /* Terminate the output */
+    if (print2fp("\n", 1, stream))
+        {
+            return -1;
+        }
+
+    return fflush(stream);
+}
+
+/* Dump the data into the specified stdio stream */
+static int print2fp(const void *buffer, size_t size, void *app_key)
+{
+    FILE *stream = (FILE *)app_key;
+
+    if (fwrite(buffer, 1, size, stream) != size)
+        {
+            return -1;
+        }
+
+    return 0;
+}
+
+/*
+ * Some compilers do not support variable args macros.
+ * This function is a replacement of ASN_DEBUG() macro.
+ */
+void ASN_DEBUG_f(const char *fmt, ...);
+void ASN_DEBUG_f(const char *fmt, ...)
+{
+    va_list ap;
+    va_start(ap, fmt);
+    vfprintf(stderr, fmt, ap);
+    fprintf(stderr, "\n");
+    va_end(ap);
+}

--- a/src/core/libs/supl/types/constr_TYPE.h
+++ b/src/core/libs/supl/types/constr_TYPE.h
@@ -1,0 +1,184 @@
+/*-
+ * SPDX-FileCopyrightText: (c) 2003, 2004 Lev Walkin <vlm@lionet.info>. All rights reserved.
+ * SPDX-License-Identifier: BSD-1-Clause
+ */
+/*
+ * This file contains the declaration structure called "ASN.1 Type Definition",
+ * which holds all information necessary for encoding and decoding routines.
+ * This structure even contains pointer to these encoding and decoding routines
+ * for each defined ASN.1 type.
+ */
+#ifndef _CONSTR_TYPE_H
+#define _CONSTR_TYPE_H
+
+#include <ber_tlv_length.h>
+#include <ber_tlv_tag.h>
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+    struct asn_TYPE_descriptor_s; /* Forward declaration */
+    struct asn_TYPE_member_s;     /* Forward declaration */
+
+    /*
+     * This type provides the context information for various ASN.1 routines,
+     * primarily ones doing decoding. A member _asn_ctx of this type must be
+     * included into certain target language's structures, such as compound
+     * types.
+     */
+    typedef struct asn_struct_ctx_s
+    {
+        short phase;        /* Decoding phase */
+        short step;         /* Elementary step of a phase */
+        int context;        /* Other context information */
+        void *ptr;          /* Decoder-specific stuff (stack elements) */
+        ber_tlv_len_t left; /* Number of bytes left, -1 for indefinite */
+    } asn_struct_ctx_t;
+
+#include <ber_decoder.h> /* Basic Encoding Rules decoder */
+#include <constraints.h> /* Subtype constraints support */
+#include <der_encoder.h> /* Distinguished Encoding Rules encoder */
+#include <per_decoder.h> /* Packet Encoding Rules decoder */
+#include <per_encoder.h> /* Packet Encoding Rules encoder */
+#include <xer_decoder.h> /* Decoder of XER (XML, text) */
+#include <xer_encoder.h> /* Encoder into XER (XML, text) */
+
+    /*
+     * Free the structure according to its specification.
+     * If (free_contents_only) is set, the wrapper structure itself (struct_ptr)
+     * will not be freed. (It may be useful in case the structure is allocated
+     * statically or arranged on the stack, yet its elements are allocated
+     * dynamically.)
+     */
+    typedef void(asn_struct_free_f)(
+        struct asn_TYPE_descriptor_s *type_descriptor, void *struct_ptr,
+        int free_contents_only);
+#define ASN_STRUCT_FREE(asn_DEF, ptr) (asn_DEF).free_struct(&(asn_DEF), ptr, 0)
+#define ASN_STRUCT_FREE_CONTENTS_ONLY(asn_DEF, ptr) \
+    (asn_DEF).free_struct(&(asn_DEF), ptr, 1)
+
+    /*
+     * Print the structure according to its specification.
+     */
+    typedef int(asn_struct_print_f)(
+        struct asn_TYPE_descriptor_s *type_descriptor, const void *struct_ptr,
+        int level, /* Indentation level */
+        asn_app_consume_bytes_f *callback, void *app_key);
+
+    /*
+     * Return the outmost tag of the type.
+     * If the type is untagged CHOICE, the dynamic operation is performed.
+     * NOTE: This function pointer type is only useful internally.
+     * Do not use it in your application.
+     */
+    typedef ber_tlv_tag_t(asn_outmost_tag_f)(
+        struct asn_TYPE_descriptor_s *type_descriptor, const void *struct_ptr,
+        int tag_mode, ber_tlv_tag_t tag);
+    /* The instance of the above function type; used internally. */
+    asn_outmost_tag_f asn_TYPE_outmost_tag;
+
+    /*
+     * The definitive description of the destination language's structure.
+     */
+    typedef struct asn_TYPE_descriptor_s
+    {
+        char *name;    /* A name of the ASN.1 type. "" in some cases. */
+        char *xml_tag; /* Name used in XML tag */
+
+        /*
+         * Generalized functions for dealing with the specific type.
+         * May be directly invoked by applications.
+         */
+        asn_struct_free_f *free_struct;        /* Free the structure */
+        asn_struct_print_f *print_struct;      /* Human readable output */
+        asn_constr_check_f *check_constraints; /* Constraints validator */
+        ber_type_decoder_f *ber_decoder;       /* Generic BER decoder */
+        der_type_encoder_f *der_encoder;       /* Canonical DER encoder */
+        xer_type_decoder_f *xer_decoder;       /* Generic XER decoder */
+        xer_type_encoder_f *xer_encoder;       /* [Canonical] XER encoder */
+        per_type_decoder_f *uper_decoder;      /* Unaligned PER decoder */
+        per_type_encoder_f *uper_encoder;      /* Unaligned PER encoder */
+
+        /***********************************************************************
+         * Internally useful members. Not to be used by applications directly. *
+         **********************************************************************/
+
+        /*
+         * Tags that are expected to occur.
+         */
+        asn_outmost_tag_f *outmost_tag; /* <optional, internal> */
+        ber_tlv_tag_t *tags;            /* Effective tags sequence for this type */
+        int tags_count;                 /* Number of tags which are expected */
+        ber_tlv_tag_t *all_tags;        /* Every tag for BER/containment */
+        int all_tags_count;             /* Number of tags */
+
+        asn_per_constraints_t *per_constraints; /* PER compiled constraints */
+
+        /*
+         * An ASN.1 production type members (members of SEQUENCE, SET, CHOICE).
+         */
+        struct asn_TYPE_member_s *elements;
+        int elements_count;
+
+        /*
+         * Additional information describing the type, used by appropriate
+         * functions above.
+         */
+        void *specifics;
+    } asn_TYPE_descriptor_t;
+
+    /*
+     * This type describes an element of the constructed type,
+     * i.e. SEQUENCE, SET, CHOICE, etc.
+     */
+    enum asn_TYPE_flags_e
+    {
+        ATF_NOFLAGS,
+        ATF_POINTER = 0x01,  /* Represented by the pointer */
+        ATF_OPEN_TYPE = 0x02 /* ANY type, without meaningful tag */
+    };
+    typedef struct asn_TYPE_member_s
+    {
+        enum asn_TYPE_flags_e flags;                   /* Element's presentation flags */
+        int optional;                                  /* Following optional members, including current */
+        int memb_offset;                               /* Offset of the element */
+        ber_tlv_tag_t tag;                             /* Outmost (most immediate) tag */
+        int tag_mode;                                  /* IMPLICIT/no/EXPLICIT tag at current level */
+        asn_TYPE_descriptor_t *type;                   /* Member type descriptor */
+        asn_constr_check_f *memb_constraints;          /* Constraints validator */
+        asn_per_constraints_t *per_constraints;        /* PER compiled constraints */
+        int (*default_value)(int setval, void **sptr); /* DEFAULT <value> */
+        char *name;                                    /* ASN.1 identifier of the element */
+    } asn_TYPE_member_t;
+
+    /*
+     * BER tag to element number mapping.
+     */
+    typedef struct asn_TYPE_tag2member_s
+    {
+        ber_tlv_tag_t el_tag; /* Outmost tag of the member */
+        int el_no;            /* Index of the associated member, base 0 */
+        int toff_first;       /* First occurrence of the el_tag, relative */
+        int toff_last;        /* Last occurrence of the el_tag, relatvie */
+    } asn_TYPE_tag2member_t;
+
+    /*
+     * This function is a wrapper around (td)->print_struct, which prints out
+     * the contents of the target language's structure (struct_ptr) into the
+     * file pointer (stream) in human readable form.
+     * RETURN VALUES:
+     *      0: The structure is printed.
+     *     -1: Problem dumping the structure.
+     * (See also xer_fprint() in xer_encoder.h)
+     */
+    int asn_fprint(FILE *stream,   /* Destination stream descriptor */
+        asn_TYPE_descriptor_t *td, /* ASN.1 type descriptor */
+        const void *struct_ptr);   /* Structure to be printed */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* _CONSTR_TYPE_H_ */

--- a/src/core/libs/supl/types/constraints.c
+++ b/src/core/libs/supl/types/constraints.c
@@ -1,0 +1,108 @@
+/*
+ * SPDX-FileCopyrightText: (c) 2003, 2004 Lev Walkin <vlm@lionet.info>. All rights reserved.
+ * SPDX-License-Identifier: BSD-1-Clause
+ */
+
+// clang-format off
+#include "asn_internal.h"
+#include "constraints.h"
+// clang-format on
+
+int asn_generic_no_constraint(asn_TYPE_descriptor_t *type_descriptor,
+    const void *struct_ptr,
+    asn_app_constraint_failed_f *cb, void *key)
+{
+    (void)type_descriptor; /* Unused argument */
+    (void)struct_ptr;      /* Unused argument */
+    (void)cb;              /* Unused argument */
+    (void)key;             /* Unused argument */
+
+    /* Nothing to check */
+    return 0;
+}
+
+int asn_generic_unknown_constraint(asn_TYPE_descriptor_t *type_descriptor,
+    const void *struct_ptr,
+    asn_app_constraint_failed_f *cb, void *key)
+{
+    (void)type_descriptor; /* Unused argument */
+    (void)struct_ptr;      /* Unused argument */
+    (void)cb;              /* Unused argument */
+    (void)key;             /* Unused argument */
+
+    /* Unknown how to check */
+    return 0;
+}
+
+struct errbufDesc
+{
+    asn_TYPE_descriptor_t *failed_type;
+    const void *failed_struct_ptr;
+    char *errbuf;
+    size_t errlen;
+};
+
+static void asn_i_ctfailcb(void *key, asn_TYPE_descriptor_t *td,
+    const void *sptr, const char *fmt, ...)
+{
+    struct errbufDesc *arg = key;
+    va_list ap;
+    ssize_t vlen;
+    ssize_t maxlen;
+
+    arg->failed_type = td;
+    arg->failed_struct_ptr = sptr;
+
+    maxlen = arg->errlen;
+    if (maxlen <= 0)
+        {
+            return;
+        }
+
+    va_start(ap, fmt);
+    vlen = vsnprintf(arg->errbuf, maxlen, fmt, ap);
+    va_end(ap);
+    if (vlen >= maxlen)
+        {
+            arg->errbuf[maxlen - 1] = '\0'; /* Ensuring libc correctness */
+            arg->errlen = maxlen - 1;       /* Not counting termination */
+            return;
+        }
+    else if (vlen >= 0)
+        {
+            arg->errbuf[vlen] = '\0'; /* Ensuring libc correctness */
+            arg->errlen = vlen;       /* Not counting termination */
+        }
+    else
+        {
+            /*
+             * The libc on this system is broken.
+             */
+            vlen = sizeof("<broken vsnprintf>") - 1;
+            maxlen--;
+            arg->errlen = vlen < maxlen ? vlen : maxlen;
+            memcpy(arg->errbuf, "<broken vsnprintf>", arg->errlen);
+            arg->errbuf[arg->errlen] = 0;
+        }
+}
+
+int asn_check_constraints(asn_TYPE_descriptor_t *type_descriptor,
+    const void *struct_ptr, char *errbuf, size_t *errlen)
+{
+    struct errbufDesc arg;
+    int ret;
+
+    arg.failed_type = 0;
+    arg.failed_struct_ptr = 0;
+    arg.errbuf = errbuf;
+    arg.errlen = errlen ? *errlen : 0;
+
+    ret = type_descriptor->check_constraints(type_descriptor, struct_ptr,
+        asn_i_ctfailcb, &arg);
+    if (ret == -1 && errlen)
+        {
+            *errlen = arg.errlen;
+        }
+
+    return ret;
+}

--- a/src/core/libs/supl/types/constraints.h
+++ b/src/core/libs/supl/types/constraints.h
@@ -1,0 +1,63 @@
+/*-
+ * SPDX-FileCopyrightText: (c) 2003, 2004 Lev Walkin <vlm@lionet.info>. All rights reserved.
+ * SPDX-License-Identifier: BSD-1-Clause
+ */
+#ifndef _ASN1_CONSTRAINTS_VALIDATOR_H
+#define _ASN1_CONSTRAINTS_VALIDATOR_H
+
+#include <asn_system.h> /* Platform-dependent types */
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+    struct asn_TYPE_descriptor_s; /* Forward declaration */
+
+    /*
+     * Validate the structure according to the ASN.1 constraints.
+     * If errbuf and errlen are given, they shall be pointing to the appropriate
+     * buffer space and its length before calling this function. Alternatively,
+     * they could be passed as NULL's. If constraints validation fails,
+     * errlen will contain the actual number of bytes taken from the errbuf
+     * to encode an error message (properly 0-terminated).
+     *
+     * RETURN VALUES:
+     * This function returns 0 in case all ASN.1 constraints are met
+     * and -1 if one or more constraints were failed.
+     */
+    int asn_check_constraints(
+        struct asn_TYPE_descriptor_s *type_descriptor,
+        const void *struct_ptr, /* Target language's structure */
+        char *errbuf,           /* Returned error description */
+        size_t *errlen          /* Length of the error description */
+    );
+
+    /*
+     * Generic type for constraint checking callback,
+     * associated with every type descriptor.
+     */
+    typedef int(asn_constr_check_f)(
+        struct asn_TYPE_descriptor_s *type_descriptor, const void *struct_ptr,
+        asn_app_constraint_failed_f *optional_callback, /* Log the error */
+        void *optional_app_key                          /* Opaque key passed to a callback */
+    );
+
+    /*******************************
+     * INTERNALLY USEFUL FUNCTIONS *
+     *******************************/
+
+    asn_constr_check_f asn_generic_no_constraint;      /* No constraint whatsoever */
+    asn_constr_check_f asn_generic_unknown_constraint; /* Not fully supported */
+
+/*
+ * Invoke the callback with a complete error message.
+ */
+#define _ASN_CTFAIL \
+    if (ctfailcb) ctfailcb
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* _ASN1_CONSTRAINTS_VALIDATOR_H_ */

--- a/src/core/libs/supl/types/der_encoder.c
+++ b/src/core/libs/supl/types/der_encoder.c
@@ -1,0 +1,234 @@
+/*-
+ * SPDX-FileCopyrightText: (c) 2003, 2004 Lev Walkin <vlm@lionet.info>. All rights reserved.
+ * SPDX-License-Identifier: BSD-1-Clause
+ */
+#include <asn_internal.h>
+#include <errno.h>
+
+static ssize_t der_write_TL(ber_tlv_tag_t tag, ber_tlv_len_t len,
+    asn_app_consume_bytes_f *cb, void *app_key,
+    int constructed);
+
+/*
+ * The DER encoder of any type.
+ */
+asn_enc_rval_t der_encode(asn_TYPE_descriptor_t *type_descriptor,
+    void *struct_ptr,
+    asn_app_consume_bytes_f *consume_bytes, void *app_key)
+{
+    ASN_DEBUG("DER encoder invoked for %s", type_descriptor->name);
+
+    /*
+     * Invoke type-specific encoder.
+     */
+    return type_descriptor->der_encoder(
+        type_descriptor, struct_ptr, /* Pointer to the destination structure */
+        0, 0, consume_bytes, app_key);
+}
+
+/*
+ * Argument type and callback necessary for der_encode_to_buffer().
+ */
+typedef struct enc_to_buf_arg
+{
+    void *buffer;
+    size_t left;
+} enc_to_buf_arg;
+static int encode_to_buffer_cb(const void *buffer, size_t size, void *key)
+{
+    enc_to_buf_arg *arg = (enc_to_buf_arg *)key;
+
+    if (arg->left < size)
+        {
+            return -1; /* Data exceeds the available buffer size */
+        }
+
+    memcpy(arg->buffer, buffer, size);
+    arg->buffer = ((char *)arg->buffer) + size;
+    arg->left -= size;
+
+    return 0;
+}
+
+/*
+ * A variant of the der_encode() which encodes the data into the provided buffer
+ */
+asn_enc_rval_t der_encode_to_buffer(asn_TYPE_descriptor_t *type_descriptor,
+    void *struct_ptr, void *buffer,
+    size_t buffer_size)
+{
+    enc_to_buf_arg arg;
+    asn_enc_rval_t ec;
+
+    arg.buffer = buffer;
+    arg.left = buffer_size;
+
+    ec = type_descriptor->der_encoder(
+        type_descriptor, struct_ptr, /* Pointer to the destination structure */
+        0, 0, encode_to_buffer_cb, &arg);
+    if (ec.encoded != -1)
+        {
+            assert(ec.encoded == (ssize_t)(buffer_size - arg.left));
+            /* Return the encoded contents size */
+        }
+    return ec;
+}
+
+/*
+ * Write out leading TL[v] sequence according to the type definition.
+ */
+ssize_t der_write_tags(asn_TYPE_descriptor_t *sd, size_t struct_length,
+    int tag_mode, int last_tag_form,
+    ber_tlv_tag_t tag, /* EXPLICIT or IMPLICIT tag */
+    asn_app_consume_bytes_f *cb, void *app_key)
+{
+    ber_tlv_tag_t *tags; /* Copy of tags stream */
+    int tags_count;      /* Number of tags */
+    size_t overall_length;
+    ssize_t *lens;
+    int i;
+
+    ASN_DEBUG("Writing tags (%s, tm=%d, tc=%d, tag=%s, mtc=%d)", sd->name,
+        tag_mode, sd->tags_count, ber_tlv_tag_string(tag),
+        tag_mode
+            ? (sd->tags_count + 1 - ((tag_mode == -1) && sd->tags_count))
+            : sd->tags_count);
+
+    if (tag_mode)
+        {
+            /*
+             * Instead of doing shaman dance like we do in ber_check_tags(),
+             * allocate a small array on the stack
+             * and initialize it appropriately.
+             */
+            int stag_offset;
+            tags = (ber_tlv_tag_t *)alloca((sd->tags_count + 1) *
+                                           sizeof(ber_tlv_tag_t));
+            if (!tags)
+                { /* Can fail on !x86 */
+                    errno = ENOMEM;
+                    return -1;
+                }
+            tags_count = sd->tags_count +
+                         1 /* EXPLICIT or IMPLICIT tag is given */
+                         - ((tag_mode == -1) && sd->tags_count);
+            /* Copy tags over */
+            tags[0] = tag;
+            stag_offset = -1 + ((tag_mode == -1) && sd->tags_count);
+            for (i = 1; i < tags_count; i++)
+                {
+                    tags[i] = sd->tags[i + stag_offset];
+                }
+        }
+    else
+        {
+            tags = sd->tags;
+            tags_count = sd->tags_count;
+        }
+
+    /* No tags to write */
+    if (tags_count == 0)
+        {
+            return 0;
+        }
+
+    lens = (ssize_t *)alloca(tags_count * sizeof(lens[0]));
+    if (!lens)
+        {
+            errno = ENOMEM;
+            return -1;
+        }
+
+    /*
+     * Array of tags is initialized.
+     * Now, compute the size of the TLV pairs, from right to left.
+     */
+    overall_length = struct_length;
+    for (i = tags_count - 1; i >= 0; --i)
+        {
+            lens[i] = der_write_TL(tags[i], overall_length, 0, 0, 0);
+            if (lens[i] == -1)
+                {
+                    return -1;
+                }
+            overall_length += lens[i];
+            lens[i] = overall_length - lens[i];
+        }
+
+    if (!cb)
+        {
+            return overall_length - struct_length;
+        }
+
+    ASN_DEBUG("%s %s TL sequence (%d elements)", cb ? "Encoding" : "Estimating",
+        sd->name, tags_count);
+
+    /*
+     * Encode the TL sequence for real.
+     */
+    for (i = 0; i < tags_count; i++)
+        {
+            ssize_t len;
+            int _constr;
+
+            /* Check if this tag happens to be constructed */
+            _constr = (last_tag_form || i < (tags_count - 1));
+
+            len = der_write_TL(tags[i], lens[i], cb, app_key, _constr);
+            if (len == -1)
+                {
+                    return -1;
+                }
+        }
+
+    return overall_length - struct_length;
+}
+
+static ssize_t der_write_TL(ber_tlv_tag_t tag, ber_tlv_len_t len,
+    asn_app_consume_bytes_f *cb, void *app_key,
+    int constructed)
+{
+    uint8_t buf[32];
+    size_t size = 0;
+    int buf_size = cb ? sizeof(buf) : 0;
+    ssize_t tmp;
+
+    /* Serialize tag (T from TLV) into possibly zero-length buffer */
+    tmp = ber_tlv_tag_serialize(tag, buf, buf_size);
+    if (tmp == -1 || tmp > (ssize_t)sizeof(buf))
+        {
+            return -1;
+        }
+    size += tmp;
+
+    /* Serialize length (L from TLV) into possibly zero-length buffer */
+    tmp = der_tlv_length_serialize(len, buf + size,
+        buf_size ? buf_size - size : 0);
+    if (tmp == -1)
+        {
+            return -1;
+        }
+    size += tmp;
+
+    if (size > sizeof(buf))
+        {
+            return -1;
+        }
+
+    /*
+     * If callback is specified, invoke it, and check its return value.
+     */
+    if (cb)
+        {
+            if (constructed)
+                {
+                    *buf |= 0x20;
+                }
+            if (cb(buf, size, app_key) < 0)
+                {
+                    return -1;
+                }
+        }
+
+    return size;
+}

--- a/src/core/libs/supl/types/der_encoder.h
+++ b/src/core/libs/supl/types/der_encoder.h
@@ -1,0 +1,67 @@
+/*-
+ * SPDX-FileCopyrightText: (c) 2003, 2004 Lev Walkin <vlm@lionet.info>. All rights reserved.
+ * SPDX-License-Identifier: BSD-1-Clause
+ */
+#ifndef _DER_ENCODER_H
+#define _DER_ENCODER_H
+
+#include <asn_application.h>
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+    struct asn_TYPE_descriptor_s; /* Forward declaration */
+
+    /*
+     * The DER encoder of any type. May be invoked by the application.
+     * The ber_decode() function (ber_decoder.h) is an opposite of der_encode().
+     */
+    asn_enc_rval_t der_encode(struct asn_TYPE_descriptor_s *type_descriptor,
+        void *struct_ptr, /* Structure to be encoded */
+        asn_app_consume_bytes_f *consume_bytes_cb,
+        void *app_key /* Arbitrary callback argument */
+    );
+
+    /* A variant of der_encode() which encodes data into the pre-allocated
+     * buffer */
+    asn_enc_rval_t der_encode_to_buffer(
+        struct asn_TYPE_descriptor_s *type_descriptor,
+        void *struct_ptr,  /* Structure to be encoded */
+        void *buffer,      /* Pre-allocated buffer */
+        size_t buffer_size /* Initial buffer size (maximum) */
+    );
+
+    /*
+     * Type of the generic DER encoder.
+     */
+    typedef asn_enc_rval_t(der_type_encoder_f)(
+        struct asn_TYPE_descriptor_s *type_descriptor,
+        void *struct_ptr, /* Structure to be encoded */
+        int tag_mode,     /* {-1,0,1}: IMPLICIT, no, EXPLICIT */
+        ber_tlv_tag_t tag,
+        asn_app_consume_bytes_f *consume_bytes_cb, /* Callback */
+        void *app_key                              /* Arbitrary callback argument */
+    );
+
+    /*******************************
+     * INTERNALLY USEFUL FUNCTIONS *
+     *******************************/
+
+    /*
+     * Write out leading TL[v] sequence according to the type definition.
+     */
+    ssize_t der_write_tags(struct asn_TYPE_descriptor_s *sd,
+        size_t struct_length,
+        int tag_mode,      /* {-1,0,1}: IMPLICIT, no, EXPLICIT */
+        int last_tag_form, /* {0,!0}: prim, constructed */
+        ber_tlv_tag_t tag,
+        asn_app_consume_bytes_f *consume_bytes_cb,
+        void *app_key);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* _DER_ENCODER_H_ */

--- a/src/core/libs/supl/types/per_decoder.c
+++ b/src/core/libs/supl/types/per_decoder.c
@@ -1,0 +1,123 @@
+/*
+ * SPDX-FileCopyrightText: (c) 2003, 2004 Lev Walkin <vlm@lionet.info>. All rights reserved.
+ * SPDX-License-Identifier: BSD-1-Clause
+ */
+
+#include <asn_application.h>
+#include <asn_internal.h>
+#include <per_decoder.h>
+
+/*
+ * Decode a "Production of a complete encoding", X.691#10.1.
+ * The complete encoding contains at least one byte, and is an integral
+ * multiple of 8 bytes.
+ */
+asn_dec_rval_t uper_decode_complete(asn_codec_ctx_t *opt_codec_ctx,
+    asn_TYPE_descriptor_t *td, void **sptr,
+    const void *buffer, size_t size)
+{
+    asn_dec_rval_t rval;
+
+    rval = uper_decode(opt_codec_ctx, td, sptr, buffer, size, 0, 0);
+    if (rval.consumed)
+        {
+            /*
+             * We've always given 8-aligned data,
+             * so convert bits to integral bytes.
+             */
+            rval.consumed += 7;
+            rval.consumed >>= 3;
+        }
+    else if (rval.code == RC_OK)
+        {
+            if (size)
+                {
+                    if (((uint8_t *)buffer)[0] == 0)
+                        {
+                            rval.consumed = 1; /* 1 byte */
+                        }
+                    else
+                        {
+                            ASN_DEBUG("Expecting single zeroed byte");
+                            rval.code = RC_FAIL;
+                        }
+                }
+            else
+                {
+                    /* Must contain at least 8 bits. */
+                    rval.code = RC_WMORE;
+                }
+        }
+
+    return rval;
+}
+
+asn_dec_rval_t uper_decode(asn_codec_ctx_t *opt_codec_ctx,
+    asn_TYPE_descriptor_t *td, void **sptr,
+    const void *buffer, size_t size, int skip_bits,
+    int unused_bits)
+{
+    asn_codec_ctx_t s_codec_ctx;
+    asn_dec_rval_t rval;
+    asn_per_data_t pd;
+
+    if (skip_bits < 0 || skip_bits > 7 || unused_bits < 0 || unused_bits > 7 ||
+        (unused_bits > 0 && !size))
+        {
+            _ASN_DECODE_FAILED;
+        }
+
+    /*
+     * Stack checker requires that the codec context
+     * must be allocated on the stack.
+     */
+    if (opt_codec_ctx)
+        {
+            if (opt_codec_ctx->max_stack_size)
+                {
+                    s_codec_ctx = *opt_codec_ctx;
+                    opt_codec_ctx = &s_codec_ctx;
+                }
+        }
+    else
+        {
+            /* If context is not given, be security-conscious anyway */
+            memset(&s_codec_ctx, 0, sizeof(s_codec_ctx));
+            s_codec_ctx.max_stack_size = _ASN_DEFAULT_STACK_MAX;
+            opt_codec_ctx = &s_codec_ctx;
+        }
+
+    /* Fill in the position indicator */
+    memset(&pd, 0, sizeof(pd));
+    pd.buffer = (const uint8_t *)buffer;
+    pd.nboff = skip_bits;
+    pd.nbits = 8 * size - unused_bits; /* 8 is CHAR_BIT from <limits.h> */
+    if (pd.nboff > pd.nbits)
+        {
+            _ASN_DECODE_FAILED;
+        }
+
+    /*
+     * Invoke type-specific decoder.
+     */
+    if (!td->uper_decoder)
+        {
+            _ASN_DECODE_FAILED; /* PER is not compiled in */
+        }
+    rval = td->uper_decoder(opt_codec_ctx, td, 0, sptr, &pd);
+    if (rval.code == RC_OK)
+        {
+            /* Return the number of consumed bits */
+            rval.consumed = ((pd.buffer - (const uint8_t *)buffer) << 3) +
+                            pd.nboff - skip_bits;
+            ASN_DEBUG("PER decoding consumed %d, counted %d", rval.consumed,
+                pd.moved);
+            assert(rval.consumed == pd.moved);
+        }
+    else
+        {
+            /* PER codec is not a restartable */
+            rval.consumed = 0;
+        }
+    return rval;
+}

--- a/src/core/libs/supl/types/per_decoder.h
+++ b/src/core/libs/supl/types/per_decoder.h
@@ -1,0 +1,59 @@
+/*-
+ * SPDX-FileCopyrightText: (c) 2003, 2004 Lev Walkin <vlm@lionet.info>. All rights reserved.
+ * SPDX-License-Identifier: BSD-1-Clause
+ */
+#ifndef _PER_DECODER_H
+#define _PER_DECODER_H
+
+#include <asn_application.h>
+#include <per_support.h>
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+    struct asn_TYPE_descriptor_s; /* Forward declaration */
+
+    /*
+     * Unaligned PER decoder of a "complete encoding" as per X.691#10.1.
+     * On success, this call always returns (.consumed >= 1), as per
+     * X.691#10.1.3.
+     */
+    asn_dec_rval_t uper_decode_complete(
+        struct asn_codec_ctx_s *opt_codec_ctx,
+        struct asn_TYPE_descriptor_s *td, /* Type to decode */
+        void **sptr,                      /* Pointer to a target structure's pointer */
+        const void *buffer,               /* Data to be decoded */
+        size_t size                       /* Size of data buffer */
+    );
+
+    /*
+     * Unaligned PER decoder of any ASN.1 type. May be invoked by the
+     * application. WARNING: This call returns the number of BITS read from the
+     * stream. Beware.
+     */
+    asn_dec_rval_t uper_decode(
+        struct asn_codec_ctx_s *opt_codec_ctx,
+        struct asn_TYPE_descriptor_s *td, /* Type to decode */
+        void **sptr,                      /* Pointer to a target structure's pointer */
+        const void *buffer,               /* Data to be decoded */
+        size_t size,                      /* Size of data buffer */
+        int skip_bits,                    /* Number of unused leading bits, 0..7 */
+        int unused_bits                   /* Number of unused tailing bits, 0..7 */
+    );
+
+    /*
+     * Type of the type-specific PER decoder function.
+     */
+    typedef asn_dec_rval_t(per_type_decoder_f)(
+        asn_codec_ctx_t *opt_codec_ctx,
+        struct asn_TYPE_descriptor_s *type_descriptor,
+        asn_per_constraints_t *constraints, void **struct_ptr,
+        asn_per_data_t *per_data);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* _PER_DECODER_H_ */

--- a/src/core/libs/supl/types/per_encoder.c
+++ b/src/core/libs/supl/types/per_encoder.c
@@ -1,0 +1,187 @@
+/*
+ * SPDX-FileCopyrightText: (c) 2003, 2004 Lev Walkin <vlm@lionet.info>. All rights reserved.
+ * SPDX-License-Identifier: BSD-1-Clause
+ */
+
+#include <asn_application.h>
+#include <asn_internal.h>
+#include <per_encoder.h>
+
+static asn_enc_rval_t uper_encode_internal(
+    asn_TYPE_descriptor_t *td, asn_per_constraints_t * /*constraints*/,
+    void *sptr, asn_app_consume_bytes_f *cb, void *app_key);
+
+asn_enc_rval_t uper_encode(asn_TYPE_descriptor_t *td, void *sptr,
+    asn_app_consume_bytes_f *cb, void *app_key)
+{
+    return uper_encode_internal(td, 0, sptr, cb, app_key);
+}
+
+/*
+ * Argument type and callback necessary for uper_encode_to_buffer().
+ */
+typedef struct enc_to_buf_arg
+{
+    void *buffer;
+    size_t left;
+} enc_to_buf_arg;
+static int encode_to_buffer_cb(const void *buffer, size_t size, void *key)
+{
+    enc_to_buf_arg *arg = (enc_to_buf_arg *)key;
+
+    if (arg->left < size)
+        {
+            return -1; /* Data exceeds the available buffer size */
+        }
+
+    memcpy(arg->buffer, buffer, size);
+    arg->buffer = ((char *)arg->buffer) + size;
+    arg->left -= size;
+
+    return 0;
+}
+
+asn_enc_rval_t uper_encode_to_buffer(asn_TYPE_descriptor_t *td, void *sptr,
+    void *buffer, size_t buffer_size)
+{
+    enc_to_buf_arg key;
+
+    key.buffer = buffer;
+    key.left = buffer_size;
+
+    if (td)
+        {
+            ASN_DEBUG("Encoding \"%s\" using UNALIGNED PER", td->name);
+        }
+
+    return uper_encode_internal(td, 0, sptr, encode_to_buffer_cb, &key);
+}
+
+typedef struct enc_dyn_arg
+{
+    void *buffer;
+    size_t length;
+    size_t allocated;
+} enc_dyn_arg;
+static int encode_dyn_cb(const void *buffer, size_t size, void *key)
+{
+    enc_dyn_arg *arg = key;
+    if (arg->length + size >= arg->allocated)
+        {
+            void *p;
+            arg->allocated = arg->allocated ? (arg->allocated << 2) : size;
+            p = REALLOC(arg->buffer, arg->allocated);
+            if (!p)
+                {
+                    FREEMEM(arg->buffer);
+                    memset(arg, 0, sizeof(*arg));
+                    return -1;
+                }
+            arg->buffer = p;
+        }
+    memcpy(((char *)arg->buffer) + arg->length, buffer, size);
+    arg->length += size;
+    return 0;
+}
+ssize_t uper_encode_to_new_buffer(asn_TYPE_descriptor_t *td,
+    asn_per_constraints_t *constraints,
+    void *sptr, void **buffer_r)
+{
+    asn_enc_rval_t er;
+    enc_dyn_arg key;
+
+    memset(&key, 0, sizeof(key));
+
+    er = uper_encode_internal(td, constraints, sptr, encode_dyn_cb, &key);
+    switch (er.encoded)
+        {
+        case -1:
+            FREEMEM(key.buffer);
+            return -1;
+        case 0:
+            FREEMEM(key.buffer);
+            key.buffer = MALLOC(1);
+            if (key.buffer)
+                {
+                    *(char *)key.buffer = '\0';
+                    *buffer_r = key.buffer;
+                    return 1;
+                }
+            else
+                {
+                    return -1;
+                }
+        default:
+            *buffer_r = key.buffer;
+            ASN_DEBUG("Complete encoded in %d bits", er.encoded);
+            return ((er.encoded + 7) >> 3);
+        }
+}
+
+/*
+ * Internally useful functions.
+ */
+
+/* Flush partially filled buffer */
+static int uper_encode_flush_outp(asn_per_outp_t *po)
+{
+    uint8_t *buf;
+
+    if (po->nboff == 0 && po->buffer == po->tmpspace)
+        {
+            return 0;
+        }
+
+    buf = po->buffer + (po->nboff >> 3);
+    /* Make sure we account for the last, partially filled */
+    if (po->nboff & 0x07)
+        {
+            buf[0] &= 0xff << (8 - (po->nboff & 0x07));
+            buf++;
+        }
+
+    return po->outper(po->tmpspace, buf - po->tmpspace, po->op_key);
+}
+
+static asn_enc_rval_t uper_encode_internal(asn_TYPE_descriptor_t *td,
+    asn_per_constraints_t *constraints,
+    void *sptr,
+    asn_app_consume_bytes_f *cb,
+    void *app_key)
+{
+    asn_per_outp_t po;
+    asn_enc_rval_t er;
+
+    /*
+     * Invoke type-specific encoder.
+     */
+    if (!td || !td->uper_encoder)
+        {
+            _ASN_ENCODE_FAILED; /* PER is not compiled in */
+        }
+
+    po.buffer = po.tmpspace;
+    po.nboff = 0;
+    po.nbits = 8 * sizeof(po.tmpspace);
+    po.outper = cb;
+    po.op_key = app_key;
+    po.flushed_bytes = 0;
+
+    er = td->uper_encoder(td, constraints, sptr, &po);
+    if (er.encoded != -1)
+        {
+            size_t bits_to_flush;
+
+            bits_to_flush = ((po.buffer - po.tmpspace) << 3) + po.nboff;
+
+            /* Set number of bits encoded to a firm value */
+            er.encoded = (po.flushed_bytes << 3) + bits_to_flush;
+
+            if (uper_encode_flush_outp(&po))
+                {
+                    _ASN_ENCODE_FAILED;
+                }
+        }
+
+    return er;
+}

--- a/src/core/libs/supl/types/per_encoder.h
+++ b/src/core/libs/supl/types/per_encoder.h
@@ -1,0 +1,68 @@
+/*-
+ * SPDX-FileCopyrightText: (c) 2003, 2004 Lev Walkin <vlm@lionet.info>. All rights reserved.
+ * SPDX-License-Identifier: BSD-1-Clause
+ */
+#ifndef _PER_ENCODER_H
+#define _PER_ENCODER_H
+
+#include <asn_application.h>
+#include <per_support.h>
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+    struct asn_TYPE_descriptor_s; /* Forward declaration */
+
+    /*
+     * Unaligned PER encoder of any ASN.1 type. May be invoked by the
+     * application. WARNING: This function returns the number of encoded bits in
+     * the .encoded field of the return value. Use the following formula to
+     * convert to bytes: bytes = ((.encoded + 7) / 8)
+     */
+    asn_enc_rval_t uper_encode(
+        struct asn_TYPE_descriptor_s *td,
+        void *sptr,                                /* Structure to be encoded */
+        asn_app_consume_bytes_f *consume_bytes_cb, /* Data collector */
+        void *app_key                              /* Arbitrary callback argument */
+    );
+
+    /*
+     * A variant of uper_encode() which encodes data into the existing buffer
+     * WARNING: This function returns the number of encoded bits in the .encoded
+     * field of the return value.
+     */
+    asn_enc_rval_t uper_encode_to_buffer(
+        struct asn_TYPE_descriptor_s *td,
+        void *sptr,        /* Structure to be encoded */
+        void *buffer,      /* Pre-allocated buffer */
+        size_t buffer_size /* Initial buffer size (max) */
+    );
+
+    /*
+     * A variant of uper_encode_to_buffer() which allocates buffer itself.
+     * Returns the number of bytes in the buffer or -1 in case of failure.
+     * WARNING: This function produces a "Production of the complete encoding",
+     * with length of at least one octet. Contrast this to precise bit-packing
+     * encoding of uper_encode() and uper_encode_to_buffer().
+     */
+    ssize_t uper_encode_to_new_buffer(
+        struct asn_TYPE_descriptor_s *td, asn_per_constraints_t *constraints,
+        void *sptr,     /* Structure to be encoded */
+        void **buffer_r /* Buffer allocated and returned */
+    );
+
+    /*
+     * Type of the generic PER encoder function.
+     */
+    typedef asn_enc_rval_t(per_type_encoder_f)(
+        struct asn_TYPE_descriptor_s *type_descriptor,
+        asn_per_constraints_t *constraints, void *struct_ptr,
+        asn_per_outp_t *per_output);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* _PER_ENCODER_H_ */

--- a/src/core/libs/supl/types/per_opentype.c
+++ b/src/core/libs/supl/types/per_opentype.c
@@ -1,0 +1,450 @@
+/*
+ * SPDX-FileCopyrightText: (c) 2003, 2004 Lev Walkin <vlm@lionet.info>. All rights reserved.
+ * SPDX-License-Identifier: BSD-1-Clause
+ */
+#include <asn_internal.h>
+#include <constr_TYPE.h>
+#include <per_opentype.h>
+#include <per_support.h>
+
+typedef struct uper_ugot_key
+{
+    asn_per_data_t oldpd; /* Old per data source */
+    size_t unclaimed;
+    size_t ot_moved; /* Number of bits moved by OT processing */
+    int repeat;
+} uper_ugot_key;
+
+static int uper_ugot_refill(asn_per_data_t *pd);
+static int per_skip_bits(asn_per_data_t *pd, int skip_nbits);
+static asn_dec_rval_t uper_sot_suck(asn_codec_ctx_t * /*ctx*/,
+    asn_TYPE_descriptor_t *td,
+    asn_per_constraints_t *constraints,
+    void **sptr, asn_per_data_t *pd);
+
+int asn_debug_indent;
+
+/*
+ * Encode an "open type field".
+ * #10.1, #10.2
+ */
+int uper_open_type_put(asn_TYPE_descriptor_t *td,
+    asn_per_constraints_t *constraints, void *sptr,
+    asn_per_outp_t *po)
+{
+    void *buf;
+    void *bptr;
+    ssize_t size;
+    size_t toGo;
+
+    ASN_DEBUG("Open type put %s ...", td->name);
+
+    size = uper_encode_to_new_buffer(td, constraints, sptr, &buf);
+    if (size <= 0)
+        {
+            return -1;
+        }
+
+    for (bptr = buf, toGo = size; toGo;)
+        {
+            ssize_t maySave = uper_put_length(po, toGo);
+            if (maySave < 0)
+                {
+                    break;
+                }
+            if (per_put_many_bits(po, bptr, maySave * 8))
+                {
+                    break;
+                }
+            bptr = (char *)bptr + maySave;
+            toGo -= maySave;
+        }
+
+    FREEMEM(buf);
+    if (toGo)
+        {
+            return -1;
+        }
+
+    ASN_DEBUG("Open type put %s of length %d + overhead (1byte?)", td->name,
+        size);
+
+    return 0;
+}
+
+static asn_dec_rval_t uper_open_type_get_simple(
+    asn_codec_ctx_t *ctx, asn_TYPE_descriptor_t *td,
+    asn_per_constraints_t *constraints, void **sptr, asn_per_data_t *pd)
+{
+    asn_dec_rval_t rv;
+    ssize_t chunk_bytes;
+    int repeat;
+    uint8_t *buf = 0;
+    size_t bufLen = 0;
+    size_t bufSize = 0;
+    asn_per_data_t spd;
+    size_t padding;
+
+    _ASN_STACK_OVERFLOW_CHECK(ctx);
+
+    ASN_DEBUG("Getting open type %s...", td->name);
+
+    do
+        {
+            chunk_bytes = uper_get_length(pd, -1, &repeat);
+            if (chunk_bytes < 0)
+                {
+                    FREEMEM(buf);
+                    _ASN_DECODE_STARVED;
+                }
+            if (bufLen + chunk_bytes > bufSize)
+                {
+                    void *ptr;
+                    bufSize = chunk_bytes + (bufSize << 2);
+                    ptr = REALLOC(buf, bufSize);
+                    if (!ptr)
+                        {
+                            FREEMEM(buf);
+                            _ASN_DECODE_FAILED;
+                        }
+                    buf = ptr;
+                }
+            if (per_get_many_bits(pd, buf + bufLen, 0, chunk_bytes << 3))
+                {
+                    FREEMEM(buf);
+                    _ASN_DECODE_STARVED;
+                }
+            bufLen += chunk_bytes;
+        }
+    while (repeat);
+
+    ASN_DEBUG("Getting open type %s encoded in %d bytes", td->name, bufLen);
+
+    memset(&spd, 0, sizeof(spd));
+    spd.buffer = buf;
+    spd.nbits = bufLen << 3;
+
+    asn_debug_indent += 4;
+    rv = td->uper_decoder(ctx, td, constraints, sptr, &spd);
+    asn_debug_indent -= 4;
+
+    if (rv.code == RC_OK)
+        {
+            /* Check padding validity */
+            padding = spd.nbits - spd.nboff;
+            if (padding < 8 && per_get_few_bits(&spd, padding) == 0)
+                {
+                    /* Everything is cool */
+                    FREEMEM(buf);
+                    return rv;
+                }
+            FREEMEM(buf);
+            if (padding >= 8)
+                {
+                    ASN_DEBUG("Too large padding %d in open type", padding);
+                    _ASN_DECODE_FAILED;
+                }
+            else
+                {
+                    ASN_DEBUG("Non-zero padding");
+                    _ASN_DECODE_FAILED;
+                }
+        }
+    else
+        {
+            FREEMEM(buf);
+            /* rv.code could be RC_WMORE, nonsense in this context */
+            rv.code = RC_FAIL; /* Noone would give us more */
+        }
+
+    return rv;
+}
+
+static asn_dec_rval_t GCC_NOTUSED uper_open_type_get_complex(
+    asn_codec_ctx_t *ctx, asn_TYPE_descriptor_t *td,
+    asn_per_constraints_t *constraints, void **sptr, asn_per_data_t *pd)
+{
+    uper_ugot_key arg;
+    asn_dec_rval_t rv;
+    ssize_t padding;
+
+    _ASN_STACK_OVERFLOW_CHECK(ctx);
+
+    ASN_DEBUG("Getting open type %s from %s", td->name, per_data_string(pd));
+    arg.oldpd = *pd;
+    arg.unclaimed = 0;
+    arg.ot_moved = 0;
+    arg.repeat = 1;
+    pd->refill = uper_ugot_refill;
+    pd->refill_key = &arg;
+    pd->nbits = pd->nboff; /* 0 good bits at this point, will refill */
+    pd->moved = 0;         /* This now counts the open type size in bits */
+
+    asn_debug_indent += 4;
+    rv = td->uper_decoder(ctx, td, constraints, sptr, pd);
+    asn_debug_indent -= 4;
+
+#define UPDRESTOREPD                                                  \
+    do                                                                \
+        {                                                             \
+            /* buffer and nboff are valid, preserve them. */          \
+            pd->nbits = arg.oldpd.nbits - (pd->moved - arg.ot_moved); \
+            pd->moved = arg.oldpd.moved + (pd->moved - arg.ot_moved); \
+            pd->refill = arg.oldpd.refill;                            \
+            pd->refill_key = arg.oldpd.refill_key;                    \
+        }                                                             \
+    while (0)
+
+    if (rv.code != RC_OK)
+        {
+            UPDRESTOREPD;
+            return rv;
+        }
+
+    ASN_DEBUG("OpenType %s pd%s old%s unclaimed=%d, repeat=%d", td->name,
+        per_data_string(pd), per_data_string(&arg.oldpd), arg.unclaimed,
+        arg.repeat);
+
+    padding = pd->moved % 8;
+    if (padding)
+        {
+            int32_t pvalue;
+            if (padding > 7)
+                {
+                    ASN_DEBUG("Too large padding %d in open type", padding);
+                    rv.code = RC_FAIL;
+                    UPDRESTOREPD;
+                    return rv;
+                }
+            padding = 8 - padding;
+            ASN_DEBUG("Getting padding of %d bits", padding);
+            pvalue = per_get_few_bits(pd, padding);
+            switch (pvalue)
+                {
+                case -1:
+                    ASN_DEBUG("Padding skip failed");
+                    UPDRESTOREPD;
+                    _ASN_DECODE_STARVED;
+                case 0:
+                    break;
+                default:
+                    ASN_DEBUG("Non-blank padding (%d bits 0x%02x)", padding,
+                        (int)pvalue);
+                    UPDRESTOREPD;
+                    _ASN_DECODE_FAILED;
+                }
+        }
+    if (pd->nboff != pd->nbits)
+        {
+            ASN_DEBUG("Open type %s overhead pd%s old%s", td->name,
+                per_data_string(pd), per_data_string(&arg.oldpd));
+            if (1)
+                {
+                    UPDRESTOREPD;
+                    _ASN_DECODE_FAILED;
+                }
+            else
+                {
+                    arg.unclaimed += pd->nbits - pd->nboff;
+                }
+        }
+
+    /* Adjust pd back so it points to original data */
+    UPDRESTOREPD;
+
+    /* Skip data not consumed by the decoder */
+    if (arg.unclaimed)
+        {
+            ASN_DEBUG("Getting unclaimed %d", arg.unclaimed);
+        }
+    if (arg.unclaimed)
+        {
+            switch (per_skip_bits(pd, arg.unclaimed))
+                {
+                case -1:
+                    ASN_DEBUG("Claim of %d failed", arg.unclaimed);
+                    _ASN_DECODE_STARVED;
+                case 0:
+                    ASN_DEBUG("Got claim of %d", arg.unclaimed);
+                    break;
+                default:
+                    /* Padding must be blank */
+                    ASN_DEBUG("Non-blank unconsumed padding");
+                    _ASN_DECODE_FAILED;
+                }
+            arg.unclaimed = 0;
+        }
+
+    if (arg.repeat)
+        {
+            ASN_DEBUG("Not consumed the whole thing");
+            rv.code = RC_FAIL;
+            return rv;
+        }
+
+    return rv;
+}
+
+asn_dec_rval_t uper_open_type_get(asn_codec_ctx_t *ctx,
+    asn_TYPE_descriptor_t *td,
+    asn_per_constraints_t *constraints,
+    void **sptr, asn_per_data_t *pd)
+{
+    return uper_open_type_get_simple(ctx, td, constraints, sptr, pd);
+}
+
+int uper_open_type_skip(asn_codec_ctx_t *ctx, asn_per_data_t *pd)
+{
+    asn_TYPE_descriptor_t s_td;
+    asn_dec_rval_t rv;
+
+    s_td.name = "<unknown extension>";
+    s_td.uper_decoder = uper_sot_suck;
+
+    rv = uper_open_type_get(ctx, &s_td, 0, 0, pd);
+    if (rv.code != RC_OK)
+        {
+            return -1;
+        }
+    else
+        {
+            return 0;
+        }
+}
+
+/*
+ * Internal functions.
+ */
+
+static asn_dec_rval_t uper_sot_suck(asn_codec_ctx_t *ctx,
+    asn_TYPE_descriptor_t *td,
+    asn_per_constraints_t *constraints,
+    void **sptr, asn_per_data_t *pd)
+{
+    asn_dec_rval_t rv;
+
+    (void)ctx;
+    (void)td;
+    (void)constraints;
+    (void)sptr;
+
+    while (per_get_few_bits(pd, 24) >= 0)
+        {
+            ;
+        }
+
+    rv.code = RC_OK;
+    rv.consumed = pd->moved;
+
+    return rv;
+}
+
+static int uper_ugot_refill(asn_per_data_t *pd)
+{
+    uper_ugot_key *arg = pd->refill_key;
+    ssize_t next_chunk_bytes;
+    ssize_t next_chunk_bits;
+    ssize_t avail;
+
+    asn_per_data_t *oldpd = &arg->oldpd;
+
+    ASN_DEBUG("REFILLING pd->moved=%d, oldpd->moved=%d", pd->moved,
+        oldpd->moved);
+
+    /* Advance our position to where pd is */
+    oldpd->buffer = pd->buffer;
+    oldpd->nboff = pd->nboff;
+    oldpd->nbits -= pd->moved - arg->ot_moved;
+    oldpd->moved += pd->moved - arg->ot_moved;
+    arg->ot_moved = pd->moved;
+
+    if (arg->unclaimed)
+        {
+            /* Refill the container */
+            if (per_get_few_bits(oldpd, 1))
+                {
+                    return -1;
+                }
+            if (oldpd->nboff == 0)
+                {
+                    assert(0);
+                    return -1;
+                }
+            pd->buffer = oldpd->buffer;
+            pd->nboff = oldpd->nboff - 1;
+            pd->nbits = oldpd->nbits;
+            ASN_DEBUG("UNCLAIMED <- return from (pd->moved=%d)", pd->moved);
+            return 0;
+        }
+
+    if (!arg->repeat)
+        {
+            ASN_DEBUG("Want more but refill doesn't have it");
+            return -1;
+        }
+
+    next_chunk_bytes = uper_get_length(oldpd, -1, &arg->repeat);
+    ASN_DEBUG("Open type LENGTH %d bytes at off %d, repeat %d",
+        next_chunk_bytes, oldpd->moved, arg->repeat);
+    if (next_chunk_bytes < 0)
+        {
+            return -1;
+        }
+    if (next_chunk_bytes == 0)
+        {
+            pd->refill = 0;       /* No more refills, naturally */
+            assert(!arg->repeat); /* Implementation guarantee */
+        }
+    next_chunk_bits = next_chunk_bytes << 3;
+    avail = oldpd->nbits - oldpd->nboff;
+    if (avail >= next_chunk_bits)
+        {
+            pd->nbits = oldpd->nboff + next_chunk_bits;
+            arg->unclaimed = 0;
+            ASN_DEBUG("!+Parent frame %d bits, alloting %d [%d..%d] (%d)",
+                next_chunk_bits, oldpd->moved, oldpd->nboff, oldpd->nbits,
+                oldpd->nbits - oldpd->nboff);
+        }
+    else
+        {
+            pd->nbits = oldpd->nbits;
+            arg->unclaimed = next_chunk_bits - avail;
+            ASN_DEBUG("!-Parent frame %d, require %d, will claim %d", avail,
+                next_chunk_bits, arg->unclaimed);
+        }
+    pd->buffer = oldpd->buffer;
+    pd->nboff = oldpd->nboff;
+    ASN_DEBUG("Refilled pd%s old%s", per_data_string(pd),
+        per_data_string(oldpd));
+    return 0;
+}
+
+static int per_skip_bits(asn_per_data_t *pd, int skip_nbits)
+{
+    int hasNonZeroBits = 0;
+    while (skip_nbits > 0)
+        {
+            int skip = 0;
+            if (skip_nbits < skip)
+                {
+                    skip = skip_nbits;
+                }
+            else
+                {
+                    skip = 24;
+                }
+            skip_nbits -= skip;
+
+            switch (per_get_few_bits(pd, skip))
+                {
+                case -1:
+                    return -1; /* Starving */
+                case 0:
+                    continue; /* Skipped empty space */
+                default:
+                    hasNonZeroBits = 1;
+                    continue;
+                }
+        }
+    return hasNonZeroBits;
+}

--- a/src/core/libs/supl/types/per_opentype.h
+++ b/src/core/libs/supl/types/per_opentype.h
@@ -1,0 +1,28 @@
+/*
+ * SPDX-FileCopyrightText: (c) 2003, 2004 Lev Walkin <vlm@lionet.info>. All rights reserved.
+ * SPDX-License-Identifier: BSD-1-Clause
+ */
+#ifndef _PER_OPENTYPE_H
+#define _PER_OPENTYPE_H
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+    asn_dec_rval_t uper_open_type_get(asn_codec_ctx_t *opt_codec_ctx,
+        asn_TYPE_descriptor_t *td,
+        asn_per_constraints_t *constraints,
+        void **sptr, asn_per_data_t *pd);
+
+    int uper_open_type_skip(asn_codec_ctx_t *opt_codec_ctx, asn_per_data_t *pd);
+
+    int uper_open_type_put(asn_TYPE_descriptor_t *td,
+        asn_per_constraints_t *constraints, void *sptr,
+        asn_per_outp_t *po);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* _PER_OPENTYPE_H_ */

--- a/src/core/libs/supl/types/per_support.c
+++ b/src/core/libs/supl/types/per_support.c
@@ -1,0 +1,652 @@
+/*
+ * SPDX-FileCopyrightText: (c) 2003, 2004 Lev Walkin <vlm@lionet.info>. All rights reserved.
+ * SPDX-License-Identifier: BSD-1-Clause
+ */
+#include <asn_internal.h>
+#include <asn_system.h>
+#include <per_support.h>
+
+char *per_data_string(asn_per_data_t *pd)
+{
+    static char buf[2][32];
+    static int n;
+    n = (n + 1) % 2;
+    snprintf(buf[n], sizeof(buf[n]), "{m=%ld span %+ld[%d..%d] (%d)}",
+        (long)pd->moved, (((long)pd->buffer) & 0xf), (int)pd->nboff,
+        (int)pd->nbits, (int)(pd->nbits - pd->nboff));
+    return buf[n];
+}
+
+void per_get_undo(asn_per_data_t *pd, int nbits)
+{
+    if ((ssize_t)pd->nboff < nbits)
+        {
+            assert((ssize_t)pd->nboff < nbits);
+        }
+    else
+        {
+            pd->nboff -= nbits;
+            pd->moved -= nbits;
+        }
+}
+
+/*
+ * Extract a small number of bits (<= 31) from the specified PER data pointer.
+ */
+int32_t per_get_few_bits(asn_per_data_t *pd, int nbits)
+{
+    size_t off;    /* Next after last bit offset */
+    ssize_t nleft; /* Number of bits left in this stream */
+    uint32_t accum;
+    const uint8_t *buf;
+
+    if (nbits < 0)
+        {
+            return -1;
+        }
+
+    nleft = pd->nbits - pd->nboff;
+    if (nbits > nleft)
+        {
+            int32_t tailv;
+            int32_t vhead;
+            if (!pd->refill || nbits > 31)
+                {
+                    return -1;
+                }
+            /* Accumulate unused bytes before refill */
+            ASN_DEBUG("Obtain the rest %d bits (want %d)", (int)nleft, nbits);
+            tailv = per_get_few_bits(pd, nleft);
+            if (tailv < 0)
+                {
+                    return -1;
+                }
+            /* Refill (replace pd contents with new data) */
+            if (pd->refill(pd))
+                {
+                    return -1;
+                }
+            nbits -= nleft;
+            vhead = per_get_few_bits(pd, nbits);
+            /* Combine the rest of previous pd with the head of new one */
+            tailv = (tailv << nbits) | vhead; /* Could == -1 */
+            return tailv;
+        }
+
+    /*
+     * Normalize position indicator.
+     */
+    if (pd->nboff >= 8)
+        {
+            pd->buffer += (pd->nboff >> 3);
+            pd->nbits -= (pd->nboff & ~0x07);
+            pd->nboff &= 0x07;
+        }
+    pd->moved += nbits;
+    pd->nboff += nbits;
+    off = pd->nboff;
+    buf = pd->buffer;
+
+    /*
+     * Extract specified number of bits.
+     */
+    if (off <= 8)
+        {
+            accum = nbits ? (buf[0]) >> (8 - off) : 0;
+        }
+    else if (off <= 16)
+        {
+            accum = ((buf[0] << 8) + buf[1]) >> (16 - off);
+        }
+    else if (off <= 24)
+        {
+            accum = ((buf[0] << 16) + (buf[1] << 8) + buf[2]) >> (24 - off);
+        }
+    else if (off <= 31)
+        {
+            accum = ((buf[0] << 24) + (buf[1] << 16) + (buf[2] << 8) + (buf[3])) >>
+                    (32 - off);
+        }
+    else if (nbits <= 31)
+        {
+            asn_per_data_t tpd = *pd;
+            /* Here are we with our 31-bits limit plus 1..7 bits offset. */
+            per_get_undo(&tpd, nbits);
+            /* The number of available bits in the stream allow
+             * for the following operations to take place without
+             * invoking the ->refill() function */
+            uint32_t two_twentyfour = 16777216;
+            accum = per_get_few_bits(&tpd, nbits - 24) * two_twentyfour;
+            accum |= per_get_few_bits(&tpd, 24);
+        }
+    else
+        {
+            per_get_undo(pd, nbits);
+            return -1;
+        }
+
+    accum &= (((uint32_t)1 << nbits) - 1);
+
+    ASN_DEBUG(
+        "  [PER got %2d<=%2d bits => span %d %+ld[%d..%d]:%02x (%d) => 0x%x]",
+        nbits, (int)nleft, (int)pd->moved, (((long)pd->buffer) & 0xf),
+        (int)pd->nboff, (int)pd->nbits,
+        ((pd->buffer != NULL) ? pd->buffer[0] : 0),
+        (int)(pd->nbits - pd->nboff), (int)accum);
+
+    return accum;
+}
+
+/*
+ * Extract a large number of bits from the specified PER data pointer.
+ */
+int per_get_many_bits(asn_per_data_t *pd, uint8_t *dst, int alright, int nbits)
+{
+    int32_t value;
+
+    if (alright && (nbits & 7))
+        {
+            /* Perform right alignment of a first few bits */
+            value = per_get_few_bits(pd, nbits & 0x07);
+            if (value < 0)
+                {
+                    return -1;
+                }
+            *dst++ = value; /* value is already right-aligned */
+            nbits &= ~7;
+        }
+
+    while (nbits)
+        {
+            if (nbits >= 24)
+                {
+                    value = per_get_few_bits(pd, 24);
+                    if (value < 0)
+                        {
+                            return -1;
+                        }
+                    *(dst++) = value >> 16;
+                    *(dst++) = value >> 8;
+                    *(dst++) = value;
+                    nbits -= 24;
+                }
+            else
+                {
+                    value = per_get_few_bits(pd, nbits);
+                    if (value < 0)
+                        {
+                            return -1;
+                        }
+                    if (nbits & 7)
+                        { /* implies left alignment */
+                            value <<= 8 - (nbits & 7), nbits += 8 - (nbits & 7);
+                            if (nbits > 24)
+                                {
+                                    *dst++ = value >> 24;
+                                }
+                        }
+                    if (nbits > 16)
+                        {
+                            *dst++ = value >> 16;
+                        }
+                    if (nbits > 8)
+                        {
+                            *dst++ = value >> 8;
+                        }
+                    *dst++ = value;
+                    break;
+                }
+        }
+
+    return 0;
+}
+
+/*
+ * X.691-201508 #10.9 General rules for encoding a length determinant.
+ * Get the optionally constrained length "n" from the stream.
+ */
+ssize_t uper_get_length(asn_per_data_t *pd, int ebits, int *repeat)
+{
+    ssize_t value;
+
+    *repeat = 0;
+
+    /* #11.9.4.1 Encoding if constrained (according to effective bits) */
+    if (ebits >= 0 && ebits <= 16)
+        {
+            return per_get_few_bits(pd, ebits);
+        }
+
+    value = per_get_few_bits(pd, 8);
+    if ((value & 0x80) == 0)
+        { /* #11.9.3.6 */
+            return (value & 0x7F);
+        }
+    else if ((value & 0x40) == 0)
+        { /* #11.9.3.7 */
+            /* bit 8 ... set to 1 and bit 7 ... set to zero */
+            value = ((value & 0x3f) << 8) | per_get_few_bits(pd, 8);
+            return value; /* potential -1 from per_get_few_bits passes through.
+                           */
+        }
+    else if (value < 0)
+        {
+            return -1;
+        }
+    value &= 0x3f; /* this is "m" from X.691, #11.9.3.8 */
+    if (value < 1 || value > 4)
+        {
+            return -1; /* Prohibited by #11.9.3.8 */
+        }
+    *repeat = 1;
+    return (16384 * value);
+}
+
+/*
+ * Get the normally small length "n".
+ * This procedure used to decode length of extensions bit-maps
+ * for SET and SEQUENCE types.
+ */
+ssize_t uper_get_nslength(asn_per_data_t *pd)
+{
+    ssize_t length;
+
+    ASN_DEBUG("Getting normally small length");
+
+    if (per_get_few_bits(pd, 1) == 0)
+        {
+            length = per_get_few_bits(pd, 6) + 1;
+            if (length <= 0)
+                {
+                    return -1;
+                }
+            ASN_DEBUG("l=%d", (int)length);
+            return length;
+        }
+    else
+        {
+            int repeat;
+            length = uper_get_length(pd, -1, &repeat);
+            if (length >= 0 && !repeat)
+                {
+                    return length;
+                }
+            return -1; /* Error, or do not support >16K extensions */
+        }
+}
+
+/*
+ * Get the normally small non-negative whole number.
+ * X.691, #10.6
+ */
+ssize_t uper_get_nsnnwn(asn_per_data_t *pd)
+{
+    ssize_t value;
+
+    value = per_get_few_bits(pd, 7);
+    if (value & 64)
+        { /* implicit (value < 0) */
+            value &= 63;
+            value <<= 2;
+            value |= per_get_few_bits(pd, 2);
+            if (value & 128)
+                { /* implicit (value < 0) */
+                    return -1;
+                }
+            if (value == 0)
+                {
+                    return 0;
+                }
+            if (value >= 3)
+                {
+                    return -1;
+                }
+            value = per_get_few_bits(pd, 8 * value);
+            return value;
+        }
+
+    return value;
+}
+
+/*
+ * X.691-11/2008, #11.6
+ * Encoding of a normally small non-negative whole number
+ */
+int uper_put_nsnnwn(asn_per_outp_t *po, int n)
+{
+    int bytes;
+
+    if (n <= 63)
+        {
+            if (n < 0)
+                {
+                    return -1;
+                }
+            return per_put_few_bits(po, n, 7);
+        }
+    if (n < 256)
+        {
+            bytes = 1;
+        }
+    else if (n < 65536)
+        {
+            bytes = 2;
+        }
+    else if (n < 256 * 65536)
+        {
+            bytes = 3;
+        }
+    else
+        {
+            return -1; /* This is not a "normally small" value */
+        }
+    if (per_put_few_bits(po, bytes, 8))
+        {
+            return -1;
+        }
+
+    return per_put_few_bits(po, n, 8 * bytes);
+}
+
+/* X.691-2008/11, #11.5.6 -> #11.3 */
+int uper_get_constrained_whole_number(asn_per_data_t *pd,
+    unsigned long *out_value, int nbits)
+{
+    unsigned long lhalf; /* Lower half of the number*/
+    long half;
+
+    if (nbits <= 31)
+        {
+            half = per_get_few_bits(pd, nbits);
+            if (half < 0)
+                {
+                    return -1;
+                }
+            *out_value = half;
+            return 0;
+        }
+
+    if ((size_t)nbits > 8 * sizeof(*out_value))
+        {
+            return -1; /* RANGE */
+        }
+
+    half = per_get_few_bits(pd, 31);
+    if (half < 0)
+        {
+            return -1;
+        }
+
+    if (uper_get_constrained_whole_number(pd, &lhalf, nbits - 31))
+        {
+            return -1;
+        }
+
+    *out_value = ((unsigned long)half << (nbits - 31)) | lhalf;
+    return 0;
+}
+
+/* X.691-2008/11, #11.5.6 -> #11.3 */
+int uper_put_constrained_whole_number_s(asn_per_outp_t *po, long v, int nbits)
+{
+    /*
+     * Assume signed number can be safely coerced into
+     * unsigned of the same range.
+     * The following testing code will likely be optimized out
+     * by compiler if it is true.
+     */
+    unsigned long uvalue1 = ULONG_MAX;
+    long svalue = uvalue1;
+    unsigned long uvalue2 = svalue;
+    assert(uvalue1 == uvalue2);
+    return uper_put_constrained_whole_number_u(po, v, nbits);
+}
+
+int uper_put_constrained_whole_number_u(asn_per_outp_t *po, unsigned long v,
+    int nbits)
+{
+    if (nbits <= 31)
+        {
+            return per_put_few_bits(po, v, nbits);
+        }
+    else
+        {
+            /* Put higher portion first, followed by lower 31-bit */
+            if (uper_put_constrained_whole_number_u(po, v >> 31, nbits - 31))
+                {
+                    return -1;
+                }
+            return per_put_few_bits(po, v, 31);
+        }
+}
+
+int per_put_aligned_flush(asn_per_outp_t *po)
+{
+    uint32_t unused_bits = (0x7 & (8 - (po->nboff & 0x07)));
+    size_t complete_bytes =
+        (po->buffer ? po->buffer - po->tmpspace : 0) + ((po->nboff + 7) >> 3);
+
+    if (unused_bits)
+        {
+            po->buffer[po->nboff >> 3] &= ~0 << unused_bits;
+        }
+
+    if (po->outper(po->tmpspace, complete_bytes, po->op_key) < 0)
+        {
+            return -1;
+        }
+    else
+        {
+            po->buffer = po->tmpspace;
+            po->nboff = 0;
+            po->nbits = 8 * sizeof(po->tmpspace);
+            po->flushed_bytes += complete_bytes;
+            return 0;
+        }
+}
+
+/*
+ * Put a small number of bits (<= 31).
+ */
+int per_put_few_bits(asn_per_outp_t *po, uint32_t bits, int obits)
+{
+    size_t off;  /* Next after last bit offset */
+    size_t omsk; /* Existing last byte meaningful bits mask */
+    uint8_t *buf;
+
+    if (obits <= 0 || obits >= 32)
+        {
+            return obits ? -1 : 0;
+        }
+
+    ASN_DEBUG("[PER put %d bits %x to %p+%d bits]", obits, (int)bits,
+        po->buffer, (int)po->nboff);
+
+    /*
+     * Normalize position indicator.
+     */
+    if (po->nboff >= 8)
+        {
+            po->buffer += (po->nboff >> 3);
+            po->nbits -= (po->nboff & ~0x07);
+            po->nboff &= 0x07;
+        }
+
+    /*
+     * Flush whole-bytes output, if necessary.
+     */
+    if (po->nboff + obits > po->nbits)
+        {
+            size_t complete_bytes;
+            if (!po->buffer)
+                {
+                    po->buffer = po->tmpspace;
+                }
+            complete_bytes = (po->buffer - po->tmpspace);
+            ASN_DEBUG("[PER output %ld complete + %ld]", (long)complete_bytes,
+                (long)po->flushed_bytes);
+            if (po->outper(po->tmpspace, complete_bytes, po->op_key) < 0)
+                {
+                    return -1;
+                }
+            if (po->nboff)
+                {
+                    po->tmpspace[0] = po->buffer[0];
+                }
+            po->buffer = po->tmpspace;
+            po->nbits = 8 * sizeof(po->tmpspace);
+            po->flushed_bytes += complete_bytes;
+        }
+
+    /*
+     * Now, due to sizeof(tmpspace), we are guaranteed large enough space.
+     */
+    buf = po->buffer;
+    omsk = ~((1 << (8 - po->nboff)) - 1);
+    off = (po->nboff + obits);
+
+    /* Clear data of debris before meaningful bits */
+    bits &= (((uint32_t)1 << obits) - 1);
+
+    ASN_DEBUG("[PER out %d %u/%x (t=%d,o=%d) %x&%x=%x]", obits, (int)bits,
+        (int)bits, (int)po->nboff, (int)off, buf[0], (int)(omsk & 0xff),
+        (int)(buf[0] & omsk));
+
+    if (off <= 8)
+        { /* Completely within 1 byte */
+            po->nboff = off, bits <<= (8 - off), buf[0] = (buf[0] & omsk) | bits;
+        }
+    else if (off <= 16)
+        {
+            po->nboff = off, bits <<= (16 - off),
+            buf[0] = (buf[0] & omsk) | (bits >> 8), buf[1] = bits;
+        }
+    else if (off <= 24)
+        {
+            po->nboff = off, bits <<= (24 - off),
+            buf[0] = (buf[0] & omsk) | (bits >> 16), buf[1] = bits >> 8,
+            buf[2] = bits;
+        }
+    else if (off <= 31)
+        {
+            po->nboff = off, bits <<= (32 - off),
+            buf[0] = (buf[0] & omsk) | (bits >> 24), buf[1] = bits >> 16,
+            buf[2] = bits >> 8, buf[3] = bits;
+        }
+    else
+        {
+            if ((obits - 24) > 0)
+                {
+                    if (per_put_few_bits(po, bits >> (obits - 24), 24))
+                        {
+                            return -1;
+                        }
+                }
+            if (per_put_few_bits(po, bits, obits - 24))
+                {
+                    return -1;
+                }
+        }
+
+    ASN_DEBUG("[PER out %u/%x => %02x buf+%ld]", (int)bits, (int)bits, buf[0],
+        (po->buffer - po->tmpspace));
+
+    return 0;
+}
+
+/*
+ * Output a large number of bits.
+ */
+int per_put_many_bits(asn_per_outp_t *po, const uint8_t *src, int nbits)
+{
+    while (nbits)
+        {
+            uint32_t value;
+
+            if (nbits >= 24)
+                {
+                    value = (src[0] << 16) | (src[1] << 8) | src[2];
+                    src += 3;
+                    nbits -= 24;
+                    if (per_put_few_bits(po, value, 24))
+                        {
+                            return -1;
+                        }
+                }
+            else
+                {
+                    value = src[0];
+                    if (nbits > 8)
+                        {
+                            value = (value << 8) | src[1];
+                        }
+                    if (nbits > 16)
+                        {
+                            value = (value << 8) | src[2];
+                        }
+                    if (nbits & 0x07)
+                        {
+                            value >>= (8 - (nbits & 0x07));
+                        }
+                    if (per_put_few_bits(po, value, nbits))
+                        {
+                            return -1;
+                        }
+                    break;
+                }
+        }
+
+    return 0;
+}
+
+/*
+ * Put the length "n" (or part of it) into the stream.
+ */
+ssize_t uper_put_length(asn_per_outp_t *po, size_t length)
+{
+    if (length <= 127)
+        { /* #10.9.3.6 */
+            return per_put_few_bits(po, length, 8) ? -1 : (ssize_t)length;
+        }
+    else if (length < 16384)
+        { /* #10.9.3.7 */
+            return per_put_few_bits(po, length | 0x8000, 16) ? -1 : (ssize_t)length;
+        }
+
+    length >>= 14;
+    if (length > 4)
+        {
+            length = 4;
+        }
+
+    return per_put_few_bits(po, 0xC0 | length, 8) ? -1
+                                                  : (ssize_t)(length << 14);
+}
+
+/*
+ * Put the normally small length "n" into the stream.
+ * This procedure used to encode length of extensions bit-maps
+ * for SET and SEQUENCE types.
+ */
+int uper_put_nslength(asn_per_outp_t *po, size_t length)
+{
+    if (length <= 64)
+        {
+            /* #10.9.3.4 */
+            if (length == 0)
+                {
+                    return -1;
+                }
+            return per_put_few_bits(po, length - 1, 7) ? -1 : 0;
+        }
+    else
+        {
+            if (uper_put_length(po, length) != (ssize_t)length)
+                {
+                    /* This might happen in case of >16K extensions */
+                    return -1;
+                }
+        }
+
+    return 0;
+}

--- a/src/core/libs/supl/types/per_support.h
+++ b/src/core/libs/supl/types/per_support.h
@@ -1,0 +1,149 @@
+/*
+ * SPDX-FileCopyrightText: (c) 2003, 2004 Lev Walkin <vlm@lionet.info>. All rights reserved.
+ * SPDX-License-Identifier: BSD-1-Clause
+ */
+#ifndef _PER_SUPPORT_H
+#define _PER_SUPPORT_H
+
+#include <asn_system.h> /* Platform-specific types */
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+    /*
+     * Pre-computed PER constraints.
+     */
+    typedef const struct asn_per_constraint_s
+    {
+        enum asn_per_constraint_flags
+        {
+            APC_UNCONSTRAINED = 0x0,    /* No PER visible constraints */
+            APC_SEMI_CONSTRAINED = 0x1, /* Constrained at "lb" */
+            APC_CONSTRAINED = 0x2,      /* Fully constrained */
+            APC_EXTENSIBLE = 0x4        /* May have extension */
+        } flags;
+        int range_bits;     /* Full number of bits in the range */
+        int effective_bits; /* Effective bits */
+        long lower_bound;   /* "lb" value */
+        long upper_bound;   /* "ub" value */
+    } asn_per_constraint_t;
+    typedef const struct asn_per_constraints_s
+    {
+        struct asn_per_constraint_s value;
+        struct asn_per_constraint_s size;
+        int (*value2code)(unsigned int value);
+        int (*code2value)(unsigned int code);
+    } asn_per_constraints_t;
+
+    /*
+     * This structure describes a position inside an incoming PER bit stream.
+     */
+    typedef struct asn_per_data_s
+    {
+        const uint8_t *buffer; /* Pointer to the octet stream */
+        size_t nboff;          /* Bit offset to the meaningful bit */
+        size_t nbits;          /* Number of bits in the stream */
+        size_t moved;          /* Number of bits moved through this bit stream */
+        int (*refill)(struct asn_per_data_s *);
+        void *refill_key;
+    } asn_per_data_t;
+
+    /*
+     * Extract a small number of bits (<= 31) from the specified PER data
+     * pointer. This function returns -1 if the specified number of bits could
+     * not be extracted due to EOD or other conditions.
+     */
+    int32_t per_get_few_bits(asn_per_data_t *pd, int get_nbits);
+
+    /* Undo the immediately preceding "get_few_bits" operation */
+    void per_get_undo(asn_per_data_t *pd, int get_nbits);
+
+    /*
+     * Extract a large number of bits from the specified PER data pointer.
+     * This function returns -1 if the specified number of bits could not be
+     * extracted due to EOD or other conditions.
+     */
+    int per_get_many_bits(asn_per_data_t *pd, uint8_t *dst, int alright,
+        int get_nbits);
+
+    /*
+     * Get the length "n" from the Unaligned PER stream.
+     */
+    ssize_t uper_get_length(asn_per_data_t *pd, int ebits, int *repeat);
+
+    /*
+     * Get the normally small length "n".
+     */
+    ssize_t uper_get_nslength(asn_per_data_t *pd);
+
+    /*
+     * Get the normally small non-negative whole number.
+     */
+    ssize_t uper_get_nsnnwn(asn_per_data_t *pd);
+
+    /* X.691-2008/11, #11.5.6 */
+    int uper_get_constrained_whole_number(asn_per_data_t *pd,
+        unsigned long *out_value, int nbits);
+
+    /* Non-thread-safe debugging function, don't use it */
+    char *per_data_string(asn_per_data_t *pd);
+
+    /*
+     * This structure supports forming PER output.
+     */
+    typedef struct asn_per_outp_s
+    {
+        uint8_t *buffer;      /* Pointer into the (tmpspace) */
+        size_t nboff;         /* Bit offset to the meaningful bit */
+        size_t nbits;         /* Number of bits left in (tmpspace) */
+        uint8_t tmpspace[32]; /* Preliminary storage to hold data */
+        int (*outper)(const void *data, size_t size, void *op_key);
+        void *op_key;         /* Key for (outper) data callback */
+        size_t flushed_bytes; /* Bytes already flushed through (outper) */
+    } asn_per_outp_t;
+
+    /* Output a small number of bits (<= 31) */
+    int per_put_few_bits(asn_per_outp_t *po, uint32_t bits, int obits);
+
+    /* Output a large number of bits */
+    int per_put_many_bits(asn_per_outp_t *po, const uint8_t *src,
+        int put_nbits);
+
+    /*
+     * Flush whole bytes (0 or more) through (outper) member.
+     * The least significant bits which are not used are guaranteed to be set to
+     * 0. Returns -1 if callback returns -1. Otherwise, 0.
+     */
+    int per_put_aligned_flush(asn_per_outp_t *po);
+
+    /* X.691-2008/11, #11.5 */
+    int uper_put_constrained_whole_number_s(asn_per_outp_t *po, long v,
+        int nbits);
+    int uper_put_constrained_whole_number_u(asn_per_outp_t *po, unsigned long v,
+        int nbits);
+
+    /*
+     * Put the length "n" to the Unaligned PER stream.
+     * This function returns the number of units which may be flushed
+     * in the next units saving iteration.
+     */
+    ssize_t uper_put_length(asn_per_outp_t *po, size_t whole_length);
+
+    /*
+     * Put the normally small length "n" to the Unaligned PER stream.
+     * Returns 0 or -1.
+     */
+    int uper_put_nslength(asn_per_outp_t *po, size_t length);
+
+    /*
+     * Put the normally small non-negative whole number.
+     */
+    int uper_put_nsnnwn(asn_per_outp_t *po, int n);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* _PER_SUPPORT_H_ */

--- a/src/core/libs/supl/types/xer_decoder.c
+++ b/src/core/libs/supl/types/xer_decoder.c
@@ -1,0 +1,436 @@
+/*
+ * SPDX-FileCopyrightText: (c) 2003, 2004 Lev Walkin <vlm@lionet.info>. All rights reserved.
+ * SPDX-License-Identifier: BSD-1-Clause
+ */
+#include <asn_application.h>
+#include <asn_internal.h>
+#include <xer_support.h> /* XER/XML parsing support */
+
+/*
+ * Decode the XER encoding of a given type.
+ */
+asn_dec_rval_t xer_decode(asn_codec_ctx_t *opt_codec_ctx,
+    asn_TYPE_descriptor_t *td, void **struct_ptr,
+    const void *buffer, size_t size)
+{
+    asn_codec_ctx_t s_codec_ctx;
+
+    /*
+     * Stack checker requires that the codec context
+     * must be allocated on the stack.
+     */
+    if (opt_codec_ctx)
+        {
+            if (opt_codec_ctx->max_stack_size)
+                {
+                    s_codec_ctx = *opt_codec_ctx;
+                    opt_codec_ctx = &s_codec_ctx;
+                }
+        }
+    else
+        {
+            /* If context is not given, be security-conscious anyway */
+            memset(&s_codec_ctx, 0, sizeof(s_codec_ctx));
+            s_codec_ctx.max_stack_size = _ASN_DEFAULT_STACK_MAX;
+            opt_codec_ctx = &s_codec_ctx;
+        }
+
+    /*
+     * Invoke type-specific decoder.
+     */
+    return td->xer_decoder(opt_codec_ctx, td, struct_ptr, 0, buffer, size);
+}
+
+struct xer__cb_arg
+{
+    pxml_chunk_type_e chunk_type;
+    size_t chunk_size;
+    const void *chunk_buf;
+    int callback_not_invoked;
+};
+
+static int xer__token_cb(pxml_chunk_type_e type, const void *_chunk_data,
+    size_t _chunk_size, void *key)
+{
+    struct xer__cb_arg *arg = (struct xer__cb_arg *)key;
+    arg->chunk_type = type;
+    arg->chunk_size = _chunk_size;
+    arg->chunk_buf = _chunk_data;
+    arg->callback_not_invoked = 0;
+    return -1; /* Terminate the XML parsing */
+}
+
+/*
+ * Fetch the next token from the XER/XML stream.
+ */
+ssize_t xer_next_token(int *stateContext, const void *buffer, size_t size,
+    pxer_chunk_type_e *ch_type)
+{
+    struct xer__cb_arg arg;
+    int new_stateContext = *stateContext;
+    ssize_t ret;
+
+    arg.callback_not_invoked = 1;
+    ret = pxml_parse(&new_stateContext, buffer, size, xer__token_cb, &arg);
+    if (ret < 0)
+        {
+            return -1;
+        }
+    if (arg.callback_not_invoked)
+        {
+            assert(ret == 0); /* No data was consumed */
+            return 0;         /* Try again with more data */
+        }
+    else
+        {
+            assert(arg.chunk_size);
+            assert(arg.chunk_buf == buffer);
+        }
+
+    /*
+     * Translate the XML chunk types into more convenient ones.
+     */
+    switch (arg.chunk_type)
+        {
+        case PXML_TEXT:
+            *ch_type = PXER_TEXT;
+            break;
+        case PXML_TAG:
+            return 0; /* Want more */
+        case PXML_TAG_END:
+            *ch_type = PXER_TAG;
+            break;
+        case PXML_COMMENT:
+        case PXML_COMMENT_END:
+            *ch_type = PXER_COMMENT;
+            break;
+        }
+
+    *stateContext = new_stateContext;
+    return arg.chunk_size;
+}
+
+#define CSLASH 0x2f /* '/' */
+#define LANGLE 0x3c /* '<' */
+#define RANGLE 0x3e /* '>' */
+
+xer_check_tag_e xer_check_tag(const void *buf_ptr, int size,
+    const char *need_tag)
+{
+    const char *buf = (const char *)buf_ptr;
+    const char *end;
+    xer_check_tag_e ct = XCT_OPENING;
+
+    if (size < 2 || buf[0] != LANGLE || buf[size - 1] != RANGLE)
+        {
+            if (size >= 2)
+                {
+                    ASN_DEBUG("Broken XML tag: \"%c...%c\"", buf[0], buf[size - 1]);
+                }
+            return XCT_BROKEN;
+        }
+
+    /*
+     * Determine the tag class.
+     */
+    if (buf[1] == CSLASH)
+        {
+            buf += 2;  /* advance past "</" */
+            size -= 3; /* strip "</" and ">" */
+            ct = XCT_CLOSING;
+            if (size > 0 && buf[size - 1] == CSLASH)
+                {
+                    return XCT_BROKEN; /* </abc/> */
+                }
+        }
+    else
+        {
+            buf++;     /* advance past "<" */
+            size -= 2; /* strip "<" and ">" */
+            if (size > 0 && buf[size - 1] == CSLASH)
+                {
+                    ct = XCT_BOTH;
+                    size--; /* One more, for "/" */
+                }
+        }
+
+    /* Sometimes we don't care about the tag */
+    if (!need_tag || !*need_tag)
+        {
+            return (xer_check_tag_e)(XCT__UNK__MASK | ct);
+        }
+
+    /*
+     * Determine the tag name.
+     */
+    for (end = buf + size; buf < end; buf++, need_tag++)
+        {
+            int b = *buf;
+            int n = *need_tag;
+            if (b != n)
+                {
+                    if (n == 0)
+                        {
+                            switch (b)
+                                {
+                                case 0x09:
+                                case 0x0a:
+                                case 0x0c:
+                                case 0x0d:
+                                case 0x20:
+                                    /* "<abc def/>": whitespace is normal */
+                                    return ct;
+                                }
+                        }
+                    return (xer_check_tag_e)(XCT__UNK__MASK | ct);
+                }
+            if (b == 0)
+                {
+                    return XCT_BROKEN; /* Embedded 0 in buf?! */
+                }
+        }
+    if (*need_tag)
+        {
+            return (xer_check_tag_e)(XCT__UNK__MASK | ct);
+        }
+
+    return ct;
+}
+
+#undef ADVANCE
+#define ADVANCE(num_bytes)                           \
+    do                                               \
+        {                                            \
+            size_t num = (num_bytes);                \
+            buf_ptr = ((const char *)buf_ptr) + num; \
+            size -= num;                             \
+            consumed_myself += num;                  \
+        }                                            \
+    while (0)
+
+#undef RETURN
+#define RETURN(_code)                                                       \
+    do                                                                      \
+        {                                                                   \
+            rval.code = _code;                                              \
+            rval.consumed = consumed_myself;                                \
+            if (rval.code != RC_OK) ASN_DEBUG("Failed with %d", rval.code); \
+            return rval;                                                    \
+        }                                                                   \
+    while (0)
+
+#define XER_GOT_BODY(chunk_buf, chunk_size, size)                      \
+    do                                                                 \
+        {                                                              \
+            ssize_t converted_size =                                   \
+                body_receiver(struct_key, chunk_buf, chunk_size,       \
+                    (size_t)(chunk_size) < (size));                    \
+            if (converted_size == -1) RETURN(RC_FAIL);                 \
+            if (converted_size == 0 && (size) == (size_t)(chunk_size)) \
+                RETURN(RC_WMORE);                                      \
+            (chunk_size) = converted_size;                             \
+        }                                                              \
+    while (0)
+#define XER_GOT_EMPTY()                                          \
+    do                                                           \
+        {                                                        \
+            if (body_receiver(struct_key, 0, 0, size > 0) == -1) \
+                RETURN(RC_FAIL);                                 \
+        }                                                        \
+    while (0)
+
+/*
+ * Generalized function for decoding the primitive values.
+ */
+asn_dec_rval_t xer_decode_general(
+    asn_codec_ctx_t *opt_codec_ctx,
+    asn_struct_ctx_t *ctx,                 /* Type decoder context */
+    void *struct_key, const char *xml_tag, /* Expected XML tag */
+    const void *buf_ptr, size_t size,
+    int (*opt_unexpected_tag_decoder)(void *struct_key, const void *chunk_buf,
+        size_t chunk_size),
+    ssize_t (*body_receiver)(void *struct_key, const void *chunk_buf,
+        size_t chunk_size, int have_more))
+{
+    asn_dec_rval_t rval;
+    ssize_t consumed_myself = 0;
+
+    (void)opt_codec_ctx;
+
+    /*
+     * Phases of XER/XML processing:
+     * Phase 0: Check that the opening tag matches our expectations.
+     * Phase 1: Processing body and reacting on closing tag.
+     */
+    if (ctx->phase > 1)
+        {
+            RETURN(RC_FAIL);
+        }
+    for (;;)
+        {
+            pxer_chunk_type_e ch_type; /* XER chunk type */
+            ssize_t ch_size;           /* Chunk size */
+            xer_check_tag_e tcv;       /* Tag check value */
+
+            /*
+             * Get the next part of the XML stream.
+             */
+            ch_size = xer_next_token(&ctx->context, buf_ptr, size, &ch_type);
+            switch (ch_size)
+                {
+                case -1:
+                    RETURN(RC_FAIL);
+                case 0:
+                    RETURN(RC_WMORE);
+                default:
+                    switch (ch_type)
+                        {
+                        case PXER_COMMENT:    /* Got XML comment */
+                            ADVANCE(ch_size); /* Skip silently */
+                            continue;
+                        case PXER_TEXT:
+                            if (ctx->phase == 0)
+                                {
+                                    /*
+                                     * We have to ignore whitespace
+                                     * here, but in order to be forward
+                                     * compatible with EXTENDED-XER
+                                     * (EMBED-VALUES, #25) any text is
+                                     * just ignored here.
+                                     */
+                                }
+                            else
+                                {
+                                    XER_GOT_BODY(buf_ptr, ch_size,
+                                        size);
+                                }
+                            ADVANCE(ch_size);
+                            continue;
+                        case PXER_TAG:
+                            break; /* Check the rest down there */
+                        }
+                }
+
+            assert(ch_type == PXER_TAG && size);
+
+            tcv = xer_check_tag(buf_ptr, ch_size, xml_tag);
+            /*
+             * Phase 0:
+             *     Expecting the opening tag
+             *     for the type being processed.
+             * Phase 1:
+             *     Waiting for the closing XML tag.
+             */
+            switch (tcv)
+                {
+                case XCT_BOTH:
+                    if (ctx->phase)
+                        {
+                            break;
+                        }
+                    /* Finished decoding of an empty element */
+                    XER_GOT_EMPTY();
+                    ADVANCE(ch_size);
+                    ctx->phase = 2; /* Phase out */
+                    RETURN(RC_OK);
+                case XCT_OPENING:
+                    if (ctx->phase)
+                        {
+                            break;
+                        }
+                    ADVANCE(ch_size);
+                    ctx->phase = 1; /* Processing body phase */
+                    continue;
+                case XCT_CLOSING:
+                    if (!ctx->phase)
+                        {
+                            break;
+                        }
+                    ADVANCE(ch_size);
+                    ctx->phase = 2; /* Phase out */
+                    RETURN(RC_OK);
+                case XCT_UNKNOWN_BO:
+                    /*
+                     * Certain tags in the body may be expected.
+                     */
+                    if (opt_unexpected_tag_decoder &&
+                        opt_unexpected_tag_decoder(struct_key, buf_ptr,
+                            ch_size) >= 0)
+                        {
+                            /* Tag's processed fine */
+                            ADVANCE(ch_size);
+                            if (!ctx->phase)
+                                {
+                                    /* We are not expecting
+                                     * the closing tag anymore. */
+                                    ctx->phase = 2; /* Phase out */
+                                    RETURN(RC_OK);
+                                }
+                            continue;
+                        }
+                    /* Fall through */
+                default:
+                    break; /* Unexpected tag */
+                }
+
+            ASN_DEBUG("Unexpected XML tag (expected \"%s\")", xml_tag);
+            break; /* Dark and mysterious things have just happened */
+        }
+
+    RETURN(RC_FAIL);
+}
+
+int xer_is_whitespace(const void *chunk_buf, size_t chunk_size)
+{
+    const char *p = (const char *)chunk_buf;
+    const char *pend = p + chunk_size;
+
+    for (; p < pend; p++)
+        {
+            switch (*p)
+                {
+                /* X.693, #8.1.4
+                 * HORISONTAL TAB (9)
+                 * LINE FEED (10)
+                 * CARRIAGE RETURN (13)
+                 * SPACE (32)
+                 */
+                case 0x09:
+                case 0x0a:
+                case 0x0d:
+                case 0x20:
+                    break;
+                default:
+                    return 0;
+                }
+        }
+    return 1; /* All whitespace */
+}
+
+/*
+ * This is a vastly simplified, non-validating XML tree skipper.
+ */
+int xer_skip_unknown(xer_check_tag_e tcv, ber_tlv_len_t *depth)
+{
+    assert(*depth > 0);
+    switch (tcv)
+        {
+        case XCT_BOTH:
+        case XCT_UNKNOWN_BO:
+            /* These negate each other. */
+            return 0;
+        case XCT_OPENING:
+        case XCT_UNKNOWN_OP:
+            ++(*depth);
+            return 0;
+        case XCT_CLOSING:
+        case XCT_UNKNOWN_CL:
+            if (--(*depth) == 0)
+                {
+                    return (tcv == XCT_CLOSING) ? 2 : 1;
+                }
+            return 0;
+        default:
+            return -1;
+        }
+}

--- a/src/core/libs/supl/types/xer_decoder.h
+++ b/src/core/libs/supl/types/xer_decoder.h
@@ -1,0 +1,108 @@
+/*-
+ * SPDX-FileCopyrightText: (c) 2003, 2004 Lev Walkin <vlm@lionet.info>. All rights reserved.
+ * SPDX-License-Identifier: BSD-1-Clause
+ */
+#ifndef _XER_DECODER_H
+#define _XER_DECODER_H
+
+#include <asn_application.h>
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+    struct asn_TYPE_descriptor_s; /* Forward declaration */
+
+    /*
+     * The XER decoder of any ASN.1 type. May be invoked by the application.
+     */
+    asn_dec_rval_t xer_decode(
+        struct asn_codec_ctx_s *opt_codec_ctx, struct asn_TYPE_descriptor_s *td,
+        void **struct_ptr,  /* Pointer to a target structure's pointer */
+        const void *buffer, /* Data to be decoded */
+        size_t size         /* Size of data buffer */
+    );
+
+    /*
+     * Type of the type-specific XER decoder function.
+     */
+    typedef asn_dec_rval_t(xer_type_decoder_f)(
+        asn_codec_ctx_t *opt_codec_ctx,
+        struct asn_TYPE_descriptor_s *type_descriptor, void **struct_ptr,
+        const char *opt_mname, /* Member name */
+        const void *buf_ptr, size_t size);
+
+    /*******************************
+     * INTERNALLY USEFUL FUNCTIONS *
+     *******************************/
+
+    /*
+     * Generalized function for decoding the primitive values.
+     * Used by more specialized functions, such as OCTET_STRING_decode_xer_utf8
+     * and others. This function should not be used by applications, as its API
+     * is subject to changes.
+     */
+    asn_dec_rval_t xer_decode_general(
+        asn_codec_ctx_t *opt_codec_ctx,
+        asn_struct_ctx_t *ctx, /* Type decoder context */
+        void *struct_key,      /* Treated as opaque pointer */
+        const char *xml_tag,   /* Expected XML tag name */
+        const void *buf_ptr, size_t size,
+        int (*opt_unexpected_tag_decoder)(void *struct_key,
+            const void *chunk_buf,
+            size_t chunk_size),
+        ssize_t (*body_receiver)(void *struct_key, const void *chunk_buf,
+            size_t chunk_size, int have_more));
+
+    /*
+     * Fetch the next XER (XML) token from the stream.
+     * The function returns the number of bytes occupied by the chunk type,
+     * returned in the _ch_type. The _ch_type is only set (and valid) when
+     * the return value is greater than 0.
+     */
+    typedef enum pxer_chunk_type
+    {
+        PXER_TAG,    /* Complete XER tag */
+        PXER_TEXT,   /* Plain text between XER tags */
+        PXER_COMMENT /* A comment, may be part of */
+    } pxer_chunk_type_e;
+    ssize_t xer_next_token(int *stateContext, const void *buffer, size_t size,
+        pxer_chunk_type_e *_ch_type);
+
+    /*
+     * This function checks the buffer against the tag name is expected to
+     * occur.
+     */
+    typedef enum xer_check_tag
+    {
+        XCT_BROKEN = 0,     /* The tag is broken */
+        XCT_OPENING = 1,    /* This is the <opening> tag */
+        XCT_CLOSING = 2,    /* This is the </closing> tag */
+        XCT_BOTH = 3,       /* This is the <modified/> tag */
+        XCT__UNK__MASK = 4, /* Mask of everything unexpected */
+        XCT_UNKNOWN_OP = 5, /* Unexpected <opening> tag */
+        XCT_UNKNOWN_CL = 6, /* Unexpected </closing> tag */
+        XCT_UNKNOWN_BO = 7  /* Unexpected <modified/> tag */
+    } xer_check_tag_e;
+    xer_check_tag_e xer_check_tag(const void *buf_ptr, int size,
+        const char *need_tag);
+
+    /*
+     * Check whether this buffer consists of entirely XER whitespace characters.
+     * RETURN VALUES:
+     * 1:    Whitespace or empty string
+     * 0:    Non-whitespace
+     */
+    int xer_is_whitespace(const void *chunk_buf, size_t chunk_size);
+
+    /*
+     * Skip the series of anticipated extensions.
+     */
+    int xer_skip_unknown(xer_check_tag_e tcv, ber_tlv_len_t *depth);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* _XER_DECODER_H_ */

--- a/src/core/libs/supl/types/xer_encoder.c
+++ b/src/core/libs/supl/types/xer_encoder.c
@@ -1,0 +1,83 @@
+/*-
+ * SPDX-FileCopyrightText: (c) 2003, 2004 Lev Walkin <vlm@lionet.info>. All rights reserved.
+ * SPDX-License-Identifier: BSD-1-Clause
+ */
+#include <asn_internal.h>
+#include <errno.h>
+#include <stdio.h>
+
+/*
+ * The XER encoder of any type. May be invoked by the application.
+ */
+asn_enc_rval_t xer_encode(asn_TYPE_descriptor_t *td, void *sptr,
+    enum xer_encoder_flags_e xer_flags,
+    asn_app_consume_bytes_f *cb, void *app_key)
+{
+    asn_enc_rval_t er;
+    asn_enc_rval_t tmper;
+    const char *mname;
+    size_t mlen;
+    int xcan = (xer_flags & XER_F_CANONICAL) ? 1 : 2;
+
+    if (!td || !sptr)
+        {
+            goto cb_failed;
+        }
+
+    mname = td->xml_tag;
+    mlen = strlen(mname);
+
+    _ASN_CALLBACK3("<", 1, mname, mlen, ">", 1);
+
+    tmper = td->xer_encoder(td, sptr, 1, xer_flags, cb, app_key);
+    if (tmper.encoded == -1)
+        {
+            return tmper;
+        }
+
+    _ASN_CALLBACK3("</", 2, mname, mlen, ">\n", xcan);
+
+    er.encoded = 4 + xcan + (2 * mlen) + tmper.encoded;
+
+    _ASN_ENCODED_OK(er);
+cb_failed:
+    _ASN_ENCODE_FAILED;
+}
+
+/*
+ * This is a helper function for xer_fprint, which directs all incoming data
+ * into the provided file descriptor.
+ */
+static int xer__print2fp(const void *buffer, size_t size, void *app_key)
+{
+    FILE *stream = (FILE *)app_key;
+
+    if (fwrite(buffer, 1, size, stream) != size)
+        {
+            return -1;
+        }
+
+    return 0;
+}
+
+int xer_fprint(FILE *stream, asn_TYPE_descriptor_t *td, void *sptr)
+{
+    asn_enc_rval_t er;
+
+    if (!stream)
+        {
+            stream = stdout;
+        }
+    if (!td || !sptr)
+        {
+            return -1;
+        }
+
+    er = xer_encode(td, sptr, XER_F_BASIC, xer__print2fp, stream);
+    if (er.encoded == -1)
+        {
+            return -1;
+        }
+
+    return fflush(stream);
+}

--- a/src/core/libs/supl/types/xer_encoder.h
+++ b/src/core/libs/supl/types/xer_encoder.h
@@ -1,0 +1,62 @@
+/*-
+ * SPDX-FileCopyrightText: (c) 2003, 2004 Lev Walkin <vlm@lionet.info>. All rights reserved.
+ * SPDX-License-Identifier: BSD-1-Clause
+ */
+#ifndef _XER_ENCODER_H
+#define _XER_ENCODER_H
+
+#include <asn_application.h>
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+    struct asn_TYPE_descriptor_s; /* Forward declaration */
+
+    /* Flags used by the xer_encode() and (*xer_type_encoder_f), defined below
+     */
+    enum xer_encoder_flags_e
+    {
+        /* Mode of encoding */
+        XER_F_BASIC = 0x01,    /* BASIC-XER (pretty-printing) */
+        XER_F_CANONICAL = 0x02 /* Canonical XER (strict rules) */
+    };
+
+    /*
+     * The XER encoder of any type. May be invoked by the application.
+     */
+    asn_enc_rval_t xer_encode(struct asn_TYPE_descriptor_s *td,
+        void *sptr, /* Structure to be encoded */
+        enum xer_encoder_flags_e xer_flags,
+        asn_app_consume_bytes_f *consume_bytes_cb,
+        void *app_key /* Arbitrary callback argument */
+    );
+
+    /*
+     * The variant of the above function which dumps the BASIC-XER (XER_F_BASIC)
+     * output into the chosen file pointer.
+     * RETURN VALUES:
+     *      0: The structure is printed.
+     *     -1: Problem printing the structure.
+     * WARNING: No sensible errno value is returned.
+     */
+    int xer_fprint(FILE *stream, struct asn_TYPE_descriptor_s *td, void *sptr);
+
+    /*
+     * Type of the generic XER encoder.
+     */
+    typedef asn_enc_rval_t(xer_type_encoder_f)(
+        struct asn_TYPE_descriptor_s *type_descriptor,
+        void *struct_ptr, /* Structure to be encoded */
+        int ilevel,       /* Level of indentation */
+        enum xer_encoder_flags_e xer_flags,
+        asn_app_consume_bytes_f *consume_bytes_cb, /* Callback */
+        void *app_key                              /* Arbitrary callback argument */
+    );
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* _XER_ENCODER_H_ */

--- a/src/core/libs/supl/types/xer_support.c
+++ b/src/core/libs/supl/types/xer_support.c
@@ -1,0 +1,274 @@
+/*
+ * SPDX-FileCopyrightText: (c) 2003, 2004 Lev Walkin <vlm@lionet.info>. All rights reserved.
+ * SPDX-License-Identifier: BSD-1-Clause
+ */
+#include <asn_system.h>
+#include <xer_support.h>
+
+/* Parser states */
+typedef enum
+{
+    ST_TEXT,
+    ST_TAG_START,
+    ST_TAG_BODY,
+    ST_TAG_QUOTE_WAIT,
+    ST_TAG_QUOTED_STRING,
+    ST_TAG_UNQUOTED_STRING,
+    ST_COMMENT_WAIT_DASH1, /* "<!--"[1] */
+    ST_COMMENT_WAIT_DASH2, /* "<!--"[2] */
+    ST_COMMENT,
+    ST_COMMENT_CLO_DASH2, /* "-->"[0] */
+    ST_COMMENT_CLO_RT     /* "-->"[1] */
+} pstate_e;
+
+static pxml_chunk_type_e final_chunk_type[] = {
+    PXML_TEXT,
+    PXML_TAG_END,
+    PXML_COMMENT_END,
+    PXML_TAG_END,
+    PXML_COMMENT_END,
+};
+
+static int _charclass[256] = {
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 0, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 0, 0, 0, 0, 0, 0, /* 01234567 89
+                                                                 */
+    0, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3,             /*  ABCDEFG HIJKLMNO */
+    3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 0, 0, 0, 0, 0,             /* PQRSTUVW XYZ      */
+    0, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3,             /*  abcdefg hijklmno */
+    3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 0, 0, 0, 0, 0              /* pqrstuvw xyz      */
+};
+#define WHITESPACE(c) (_charclass[(unsigned char)(c)] == 1)
+#define ALNUM(c) (_charclass[(unsigned char)(c)] >= 2)
+#define ALPHA(c) (_charclass[(unsigned char)(c)] == 3)
+
+/* Aliases for characters, ASCII/UTF-8 */
+// clang-format off
+#define EXCLAM 0x21 /* '!' */
+#define CQUOTE 0x22 /* '"' */
+#define CDASH 0x2d  /* '-' */
+#define CSLASH 0x2f /* '/' */
+#define LANGLE 0x3c /* '<' */
+#define CEQUAL 0x3d /* '=' */
+#define RANGLE 0x3e /* '>' */
+#define CQUEST 0x3f /* '?' */
+// clang-format on
+
+/* Invoke token callback */
+#define TOKEN_CB_CALL(type, _ns, _current_too, _final)            \
+    do                                                            \
+        {                                                         \
+            int _ret;                                             \
+            pstate_e ns = _ns;                                    \
+            ssize_t _sz = (p - chunk_start) + (_current_too);     \
+            if (!_sz)                                             \
+                {                                                 \
+                    /* Shortcut */                                \
+                    state = _ns;                                  \
+                    break;                                        \
+                }                                                 \
+            _ret = cb(type, chunk_start, _sz, key);               \
+            if (_ret < _sz)                                       \
+                {                                                 \
+                    if ((_current_too) && _ret == -1) state = ns; \
+                    goto finish;                                  \
+                }                                                 \
+            chunk_start = p + (_current_too);                     \
+            state = ns;                                           \
+        }                                                         \
+    while (0)
+
+#define TOKEN_CB(_type, _ns, _current_too) \
+    TOKEN_CB_CALL(_type, _ns, _current_too, 0)
+
+#define TOKEN_CB_FINAL(_type, _ns, _current_too) \
+    TOKEN_CB_CALL(final_chunk_type[_type], _ns, _current_too, 1)
+
+/*
+ * Parser itself
+ */
+ssize_t pxml_parse(int *stateContext, const void *xmlbuf, size_t size,
+    pxml_callback_f *cb, void *key)
+{
+    pstate_e state = (pstate_e)*stateContext;
+    const char *chunk_start = (const char *)xmlbuf;
+    const char *p = chunk_start;
+    const char *end = p + size;
+
+    for (; p < end; p++)
+        {
+            int C = *(const unsigned char *)p;
+            switch (state)
+                {
+                case ST_TEXT:
+                    /*
+                     * Initial state: we're in the middle of some text,
+                     * or just have started.
+                     */
+                    if (C == LANGLE)
+                        { /* We're now in the tag, probably */
+                            TOKEN_CB(PXML_TEXT, ST_TAG_START, 0);
+                        }
+                    break;
+                case ST_TAG_START:
+                    if (ALPHA(C) || (C == CSLASH))
+                        {
+                            state = ST_TAG_BODY;
+                        }
+                    else if (C == EXCLAM)
+                        {
+                            state = ST_COMMENT_WAIT_DASH1;
+                        }
+                    else
+                        {
+                            /*
+                             * Not characters and not whitespace.
+                             * Must be something like "3 < 4".
+                             */
+                            TOKEN_CB(PXML_TEXT, ST_TEXT, 1); /* Flush as data */
+                        }
+                    break;
+                case ST_TAG_BODY:
+                    switch (C)
+                        {
+                        case RANGLE:
+                            /* End of the tag */
+                            TOKEN_CB_FINAL(PXML_TAG, ST_TEXT, 1);
+                            break;
+                        case LANGLE:
+                            /*
+                             * The previous tag wasn't completed, but
+                             * still recognized as valid.
+                             * (Mozilla-compatible)
+                             */
+                            TOKEN_CB_FINAL(PXML_TAG, ST_TAG_START, 0);
+                            break;
+                        case CEQUAL:
+                            state = ST_TAG_QUOTE_WAIT;
+                            break;
+                        }
+                    break;
+                case ST_TAG_QUOTE_WAIT:
+                    /*
+                     * State after the equal sign ("=") in the tag.
+                     */
+                    switch (C)
+                        {
+                        case CQUOTE:
+                            state = ST_TAG_QUOTED_STRING;
+                            break;
+                        case RANGLE:
+                            /* End of the tag */
+                            TOKEN_CB_FINAL(PXML_TAG, ST_TEXT, 1);
+                            break;
+                        default:
+                            if (!WHITESPACE(
+                                    C))
+                                { /* Unquoted string value */
+                                    state = ST_TAG_UNQUOTED_STRING;
+                                }
+                        }
+                    break;
+                case ST_TAG_QUOTED_STRING:
+                    /*
+                     * Tag attribute's string value in quotes.
+                     */
+                    if (C == CQUOTE)
+                        {
+                            /* Return back to the tag state */
+                            state = ST_TAG_BODY;
+                        }
+                    break;
+                case ST_TAG_UNQUOTED_STRING:
+                    if (C == RANGLE)
+                        {
+                            /* End of the tag */
+                            TOKEN_CB_FINAL(PXML_TAG, ST_TEXT, 1);
+                        }
+                    else if (WHITESPACE(C))
+                        {
+                            /* Return back to the tag state */
+                            state = ST_TAG_BODY;
+                        }
+                    break;
+                case ST_COMMENT_WAIT_DASH1:
+                    if (C == CDASH)
+                        {
+                            state = ST_COMMENT_WAIT_DASH2;
+                        }
+                    else
+                        {
+                            /* Some ordinary tag. */
+                            state = ST_TAG_BODY;
+                        }
+                    break;
+                case ST_COMMENT_WAIT_DASH2:
+                    if (C == CDASH)
+                        {
+                            /* Seen "<--" */
+                            state = ST_COMMENT;
+                        }
+                    else
+                        {
+                            /* Some ordinary tag */
+                            state = ST_TAG_BODY;
+                        }
+                    break;
+                case ST_COMMENT:
+                    if (C == CDASH)
+                        {
+                            state = ST_COMMENT_CLO_DASH2;
+                        }
+                    break;
+                case ST_COMMENT_CLO_DASH2:
+                    if (C == CDASH)
+                        {
+                            state = ST_COMMENT_CLO_RT;
+                        }
+                    else
+                        {
+                            /* This is not an end of a comment */
+                            state = ST_COMMENT;
+                        }
+                    break;
+                case ST_COMMENT_CLO_RT:
+                    if (C == RANGLE)
+                        {
+                            TOKEN_CB_FINAL(PXML_COMMENT, ST_TEXT, 1);
+                        }
+                    else if (C == CDASH)
+                        {
+                            /* Maintain current state, still waiting for '>'
+                             */
+                        }
+                    else
+                        {
+                            state = ST_COMMENT;
+                        }
+                    break;
+                } /* switch(*ptr) */
+        }         /* for() */
+
+    /*
+     * Flush the partially processed chunk, state permitting.
+     */
+    if (p - chunk_start)
+        {
+            switch (state)
+                {
+                case ST_COMMENT:
+                    TOKEN_CB(PXML_COMMENT, state, 0);
+                    break;
+                case ST_TEXT:
+                    TOKEN_CB(PXML_TEXT, state, 0);
+                    break;
+                default:
+                    break; /* a no-op */
+                }
+        }
+
+finish:
+    *stateContext = (int)state;
+    return chunk_start - (const char *)xmlbuf;
+}

--- a/src/core/libs/supl/types/xer_support.h
+++ b/src/core/libs/supl/types/xer_support.h
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2003, 2004 X/IO Labs, xiolabs.com.
+ * SPDX-FileCopyrightText: (c) 2003, 2004 Lev Walkin <vlm@lionet.info>. All rights reserved.
+ * SPDX-License-Identifier: BSD-1-Clause
+ */
+#ifndef _XER_SUPPORT_H
+#define _XER_SUPPORT_H
+
+#include <asn_system.h> /* Platform-specific types */
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+    /*
+     * Types of data transferred to the application.
+     */
+    typedef enum
+    {
+        PXML_TEXT,    /* Plain text between XML tags. */
+        PXML_TAG,     /* A tag, starting with '<'. */
+        PXML_COMMENT, /* An XML comment, including "<!--" and "-->". */
+        /*
+         * The following chunk types are reported if the chunk
+         * terminates the specified XML element.
+         */
+        PXML_TAG_END,    /* Tag ended */
+        PXML_COMMENT_END /* Comment ended */
+    } pxml_chunk_type_e;
+
+    /*
+     * Callback function that is called by the parser when parsed data is
+     * available. The _opaque is the pointer to a field containing opaque user
+     * data specified in pxml_create() call. The chunk type is _type and the
+     * text data is the piece of buffer identified by _bufid (as supplied to
+     * pxml_feed() call) starting at offset _offset and of _size bytes size.
+     * The chunk is NOT '\0'-terminated.
+     */
+    typedef int(pxml_callback_f)(pxml_chunk_type_e _type,
+        const void *_chunk_data, size_t _chunk_size,
+        void *_key);
+
+    /*
+     * Parse the given buffer as it were a chunk of XML data.
+     * Invoke the specified callback each time the meaningful data is found.
+     * This function returns number of bytes consumed from the buffer.
+     * It will always be lesser than or equal to the specified _size.
+     * The next invocation of this function must account the difference.
+     */
+    ssize_t pxml_parse(int *_stateContext, const void *xmlbuf, size_t _size,
+        pxml_callback_f *cb, void *_key);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* _XER_SUPPORT_H_ */


### PR DESCRIPTION
Signed-off-by: Will Silberman [wsilberm@google.com](mailto:wsilberm@google.com)

Move duplicated files in asn-supl/ and asn-rrl/ to a new types/ subdir. Note that in some cases, there are slight differences between the versions from the two folders, such as function argument names or in some cases data types; eg here's the diff between asn-supl/INTEGER.c and asn-rrlp/INTEGER.c:

54c54
<      * (Remove too int64_t sign extension, remove some first 0x00 bytes)
---
>      * (Remove too long sign extension, remove some first 0x00 bytes)
226c226
<     /* Output in the int64_t xx:yy:zz... format */
---
>     /* Output in the long xx:yy:zz... format */
421c421
<     int64_t sign = 1LL;
---
>     int64_t sign = 1;
1057c1057
<              * able to >sizeof(int64_t) bytes,
---
>              * able to >sizeof(long) bytes,
1085c1085
<                     /* Still cannot fit the int64_t */
---
>                     /* Still cannot fit the long */

I suspect such changes are inadvertent from after the code was duplicated, so could probably use some guidance on which versions to use.

Having the duplicated symbols is error prone, and causes issues when linking with some compilers.

I tested this by building and running gnss-sdr per https://gnss-sdr.org/my-first-fix/, and the program ran fine as far as I could tell.