### PR TITLE
acquisition: populate gnss_synchro.fs with acquisition sample rate

### DIFF
--- a/src/algorithms/acquisition/gnuradio_blocks/pcps_acquisition.cc
+++ b/src/algorithms/acquisition/gnuradio_blocks/pcps_acquisition.cc
@@ -686,12 +686,14 @@ void pcps_acquisition::acquisition_core(uint64_t samp_count)
                     d_gnss_synchro->Acq_delay_samples -= static_cast<double>(d_acq_parameters.resampler_latency_samples);  // account the resampler filter latency
                     d_gnss_synchro->Acq_doppler_hz = static_cast<double>(doppler);
                     d_gnss_synchro->Acq_samplestamp_samples = rint(static_cast<double>(samp_count) * d_acq_parameters.resampler_ratio);
+                    d_gnss_synchro->fs = d_acq_parameters.resampled_fs;
                 }
             else
                 {
                     d_gnss_synchro->Acq_delay_samples = static_cast<double>(std::fmod(static_cast<float>(indext), d_acq_parameters.samples_per_code));
                     d_gnss_synchro->Acq_doppler_hz = static_cast<double>(doppler);
                     d_gnss_synchro->Acq_samplestamp_samples = samp_count;
+                    d_gnss_synchro->fs = d_acq_parameters.fs_in;
                 }
         }
     else
@@ -745,6 +747,7 @@ void pcps_acquisition::acquisition_core(uint64_t samp_count)
                     d_gnss_synchro->Acq_doppler_hz = static_cast<double>(doppler);
                     d_gnss_synchro->Acq_samplestamp_samples = rint(static_cast<double>(samp_count) * d_acq_parameters.resampler_ratio);
                     d_gnss_synchro->Acq_doppler_step = d_acq_parameters.doppler_step2;
+                    d_gnss_synchro->fs = d_acq_parameters.resampled_fs;
                 }
             else
                 {
@@ -752,6 +755,7 @@ void pcps_acquisition::acquisition_core(uint64_t samp_count)
                     d_gnss_synchro->Acq_doppler_hz = static_cast<double>(doppler);
                     d_gnss_synchro->Acq_samplestamp_samples = samp_count;
                     d_gnss_synchro->Acq_doppler_step = d_acq_parameters.doppler_step2;
+                    d_gnss_synchro->fs = d_acq_parameters.fs_in;
                 }
         }
 


### PR DESCRIPTION
This makes it possible to use GNSS-SDR-Monitor to monitor acquisition
process too.
Set AcquisitionMonitor.udp_port to the same value as Monitor.udp_port to
see acquisition results.
The acquisitions will be shown with a red telemetry mark and no tracking
data.
![gnss-sdr-monitor](https://user-images.githubusercontent.com/17007837/198424209-2ea5724b-07fe-4233-a5c0-126fadc00886.png)
