### PR TITLE
Moved decimation factor count variable to the class

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,10 @@ cmake-build-debug/
 .vscode/
 .vs/
 Testing/
+
+GSDR*
+PVT_*
+HAS_*
+gnss_sdr_pvt.nmea
+build-debug/
+build-release/

--- a/src/algorithms/signal_source/libs/ad936x_iio_custom.cc
+++ b/src/algorithms/signal_source/libs/ad936x_iio_custom.cc
@@ -22,6 +22,7 @@
 #include <string>
 #include <utility>
 #include <vector>
+#include "display.h"
 
 #if USE_GLOG_AND_GFLAGS
 #include <glog/logging.h>
@@ -849,10 +850,11 @@ void ad936x_iio_custom::monitor_thread_fn()
             // } else {
             if (val & 4)
                 {
-                    std::cout << "WARNING: IIO status register reported overflow!\n";
-                    LOG(INFO) << "WARNING: IIO status register reported overflow!";
+                    std::cout 
+                        << TEXT_BOLD_RED
+                        << "WARNING: IIO status register reported overflow!\n";
+                    LOG(WARNING) << "WARNING: IIO status register reported overflow!";
                 }
-
 
             /* Clear bits */
             if (val)

--- a/src/core/monitor/gnss_synchro_monitor.cc
+++ b/src/core/monitor/gnss_synchro_monitor.cc
@@ -50,6 +50,7 @@ gnss_synchro_monitor::gnss_synchro_monitor(int n_channels,
       d_decimation_factor(decimation_factor)
 {
     udp_sink_ptr = std::make_unique<Gnss_Synchro_Udp_Sink>(udp_addresses, udp_port, enable_protobuf);
+    count = 0;
 }
 
 
@@ -73,7 +74,6 @@ int gnss_synchro_monitor::general_work(int noutput_items __attribute__((unused))
     for (int channel_index = 0; channel_index < d_nchannels; channel_index++)
         {
             // Loop through each item in each input stream channel
-            int count = 0;
             for (int item_index = 0; item_index < ninput_items[channel_index]; item_index++)
                 {
                     // Use the count variable to limit how many items are sent per channel

--- a/src/core/monitor/gnss_synchro_monitor.h
+++ b/src/core/monitor/gnss_synchro_monitor.h
@@ -71,9 +71,10 @@ private:
         const std::vector<std::string>& udp_addresses,
         bool enable_protobuf);
 
+    std::unique_ptr<Gnss_Synchro_Udp_Sink> udp_sink_ptr;
+    int count;
     int d_nchannels;
     int d_decimation_factor;
-    std::unique_ptr<Gnss_Synchro_Udp_Sink> udp_sink_ptr;
 };
 
 


### PR DESCRIPTION
The variable count has been moved into the class definition, as it where it was before it was being reset to 0 before it could get to the d_decimation_factor value and send an udp package.
