### PR TITLE
when using the acquisition in non-blocking mode do not clear the Acq_…

### DIFF
--- a/src/algorithms/acquisition/gnuradio_blocks/pcps_acquisition.cc
+++ b/src/algorithms/acquisition/gnuradio_blocks/pcps_acquisition.cc
@@ -932,7 +932,6 @@ int pcps_acquisition::general_work(int noutput_items __attribute__((unused)),
             {
                 // Restart acquisition variables
                 d_gnss_synchro->Acq_delay_samples = 0.0;
-                d_gnss_synchro->Acq_doppler_hz = 0.0;
                 d_gnss_synchro->Acq_samplestamp_samples = 0ULL;
                 d_gnss_synchro->Acq_doppler_step = 0U;
                 d_mag = 0.0;
@@ -942,6 +941,14 @@ int pcps_acquisition::general_work(int noutput_items __attribute__((unused)),
                     {
                         d_sample_counter += static_cast<uint64_t>(ninput_items[0]);  // sample counter
                         consume_each(ninput_items[0]);
+                    }
+                else
+                    {
+                        // do not initialize d_gnss_synchro->Acq_doppler_hz if d_acq_parameters.blocking_on_standby is false
+                        // because d_gnss_synchro->Acq_doppler_hz is later used to initialize d_doppler_center_step_two.
+                        // If d_acq_parameters.blocking_on_standby is true then d_gnss_synchro->Acq_doppler_hz can be cleared
+                        // because d_doppler_center_step_two is already initialized before entering state 0
+                        d_gnss_synchro->Acq_doppler_hz = 0.0;
                     }
                 break;
             }


### PR DESCRIPTION
Do not clear the Acq_doppler_hz in state 0 when running the acquisition in non-blocking mode (blocking=false).
When using the acquisition in non-blocking mode the acquisition goes back to state 0 before the first-step acquisition process finishes. If Acq_doppler_hz is cleared in state 0, then the second-step acquisition Doppler center frequency (d_doppler_center_step_two) is also cleared and the second-step acquisition does not perform properly.