### PR TITLE
Glonass : avoid passing corrupt ephemeris and TOW measurements to observables

### DIFF
--- a/src/algorithms/telemetry_decoder/gnuradio_blocks/glonass_l1_ca_telemetry_decoder_gs.h
+++ b/src/algorithms/telemetry_decoder/gnuradio_blocks/glonass_l1_ca_telemetry_decoder_gs.h
@@ -120,6 +120,9 @@ private:
     bool d_remove_dat;
     bool d_enable_navdata_monitor;
     bool d_dump_crc_stats;
+    int32_t d_ecc_errors_resync;
+    uint32_t d_validator_thr;
+    bool d_validator_accept_first;
 };
 
 

--- a/src/algorithms/telemetry_decoder/gnuradio_blocks/glonass_l2_ca_telemetry_decoder_gs.cc
+++ b/src/algorithms/telemetry_decoder/gnuradio_blocks/glonass_l2_ca_telemetry_decoder_gs.cc
@@ -33,8 +33,6 @@
 #include <iostream>         // for cout
 #include <memory>           // for shared_ptr, make_shared
 
-#define CRC_ERROR_LIMIT 6
-
 
 glonass_l2_ca_telemetry_decoder_gs_sptr
 glonass_l2_ca_make_telemetry_decoder_gs(const Gnss_Satellite &satellite, const Tlm_Conf &conf)
