### PR TITLE
Find GFLAGS PATH for loongarch64

### DIFF
--- a/cmake/Modules/FindGFLAGS.cmake
+++ b/cmake/Modules/FindGFLAGS.cmake
@@ -78,6 +78,7 @@ else()
             /usr/lib/x86_64-linux-gnux32
             /usr/lib/alpha-linux-gnu
             /usr/lib/riscv64-linux-gnu
+            /usr/lib/loongarch64-linux-gnu
             /usr/local/lib
             /usr/local/lib64
             /opt/local/lib


### PR DESCRIPTION
Compiling the audit failed for loong64 in the Debian Package Auto-Building environment.
Build failed 8 times.
The error log is as follows,
```
-- Cannot find gflags
-- Could NOT find GFLAGS (missing: GFlags_LIBS GFlags_INCLUDE_DIRS) 
--  The gflags library has not been found.
......
```
The full build log can be found at https://buildd.debian.org/status/fetch.php?pkg=gnss-sdr&arch=loong64&ver=0.0.19-2&stamp=1725314313&raw=0.

Please review the patch (Find GFLAGS PATH for loongarch64).
The gnss-sdr source package was built successfully on my local ENV.
```
Checking test dependency graph end
test 1
    Start 1: matio_test

1: Test command: /home/gnss-sdr/gnss-sdr-0.0.19/obj-loongarch64-linux-gnu/src/tests/matio_test
1: Working Directory: /home/gnss-sdr/gnss-sdr-0.0.19/obj-loongarch64-linux-gnu/src/tests
1: Test timeout computed to be: 30
1: [==========] Running 2 tests from 1 test suite.
1: [----------] Global test environment set-up.
1: [----------] 2 tests from MatioTest
1: [ RUN      ] MatioTest.WriteAndReadDoubles
1: [       OK ] MatioTest.WriteAndReadDoubles (5 ms)
1: [ RUN      ] MatioTest.WriteAndReadGrComplex
1: [       OK ] MatioTest.WriteAndReadGrComplex (4 ms)
1: [----------] 2 tests from MatioTest (10 ms total)
1: 
1: [----------] Global test environment tear-down
1: [==========] 2 tests from 1 test suite ran. (10 ms total)
1: [  PASSED  ] 2 tests.
1/1 Test #1: matio_test .......................   Passed    0.02 sec

100% tests passed, 0 tests failed out of 1

Total Test time (real) =   0.03 sec
......
dpkg-deb: building package 'gnss-sdr-dbgsym' in '../gnss-sdr-dbgsym_0.0.19-2_loong64.deb'.
dpkg-deb: building package 'gnss-sdr' in '../gnss-sdr_0.0.19-2_loong64.deb'.
 dpkg-genbuildinfo -O../gnss-sdr_0.0.19-2_loong64.buildinfo
 dpkg-genchanges -O../gnss-sdr_0.0.19-2_loong64.changes
```