### PR TITLE
Secure User Location Protocol fixes

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -182,6 +182,16 @@ jobs:
       run: cd build && ctest -C Release --exclude-regex volk_gnsssdr_32fc_32f_rotator_dotprodxnpuppet_32fc
 
 
+  shellcheck:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - name: install dependencies
+      run: sudo apt install shellcheck
+    - name: check scripts
+      run: shellcheck src/utils/scripts/*
+
+
   REUSE-compliance:
     runs-on: ubuntu-latest
     steps:

--- a/src/core/libs/gnss_sdr_supl_client.cc
+++ b/src/core/libs/gnss_sdr_supl_client.cc
@@ -510,9 +510,9 @@ bool Gnss_Sdr_Supl_Client::load_gnav_ephemeris_xml(const std::string& file_name)
         {
             ifs.open(file_name.c_str(), std::ifstream::binary | std::ifstream::in);
             boost::archive::xml_iarchive xml(ifs);
-            gps_cnav_ephemeris_map.clear();
+            glonass_gnav_ephemeris_map.clear();
             xml >> boost::serialization::make_nvp("GNSS-SDR_gnav_ephemeris_map", this->glonass_gnav_ephemeris_map);
-            LOG(INFO) << "Loaded GLONASS ephemeris map data with " << this->gps_cnav_ephemeris_map.size() << " satellites";
+            LOG(INFO) << "Loaded GLONASS ephemeris map data with " << this->glonass_gnav_ephemeris_map.size() << " satellites";
         }
     catch (std::exception& e)
         {

--- a/src/core/libs/gnss_sdr_supl_client.cc
+++ b/src/core/libs/gnss_sdr_supl_client.cc
@@ -429,7 +429,7 @@ bool Gnss_Sdr_Supl_Client::load_gal_ephemeris_xml(const std::string& file_name)
 }
 
 
-bool save_gal_ephemeris_map_xml(const std::string& file_name, std::map<int, Galileo_Ephemeris> eph_map)
+bool Gnss_Sdr_Supl_Client::save_gal_ephemeris_map_xml(const std::string& file_name, std::map<int, Galileo_Ephemeris> eph_map)
 {
     if (eph_map.empty() == false)
         {
@@ -476,7 +476,7 @@ bool Gnss_Sdr_Supl_Client::load_cnav_ephemeris_xml(const std::string& file_name)
 }
 
 
-bool save_cnav_ephemeris_map_xml(const std::string& file_name, std::map<int, Gps_CNAV_Ephemeris> eph_map)
+bool Gnss_Sdr_Supl_Client::save_cnav_ephemeris_map_xml(const std::string& file_name, std::map<int, Gps_CNAV_Ephemeris> eph_map)
 {
     if (eph_map.empty() == false)
         {
@@ -523,7 +523,7 @@ bool Gnss_Sdr_Supl_Client::load_gnav_ephemeris_xml(const std::string& file_name)
 }
 
 
-bool save_gnav_ephemeris_map_xml(const std::string& file_name, std::map<int, Glonass_Gnav_Ephemeris> eph_map)
+bool Gnss_Sdr_Supl_Client::save_gnav_ephemeris_map_xml(const std::string& file_name, std::map<int, Glonass_Gnav_Ephemeris> eph_map)
 {
     if (eph_map.empty() == false)
         {

--- a/src/core/libs/gnss_sdr_supl_client.h
+++ b/src/core/libs/gnss_sdr_supl_client.h
@@ -122,7 +122,7 @@ public:
     /*!
      * \brief Save GPS CNAV ephemeris map to XML file.
      */
-    bool save_cnav_ephemeris_map_xml(const std::string file_name,
+    bool save_cnav_ephemeris_map_xml(const std::string& file_name,
         std::map<int, Gps_CNAV_Ephemeris> eph_map);
 
     /*!
@@ -133,7 +133,7 @@ public:
     /*!
      * \brief Save Galileo ephemeris map to XML file.
      */
-    bool save_gal_ephemeris_map_xml(const std::string file_name,
+    bool save_gal_ephemeris_map_xml(const std::string& file_name,
         std::map<int, Galileo_Ephemeris> eph_map);
 
     /*!
@@ -144,7 +144,7 @@ public:
     /*!
      * \brief Save GLONASS GNAV ephemeris map to XML file.
      */
-    bool save_gnav_ephemeris_map_xml(const std::string file_name,
+    bool save_gnav_ephemeris_map_xml(const std::string &file_name,
         std::map<int, Glonass_Gnav_Ephemeris> eph_map);
 
     /*!

--- a/src/core/libs/gnss_sdr_supl_client.h
+++ b/src/core/libs/gnss_sdr_supl_client.h
@@ -144,7 +144,7 @@ public:
     /*!
      * \brief Save GLONASS GNAV ephemeris map to XML file.
      */
-    bool save_gnav_ephemeris_map_xml(const std::string &file_name,
+    bool save_gnav_ephemeris_map_xml(const std::string& file_name,
         std::map<int, Glonass_Gnav_Ephemeris> eph_map);
 
     /*!


### PR DESCRIPTION
1. Member function definitions in `core/libs/gnss_sdr_supl_client.cc` did not have class name qualifiers, so I have added them.
2. Declarations of these functions in `core/libs/gnss_sdr_supl_client.h` did not have ampersands, also added those.
3. Function `Gnss_Sdr_Supl_Client::load_gnav_ephemeris_xml` used wrong ephemeris map (GPS instead of GLONASS)