### PR TITLE
Fix finding packages for homebrew on M1 macs

### DIFF
--- a/cmake/Modules/AvoidAccelerate.cmake
+++ b/cmake/Modules/AvoidAccelerate.cmake
@@ -27,6 +27,7 @@ find_library(BLAS_LIBRARIES
         /opt/local/lib/lapack
         /opt/local/lib/
         /usr/local/opt/lapack/lib
+        /opt/homebrew/opt/lapack/lib
     NO_DEFAULT_PATH
     NO_SYSTEM_ENVIRONMENT_PATH
     NO_CMAKE_ENVIRONMENT_PATH
@@ -47,6 +48,7 @@ find_library(LAPACK_LIBRARIES
         ${BLAS_ROOT_USER_DEFINED}/lapack
         /opt/local/lib/lapack
         /usr/local/opt/lapack/lib
+        /opt/homebrew/opt/lapack/lib
     NO_DEFAULT_PATH
     NO_SYSTEM_ENVIRONMENT_PATH
     NO_CMAKE_ENVIRONMENT_PATH

--- a/cmake/Modules/FindGFLAGS.cmake
+++ b/cmake/Modules/FindGFLAGS.cmake
@@ -44,6 +44,7 @@ if(APPLE)
             ${GFLAGS_ROOT_USER_PROVIDED}/lib
             /usr/local/lib
             /opt/local/lib
+            /opt/homebrew/opt/gflags/lib
     )
 else()
     find_path(GFlags_ROOT_DIR
@@ -84,6 +85,7 @@ else()
 endif()
 
 if(GFlags_ROOT_DIR)
+    unset(GFlags_INCLUDE_DIRS CACHE)
     # We are testing only a couple of files in the include directories
     find_path(GFlags_INCLUDE_DIRS
         gflags/gflags.h
@@ -93,6 +95,7 @@ if(GFlags_ROOT_DIR)
             /usr/include
             /usr/local/include
             /opt/local/include
+            /opt/homebrew/opt/gflags/include
     )
 
     # Find the libraries

--- a/cmake/Modules/FindGLOG.cmake
+++ b/cmake/Modules/FindGLOG.cmake
@@ -109,6 +109,7 @@ else()
             /usr/include/glog
             /usr/local/include/glog
             /opt/local/include/glog   # default location in Macports
+            /opt/homebrew/opt/glog/include/glog
             ${GLOG_ROOT}/include/glog
     )
 endif()

--- a/cmake/Modules/FindGOOGLETEST.cmake
+++ b/cmake/Modules/FindGOOGLETEST.cmake
@@ -47,6 +47,7 @@ find_path(LIBGTEST_DEV_DIR
         /usr/include/gtest
         /usr/local/src/googletest/googletest
         /opt/local/src/gtest-1.7.0
+        /opt/homebrew/opt/googletest/include/googletest/googletest
 )
 
 find_path(GTEST_INCLUDE_DIRS
@@ -57,6 +58,7 @@ find_path(GTEST_INCLUDE_DIRS
         /usr/include
         /usr/local/include
         /opt/local/src/gtest-1.7.0/include
+        /opt/homebrew/opt/googletest/include
 )
 
 include(FindPackageHandleStandardArgs)


### PR DESCRIPTION
Add CMake search paths for homebrew on M1 Macs such as mentioned in #578.
Successfully built on M2 Macbook Air Sonoma 14.2.1.