### PR TITLE
Wrong decoding of GLONASS navigation message parameter P1

### DIFF
--- a/src/algorithms/PVT/libs/rtcm.cc
+++ b/src/algorithms/PVT/libs/rtcm.cc
@@ -1873,8 +1873,8 @@ int32_t Rtcm::read_MT1020(const std::string& message, Glonass_Gnav_Ephemeris& gl
         {
         }  // Avoid compiler warning
 
-    glonass_gnav_eph.d_P_1 = static_cast<double>(Rtcm::bin_to_uint(message_bin.substr(index, 2)));
-    glonass_gnav_eph.d_P_1 = (glonass_gnav_eph.d_P_1 + 1) * 15;
+    uint32_t P_1_tmp = Rtcm::bin_to_uint(message_bin.substr(index, 2));
+    glonass_gnav_eph.d_P_1 = (P_1_tmp == 0) ? 0. : (P_1_tmp + 1) * 15;
     index += 2;
 
     glonass_gnav_eph.d_t_k += static_cast<double>(Rtcm::bin_to_int(message_bin.substr(index, 5))) * 3600;
@@ -5102,8 +5102,9 @@ int32_t Rtcm::set_DF105(uint32_t glonass_gnav_alm_health_ind)
 
 int32_t Rtcm::set_DF106(const Glonass_Gnav_Ephemeris& glonass_gnav_eph)
 {
-    // Convert the value from (15, 30, 45, 60) to (00, 01, 10, 11)
-    const auto P_1 = static_cast<uint32_t>(std::round(glonass_gnav_eph.d_P_1 / 15.0 - 1.0));
+    // Convert the value from (0, 30, 45, 60) to (00, 01, 10, 11)
+    uint32_t P_1_tmp = std::round(glonass_gnav_eph.d_P_1 / 15.);
+    uint32_t P_1 = (P_1_tmp == 0) ? 0 : P_1_tmp - 1;
     DF106 = std::bitset<2>(P_1);
     return 0;
 }

--- a/src/core/system_parameters/glonass_gnav_navigation_message.cc
+++ b/src/core/system_parameters/glonass_gnav_navigation_message.cc
@@ -235,6 +235,7 @@ int32_t Glonass_Gnav_Navigation_Message::string_decoder(const std::string& frame
 {
     int32_t J = 0;
     d_frame_ID = 0U;
+    uint64_t P_1_tmp = 0;
 
     // Unpack bytes to bits
     const std::bitset<GLONASS_GNAV_STRING_BITS> string_bits(frame_string);
@@ -252,7 +253,8 @@ int32_t Glonass_Gnav_Navigation_Message::string_decoder(const std::string& frame
         {
         case 1:
             // --- It is string 1 -----------------------------------------------
-            gnav_ephemeris.d_P_1 = (static_cast<double>(read_navigation_unsigned(string_bits, P1)) + 1) * 15;
+            P_1_tmp = read_navigation_unsigned(string_bits, P1);
+            gnav_ephemeris.d_P_1 = (P_1_tmp == 0) ? 0. : (P_1_tmp + 1) * 15;
             gnav_ephemeris.d_t_k = static_cast<double>(read_navigation_unsigned(string_bits, T_K_HR)) * 3600 +
                                    static_cast<double>(read_navigation_unsigned(string_bits, T_K_MIN)) * 60 +
                                    static_cast<double>(read_navigation_unsigned(string_bits, T_K_SEC)) * 30;

--- a/src/tests/unit-tests/signal-processing-blocks/pvt/rtcm_test.cc
+++ b/src/tests/unit-tests/signal-processing-blocks/pvt/rtcm_test.cc
@@ -274,13 +274,13 @@ TEST(RtcmTest, MT1020)
     Glonass_Gnav_Utc_Model gnav_utc_model_read = Glonass_Gnav_Utc_Model();
 
     // Perform data read and print of special values types
-    gnav_ephemeris.d_P_1 = 15;
+    gnav_ephemeris.d_P_1 = 0.;
     // Bit distribution per fields
-    gnav_ephemeris.d_t_k = 7560;
+    gnav_ephemeris.d_t_k = 7560.;
     // Glonass signed values
     gnav_ephemeris.d_VXn = -0.490900039672852;
     // Bit distribution per fields dependent on other factors
-    gnav_ephemeris.d_t_b = 8100;
+    gnav_ephemeris.d_t_b = 8100.;
     // Binary flag representation
     gnav_ephemeris.d_P_3 = true;
 

--- a/src/tests/unit-tests/system-parameters/glonass_gnav_nav_message_test.cc
+++ b/src/tests/unit-tests/system-parameters/glonass_gnav_nav_message_test.cc
@@ -76,10 +76,10 @@ TEST(GlonassGnavNavigationMessageTest, String1Decoder)
     Glonass_Gnav_Ephemeris gnav_ephemeris;
 
     // Fill out ephemeris values for truth
-    gnav_ephemeris.d_P_1 = 15;
-    gnav_ephemeris.d_t_k = 7560;
+    gnav_ephemeris.d_P_1 = 0.;
+    gnav_ephemeris.d_t_k = 7560.;
     gnav_ephemeris.d_VXn = -0.490900039672852;
-    gnav_ephemeris.d_AXn = 0;
+    gnav_ephemeris.d_AXn = 0.;
     gnav_ephemeris.d_Xn = -11025.6669921875;
 
     // Call target test method


### PR DESCRIPTION
Current version of GNSS SDR produces values of P1 according to the following table

P1 | d_P1
00 | 15
01 | 30
10 | 45
11 | 60

However Glonass manual says that the table should be as follows

![glonass-p1](https://user-images.githubusercontent.com/29396421/184679180-5f46b50f-3ef5-4e6d-a4f1-662316893872.jpg)

(sorry, cannot find an english version of the manual).

Therefore I've changed conversion rules and tests, corresponding to these conversion rules