### PR TITLE
Simplify configuration

### DIFF
--- a/src/core/receiver/gnss_flowgraph.cc
+++ b/src/core/receiver/gnss_flowgraph.cc
@@ -1010,7 +1010,8 @@ int GNSSFlowgraph::connect_signal_conditioners_to_channels()
 
             try
                 {
-                    selected_signal_conditioner_ID = configuration_->property("Channel" + std::to_string(i) + ".RF_channel_ID", 0);
+                    selected_signal_conditioner_ID = configuration_->property("Channels_" + channels_.at(i)->get_signal().get_signal_str() + ".RF_channel_ID", 0);
+                    selected_signal_conditioner_ID = configuration_->property("Channel" + std::to_string(i) + ".RF_channel_ID", selected_signal_conditioner_ID);
                 }
             catch (const std::exception& e)
                 {


### PR DESCRIPTION
Make it possible to specify signal source per channel group.
Example:

;Set GPS L1 C/A channels RF channel ID to 1
Channels_1C.RF_channel_ID=1

instead of

;Set GPS L1 C/A channels RF channel ID to 1
Channel0.RF_channel_ID=1
Channel1.RF_channel_ID=1
Channel2.RF_channel_ID=1
....