### PR TITLE
Fix input item type in config file and remove not working options

### DIFF
--- a/conf/gnss-sdr_GPS_L1_2ch_fmcomms2_realtime.conf
+++ b/conf/gnss-sdr_GPS_L1_2ch_fmcomms2_realtime.conf
@@ -32,7 +32,6 @@ SignalSource.samples=0
 SignalSource.repeat=false
 SignalSource.dump=false
 SignalSource.dump_filename=../data/signal_source.dat
-SignalSource.enable_throttle_control=false
 SignalSource.enable_dds_lo=false
 SignalSource.freq_rf_tx_hz=1260000000
 SignalSource.freq_dds_tx_hz=1000

--- a/conf/gnss-sdr_GPS_L1_USRP_X300_realtime.conf
+++ b/conf/gnss-sdr_GPS_L1_USRP_X300_realtime.conf
@@ -42,7 +42,6 @@ SignalSource.samples=0
 SignalSource.repeat=false
 SignalSource.dump=false
 SignalSource.dump_filename=../data/signal_source.dat
-SignalSource.enable_throttle_control=false
 
 
 ;######### SIGNAL_CONDITIONER CONFIG ############

--- a/conf/gnss-sdr_GPS_L1_USRP_realtime.conf
+++ b/conf/gnss-sdr_GPS_L1_USRP_realtime.conf
@@ -41,7 +41,6 @@ SignalSource.samples=0
 SignalSource.repeat=false
 SignalSource.dump=false
 SignalSource.dump_filename=../data/signal_source.dat
-SignalSource.enable_throttle_control=false
 
 
 ;######### SIGNAL_CONDITIONER CONFIG ############

--- a/conf/gnss-sdr_GPS_L1_bladeRF.conf
+++ b/conf/gnss-sdr_GPS_L1_bladeRF.conf
@@ -23,7 +23,6 @@ SignalSource.AGC_enabled=false
 SignalSource.samples=0
 SignalSource.repeat=false
 SignalSource.osmosdr_args=bladerf=0  ; This line enables the bladeRF
-SignalSource.enable_throttle_control=false
 SignalSource.dump=false
 SignalSource.dump_filename=./signal_source.dat
 

--- a/conf/gnss-sdr_GPS_L1_fmcomms2_realtime.conf
+++ b/conf/gnss-sdr_GPS_L1_fmcomms2_realtime.conf
@@ -42,7 +42,6 @@ SignalSource.samples=0
 SignalSource.repeat=false
 SignalSource.dump=false
 SignalSource.dump_filename=../data/signal_source.dat
-SignalSource.enable_throttle_control=false
 
 ;######### SIGNAL_CONDITIONER CONFIG ############
 SignalConditioner.implementation=Signal_Conditioner

--- a/conf/gnss-sdr_GPS_L1_ishort.conf
+++ b/conf/gnss-sdr_GPS_L1_ishort.conf
@@ -31,13 +31,15 @@ SignalSource.enable_throttle_control=false
 ;######### SIGNAL_CONDITIONER CONFIG ############
 SignalConditioner.implementation=Signal_Conditioner
 
-DataTypeAdapter.implementation=Ishort_To_Cshort
+;######### DATA_TYPE_ADAPTER CONFIG ############
+DataTypeAdapter.implementation=Ishort_To_Complex
+
 InputFilter.implementation=Pass_Through
 InputFilter.item_type=cshort
 Resampler.implementation=Direct_Resampler
 Resampler.sample_freq_in=4000000
 Resampler.sample_freq_out=2000000
-Resampler.item_type=cshort
+Resampler.item_type=gr_complex
 
 ;######### CHANNELS GLOBAL CONFIG ############
 Channels_1C.count=8
@@ -47,7 +49,7 @@ Channel.signal=1C
 
 ;######### ACQUISITION GLOBAL CONFIG ############
 Acquisition_1C.implementation=GPS_L1_CA_PCPS_Acquisition
-Acquisition_1C.item_type=cshort
+Acquisition_1C.item_type=gr_complex
 Acquisition_1C.coherent_integration_time_ms=1
 Acquisition_1C.pfa=0.01
 ;Acquisition_1C.pfa=0.000001
