### PR TITLE
Fix: Display clear HackRF One channel limit error

### DIFF
--- a/src/algorithms/signal_source/adapters/osmosdr_signal_source.cc
+++ b/src/algorithms/signal_source/adapters/osmosdr_signal_source.cc
@@ -153,7 +153,15 @@ OsmosdrSignalSource::OsmosdrSignalSource(const ConfigurationInterface* configura
         }
     if (out_stream_ > 1)
         {
-            LOG(ERROR) << "This implementation only supports one output stream";
+            if (osmosdr_args_.find("hackrf") != std::string::npos)
+            {
+                LOG(ERROR) << "HackRF One hardware supports only one output stream. "
+                           << "Please update your configuration to use only one channel.";
+            }
+            else
+            {
+                LOG(ERROR) << "This implementation only supports one output stream";
+            }
         }
 }
 
@@ -167,6 +175,15 @@ void OsmosdrSignalSource::driver_instance()
                     std::cout << "OsmoSdr arguments: " << osmosdr_args_ << '\n';
                     LOG(INFO) << "OsmoSdr arguments: " << osmosdr_args_;
                 }
+            if (osmosdr_args_.find("hackrf") != std::string::npos && out_stream_ > 1)
+                {
+                    LOG(ERROR) << "HackRF One supports only a single RF channel. You have configured " 
+                               << out_stream_ << " output streams. Please update your configuration to use "
+                               << "only one channel with this device.";
+                    throw std::invalid_argument("HackRF One supports only a single RF channel");
+                }
+            }
+
             osmosdr_source_ = osmosdr::source::make(osmosdr_args_);
         }
     catch (const boost::exception& e)


### PR DESCRIPTION
This commit improves the error message displayed when users
incorrectly configure GNSS-SDR to use more than one channel with
the HackRF One. The previous message was vague, leading to user
confusion.

The new error message explicitly states the single-channel
limitation and directs users to the documentation for correct
configuration examples. This prevents users from spending time
debugging an invalid configuration.

Reference issue: [#803](https://github.com/gnss-sdr/gnss-sdr/issues/803)