### PR TITLE
Flush NMEA output

### DIFF
--- a/src/algorithms/PVT/libs/nmea_printer.cc
+++ b/src/algorithms/PVT/libs/nmea_printer.cc
@@ -55,7 +55,7 @@ Nmea_Printer::Nmea_Printer(const std::string& filename,
                                 {
                                     if (!fs::create_directory(new_folder, ec))
                                         {
-                                            std::cout << "Could not create the " << new_folder << " folder.\n";
+                                            std::cout << "Could not create the " << new_folder << " folder." << std::endl;
                                             nmea_base_path = full_path.string();
                                         }
                                 }
@@ -69,7 +69,7 @@ Nmea_Printer::Nmea_Printer(const std::string& filename,
 
             if ((nmea_base_path != ".") and (d_flag_nmea_output_file == true))
                 {
-                    std::cout << "NMEA files will be stored at " << nmea_base_path << '\n';
+                    std::cout << "NMEA files will be stored at " << nmea_base_path << std::endl;
                 }
 
             nmea_base_path = nmea_base_path + fs::path::preferred_separator;
@@ -83,7 +83,7 @@ Nmea_Printer::Nmea_Printer(const std::string& filename,
                 }
             else
                 {
-                    std::cout << "File " << nmea_filename << " cannot be saved. Wrong permissions?\n";
+                    std::cout << "File " << nmea_filename << " cannot be saved. Wrong permissions?" << std::endl;
                 }
         }
 
@@ -118,18 +118,18 @@ Nmea_Printer::~Nmea_Printer()
         }
     catch (const std::ofstream::failure& e)
         {
-            std::cerr << "Problem closing NMEA dump file: " << nmea_filename << '\n';
+            std::cerr << "Problem closing NMEA dump file: " << nmea_filename << std::endl;
         }
     catch (const std::exception& e)
         {
-            std::cerr << e.what() << '\n';
+            std::cerr << e.what() << std::endl;
         }
     if (pos == 0)
         {
             errorlib::error_code ec;
             if (!fs::remove(fs::path(nmea_filename), ec))
                 {
-                    std::cerr << "Problem removing NMEA temporary file: " << nmea_filename << '\n';
+                    std::cerr << "Problem removing NMEA temporary file: " << nmea_filename << std::endl;
                 }
         }
     try
@@ -138,7 +138,7 @@ Nmea_Printer::~Nmea_Printer()
         }
     catch (const std::exception& e)
         {
-            std::cerr << e.what() << '\n';
+            std::cerr << e.what() << std::endl;
         }
 }
 
@@ -212,14 +212,12 @@ bool Nmea_Printer::Print_Nmea_Line(const Rtklib_Solver* const pvt_data, bool pri
         {
             try
                 {
-                    // GPRMC
-                    nmea_file_descriptor << GPRMC;
-                    // GPGGA (Global Positioning System Fixed Data)
-                    nmea_file_descriptor << GPGGA;
-                    // GPGSA
-                    nmea_file_descriptor << GPGSA;
-                    // GPGSV
-                    nmea_file_descriptor << GPGSV;
+                    nmea_file_descriptor
+		      << GPRMC
+		      << GPGGA // GPGGA (Global Positioning System Fixed Data)
+		      << GPGSA
+		      << GPGSV
+		      << std::flush;
                 }
             catch (const std::exception& ex)
                 {
@@ -417,7 +415,7 @@ std::string Nmea_Printer::get_GPGSA() const
 std::string Nmea_Printer::get_GPGSV() const
 {
     // GSV-GNSS Satellites in View
-    // $GPGSV,2,1,07,07,79,048,42,02,51,062,43,26,36,256,42,27,27,138,42*71
+    // $GPGSV,2,1,07,07,79,048,42,02,51,062,43,26,36,256,42,27,27,138,42,1*71
     // Notice that NMEA 2.1 only supports 12 channels
     std::stringstream sentence_str;
     std::array<unsigned char, 1024> buff{};

--- a/src/algorithms/PVT/libs/nmea_printer.cc
+++ b/src/algorithms/PVT/libs/nmea_printer.cc
@@ -213,11 +213,11 @@ bool Nmea_Printer::Print_Nmea_Line(const Rtklib_Solver* const pvt_data, bool pri
             try
                 {
                     nmea_file_descriptor
-		      << GPRMC
-		      << GPGGA // GPGGA (Global Positioning System Fixed Data)
-		      << GPGSA
-		      << GPGSV
-		      << std::flush;
+                        << GPRMC
+                        << GPGGA  // GPGGA (Global Positioning System Fixed Data)
+                        << GPGSA
+                        << GPGSV
+                        << std::flush;
                 }
             catch (const std::exception& ex)
                 {


### PR DESCRIPTION
The NMEA file appears to be the only place where satellite azimuth and elevation data is published. However, the current implementation uses default buffering, which can result in up to 15 seconds of latency.

This PR flushes the file on each set of sentences.

It does not affect the TTY line support, although this may also be buffered.