@@ -59,7 +61,7 @@ Acquisition_1C.blocking=false;
 
 ;######### TRACKING GLOBAL CONFIG ############
 Tracking_1C.implementation=GPS_L1_CA_DLL_PLL_Tracking
-Tracking_1C.item_type=cshort
+Tracking_1C.item_type=gr_complex
 Tracking_1C.pll_bw_hz=40.0;
 Tracking_1C.dll_bw_hz=4.0;
 Tracking_1C.order=3;

--- a/conf/gnss-sdr_GPS_L1_plutosdr_realtime.conf
+++ b/conf/gnss-sdr_GPS_L1_plutosdr_realtime.conf
@@ -44,7 +44,6 @@ SignalSource.buffer_size=65000
 SignalSource.repeat=false
 SignalSource.dump=false
 SignalSource.dump_filename=./capture.dat
-SignalSource.enable_throttle_control=false
 
 ;######### SIGNAL_CONDITIONER CONFIG ############
 SignalConditioner.implementation=Pass_Through

--- a/conf/gnss-sdr_GPS_L1_rtl_tcp_realtime.conf
+++ b/conf/gnss-sdr_GPS_L1_rtl_tcp_realtime.conf
@@ -44,7 +44,6 @@ SignalSource.samples=0
 SignalSource.repeat=false
 SignalSource.dump=false
 SignalSource.dump_filename=../data/signal_source.dat
-SignalSource.enable_throttle_control=false
 SignalSource.address=127.0.0.1
 SignalSource.port=1234
 SignalSource.swap_iq=false

--- a/conf/gnss-sdr_GPS_L1_rtlsdr_realtime.conf
+++ b/conf/gnss-sdr_GPS_L1_rtlsdr_realtime.conf
@@ -45,7 +45,6 @@ SignalSource.samples=0
 SignalSource.repeat=false
 SignalSource.dump=false
 SignalSource.dump_filename=../data/signal_source.dat
-SignalSource.enable_throttle_control=false
 
 ;# Please note that the new RTL-SDR Blog V3 dongles ship a < 1 PPM
 ;# temperature compensated oscillator (TCXO), which is well suited for GNSS

--- a/conf/gnss-sdr_GPS_L2C_USRP1_realtime.conf
+++ b/conf/gnss-sdr_GPS_L2C_USRP1_realtime.conf
@@ -40,7 +40,6 @@ SignalSource.samples=0
 SignalSource.repeat=false
 SignalSource.dump=false
 SignalSource.dump_filename=../data/signal_source.dat
-SignalSource.enable_throttle_control=false
 
 
 ;######### SIGNAL_CONDITIONER CONFIG ############

--- a/conf/gnss-sdr_GPS_L2C_USRP_X300_realtime.conf
+++ b/conf/gnss-sdr_GPS_L2C_USRP_X300_realtime.conf
@@ -43,7 +43,6 @@ SignalSource.samples=0
 SignalSource.repeat=false
 SignalSource.dump=false
 SignalSource.dump_filename=../data/signal_source.dat
-SignalSource.enable_throttle_control=false
 
 
 ;######### SIGNAL_CONDITIONER CONFIG ############

--- a/conf/gnss-sdr_Galileo_E1_USRP_X300_realtime.conf
+++ b/conf/gnss-sdr_Galileo_E1_USRP_X300_realtime.conf
@@ -28,7 +28,6 @@ SignalSource.subdevice=A:0
 SignalSource.samples=0
 SignalSource.dump=false
 SignalSource.dump_filename=../data/signal_source.dat
-SignalSource.enable_throttle_control=false
 
 
 ;######### SIGNAL_CONDITIONER CONFIG ############


### PR DESCRIPTION
:Fix input item type in gnss-sdr_GPS_L1_ishort.conf config file from cshort to gr_complex.
Remove SignalSource.enable_throttle_control=false option from hardware type config files as it does not work. In such case hardware determines sample rate and this option cannot be set to false.