### PR TITLE
Fix register unpacking for Labsat3W files

### DIFF
--- a/src/algorithms/signal_source/gnuradio_blocks/labsat23_source.cc
+++ b/src/algorithms/signal_source/gnuradio_blocks/labsat23_source.cc
@@ -21,6 +21,7 @@
 #include "INIReader.h"
 #include "command_event.h"
 #include "gnss_sdr_make_unique.h"
+#include <boost/endian/conversion.hpp>
 #include <gnuradio/io_signature.h>
 #include <algorithm>
 #include <array>
@@ -737,7 +738,8 @@ void labsat23_source::decode_ls3w_register(uint64_t input, std::vector<gr_comple
 {
     std::bitset<64> bs(input);
 
-    // Reverse, since register are written to file as 64-bit little endian words
+    // Earlier samples are written in the MSBs of the register. Bit-reverse the register
+    // for easier indexing. Note this bit-reverses individual samples as well for quant > 1 bit
     for (std::size_t i = 0; i < 32; ++i)
         {
             bool t = bs[i];
@@ -1074,14 +1076,10 @@ int labsat23_source::general_work(int noutput_items,
                     std::size_t output_pointer = 0;
                     for (int i = 0; i < registers_to_read; i++)
                         {
-                            std::array<char, 8> memory_block{};
-                            binary_input_file.read(memory_block.data(), 8);
                             uint64_t read_register = 0ULL;
-                            for (int k = 7; k >= 0; --k)
-                                {
-                                    read_register <<= 8;
-                                    read_register |= uint64_t(memory_block[k]);
-                                }
+                            // Labsat3W writes its 64-bit shift register to files in little endian. Read and convert to host endianness.
+                            binary_input_file.read(reinterpret_cast<char *>(&read_register), sizeof(read_register));
+                            boost::endian::little_to_native_inplace(read_register);
 
                             if (binary_input_file.gcount() == 8)
                                 {


### PR DESCRIPTION
This change fixes a bug in the unpacking of Labsat 3 Wideband files when using the Labsat_Signal_Source. The original endian conversion loop includes a cast from char->uint64_t that (surprisingly) incurs a sign extension when the MSB of the char is set. ORing the unmasked uint64_t into the register can set undesired bits.

The changes replace the old endian conversion loop with a ``boost`` utility function.

Testing: Ran Labsat "UK Static" 3W demo through to PVT on a x86_64 (little endian) PC. I didn't have a big endian machine available for testing.