### PR TITLE
Fixup MacOS install `cask` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -875,7 +875,7 @@ $ brew update && brew upgrade
 $ brew install armadillo cmake hdf5 gflags glog gnuradio lapack libmatio log4cpp \
     openssl pkg-config protobuf pugixml
 $ pip3 install mako
-$ brew cask install mactex  # when completed, restart Terminal
+$ brew install --cask mactex  # when completed, restart Terminal
 $ brew install graphviz doxygen
 ```
 


### PR DESCRIPTION
Encountered this while trying to install on macos, as newer versions of brew have deprecated the old way.

`Signed-off-by: Jonathan de Jong <jonathan@automatia.nl>`