### PR TITLE
do not propagate tags

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,7 +48,7 @@ option(ENABLE_FLEXIBAND "Enable the use of the signal source adater for the Tele
 
 option(ENABLE_ARRAY "Enable the use of CTTC's antenna array front-end as signal source (experimental)" OFF)
 
-option(ENABLE_ZMQ "Enable GNU Radio ZeroMQ Messaging, requires gr-zeromq" OFF)
+option(ENABLE_ZMQ "Enable GNU Radio ZeroMQ Messaging, requires gr-zeromq" ON)
 
 # Performance analysis tools
 option(ENABLE_GPERFTOOLS "Enable linking to Gperftools libraries (tcmalloc and profiler)" OFF)

--- a/src/algorithms/signal_source/adapters/zmq_signal_source.cc
+++ b/src/algorithms/signal_source/adapters/zmq_signal_source.cc
@@ -44,6 +44,7 @@ ZmqSignalSource::ZmqSignalSource(const ConfigurationInterface* configuration,
             LOG(INFO) << "Connecting to ZMQ pub at " << endpoint;
             // work around gnuradio interface deficiency
             d_source_block = gr::zeromq::sub_source::make(d_item_size, vlen, const_cast<char*>(endpoint.data()), timeout_ms, pass_tags, hwm);
+	    d_source_block->set_tag_propagation_policy(TPP_DONT); // GNSS-SDR doesn't do well with tags/
         }
     else
         {

--- a/src/algorithms/signal_source/adapters/zmq_signal_source.cc
+++ b/src/algorithms/signal_source/adapters/zmq_signal_source.cc
@@ -44,7 +44,7 @@ ZmqSignalSource::ZmqSignalSource(const ConfigurationInterface* configuration,
             LOG(INFO) << "Connecting to ZMQ pub at " << endpoint;
             // work around gnuradio interface deficiency
             d_source_block = gr::zeromq::sub_source::make(d_item_size, vlen, const_cast<char*>(endpoint.data()), timeout_ms, pass_tags, hwm);
-	    d_source_block->set_tag_propagation_policy(TPP_DONT); // GNSS-SDR doesn't do well with tags/
+            d_source_block->set_tag_propagation_policy(gr::block::TPP_DONT);  // GNSS-SDR doesn't do well with tags/
         }
     else
         {


### PR DESCRIPTION
GNSS-SDR does not do well with tags. If they are in the data stream, downstream (acquisition and tracking) get "gummed up" as the system tries to preserve tags for insertion into the (heavily) decimated output.

However, the GNU Radio ZMQ blocks treat tags as part of the wire interface. If the source produces tags, the destination **must** enable them or the data is corrupted.

This change is specific to the ZMQ source, but any source that includes tags should similarly not pass them blindly downstream.