### PR TITLE
add options for changing usrp device arguments

### DIFF
--- a/src/algorithms/signal_source/adapters/uhd_signal_source.cc
+++ b/src/algorithms/signal_source/adapters/uhd_signal_source.cc
@@ -65,6 +65,20 @@ UhdSignalSource::UhdSignalSource(const ConfigurationInterface* configuration,
     sample_rate_ = configuration->property(role + ".sampling_frequency", 4.0e6);
     item_type_ = configuration->property(role + ".item_type", default_item_type);
 
+    // UHD TRANSPORT PARAMETERS
+    // option to manually set device "num_recv_frames"
+    std::string device_num_recv_frames = configuration->property(role + ".device_num_recv_frames", empty);
+    if (empty != device_num_recv_frames)  // if not empty
+        {
+            dev_addr["num_recv_frames"] = device_num_recv_frames;
+        }
+    // option to manually set device "recv_frame_size"
+    std::string device_recv_frame_size = configuration->property(role + ".device_recv_frame_size", empty);
+    if (empty != device_recv_frame_size)  // if not empty
+        {
+            dev_addr["recv_frame_size"] = device_recv_frame_size;
+        }
+
     if (RF_channels_ == 1)
         {
             // Single RF channel UHD operation (backward compatible config file format)


### PR DESCRIPTION
Signed-off-by: Into Pääkkönen <into.paakkonen@aalto.fi>

These changes allow the user to change "num_recv_frames" and "recv_frame_size" transport parameters when using USRP devices. Default values for the parameters often cause issues such as overflows when transporting data from USRP device to host. Detailed explanation of these parameters are given in USRP Manual Transport notes: https://files.ettus.com/manual/page_transport.html