### PR TITLE
Osmosdr bandwidth selection

### DIFF
--- a/src/algorithms/signal_source/adapters/osmosdr_signal_source.cc
+++ b/src/algorithms/signal_source/adapters/osmosdr_signal_source.cc
@@ -42,6 +42,7 @@ OsmosdrSignalSource::OsmosdrSignalSource(const ConfigurationInterface* configura
       gain_(configuration->property(role + ".gain", 40.0)),
       if_gain_(configuration->property(role + ".if_gain", 40.0)),
       rf_gain_(configuration->property(role + ".rf_gain", 40.0)),
+      if_bw_(configuration->property(role + ".if_bw", 0.0)),
       samples_(configuration->property(role + ".samples", static_cast<int64_t>(0))),
       in_stream_(in_stream),
       out_stream_(out_stream),
@@ -116,6 +117,12 @@ OsmosdrSignalSource::OsmosdrSignalSource(const ConfigurationInterface* configura
                                     LOG(INFO) << "Actual RX Gain: " << osmosdr_source_->get_gain() << " dB...";
                                 }
                         }
+                }
+
+            // 5. set bandwidth
+            if (if_bw_ > 0.0)
+                {
+                    osmosdr_source_->set_bandwidth(if_bw_, 0);
                 }
 
             // Get actual bandwidth

--- a/src/algorithms/signal_source/adapters/osmosdr_signal_source.h
+++ b/src/algorithms/signal_source/adapters/osmosdr_signal_source.h
@@ -79,6 +79,7 @@ private:
     double gain_;
     double if_gain_;
     double rf_gain_;
+    double if_bw_;
 
     size_t item_size_;
     int64_t samples_;


### PR DESCRIPTION
Make it possible to override osmosdr default filter bandwidth.
Add new config file parameter:

SignalSource.if_bw=&lt;bandwidth in Hz&gt;