@@ -61,7 +59,10 @@ glonass_l2_ca_telemetry_decoder_gs::glonass_l2_ca_telemetry_decoder_gs(
                             d_dump_mat(conf.dump_mat),
                             d_remove_dat(conf.remove_dat),
                             d_enable_navdata_monitor(conf.enable_navdata_monitor),
-                            d_dump_crc_stats(conf.dump_crc_stats)
+                            d_dump_crc_stats(conf.dump_crc_stats),
+                            d_ecc_errors_resync(conf.ecc_errors_resync),
+                            d_validator_thr(conf.validator_thr),
+                            d_validator_accept_first(conf.validator_accept_first)
 {
     // prevent telemetry symbols accumulation in output buffers
     this->set_max_noutput_items(1);
@@ -236,9 +237,20 @@ void glonass_l2_ca_telemetry_decoder_gs::decode_string(const double *frame_symbo
             // get object for this SV (mandatory)
             d_nav.set_rf_link(d_satellite.get_rf_link());
             const std::shared_ptr<Glonass_Gnav_Ephemeris> tmp_obj = std::make_shared<Glonass_Gnav_Ephemeris>(d_nav.get_ephemeris());
-            this->message_port_pub(pmt::mp("telemetry"), pmt::make_any(tmp_obj));
-            LOG(INFO) << "GLONASS GNAV Ephemeris have been received in channel" << d_channel << " from satellite " << d_satellite;
-            std::cout << TEXT_CYAN << "New GLONASS L2 GNAV message received in channel " << d_channel << ": ephemeris from satellite " << d_satellite << TEXT_RESET << '\n';
+            static Gnss_Ephemeris::history_set prev(27);
+            if (tmp_obj->PRN == d_satellite.get_PRN())
+                {
+                    if (Gnss_Ephemeris::validate(prev, tmp_obj, d_validator_thr, d_validator_accept_first))
+                        {
+                            this->message_port_pub(pmt::mp("telemetry"), pmt::make_any(tmp_obj));
+                            LOG(INFO) << "GLONASS GNAV Ephemeris have been received in channel" << d_channel << " from satellite " << d_satellite;
+                            std::cout << TEXT_CYAN << "New GLONASS L2 GNAV message received in channel " << d_channel << ": ephemeris from satellite " << d_satellite << TEXT_RESET << '\n';
+                        }
+                }
+            else
+                {
+                    std::cout << "PRN " << tmp_obj->PRN << "!=" << d_satellite.get_PRN() << "\n";
+                }
         }
     if (d_nav.have_new_utc_model() == true)
         {
@@ -405,7 +417,8 @@ int glonass_l2_ca_telemetry_decoder_gs::general_work(int noutput_items __attribu
 
                     // call the decoder
                     decode_string(string_symbols.data(), string_length);
-                    if (d_nav.get_flag_CRC_test() == true)
+                    bool crc_ok = d_nav.get_flag_CRC_test();
+                    if ((crc_ok == true) && (abs(corr_value) >= d_symbols_per_preamble * 2 / 3))
                         {
                             d_CRC_error_counter = 0;
                             d_flag_preamble = true;               // valid preamble indicator (initialized to false every work())
@@ -421,11 +434,13 @@ int glonass_l2_ca_telemetry_decoder_gs::general_work(int noutput_items __attribu
                         {
                             d_CRC_error_counter++;
                             d_preamble_index = d_sample_counter;  // record the preamble sample stamp
-                            if (d_CRC_error_counter > CRC_ERROR_LIMIT)
+                            if (d_CRC_error_counter > d_ecc_errors_resync)
                                 {
                                     LOG(INFO) << "Lost of frame sync SAT " << this->d_satellite;
                                     d_flag_frame_sync = false;
+                                    d_flag_preamble = false;
                                     d_stat = 0;
+                                    d_nav = Glonass_Gnav_Navigation_Message();
                                 }
                         }
                 }

--- a/src/algorithms/telemetry_decoder/gnuradio_blocks/glonass_l2_ca_telemetry_decoder_gs.h
+++ b/src/algorithms/telemetry_decoder/gnuradio_blocks/glonass_l2_ca_telemetry_decoder_gs.h
@@ -113,6 +113,9 @@ private:
     bool d_remove_dat;
     bool d_enable_navdata_monitor;
     bool d_dump_crc_stats;
+    int32_t d_ecc_errors_resync;
+    uint32_t d_validator_thr;
+    bool d_validator_accept_first;
 };
 
 

--- a/src/algorithms/telemetry_decoder/libs/tlm_conf.cc
+++ b/src/algorithms/telemetry_decoder/libs/tlm_conf.cc
@@ -34,4 +34,10 @@ void Tlm_Conf::SetFromConfiguration(const ConfigurationInterface *configuration,
         {
             there_are_e6_channels = true;
         }
+    ecc_errors_reject = configuration->property(role + ".ecc_reject", 1);
+    ecc_errors_reject = (ecc_errors_reject < 1) ? 1 : ecc_errors_reject;
+    ecc_errors_resync = configuration->property(role + ".ecc_resync", 6);
+    ecc_errors_resync = (ecc_errors_resync < 1) ? 1 : ecc_errors_resync;
+    validator_thr = configuration->property(role + ".validator_thr", 2);
+    validator_accept_first = configuration->property(role + ".validator_accept_first", true);
 }

--- a/src/algorithms/telemetry_decoder/libs/tlm_conf.h
+++ b/src/algorithms/telemetry_decoder/libs/tlm_conf.h
@@ -43,6 +43,10 @@ public:
     bool dump_crc_stats{false};       // telemetry CRC statistics
     bool enable_navdata_monitor{false};
     bool there_are_e6_channels{false};
+    int32_t ecc_errors_reject{1};
+    int32_t ecc_errors_resync{6};
+    uint32_t validator_thr{2};
+    bool validator_accept_first{true};
 };
 
 

--- a/src/core/system_parameters/CMakeLists.txt
+++ b/src/core/system_parameters/CMakeLists.txt
@@ -6,6 +6,7 @@
 
 
 set(SYSTEM_PARAMETERS_SOURCES
+    common_ephemeris.cc
     gnss_almanac.cc
     gnss_ephemeris.cc
     gnss_satellite.cc
@@ -31,6 +32,7 @@ set(SYSTEM_PARAMETERS_SOURCES
 )
 
 set(SYSTEM_PARAMETERS_HEADERS
+    common_ephemeris.h
     gnss_almanac.h
     gnss_ephemeris.h
     gnss_satellite.h

--- a/src/core/system_parameters/common_ephemeris.cc
+++ b/src/core/system_parameters/common_ephemeris.cc
@@ -1,0 +1,83 @@
+/*!
+ * \file common_ephemeris.cc
+ * \brief Base class for GNSS Ephemeris
+ * \author Vladislav P, 2022. vladisslav2011(at)gmail.com
+ *
+ *
+ * -----------------------------------------------------------------------------
+ *
+ * GNSS-SDR is a Global Navigation Satellite System software-defined receiver.
+ * This file is part of GNSS-SDR.
+ *
+ * Copyright (C) 2010-2021  (see AUTHORS file for a list of contributors)
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ *
+ * -----------------------------------------------------------------------------
+ */
+
+#include "common_ephemeris.h"
+#include <cmath>
+#include <numeric>
+
+bool Common_Ephemeris::validate(history_set &hist, const std::shared_ptr<Common_Ephemeris> &eph, const int thr, const bool first_pass)
+{
+    double dev_last = -1.0;
+    double dev_val = -1.0;
+    const int prn = eph->PRN - 1;
+    bool ret = false;
+    if (thr == 0)
+        {
+            return true;
+        }
+    if (hist[prn].last_eph.get())
+        {
+            dev_last = hist[prn].last_eph->max_deviation(*eph.get());
+#ifdef EPHEMERIS_VALIDATOR_DEBUG
+            if (hist[prn].last_eph.get() == eph.get())
+                {
+                    std::cout << "\nhist[prn].last_eph.get() == eph.get()\n\n";
+                }
+#endif
+        }
+    if (hist[prn].valid_eph.get())
+        {
+            dev_val = hist[prn].valid_eph->max_deviation(*eph.get());
+#ifdef EPHEMERIS_VALIDATOR_DEBUG
+            if (hist[prn].valid_eph.get() == eph.get())
+                {
+                    std::cout << "\nhist[prn].last_eph.get() == eph.get()\n\n";
+                }
+#endif
+            if (dev_last < dev_val)
+                {
+                    if (dev_last < DEVIATION_THRESHOLD)
+                        {
+                            hist[prn].valid_eph = eph;
+                            hist[prn].valid_eph_count = 2;
+                            ret = hist[prn].valid_eph_count >= hist[prn].valid_eph_thr;
+                            hist[prn].valid_eph_thr = (thr > 2) ? thr : 2;
+                        }
+                }
+            else
+                {
+                    if (dev_val < DEVIATION_THRESHOLD)
+                        {
+                            hist[prn].valid_eph_count++;
+                            hist[prn].valid_eph_thr = (thr > 2) ? thr : 2;
+                            ret = hist[prn].valid_eph_count >= hist[prn].valid_eph_thr;
+                        }
+                }
+        }
+    else
+        {
+            hist[prn].valid_eph = eph;
+            hist[prn].valid_eph_count = 1;
+            hist[prn].valid_eph_thr = thr;
+            ret = first_pass || hist[prn].valid_eph_count >= hist[prn].valid_eph_thr;
+        }
+    hist[prn].last_eph = eph;
+#ifdef EPHEMERIS_VALIDATOR_DEBUG
+    std::cout << "PRN " << eph->PRN << " dev_last = " << dev_last << " dev_val = " << dev_val << " count = " << hist[prn].valid_eph_count << "\n";
+#endif
+    return ret;
+}

--- a/src/core/system_parameters/common_ephemeris.h
+++ b/src/core/system_parameters/common_ephemeris.h
@@ -1,0 +1,71 @@
+/*!
+ * \file common_ephemeris.h
+ * \brief Base class for GNSS Ephemeris
+ * \author Vladislav P, 2022. vladisslav2011(at)gmail.com
+ *
+ *
+ * -----------------------------------------------------------------------------
+ *
+ * GNSS-SDR is a Global Navigation Satellite System software-defined receiver.
+ * This file is part of GNSS-SDR.
+ *
+ * Copyright (C) 2010-2021  (see AUTHORS file for a list of contributors)
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ *
+ * -----------------------------------------------------------------------------
+ */
+
+
+#ifndef GNSS_SDR_COMMON_EPHEMERIS_H
+#define GNSS_SDR_COMMON_EPHEMERIS_H
+
+#include <cstdint>
+#include <memory>
+#include <vector>
+
+#ifdef EPHEMERIS_VALIDATOR_DEBUG
+#include <iostream>
+#define update_eph_deviation(NN)                                                                                                             \
+    {                                                                                                                                        \
+        if (std::fabs((NN)-tmp.NN) > dev)                                                                                                    \
+            {                                                                                                                                \
+                dev = std::fabs((NN)-tmp.NN);                                                                                                \
+                std::cout << "Gnss_Ephemeris::max_deviation " #NN << ": " << (NN) << "-" << tmp.NN << "=" << std::fabs((NN)-tmp.NN) << "\n"; \
+            }                                                                                                                                \
+    }
+#else
+#define update_eph_deviation(NN)              \
+    {                                         \
+        if (std::fabs((NN)-tmp.NN) > dev)     \
+            {                                 \
+                dev = std::fabs((NN)-tmp.NN); \
+            }                                 \
+    }
+#endif
+
+
+class Common_Ephemeris
+{
+private:
+    using last_valid = struct
+    {
+        std::shared_ptr<Common_Ephemeris> last_eph;
+        std::shared_ptr<Common_Ephemeris> valid_eph;
+        int valid_eph_count;
+        int valid_eph_thr;
+    };
+
+protected:
+    static constexpr double DEVIATION_THRESHOLD = 0.00001;
+
+public:
+    using history_set = std::vector<last_valid>;
+    Common_Ephemeris() = default;
+    virtual ~Common_Ephemeris() = default;
+    virtual double max_deviation(Common_Ephemeris &from) = 0;  //!< Compare a set of ephemeris to another one
+    static bool validate(history_set &hist, const std::shared_ptr<Common_Ephemeris> &eph, const int thr, const bool first_pass);
+    uint32_t PRN{};  //!< SV ID
+};
+
+
+#endif  // GNSS_SDR_COMMON_EPHEMERIS_H

--- a/src/core/system_parameters/glonass_gnav_ephemeris.cc
+++ b/src/core/system_parameters/glonass_gnav_ephemeris.cc
@@ -23,6 +23,51 @@
 #include <cmath>
 #include <string>
 
+double Glonass_Gnav_Ephemeris::max_deviation(Common_Ephemeris &from)
+{
+    const Glonass_Gnav_Ephemeris &tmp = dynamic_cast<Glonass_Gnav_Ephemeris &>(from);
+    double dev = 0.0;
+    update_eph_deviation(PRN);
+    // TODO: compare to previous value?
+    // update_eph_deviation(d_t_k);
+    update_eph_deviation(d_t_b);
+    update_eph_deviation(d_gamma_n);
+    update_eph_deviation(d_tau_n);
+    update_eph_deviation(d_Xn);
+    update_eph_deviation(d_Yn);
+    update_eph_deviation(d_Zn);
+    update_eph_deviation(d_VXn);
+    update_eph_deviation(d_VYn);
+    update_eph_deviation(d_VZn);
+    update_eph_deviation(d_AXn);
+    update_eph_deviation(d_AYn);
+    update_eph_deviation(d_AZn);
+    update_eph_deviation(d_B_n);
+    update_eph_deviation(d_P);
+    update_eph_deviation(d_N_T);
+    update_eph_deviation(d_F_T);
+    update_eph_deviation(d_n);
+    update_eph_deviation(d_Delta_tau_n);
+    update_eph_deviation(d_E_n);
+    update_eph_deviation(d_P_1);
+    update_eph_deviation(d_yr);
+    update_eph_deviation(d_satClkDrift);
+    update_eph_deviation(d_dtr);
+    update_eph_deviation(d_iode);
+    update_eph_deviation(d_tau_c);
+    // update_eph_deviation(d_TOW);
+    // update_eph_deviation(d_tod);
+
+    update_eph_deviation(i_satellite_freq_channel);
+    update_eph_deviation(i_satellite_slot_number);
+    update_eph_deviation(d_WN);
+    // d_P_2
+    // d_P_3
+    // d_P_4
+    // d_l3rd_n
+    // d_l5th_n
+    return dev;
+}
 
 boost::posix_time::ptime Glonass_Gnav_Ephemeris::compute_GLONASS_time(double offset_time) const
 {
@@ -84,7 +129,7 @@ boost::posix_time::ptime Glonass_Gnav_Ephemeris::glot_to_utc(double offset_time,
 }
 
 
-void Glonass_Gnav_Ephemeris::glot_to_gpst(double tod_offset, double glot2utc_corr, double glot2gpst_corr, int32_t* wn, double* tow) const
+void Glonass_Gnav_Ephemeris::glot_to_gpst(double tod_offset, double glot2utc_corr, double glot2gpst_corr, int32_t *wn, double *tow) const
 {
     const double glot2utc = 3 * 3600;
     double days = 0.0;

--- a/src/core/system_parameters/glonass_gnav_ephemeris.h
+++ b/src/core/system_parameters/glonass_gnav_ephemeris.h
@@ -22,6 +22,7 @@
 
 
 #include "glonass_gnav_utc_model.h"
+#include "gnss_ephemeris.h"
 #include <boost/date_time/posix_time/ptime.hpp>  // for ptime
 #include <boost/serialization/nvp.hpp>
 #include <cstdint>
@@ -37,13 +38,14 @@
  * \note Code added as part of GSoC 2017 program
  * \see <a href="http://russianspacesystems.ru/wp-content/uploads/2016/08/ICD_GLONASS_eng_v5.1.pdf">GLONASS ICD</a>
  */
-class Glonass_Gnav_Ephemeris
+class Glonass_Gnav_Ephemeris : public Common_Ephemeris
 {
 public:
     /*!
      * Default constructor
      */
     Glonass_Gnav_Ephemeris() = default;
+    double max_deviation(Common_Ephemeris& from) override;  //!< Compare a set of ephemeris to another one
 
     double d_m{};            //!< String number within frame [dimensionless]
     double d_t_k{};          //!< GLONASS Time (UTC(SU) + 3 h) referenced to the beginning of the frame within the current day [s]
@@ -77,7 +79,6 @@ public:
     // Immediate deliverables of ephemeris information
     // Satellite Identification Information
     int32_t i_satellite_freq_channel{};  //!< SV Frequency Channel Number
-    uint32_t PRN{};                      //!< SV PRN Number, equivalent to slot number for compatibility with GPS
     uint32_t i_satellite_slot_number{};  //!< SV Slot Number
     double d_yr = 1972.0;                //!< Current year
     double d_satClkDrift{};              //!< GLONASS clock error

--- a/src/core/system_parameters/glonass_gnav_navigation_message.cc
+++ b/src/core/system_parameters/glonass_gnav_navigation_message.cc
@@ -20,11 +20,11 @@
 #include "MATH_CONSTANTS.h"  // for TWO_N20, TWO_N30, TWO_N14, TWO_N15, TWO_N18
 #include "gnss_satellite.h"
 #include <glog/logging.h>
-#include <cstddef>  // for size_t
-#include <ostream>  // for operator<<
+#include <cstddef>   // for size_t
+#include <iostream>  // for operator<<
 
 
-Glonass_Gnav_Navigation_Message::Glonass_Gnav_Navigation_Message()
+Glonass_Gnav_Navigation_Message::Glonass_Gnav_Navigation_Message() : d_prev_TOW(-1.0)
 {
     auto gnss_sat = Gnss_Satellite();
     std::string _system("GLONASS");
@@ -361,8 +361,26 @@ int32_t Glonass_Gnav_Navigation_Message::string_decoder(const std::string& frame
                     if (flag_ephemeris_str_1 == true)
                         {
                             gnav_ephemeris.glot_to_gpst(gnav_ephemeris.d_t_k + 10, gnav_utc_model.d_tau_c, gnav_utc_model.d_tau_gps, &gnav_ephemeris.d_WN, &gnav_ephemeris.d_TOW);
-                            flag_TOW_set = true;
-                            flag_TOW_new = true;
+                            if (d_prev_TOW == -1.0)
+                                {
+                                    flag_TOW_set = true;
+                                    flag_TOW_new = true;
+                                }
+                            else
+                                {
+                                    if (static_cast<int>(std::round(gnav_ephemeris.d_TOW - d_prev_TOW)) % 30 == 0)
+                                        {
+                                            flag_TOW_set = true;
+                                            flag_TOW_new = true;
+                                        }
+                                    else
+                                        {
+                                            flag_TOW_set = false;
+                                            flag_TOW_new = false;
+                                        }
+                                }
+                            std::cout << "-----------------------------------TOW diff=" << (gnav_ephemeris.d_TOW - d_prev_TOW) << "\n";
+                            d_prev_TOW = gnav_ephemeris.d_TOW;
                         }
 
                     // 4) Set time of day (tod) when ephemeris data is complety decoded
@@ -630,18 +648,15 @@ bool Glonass_Gnav_Navigation_Message::have_new_ephemeris()  // Check if we have 
         (flag_ephemeris_str_3 == true) and (flag_ephemeris_str_4 == true) and
         (flag_utc_model_str_5 == true))
         {
-            if (d_previous_tb != gnav_ephemeris.d_t_b)
-                {
-                    flag_ephemeris_str_1 = false;  // clear the flag
-                    flag_ephemeris_str_2 = false;  // clear the flag
-                    flag_ephemeris_str_3 = false;  // clear the flag
-                    flag_ephemeris_str_4 = false;  // clear the flag
-                    flag_all_ephemeris = true;
-                    // Update the time of ephemeris information
-                    d_previous_tb = gnav_ephemeris.d_t_b;
-                    DLOG(INFO) << "GLONASS GNAV Ephemeris (1, 2, 3, 4) have been received and belong to the same batch";
-                    new_eph = true;
-                }
+            flag_ephemeris_str_1 = false;  // clear the flag
+            flag_ephemeris_str_2 = false;  // clear the flag
+            flag_ephemeris_str_3 = false;  // clear the flag
+            flag_ephemeris_str_4 = false;  // clear the flag
+            flag_all_ephemeris = true;
+            // Update the time of ephemeris information
+            d_previous_tb = gnav_ephemeris.d_t_b;
+            DLOG(INFO) << "GLONASS GNAV Ephemeris (1, 2, 3, 4) have been received and belong to the same batch";
+            new_eph = true;
         }
 
     return new_eph;

--- a/src/core/system_parameters/glonass_gnav_navigation_message.h
+++ b/src/core/system_parameters/glonass_gnav_navigation_message.h
@@ -214,6 +214,7 @@ private:
 
     bool flag_TOW_set{};  // Flag indicating when the TOW has been set
     bool flag_TOW_new{};  // Flag indicating when a new TOW has been computed
+    double d_prev_TOW{};
 };
 
 

--- a/src/core/system_parameters/gnss_ephemeris.cc
+++ b/src/core/system_parameters/gnss_ephemeris.cc
@@ -21,9 +21,9 @@
 #include <algorithm>
 #include <cmath>
 #include <functional>
+#include <iostream>
 #include <numeric>
 #include <vector>
-
 
 double Gnss_Ephemeris::sv_clock_drift(double transmitTime)
 {
@@ -165,8 +165,37 @@ void Gnss_Ephemeris::satellitePosition(double transmitTime)
     this->dtr = pos_vel_dtr[6];
 }
 
+double Gnss_Ephemeris::max_deviation(Common_Ephemeris &from)
+{
+    const Gnss_Ephemeris &tmp = dynamic_cast<Gnss_Ephemeris &>(from);
+    double dev = 0.0;
+    update_eph_deviation(PRN);
+    update_eph_deviation(M_0);
+    update_eph_deviation(delta_n);
+    update_eph_deviation(ecc);
+    update_eph_deviation(sqrtA);
+    update_eph_deviation(OMEGA_0);
+    update_eph_deviation(i_0);
+    update_eph_deviation(omega);
+    update_eph_deviation(OMEGAdot);
+    update_eph_deviation(idot);
+    update_eph_deviation(Cuc);
+    update_eph_deviation(Cus);
+    update_eph_deviation(Crc);
+    update_eph_deviation(Crs);
+    update_eph_deviation(Cic);
+    update_eph_deviation(Cis);
+    // update_eph_deviation(toe);
+    // update_eph_deviation(toc);
+    update_eph_deviation(af0);
+    update_eph_deviation(af1);
+    update_eph_deviation(af2);
+    update_eph_deviation(satClkDrift);
+    update_eph_deviation(dtr);
+    return dev;
+}
 
-void Gnss_Ephemeris::satellitePosVelComputation(double transmitTime, std::array<double, 7>& pos_vel_dtr) const
+void Gnss_Ephemeris::satellitePosVelComputation(double transmitTime, std::array<double, 7> &pos_vel_dtr) const
 {
     // Restore semi-major axis
     const double a = this->sqrtA * this->sqrtA;

--- a/src/core/system_parameters/gnss_ephemeris.h
+++ b/src/core/system_parameters/gnss_ephemeris.h
@@ -19,13 +19,16 @@
 #ifndef GNSS_SDR_GNSS_EPHEMERIS_H
 #define GNSS_SDR_GNSS_EPHEMERIS_H
 
+#include "common_ephemeris.h"
 #include <array>
 #include <cstdint>
+#include <memory>
+#include <vector>
 
 /*!
  * \brief Base class for GNSS ephemeris storage
  */
-class Gnss_Ephemeris
+class Gnss_Ephemeris : public Common_Ephemeris
 {
 public:
     Gnss_Ephemeris() = default;
@@ -65,9 +68,9 @@ public:
      */
     double predicted_doppler(double rx_time_s, double lat, double lon, double h, double ve, double vn, double vu, int band) const;
 
-    void satellitePosition(double transmitTime);  //!< Computes the ECEF SV coordinates and ECEF velocity
+    void satellitePosition(double transmitTime);            //!< Computes the ECEF SV coordinates and ECEF velocity
+    double max_deviation(Common_Ephemeris &from) override;  //!< Compare a set of ephemeris to another one
 
-    uint32_t PRN{};     //!< SV ID
     double M_0{};       //!< Mean anomaly at reference time [rad]
     double delta_n{};   //!< Mean motion difference from computed value [rad/sec]
     double ecc{};       //!< Eccentricity
@@ -112,7 +115,7 @@ protected:
     char System{};  //!< Character ID of the GNSS system. 'G': GPS.  'E': Galileo.  'B': BeiDou
 
 private:
-    void satellitePosVelComputation(double transmitTime, std::array<double, 7>& pos_vel_dtr) const;
+    void satellitePosVelComputation(double transmitTime, std::array<double, 7> &pos_vel_dtr) const;
     double check_t(double time) const;
     double sv_clock_relativistic_term(double transmitTime) const;
 };


### PR DESCRIPTION
Implemented Glonass ephemeris validation (much the same as with BeiDou).

Demonstration: https://www.youtube.com/watch?v=QvpAruQmgy8
GPS+Galileo for comparison: https://www.youtube.com/watch?v=WA-wMrXQyWg