### PR TITLE
Remove marketing blurb for snapcraft instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -962,10 +962,8 @@ compile time if they are not detected in your machine.
   [https://github.com/carlesfernandez/docker-pybombs-gnsssdr](https://github.com/carlesfernandez/docker-pybombs-gnsssdr)
   for instructions.
 
-- **Snap package**: [Snaps](https://snapcraft.io) are universal Linux packages
-  aimed to work on any distribution or device, from IoT devices to servers,
-  desktops to mobile devices. Visit
-  [https://github.com/carlesfernandez/snapcraft-sandbox](https://github.com/carlesfernandez/snapcraft-sandbox)
+- **Snap package**: [Snaps](https://snapcraft.io) are Linux packages aimed for Ubuntu or Ubuntu-like distros.
+  Visit [https://github.com/carlesfernandez/snapcraft-sandbox](https://github.com/carlesfernandez/snapcraft-sandbox)
   for instructions, or directly
   [get the software from the Snap Store](https://snapcraft.io/gnss-sdr-next):
 


### PR DESCRIPTION
While I have some personal opinions about the base reasoning of snaps, the blurb that tells they're "universal" is categorically not true, as snaps require a lot of invasive changes that distros other than ubuntu (or very ubuntu-like) simply do not execute.

I think describing the reality - that snaps are best used on an ubuntu distro - will go further in addressing the needs of someone looking at this software, which is "how and where can i use this?", instead of becoming frustrated that snaps arent widely accepted.

`Signed-off-by: Jonathan de Jong <jonathan@automatia.nl>`