### PR TITLE
Fix run FPGA acquisition

### DIFF
--- a/src/core/receiver/gnss_flowgraph.cc
+++ b/src/core/receiver/gnss_flowgraph.cc
@@ -1784,13 +1784,7 @@ void GNSSFlowgraph::acquisition_manager(unsigned int who)
                                     // set Doppler center to 0 Hz
                                     channels_[current_channel]->assist_acquisition_doppler(0);
                                 }
-#if ENABLE_FPGA
-                            // create a task for the FPGA such that it doesn't stop the flow
-                            std::thread tmp_thread(&ChannelInterface::start_acquisition, channels_[current_channel]);
-                            tmp_thread.detach();
-#else
                             channels_[current_channel]->start_acquisition();
-#endif
                         }
                     else
                         {

--- a/src/core/receiver/gnss_flowgraph.cc
+++ b/src/core/receiver/gnss_flowgraph.cc
@@ -1883,14 +1883,7 @@ void GNSSFlowgraph::apply_action(unsigned int who, unsigned int what)
                     acq_channels_count_++;
                     DLOG(INFO) << "Channel " << who << " Starting acquisition " << gs.get_satellite() << ", Signal " << gs.get_signal_str();
                     channels_[who]->set_signal(channels_[who]->get_signal());
-
-#if ENABLE_FPGA
-                    // create a task for the FPGA such that it doesn't stop the flow
-                    std::thread tmp_thread(&ChannelInterface::start_acquisition, channels_[who]);
-                    tmp_thread.detach();
-#else
                     channels_[who]->start_acquisition();
-#endif
                 }
             else
                 {


### PR DESCRIPTION
there is no need to create a detached process to run the FPGA acquisition HW accelerator