### PR TITLE
improve string handling to avoid buffer overrun

### DIFF
--- a/src/algorithms/libs/rtklib/rtklib.h
+++ b/src/algorithms/libs/rtklib/rtklib.h
@@ -1108,7 +1108,7 @@ typedef struct
 } serial_t;
 
 
-typedef struct
+struct file_t
 {                               /* file control type */
     FILE *fp = nullptr;         /* file pointer */
     FILE *fp_tag = nullptr;     /* file pointer of tag file */
@@ -1129,7 +1129,7 @@ typedef struct
     double speed = 0;           /* replay speed (time factor) */
     double swapintv = 0;        /* swap interval (hr) (0: no swap) */
     lock_t lock;                /* lock flag */
-} file_t;
+};
 
 
 typedef struct

--- a/src/algorithms/libs/rtklib/rtklib.h
+++ b/src/algorithms/libs/rtklib/rtklib.h
@@ -1109,26 +1109,26 @@ typedef struct
 
 
 typedef struct
-{                              /* file control type */
-    FILE *fp;                  /* file pointer */
-    FILE *fp_tag;              /* file pointer of tag file */
-    FILE *fp_tmp;              /* temporary file pointer for swap */
-    FILE *fp_tag_tmp;          /* temporary file pointer of tag file for swap */
-    char path[MAXSTRPATH];     /* file path */
-    char openpath[MAXSTRPATH]; /* open file path */
-    int mode;                  /* file mode */
-    int timetag;               /* time tag flag (0:off,1:on) */
-    int repmode;               /* replay mode (0:master,1:slave) */
-    int offset;                /* time offset (ms) for slave */
-    gtime_t time;              /* start time */
-    gtime_t wtime;             /* write time */
-    unsigned int tick;         /* start tick */
-    unsigned int tick_f;       /* start tick in file */
-    unsigned int fpos;         /* current file position */
-    double start;              /* start offset (s) */
-    double speed;              /* replay speed (time factor) */
-    double swapintv;           /* swap interval (hr) (0: no swap) */
-    lock_t lock;               /* lock flag */
+{                               /* file control type */
+    FILE *fp = nullptr;         /* file pointer */
+    FILE *fp_tag = nullptr;     /* file pointer of tag file */
+    FILE *fp_tmp = nullptr;     /* temporary file pointer for swap */
+    FILE *fp_tag_tmp = nullptr; /* temporary file pointer of tag file for swap */
+    std::string path;           /* file path */
+    std::string openpath;       /* open file path */
+    int mode = 0;               /* file mode */
+    int timetag;                /* time tag flag (0:off,1:on) */
+    int repmode = 0;            /* replay mode (0:master,1:slave) */
+    int offset = 0;             /* time offset (ms) for slave */
+    gtime_t time = {};          /* start time */
+    gtime_t wtime = {};         /* write time */
+    unsigned int tick = 0;      /* start tick */
+    unsigned int tick_f = 0;    /* start tick in file */
+    unsigned int fpos = 0;      /* current file position */
+    double start = 0;           /* start offset (s) */
+    double speed = 0;           /* replay speed (time factor) */
+    double swapintv = 0;        /* swap interval (hr) (0: no swap) */
+    lock_t lock;                /* lock flag */
 } file_t;
 
 

--- a/src/algorithms/libs/rtklib/rtklib_pntpos.cc
+++ b/src/algorithms/libs/rtklib/rtklib_pntpos.cc
@@ -720,7 +720,6 @@ int raim_fde(const obsd_t *obs, int n, const double *rs,
     obsd_t *obs_e;
     sol_t sol_e = {{0, 0}, {}, {}, {}, '0', '0', '0', 0.0, 0.0, 0.0};
     char tstr[32];
-    char name[16];
     char msg_e[128];
     double *rs_e;
     double *dts_e;
@@ -819,8 +818,8 @@ int raim_fde(const obsd_t *obs, int n, const double *rs,
     if (stat)
         {
             time2str(obs[0].time, tstr, 2);
-            satno2id(sat, name);
-            trace(2, "%s: %s excluded by raim\n", tstr + 11, name);
+            auto name = satno2id(sat);
+            trace(2, "%s: %s excluded by raim\n", tstr + 11, name.data());
         }
     free(obs_e);
     free(rs_e);

--- a/src/algorithms/libs/rtklib/rtklib_ppp.cc
+++ b/src/algorithms/libs/rtklib/rtklib_ppp.cc
@@ -747,7 +747,6 @@ void pppoutsolstat(rtk_t *rtk, int level, FILE *fp)
     int j;
     int week;
     int nfreq = 1;
-    char id[32];
 
     if (level <= 0 || !fp)
         {
@@ -804,11 +803,11 @@ void pppoutsolstat(rtk_t *rtk, int level, FILE *fp)
                 {
                     continue;
                 }
-            satno2id(i + 1, id);
+            auto id = satno2id(i + 1);
             for (j = 0; j < nfreq; j++)
                 {
                     fprintf(fp, "$SAT,%d,%.3f,%s,%d,%.1f,%.1f,%.4f,%.4f,%d,%.0f,%d,%d,%d,%d,%d,%d\n",
-                        week, tow, id, j + 1, ssat->azel[0] * R2D, ssat->azel[1] * R2D,
+			    week, tow, id.data(), j + 1, ssat->azel[0] * R2D, ssat->azel[1] * R2D,
                         ssat->resp[j], ssat->resc[j], ssat->vsat[j], ssat->snr[j] * 0.25,
                         ssat->fix[j], ssat->slip[j] & 3, ssat->lock[j], ssat->outc[j],
                         ssat->slipc[j], ssat->rejc[j]);

--- a/src/algorithms/libs/rtklib/rtklib_ppp.cc
+++ b/src/algorithms/libs/rtklib/rtklib_ppp.cc
@@ -807,7 +807,7 @@ void pppoutsolstat(rtk_t *rtk, int level, FILE *fp)
             for (j = 0; j < nfreq; j++)
                 {
                     fprintf(fp, "$SAT,%d,%.3f,%s,%d,%.1f,%.1f,%.4f,%.4f,%d,%.0f,%d,%d,%d,%d,%d,%d\n",
-			    week, tow, id.data(), j + 1, ssat->azel[0] * R2D, ssat->azel[1] * R2D,
+                        week, tow, id.data(), j + 1, ssat->azel[0] * R2D, ssat->azel[1] * R2D,
                         ssat->resp[j], ssat->resc[j], ssat->vsat[j], ssat->snr[j] * 0.25,
                         ssat->fix[j], ssat->slip[j] & 3, ssat->lock[j], ssat->outc[j],
                         ssat->slipc[j], ssat->rejc[j]);

--- a/src/algorithms/libs/rtklib/rtklib_rtkcmn.cc
+++ b/src/algorithms/libs/rtklib/rtklib_rtkcmn.cc
@@ -3102,7 +3102,7 @@ void readpos(const char *file, const char *rcv, double *pos)
                 {
                     continue;
                 }
-            auto sta = stas[np++];
+            auto sta = stas[np++]; // NOLINT(readability-qualified-auto)
             std::strncpy(sta, str, 16);
             sta[15] = '\0';
         }

--- a/src/algorithms/libs/rtklib/rtklib_rtkcmn.cc
+++ b/src/algorithms/libs/rtklib/rtklib_rtkcmn.cc
@@ -4118,15 +4118,15 @@ int execcmd(const char *cmd)
  * return : none
  * notes  : not recursive. only one level
  *-----------------------------------------------------------------------------*/
-void createdir(std::filesystem::path const& path)
+void createdir(std::filesystem::path const &path)
 {
-  std::error_code ec;
+    std::error_code ec;
 
-  auto created = std::filesystem::create_directory(path, ec);
-  if (not created)
-    {
-      trace(1, "Error creating folder: %s", path.c_str());
-    }
+    auto created = std::filesystem::create_directory(path, ec);
+    if (not created)
+        {
+            trace(1, "Error creating folder: %s", path.c_str());
+        }
 }
 
 

--- a/src/algorithms/libs/rtklib/rtklib_rtkcmn.cc
+++ b/src/algorithms/libs/rtklib/rtklib_rtkcmn.cc
@@ -3102,7 +3102,7 @@ void readpos(const char *file, const char *rcv, double *pos)
                 {
                     continue;
                 }
-            auto sta = stas[np++]; // NOLINT(readability-qualified-auto)
+            auto sta = stas[np++];  // NOLINT(readability-qualified-auto)
             std::strncpy(sta, str, 16);
             sta[15] = '\0';
         }

--- a/src/algorithms/libs/rtklib/rtklib_rtkcmn.h
+++ b/src/algorithms/libs/rtklib/rtklib_rtkcmn.h
@@ -59,6 +59,7 @@
 #define GNSS_SDR_RTKLIB_RTKCMN_H
 
 #include "rtklib.h"
+#include <filesystem>
 #include <cstddef>
 #include <string>
 
@@ -102,7 +103,7 @@ void fatalerr(const char *format, ...);
 int satno(int sys, int prn);
 int satsys(int sat, int *prn);
 int satid2no(const char *id);
-void satno2id(int sat, char *id);
+std::string satno2id(int sat);
 int satexclude(int sat, int svh, const prcopt_t *opt);
 int testsnr(int base, int freq, double el, double snr, const snrmask_t *mask);
 unsigned char obs2code(const char *obs, int *freq);
@@ -229,12 +230,9 @@ void traceobs(int level, const obsd_t *obs, int n);
 // void traceb  (int level, const unsigned char *p, int n);
 
 int execcmd(const char *cmd);
-void createdir(const char *path);
-int repstr(char *str, const char *pat, const char *rep);
-int reppath(const char *path, char *rpath, gtime_t time, const char *rov,
-    const char *base);
-int reppaths(const char *path, char *rpath[], int nmax, gtime_t ts,
-    gtime_t te, const char *rov, const char *base);
+void createdir(std::filesystem::path const& path);
+int reppath(std::string const &path, std::string &rpath, gtime_t time, const char *rov,
+	    const char *base);
 double satwavelen(int sat, int frq, const nav_t *nav);
 double geodist(const double *rs, const double *rr, double *e);
 double satazel(const double *pos, const double *e, double *azel);

--- a/src/algorithms/libs/rtklib/rtklib_rtkcmn.h
+++ b/src/algorithms/libs/rtklib/rtklib_rtkcmn.h
@@ -59,8 +59,8 @@
 #define GNSS_SDR_RTKLIB_RTKCMN_H
 
 #include "rtklib.h"
-#include <filesystem>
 #include <cstddef>
+#include <filesystem>
 #include <string>
 
 
@@ -230,9 +230,9 @@ void traceobs(int level, const obsd_t *obs, int n);
 // void traceb  (int level, const unsigned char *p, int n);
 
 int execcmd(const char *cmd);
-void createdir(std::filesystem::path const& path);
+void createdir(std::filesystem::path const &path);
 int reppath(std::string const &path, std::string &rpath, gtime_t time, const char *rov,
-	    const char *base);
+    const char *base);
 double satwavelen(int sat, int frq, const nav_t *nav);
 double geodist(const double *rs, const double *rr, double *e);
 double satazel(const double *pos, const double *e, double *azel);

--- a/src/algorithms/libs/rtklib/rtklib_rtkpos.cc
+++ b/src/algorithms/libs/rtklib/rtklib_rtkpos.cc
@@ -37,6 +37,7 @@
 #include "rtklib_tides.h"
 #include <cmath>
 #include <cstring>
+#include <string>
 #include <vector>
 
 static int resamb_WLNL(rtk_t *rtk __attribute((unused)), const obsd_t *obs __attribute((unused)), const int *sat __attribute((unused)),

--- a/src/algorithms/libs/rtklib/rtklib_rtkpos.cc
+++ b/src/algorithms/libs/rtklib/rtklib_rtkpos.cc
@@ -124,7 +124,7 @@ static gtime_t time_stat = {0, 0}; /* rtk status file time */
 int rtkopenstat(const char *file, int level)
 {
     gtime_t time = utc2gpst(timeget());
-    char path[1024];
+    std::string path;
 
     trace(3, "rtkopenstat: file=%s level=%d\n", file, level);
 
@@ -135,9 +135,9 @@ int rtkopenstat(const char *file, int level)
 
     reppath(file, path, time, "", "");
 
-    if (!(fp_stat = fopen(path, "we")))
+    if (!(fp_stat = fopen(path.data(), "we")))
         {
-            trace(1, "rtkopenstat: file open error path=%s\n", path);
+            trace(1, "rtkopenstat: file open error path=%s\n", path.data());
             return 0;
         }
     if (strlen(file) < 1025)
@@ -191,7 +191,6 @@ void rtkoutstat(rtk_t *rtk, char *buff __attribute__((unused)))
     int est;
     int nfreq;
     int nf = NF_RTK(&rtk->opt);
-    char id[32];
 
     if (statlevel <= 0 || !fp_stat)
         {
@@ -264,11 +263,11 @@ void rtkoutstat(rtk_t *rtk, char *buff __attribute__((unused)))
                         {
                             continue;
                         }
-                    satno2id(i + 1, id);
+                    auto id = satno2id(i + 1);
                     j = II_RTK(i + 1, &rtk->opt);
                     xa[0] = j < rtk->na ? rtk->xa[j] : 0.0;
                     fprintf(fp_stat, "$ION,%d,%.3f,%d,%s,%.1f,%.1f,%.4f,%.4f\n", week, tow, rtk->sol.stat,
-                        id, ssat->azel[0] * R2D, ssat->azel[1] * R2D, rtk->x[j], xa[0]);
+                        id.data(), ssat->azel[0] * R2D, ssat->azel[1] * R2D, rtk->x[j], xa[0]);
                 }
         }
     /* tropospheric parameters */
@@ -306,11 +305,11 @@ void rtkoutstat(rtk_t *rtk, char *buff __attribute__((unused)))
                 {
                     continue;
                 }
-            satno2id(i + 1, id);
+            auto id = satno2id(i + 1);
             for (j = 0; j < nfreq; j++)
                 {
                     fprintf(fp_stat, "$SAT,%d,%.3f,%s,%d,%.1f,%.1f,%.4f,%.4f,%d,%.0f,%d,%d,%d,%d,%d,%d\n",
-                        week, tow, id, j + 1, ssat->azel[0] * R2D, ssat->azel[1] * R2D,
+                        week, tow, id.data(), j + 1, ssat->azel[0] * R2D, ssat->azel[1] * R2D,
                         ssat->resp[j], ssat->resc[j], ssat->vsat[j], ssat->snr[j] * 0.25,
                         ssat->fix[j], ssat->slip[j] & 3, ssat->lock[j], ssat->outc[j],
                         ssat->slipc[j], ssat->rejc[j]);
@@ -323,7 +322,7 @@ void rtkoutstat(rtk_t *rtk, char *buff __attribute__((unused)))
 void swapsolstat()
 {
     gtime_t time = utc2gpst(timeget());
-    char path[1024];
+    std::string path;
 
     if (static_cast<int>(time2gpst(time, nullptr) / INT_SWAP_STAT) ==
         static_cast<int>(time2gpst(time_stat, nullptr) / INT_SWAP_STAT))
@@ -341,12 +340,12 @@ void swapsolstat()
             fclose(fp_stat);
         }
 
-    if (!(fp_stat = fopen(path, "we")))
+    if (!(fp_stat = fopen(path.data(), "we")))
         {
-            trace(2, "swapsolstat: file open error path=%s\n", path);
+            trace(2, "swapsolstat: file open error path=%s\n", path.data());
             return;
         }
-    trace(3, "swapsolstat: path=%s\n", path);
+    trace(3, "swapsolstat: path=%s\n", path.data());
 }
 
 
@@ -367,7 +366,6 @@ void outsolstat(rtk_t *rtk)
     int est;
     int nfreq;
     int nf = NF_RTK(&rtk->opt);
-    char id[32];
 
     if (statlevel <= 0 || !fp_stat)
         {
@@ -440,11 +438,11 @@ void outsolstat(rtk_t *rtk)
                         {
                             continue;
                         }
-                    satno2id(i + 1, id);
+                    auto id = satno2id(i + 1);
                     j = II_RTK(i + 1, &rtk->opt);
                     xa[0] = j < rtk->na ? rtk->xa[j] : 0.0;
                     fprintf(fp_stat, "$ION,%d,%.3f,%d,%s,%.1f,%.1f,%.4f,%.4f\n", week, tow, rtk->sol.stat,
-                        id, ssat->azel[0] * R2D, ssat->azel[1] * R2D, rtk->x[j], xa[0]);
+                        id.data(), ssat->azel[0] * R2D, ssat->azel[1] * R2D, rtk->x[j], xa[0]);
                 }
         }
     /* tropospheric parameters */
@@ -482,11 +480,11 @@ void outsolstat(rtk_t *rtk)
                 {
                     continue;
                 }
-            satno2id(i + 1, id);
+            auto id = satno2id(i + 1);
             for (j = 0; j < nfreq; j++)
                 {
                     fprintf(fp_stat, "$SAT,%d,%.3f,%s,%d,%.1f,%.1f,%.4f,%.4f,%d,%.0f,%d,%d,%d,%d,%d,%d\n",
-                        week, tow, id, j + 1, ssat->azel[0] * R2D, ssat->azel[1] * R2D,
+                        week, tow, id.data(), j + 1, ssat->azel[0] * R2D, ssat->azel[1] * R2D,
                         ssat->resp[j], ssat->resc[j], ssat->vsat[j], ssat->snr[j] * 0.25,
                         ssat->fix[j], ssat->slip[j] & 3, ssat->lock[j], ssat->outc[j],
                         ssat->slipc[j], ssat->rejc[j]);

--- a/src/algorithms/libs/rtklib/rtklib_stream.cc
+++ b/src/algorithms/libs/rtklib/rtklib_stream.cc
@@ -419,7 +419,7 @@ file_t *openfile(std::string const &path, int mode, char *msg)
                     std::istringstream ss(tag);
                     ss.ignore(1, 'S').ignore(1, '=') >> swapintv;
                     // do we care if there are extra characters?
-                    if (swapintv < 0) swapintv = 0;
+                    if (swapintv < 0) swapintv = 0;  // NOLINT(readability-braces-around-statements)
                     file->swapintv = swapintv;
                 }
             else

--- a/src/algorithms/libs/rtklib/rtklib_stream.cc
+++ b/src/algorithms/libs/rtklib/rtklib_stream.cc
@@ -1956,7 +1956,7 @@ void *ftpthread(void *arg)
 
     /* if local file exist, skip download */
     auto tmpfile = local;
-    for (auto ext : {".z", ".gz", ".zip", ".Z", ".GZ", ".ZIP"}) // NOLINT(readability-qualified-auto): auto decoration is less readable
+    for (auto ext : {".z", ".gz", ".zip", ".Z", ".GZ", ".ZIP"})  // NOLINT(readability-qualified-auto): auto decoration is less readable
         {
             if (tmpfile.extension() == ext)
                 {
@@ -1980,7 +1980,7 @@ void *ftpthread(void *arg)
     if (*proxyaddr)
         {
             auto proto = "ftp"s;
-            if (ftp->proto) proto = "http"s; // NOLINT(readability-braces-around-statements): adding braces reduces readability
+            if (ftp->proto) proto = "http"s;  // NOLINT(readability-braces-around-statements): adding braces reduces readability
             env = "set "s + proto + "_proxy=http://"s + std::string(proxyaddr) + " % ";
             proxyopt = "--proxy=on ";
         }
@@ -2024,7 +2024,7 @@ void *ftpthread(void *arg)
         }
 
     /* uncompress downloaded file */
-    for (auto ext : {".z", ".gz", ".zip", ".Z", ".GZ", ".ZIP"})	// NOLINT(readability-qualified-auto): auto decoration is less readable
+    for (auto ext : {".z", ".gz", ".zip", ".Z", ".GZ", ".ZIP"})  // NOLINT(readability-qualified-auto): auto decoration is less readable
         {
             if (local.extension() == ext)
                 {

--- a/src/algorithms/libs/rtklib/rtklib_stream.cc
+++ b/src/algorithms/libs/rtklib/rtklib_stream.cc
@@ -386,7 +386,7 @@ file_t *openfile(std::string const &path, int mode, char *msg)
             tokens.pop_front();
 
             // edge case that may not be possible, but I don't want to test for right now
-            if (tag.empty()) continue;
+            if (tag.empty()) continue;  // NOLINT(readability-braces-around-statements)
 
             if (tag == "T")
                 {

--- a/src/algorithms/libs/rtklib/rtklib_stream.cc
+++ b/src/algorithms/libs/rtklib/rtklib_stream.cc
@@ -38,7 +38,9 @@
 #include <cerrno>
 #include <cinttypes>
 #include <cstring>
+#include <deque>
 #include <fcntl.h>
+#include <memory>
 #include <netdb.h>
 #include <netinet/tcp.h>
 #include <regex>

--- a/src/algorithms/libs/rtklib/rtklib_stream.cc
+++ b/src/algorithms/libs/rtklib/rtklib_stream.cc
@@ -1956,7 +1956,7 @@ void *ftpthread(void *arg)
 
     /* if local file exist, skip download */
     auto tmpfile = local;
-    for (auto ext : {".z", ".gz", ".zip", ".Z", ".GZ", ".ZIP"})
+    for (auto ext : {".z", ".gz", ".zip", ".Z", ".GZ", ".ZIP"}) // NOLINT(readability-qualified-auto): auto decoration is less readable
         {
             if (tmpfile.extension() == ext)
                 {
@@ -1980,7 +1980,7 @@ void *ftpthread(void *arg)
     if (*proxyaddr)
         {
             auto proto = "ftp"s;
-            if (ftp->proto) proto = "http"s;
+            if (ftp->proto) proto = "http"s; // NOLINT(readability-braces-around-statements): adding braces reduces readability
             env = "set "s + proto + "_proxy=http://"s + std::string(proxyaddr) + " % ";
             proxyopt = "--proxy=on ";
         }
@@ -1991,18 +1991,18 @@ void *ftpthread(void *arg)
         { /* ftp */
             auto opt_str = "--ftp-user="s + std::string(ftp->user) + " --ftp-password="s + std::string(ftp->passwd) +
                            " --glob=off --passive-ftp "s + proxyopt + "s-t 1 -T "s + std::to_string(FTP_TIMEOUT) +
-                           " -O \"" + local.native() + "\""s;
+                           R"( -O ")" + local.native() + R"(")"s;
 
             // TODO: this uses shell syntax; consider escaping paths
             cmd_str = env + std::string(FTP_CMD) + " "s + opt_str + " "s +
-                      "\"ftp://"s + std::string(ftp->addr) + "/"s + remotePath.native() + "\" 2> \""s + errfile.native() + "\"\n"s;
+                      R"("ftp://)"s + std::string(ftp->addr) + "/"s + remotePath.native() + R"(" 2> ")"s + errfile.native() + "\"\n"s;
         }
     else
         { /* http */
             auto opt_str = proxyopt + " -t 1 -T "s + std::to_string(FTP_TIMEOUT) + " -O \""s + local.native() + "\""s;
 
             cmd_str = env + std::string(FTP_CMD) + " "s + opt_str + " "s +
-                      "\"http://"s + std::string(ftp->addr) + "/"s + remotePath.native() + "\" 2> \""s + errfile.native() + "\"\n";
+                      R"("http://)"s + std::string(ftp->addr) + "/"s + remotePath.native() + R"(" 2> ")"s + errfile.native() + "\"\n";
         }
     /* execute download command */
     std::error_code ec;  // prevent exceptions
@@ -2024,7 +2024,7 @@ void *ftpthread(void *arg)
         }
 
     /* uncompress downloaded file */
-    for (auto ext : {".z", ".gz", ".zip", ".Z", ".GZ", ".ZIP"})
+    for (auto ext : {".z", ".gz", ".zip", ".Z", ".GZ", ".ZIP"})	// NOLINT(readability-qualified-auto): auto decoration is less readable
         {
             if (local.extension() == ext)
                 {
@@ -2074,7 +2074,7 @@ ftp_t *openftp(const char *path, int type, char *msg)
     ftp->state = 0;
     ftp->proto = type;
     ftp->error = 0;
-    ftp->thread = 0;  // NOLINT
+    ftp->thread = pthread_t();
     ftp->local[0] = '\0';
 
     /* decode ftp path */

--- a/src/algorithms/libs/rtklib/rtklib_stream.cc
+++ b/src/algorithms/libs/rtklib/rtklib_stream.cc
@@ -44,6 +44,7 @@
 #include <netdb.h>
 #include <netinet/tcp.h>
 #include <regex>
+#include <sstream>
 #include <string>
 #include <sys/socket.h>
 #include <sys/stat.h>
@@ -235,7 +236,7 @@ int openfile_(file_t *file, gtime_t time, char *msg)
     char tagpath[MAXSTRPATH + 4] = "";
     char tagh[TIMETAGH_LEN + 1] = "";
 
-    tracet(3, "openfile_: path=%s time=%s\n", file->path, time_str(time, 0));
+    tracet(3, "openfile_: path=%s time=%s\n", file->path.data(), time_str(time, 0));
 
     file->time = utc2gpst(timeget());
     file->tick = file->tick_f = tickget();
@@ -331,7 +332,7 @@ int openfile_(file_t *file, gtime_t time, char *msg)
 /* close file ----------------------------------------------------------------*/
 void closefile_(file_t *file)
 {
-    tracet(3, "closefile_: path=%s\n", file->path);
+    tracet(3, "closefile_: path=%s\n", file->path.data());
     if (file->fp)
         {
             fclose(file->fp);
@@ -358,7 +359,7 @@ void closefile_(file_t *file)
 /* open file (path=filepath[::T[::+<off>][::x<speed>]][::S=swapintv]) --------*/
 file_t *openfile(std::string const &path, int mode, char *msg)
 {
-    tracet(3, "openfile: path=%s mode=%d\n", path, mode);
+    tracet(3, "openfile: path=%s mode=%d\n", path.data(), mode);
 
     if ((mode & (STR_MODE_R | STR_MODE_W)) == 0)
         {

--- a/src/algorithms/libs/rtklib/rtklib_stream.cc
+++ b/src/algorithms/libs/rtklib/rtklib_stream.cc
@@ -1976,9 +1976,9 @@ void *ftpthread(void *arg)
     auto proxyopt = std::string();
     if (*proxyaddr)
         {
-	  auto proto = "ftp"s;
-	  if (ftp->proto) proto = "http"s;
-	    env = "set "s + proto + "_proxy=http://"s + std::string(proxyaddr) + " % ";
+            auto proto = "ftp"s;
+            if (ftp->proto) proto = "http"s;
+            env = "set "s + proto + "_proxy=http://"s + std::string(proxyaddr) + " % ";
             proxyopt = "--proxy=on ";
         }
 
@@ -2025,7 +2025,7 @@ void *ftpthread(void *arg)
         {
             if (local.extension() == ext)
                 {
-		  char tmpfile_arg[1024];
+                    char tmpfile_arg[1024];
                     ret = rtk_uncompress(local.c_str(), tmpfile_arg);
                     if (ret != 0)  // success
                         {

--- a/src/algorithms/libs/rtklib/rtklib_stream.cc
+++ b/src/algorithms/libs/rtklib/rtklib_stream.cc
@@ -41,6 +41,7 @@
 #include <fcntl.h>
 #include <netdb.h>
 #include <netinet/tcp.h>
+#include <regex>
 #include <string>
 #include <sys/socket.h>
 #include <sys/stat.h>
@@ -48,6 +49,7 @@
 #include <termios.h>
 #include <unistd.h>
 
+using namespace std::string_literals;
 
 /* global options ------------------------------------------------------------*/
 
@@ -118,7 +120,7 @@ serial_t *openserial(const char *path, int mode, char *msg)
         }
     parity = static_cast<char>(toupper(static_cast<int>(parity)));
 
-    std::string s_aux = "/dev/" + std::string(port);
+    std::string s_aux = "/dev/"s + std::string(port);
     s_aux.resize(128, '\0');
     int n = s_aux.length();
     for (i = 0; i < n; i++)
@@ -228,7 +230,6 @@ int stateserial(serial_t *serial)
 int openfile_(file_t *file, gtime_t time, char *msg)
 {
     FILE *fp;
-    char *rw;
     char tagpath[MAXSTRPATH + 4] = "";
     char tagh[TIMETAGH_LEN + 1] = "";
 
@@ -238,8 +239,8 @@ int openfile_(file_t *file, gtime_t time, char *msg)
     file->tick = file->tick_f = tickget();
     file->fpos = 0;
 
-    /* use stdin or stdout if file path is null */
-    if (!*file->path)
+    /* use stdin or stdout if file path is empty */
+    if (file->path.empty())
         {
             file->fp = file->mode & STR_MODE_R ? stdin : stdout;
             return 1;
@@ -250,37 +251,39 @@ int openfile_(file_t *file, gtime_t time, char *msg)
     /* create directory */
     if ((file->mode & STR_MODE_W) && !(file->mode & STR_MODE_R))
         {
-            createdir(file->openpath);
+            createdir(file->openpath.data());
         }
+
+    char const *mode;
     if (file->mode & STR_MODE_R)
         {
-            rw = const_cast<char *>("rb");
+            mode = "rb";
         }
     else
         {
-            rw = const_cast<char *>("wb");
+            mode = "wb";
         }
 
-    if (!(file->fp = fopen(file->openpath, rw)))
+    if (!(file->fp = fopen(file->openpath.data(), mode)))
         {
             std::snprintf(msg, MAXSTRMSG, "file open error");
             tracet(1, "openfile: %s\n", msg);
             return 0;
         }
-    tracet(4, "openfile_: open file %s (%s)\n", file->openpath, rw);
+    tracet(4, "openfile_: open file %s (%s)\n", file->openpath.data(), mode);
 
-    std::snprintf(tagpath, MAXSTRPATH + 4, "%s.tag", file->openpath);
+    std::snprintf(tagpath, MAXSTRPATH + 4, "%s.tag", file->openpath.data());
 
     if (file->timetag)
         { /* output/sync time-tag */
-            if (!(file->fp_tag = fopen(tagpath, rw)))
+            if (!(file->fp_tag = fopen(tagpath, mode)))
                 {
                     std::snprintf(msg, MAXSTRMSG, "tag open error");
                     tracet(1, "openfile: %s\n", msg);
                     fclose(file->fp);
                     return 0;
                 }
-            tracet(4, "openfile_: open tag file %s (%s)\n", tagpath, rw);
+            tracet(4, "openfile_: open tag file %s (%s)\n", tagpath, mode);
 
             if (file->mode & STR_MODE_R)
                 {
@@ -330,127 +333,128 @@ void closefile_(file_t *file)
     if (file->fp)
         {
             fclose(file->fp);
+            file->fp = nullptr;
         }
     if (file->fp_tag)
         {
             fclose(file->fp_tag);
+            file->fp_tag = nullptr;
         }
     if (file->fp_tmp)
         {
             fclose(file->fp_tmp);
+            file->fp_tmp = nullptr;
         }
     if (file->fp_tag_tmp)
         {
             fclose(file->fp_tag_tmp);
+            file->fp_tag_tmp = nullptr;
         }
-    file->fp = file->fp_tag = file->fp_tmp = file->fp_tag_tmp = nullptr;
 }
 
 
 /* open file (path=filepath[::T[::+<off>][::x<speed>]][::S=swapintv]) --------*/
-file_t *openfile(const char *path, int mode, char *msg)
+file_t *openfile(std::string const &path, int mode, char *msg)
 {
-    file_t *file;
-    gtime_t time;
-    gtime_t time0 = {0, 0.0};
-    double speed = 0.0;
-    double start = 0.0;
-    double swapintv = 0.0;
-    char *p;
-    int timetag = 0;
-
     tracet(3, "openfile: path=%s mode=%d\n", path, mode);
 
-    if (!(mode & (STR_MODE_R | STR_MODE_W)))
+    if ((mode & (STR_MODE_R | STR_MODE_W)) == 0)
         {
             return nullptr;
         }
+
+    // Split the string by regular expression (in this case, the trivial "::" string)
+    std::regex re("::");
+    auto first = std::sregex_token_iterator(path.begin(), path.end(), re, -1);
+    auto last = std::sregex_token_iterator();
+    std::deque<std::string> tokens(first, last);
+
+    auto file = std::make_unique<file_t>();
+
+    file->mode = mode;
+    file->path = tokens.front();  // first token is the path
+    tokens.pop_front();
+
 
     /* file options */
-    for (p = const_cast<char *>(path); (p = strstr(p, "::")); p += 2)
-        { /* file options */
-            if (*(p + 2) == 'T')
-                {
-                    timetag = 1;
-                }
-            else if (*(p + 2) == '+')
-                {
-                    sscanf(p + 2, "+%lf", &start);
-                }
-            else if (*(p + 2) == 'x')
-                {
-                    sscanf(p + 2, "x%lf", &speed);
-                }
-            else if (*(p + 2) == 'S')
-                {
-                    sscanf(p + 2, "S=%lf", &swapintv);
-                }
-        }
-    if (start <= 0.0)
+    while (not tokens.empty())
         {
-            start = 0.0;
-        }
-    if (swapintv <= 0.0)
-        {
-            swapintv = 0.0;
+            auto tag = tokens.front();
+            tokens.pop_front();
+
+            // edge case that may not be possible, but I don't want to test for right now
+            if (tag.empty()) continue;
+
+            if (tag == "T")
+                {
+                    file->timetag = 1;
+                }
+            else if (tag[0] == '+')
+                {
+                    double start = 0.0;
+                    std::istringstream ss(tag);
+                    ss.ignore(1, '+') >> start;
+                    // do we care if there are extra characters?
+
+                    if (start < 0)
+                        {
+                            start = 0;
+                        }
+                    file->start = start;
+                }
+            else if (tag[0] == 'x')
+                {
+                    double speed = 0.0;
+                    std::istringstream ss(tag);
+                    ss.ignore(1, 'x') >> speed;
+                    // do we care if there are extra characters?
+                    file->speed = speed;
+                }
+            else if (tag[0] == 'S')
+                {
+                    double swapintv = 0.0;
+                    std::istringstream ss(tag);
+                    ss.ignore(1, 'S').ignore(1, '=') >> swapintv;
+                    // do we care if there are extra characters?
+                    if (swapintv < 0) swapintv = 0;
+                    file->swapintv = swapintv;
+                }
+            else
+                {
+                    // unexpected value ... not previously handled
+                }
         }
 
-    if (!(file = static_cast<file_t *>(malloc(sizeof(file_t)))))
-        {
-            return nullptr;
-        }
-
-    file->fp = file->fp_tag = file->fp_tmp = file->fp_tag_tmp = nullptr;
-    if (strlen(path) < MAXSTRPATH)
-        {
-            std::strncpy(file->path, path, MAXSTRPATH);
-            file->path[MAXSTRPATH - 1] = '\0';
-        }
-    if ((p = strstr(file->path, "::")))
-        {
-            *p = '\0';
-        }
-    file->openpath[0] = '\0';
-    file->mode = mode;
-    file->timetag = timetag;
-    file->repmode = 0;
-    file->offset = 0;
-    file->time = file->wtime = time0;
-    file->tick = file->tick_f = file->fpos = 0;
-    file->start = start;
-    file->speed = speed;
-    file->swapintv = swapintv;
     initlock(&file->lock);
 
-    time = utc2gpst(timeget());
+    auto time = utc2gpst(timeget());
 
     /* open new file */
-    if (!openfile_(file, time, msg))
+    if (!openfile_(file.get(), time, msg))
         {
-            free(file);
-            return nullptr;
+            file.reset();
         }
-    return file;
+    return file.release();  // ownership belongs to the caller now
 }
 
 
 /* close file ----------------------------------------------------------------*/
 void closefile(file_t *file)
 {
-    if (!file)
+    if (file)
         {
-            return;
+            std::unique_ptr<file_t> fileH(file);
+            tracet(3, "closefile: fp=%p \n", fileH->fp);
+
+            closefile_(fileH.get());
         }
-    tracet(3, "closefile: fp=%p \n", file->fp);
-    closefile_(file);
-    free(file);
 }
 
 
 /* open new swap file --------------------------------------------------------*/
 void swapfile(file_t *file, gtime_t time, char *msg)
 {
-    char openpath[MAXSTRPATH];
+    std::string openpath;
 
     tracet(3, "swapfile: fp=%p \n time=%s\n", file->fp, time_str(time, 0));
 
@@ -463,9 +467,9 @@ void swapfile(file_t *file, gtime_t time, char *msg)
     /* check path of new swap file */
     reppath(file->path, openpath, time, "", "");
 
-    if (!strcmp(openpath, file->openpath))
+    if (openpath == file->openpath)
         {
-            tracet(2, "swapfile: no need to swap %s\n", openpath);
+            tracet(2, "swapfile: no need to swap %s\n", openpath.data());
             return;
         }
     /* save file pointer to temporary pointer */
@@ -1739,7 +1743,7 @@ ntrip_t *openntrip(const char *path, int type, char *msg)
     /* ntrip access via proxy server */
     if (*proxyaddr)
         {
-            std::string s_aux = "http://" + std::string(tpath);
+            std::string s_aux = "http://"s + std::string(tpath);
             int n = s_aux.length();
             if (n < 256)
                 {
@@ -1924,19 +1928,6 @@ gtime_t nextdltime(const int *topts, int stat)
 void *ftpthread(void *arg)
 {
     auto *ftp = static_cast<ftp_t *>(arg);
-    FILE *fp;
-    gtime_t time;
-    char remote[1024];
-    char local[1024];
-    char tmpfile[1024];
-    char errfile[1024];
-    char *p;
-    char cmd[2048];
-    char env[1024] = "";
-    char opt[1024];
-    char *proxyopt = const_cast<char *>("");
-    char *proto;
-    int ret;
 
     tracet(3, "ftpthread:\n");
 
@@ -1948,152 +1939,117 @@ void *ftpthread(void *arg)
             return nullptr;
         }
     /* replace keyword in file path and local path */
-    time = timeadd(utc2gpst(timeget()), ftp->topts[0]);
+    auto time = timeadd(utc2gpst(timeget()), ftp->topts[0]);
+
+    std::string remote;
     reppath(ftp->file, remote, time, "", "");
+    auto remotePath = std::filesystem::path(remote);
 
-    if ((p = strrchr(remote, '/')))
-        {
-            p++;
-        }
-    else
-        {
-            p = remote;
-        }
-    std::string s_aux = std::string(localdir) + std::to_string(FILEPATHSEP) + std::string(p);
-    int n = s_aux.length();
-    if (n < 1024)
-        {
-            for (int i = 0; i < n; i++)
-                {
-                    local[i] = s_aux[i];
-                }
-        }
+    auto local = std::filesystem::path(localdir);
+    local /= remotePath.filename();
 
-    std::string s_aux2 = std::string(local) + ".err";
-    n = s_aux2.length();
-    if (n < 1024)
-        {
-            for (int i = 0; i < n; i++)
-                {
-                    errfile[i] = s_aux2[i];
-                }
-        }
+    auto errfile = std::filesystem::path(local);
+    errfile.replace_extension("err");
 
     /* if local file exist, skip download */
-    std::strncpy(tmpfile, local, 1024);
-    tmpfile[1023] = '\0';
-    if ((p = strrchr(tmpfile, '.')) &&
-        (!strcmp(p, ".z") || !strcmp(p, ".gz") || !strcmp(p, ".zip") ||
-            !strcmp(p, ".Z") || !strcmp(p, ".GZ") || !strcmp(p, ".ZIP")))
+    auto tmpfile = local;
+    for (auto ext : {".z", ".gz", ".zip", ".Z", ".GZ", ".ZIP"})
         {
-            *p = '\0';
+            if (tmpfile.extension() == ext)
+                {
+                    tmpfile.replace_extension("");
+                    break;
+                }
         }
-    if ((fp = fopen(tmpfile, "rbe")))
+    if (std::filesystem::exists(tmpfile))
         {
-            fclose(fp);
-            std::strncpy(ftp->local, tmpfile, 1024);
+            std::strncpy(ftp->local, tmpfile.c_str(), 1024);
             ftp->local[1023] = '\0';
             tracet(3, "ftpthread: file exists %s\n", ftp->local);
             ftp->state = 2;
             return nullptr;
         }
+
+    std::string env;
+
     /* proxy settings for wget (ref [2]) */
+    auto proxyopt = std::string();
     if (*proxyaddr)
         {
-            proto = ftp->proto ? const_cast<char *>("http") : const_cast<char *>("ftp");
-            std::snprintf(env, sizeof(env), "set %s_proxy=http://%s & ", proto, proxyaddr);
-            proxyopt = const_cast<char *>("--proxy=on ");
+	  auto proto = "ftp"s;
+	  if (ftp->proto) proto = "http"s;
+	    env = "set "s + proto + "_proxy=http://"s + std::string(proxyaddr) + " % ";
+            proxyopt = "--proxy=on ";
         }
+
     /* download command (ref [2]) */
+    auto cmd_str = std::string();
     if (ftp->proto == 0)
         { /* ftp */
-            s_aux = "--ftp-user=" + std::string(ftp->user) + " --ftp-password=" + std::string(ftp->passwd) +
-                    " --glob=off --passive-ftp " + std::string(proxyopt) + "s-t 1 -T " + std::to_string(FTP_TIMEOUT) +
-                    " -O \"" + std::string(local) + "\"";
-            int k = s_aux.length();
-            if (k < 1024)
-                {
-                    for (int i = 0; i < k; i++)
-                        {
-                            opt[i] = s_aux[i];
-                        }
-                }
+            auto opt_str = "--ftp-user="s + std::string(ftp->user) + " --ftp-password="s + std::string(ftp->passwd) +
+                           " --glob=off --passive-ftp "s + proxyopt + "s-t 1 -T "s + std::to_string(FTP_TIMEOUT) +
+                           " -O \"" + local.native() + "\""s;
 
-            s_aux2 = std::string(env) + std::string(FTP_CMD) + " " + std::string(opt) + " " +
-                     "\"ftp://" + std::string(ftp->addr) + "/" + std::string(remote) + "\" 2> \"" + std::string(errfile) + "\"\n";
-            k = s_aux2.length();
-            for (int i = 0; (i < k) && (i < 1024); i++)
-                {
-                    cmd[i] = s_aux2[i];
-                }
+            // TODO: this uses shell syntax; consider escaping paths
+            cmd_str = env + std::string(FTP_CMD) + " "s + opt_str + " "s +
+                      "\"ftp://"s + std::string(ftp->addr) + "/"s + remotePath.native() + "\" 2> \""s + errfile.native() + "\"\n"s;
         }
     else
         { /* http */
-            s_aux = std::string(proxyopt) + " -t 1 -T " + std::to_string(FTP_TIMEOUT) + " -O \"" + std::string(local) + "\"";
-            int l = s_aux.length();
-            for (int i = 0; (i < l) && (i < 1024); i++)
-                {
-                    opt[i] = s_aux[i];
-                }
+            auto opt_str = proxyopt + " -t 1 -T "s + std::to_string(FTP_TIMEOUT) + " -O \""s + local.native() + "\""s;
 
-            s_aux2 = std::string(env) + std::string(FTP_CMD) + " " + std::string(opt) + " " +
-                     "\"http://" + std::string(ftp->addr) + "/" + std::string(remote) + "\" 2> \"" + std::string(errfile) + "\"\n";
-            l = s_aux2.length();
-            for (int i = 0; (i < l) && (i < 1024); i++)
-                {
-                    cmd[i] = s_aux2[i];
-                }
+            cmd_str = env + std::string(FTP_CMD) + " "s + opt_str + " "s +
+                      "\"http://"s + std::string(ftp->addr) + "/"s + remotePath.native() + "\" 2> \""s + errfile.native() + "\"\n";
         }
     /* execute download command */
-    if ((ret = execcmd(cmd)))
+    std::error_code ec;  // prevent exceptions
+    auto ret = execcmd(cmd_str.c_str());
+    if ((ret != 0))
         {
-            if (remove(local) != 0)
+            if (std::filesystem::remove(local, ec) == false)
                 {
-                    trace(1, "Error removing file");
+                    trace(1, "Error removing file %s", local.c_str());
                 }
-            tracet(1, "execcmd error: cmd=%s ret=%d\n", cmd, ret);
+            tracet(1, "execcmd error: cmd=%s ret=%d\n", cmd_str.data(), ret);
             ftp->error = ret;
             ftp->state = 3;
             return nullptr;
         }
-    if (remove(errfile) != 0)
+    if (std::filesystem::remove(errfile, ec) == false)
         {
-            trace(1, "Error removing file");
+            trace(1, "Error removing file %s", errfile.c_str());
         }
 
     /* uncompress downloaded file */
-    if ((p = strrchr(local, '.')) &&
-        (!strcmp(p, ".z") || !strcmp(p, ".gz") || !strcmp(p, ".zip") ||
-            !strcmp(p, ".Z") || !strcmp(p, ".GZ") || !strcmp(p, ".ZIP")))
+    for (auto ext : {".z", ".gz", ".zip", ".Z", ".GZ", ".ZIP"})
         {
-            if (rtk_uncompress(local, tmpfile))
+            if (local.extension() == ext)
                 {
-                    if (remove(local) != 0)
+		  char tmpfile_arg[1024];
+                    ret = rtk_uncompress(local.c_str(), tmpfile_arg);
+                    if (ret != 0)  // success
                         {
-                            trace(1, "Error removing file");
+                            if (std::filesystem::remove(local, ec) == false)
+                                {
+                                    trace(1, "Error removing file %s", local.c_str());
+                                }
+                            local = tmpfile_arg;
                         }
-                    if (strlen(tmpfile) < 1024)
+                    else
                         {
-                            std::strncpy(local, tmpfile, 1024);
-                            local[1023] = '\0';
+                            tracet(1, "file uncompact error: %s\n", local.c_str());
+                            ftp->error = 12;
+                            ftp->state = 3;
+                            return nullptr;
                         }
-                }
-            else
-                {
-                    tracet(1, "file uncompact error: %s\n", local);
-                    ftp->error = 12;
-                    ftp->state = 3;
-                    return nullptr;
+                    break;
                 }
         }
-    if (strlen(local) < 1024)
-        {
-            std::strncpy(ftp->local, local, 1024);
-            ftp->local[1023] = '\0';
-        }
+    std::strncpy(ftp->local, local.c_str(), 1024);
+    ftp->local[1023] = '\0';
     ftp->state = 2; /* ftp completed */
 
-    tracet(3, "ftpthread: complete cmd=%s\n", cmd);
+    tracet(3, "ftpthread: complete cmd=%s\n", cmd_str.data());
     return nullptr;
 }
 


### PR DESCRIPTION
I was required to perform a static code analysis of GNSS-SDR. There was one critical error identified.
![image001](https://user-images.githubusercontent.com/7908039/181844163-5a0fc2d2-d0e1-4a06-9e0b-3a33710a94fd.png)

The fundamental issue is that if `strncpy` truncates the string, the result is not null-terminated, potentially leading to a buffer overrun. However, the specific error is that a substring is copied using the size of the whole string as a boundary. Underlying is the inherent lack of safety in using null-terminated strings. C++ addressed this issue (slowly) by creating a robust, efficient, and safe string class. Still, C-strings abound, and lots of legacy C code was just compiled with a C++ compiler without improvement.

I naively thought that I could easily refactor the offending portion of code to not use strncpy and friends, but it turns out that I found myself in one of those collections of "legacy C code compiled with a C++ compiler". 

Believe it or not, I tried very hard to limit the scope of this change; there was a lot more I could have done in this area. A major concern is that I don't know how to test this portion of the code. I would like to write unit tests, but we don't have the plumbing for low-level unit testing like this. I'm open to suggestions.

One point of orientation: the `file_t` structure and friends is (was) allocated using `malloc`; this means that no C++ constructors are called, making replacing fixed length character arrays with `std::string` was a lurking nightmare. So I carefully(? I think) found the allocation/deallocation code for _just that type_ and replaced with new/delete (actually using `std::unique_ptr`). This is **required** for classes with constructors to be used in the struct.

A lot of the code I ended up modifying should have been class member functions on the affected structure. That would be a useful improvement, but I didn't want to cloud this issue.
