### PR TITLE
Conditionally link protobuf to its dependencies in Debug mode

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2623,6 +2623,8 @@ else()
     find_package(Protobuf)
 
     if((CMAKE_BUILD_TYPE STREQUAL "Debug") AND Protobuf_FOUND AND absl_FOUND)
+        # This Regular Expression is used to convert the version string provided by `find_package(Protobuf)` into the
+        # appropriate binary version string. So, for instance, "4.25.3" becomes "25.3.0".
         string(REGEX REPLACE "^[0-9]+\.([0-9]+\.[0-9]+)$" "\\1.0" PROTOBUF_LIBRARY_VERSION "${Protobuf_VERSION}")
         if((PROTOBUF_LIBRARY_VERSION VERSION_GREATER_EQUAL "22") AND (PROTOBUF_LIBRARY_VERSION VERSION_LESS "26"))
             find_package(PkgConfig REQUIRED)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2621,6 +2621,15 @@ if(((CMAKE_CXX_COMPILER_ID STREQUAL "GNU") AND (CMAKE_CXX_COMPILER_VERSION VERSI
     endif()
 else()
     find_package(Protobuf)
+
+    if((CMAKE_BUILD_TYPE STREQUAL "Debug") AND Protobuf_FOUND AND absl_FOUND)
+        string(REGEX REPLACE "^[0-9]+\.([0-9]+\.[0-9]+)$" "\\1.0" PROTOBUF_LIBRARY_VERSION "${Protobuf_VERSION}")
+        if((PROTOBUF_LIBRARY_VERSION VERSION_GREATER_EQUAL "22") AND (PROTOBUF_LIBRARY_VERSION VERSION_LESS "26"))
+            find_package(PkgConfig REQUIRED)
+            pkg_check_modules(protobuf REQUIRED IMPORTED_TARGET protobuf=${PROTOBUF_LIBRARY_VERSION})
+            target_link_libraries(protobuf::libprotobuf INTERFACE PkgConfig::protobuf)
+        endif()
+    endif()
 endif()
 set_package_properties(Protobuf PROPERTIES
     URL "https://protobuf.dev/"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2627,7 +2627,6 @@ else()
         # appropriate binary version string. So, for instance, "4.25.3" becomes "25.3.0".
         string(REGEX REPLACE "^[0-9]+\.([0-9]+\.[0-9]+)$" "\\1.0" PROTOBUF_LIBRARY_VERSION "${Protobuf_VERSION}")
         if((PROTOBUF_LIBRARY_VERSION VERSION_GREATER_EQUAL "22") AND (PROTOBUF_LIBRARY_VERSION VERSION_LESS "26"))
-            find_package(PkgConfig REQUIRED)
             pkg_check_modules(protobuf REQUIRED IMPORTED_TARGET protobuf=${PROTOBUF_LIBRARY_VERSION})
             target_link_libraries(protobuf::libprotobuf INTERFACE PkgConfig::protobuf)
         endif()


### PR DESCRIPTION
Some versions of Protocol Buffers don't export their dependencies when calling `find_package(Protobuf)` from CMake, thus causing link errors from missing symbols from `abseil-cpp`.

This seems to be a known upstream bug:
https://github.com/protocolbuffers/protobuf/issues/12637

This PR implements a somewhat hacky solution shown in a comment:
https://github.com/protocolbuffers/protobuf/issues/12637#issuecomment-1871458639

This will link the results of calling `PkgConfig` for `protobuf` to the target imported by `find_package(Protobuf)`, but only if the following conditions apply:

- Build type is **Debug** (For some reason, this only happens in Debug)
- `abseil-cpp` was found
- `Protobuf` was actually found as a **system package**
- `Protobuf` version is >= 22.0 and < 26.0

This PR should resolve Issue #773 