### PR TITLE
gps navigation message satellite validation: IODE field must be…

### DIFF
--- a/src/core/system_parameters/gps_navigation_message.cc
+++ b/src/core/system_parameters/gps_navigation_message.cc
@@ -516,7 +516,7 @@ bool Gps_Navigation_Message::satellite_validation()
     // and check if the data have been filled (!=0)
     if (d_TOW_SF1 != 0.0 and d_TOW_SF2 != 0.0 and d_TOW_SF3 != 0.0)
         {
-            if (d_IODE_SF2 == d_IODE_SF3 and d_IODC == d_IODE_SF2 and d_IODC != -1.0)
+            if (d_IODE_SF2 == d_IODE_SF3 and (d_IODC & 0xFF) == d_IODE_SF2 and d_IODC != -1.0)
                 {
                     flag_data_valid = true;
                     b_valid_ephemeris_set_flag = true;


### PR DESCRIPTION
In https://www.gps.gov/technical/icwg/meetings/2021/presentation.pdf:
The broadcast IODE does not match the 8 LSBs of the broadcast IODC (excluding normal data set cutovers, see paragraph 20.3.3.4.1)