### PR TITLE
Cleanup gnss flowgraph available prns

### DIFF
--- a/src/core/receiver/gnss_flowgraph.cc
+++ b/src/core/receiver/gnss_flowgraph.cc
@@ -2224,6 +2224,7 @@ Gnss_Signal GNSSFlowgraph::search_next_signal(const std::string& searched_signal
             auto& available_signals = available_signals_map_.at(searched_signal);
             result = available_signals.front();
             available_signals.pop_front();
+            available_signals.push_back(result);
         }
 
     return result;

--- a/src/core/receiver/gnss_flowgraph.cc
+++ b/src/core/receiver/gnss_flowgraph.cc
@@ -2163,6 +2163,7 @@ Gnss_Signal GNSSFlowgraph::search_next_signal(const std::string& searched_signal
     Gnss_Signal result{};
     bool found_signal = false;
     std::string assist_signal = "";
+    auto& available_signals = available_signals_map_.at(searched_signal);
 
     switch (mapStringValues_[searched_signal])
         {
@@ -2200,7 +2201,6 @@ Gnss_Signal GNSSFlowgraph::search_next_signal(const std::string& searched_signal
                             if (std::string(current_status.second->Signal) == assist_signal)
                                 {
                                     std::list<Gnss_Signal>::iterator it2;
-                                    auto& available_signals = available_signals_map_.at(searched_signal);
                                     it2 = std::find_if(std::begin(available_signals), std::end(available_signals),
                                         [&](Gnss_Signal const& sig) { return sig.get_satellite().get_PRN() == current_status.second->PRN; });
 
@@ -2221,7 +2221,6 @@ Gnss_Signal GNSSFlowgraph::search_next_signal(const std::string& searched_signal
 
     if (found_signal == false)
         {
-            auto& available_signals = available_signals_map_.at(searched_signal);
             result = available_signals.front();
             available_signals.pop_front();
             available_signals.push_back(result);

--- a/src/core/receiver/gnss_flowgraph.cc
+++ b/src/core/receiver/gnss_flowgraph.cc
@@ -2188,14 +2188,14 @@ Gnss_Signal GNSSFlowgraph::search_next_signal(const std::string& searched_signal
             break;
         }
 
-    if (assist_signal != "")
+    if (!assist_signal.empty())
         {
             if (configuration_->property("Channels_" + assist_signal + ".count", 0) > 0)
                 {
                     // 1. Get the current channel status map
-                    std::map<int, std::shared_ptr<Gnss_Synchro>> current_channels_status = channels_status_->get_current_status_map();
+                    const auto current_channels_status = channels_status_->get_current_status_map();
                     // 2. search the currently tracked primary signal satellites and assist the acquisition if the satellite is not tracked on the assisted signal
-                    for (auto& current_status : current_channels_status)
+                    for (const auto& current_status : current_channels_status)
                         {
                             if (std::string(current_status.second->Signal) == assist_signal)
                                 {

--- a/src/core/receiver/gnss_flowgraph.cc
+++ b/src/core/receiver/gnss_flowgraph.cc
@@ -1534,10 +1534,9 @@ int GNSSFlowgraph::assign_channels()
                 }
         }
 
-    for (const auto& [signal_str, signal_info] : signal_mapping)
+    for (const auto& [signal_str, available_signals] : available_signals_map_)
         {
-            const auto& [gnss_system_str, signal_pretty_str] = signal_info;
-            const auto available_signals = available_signals_map_.at(signal_str);
+            const auto& [gnss_system_str, signal_pretty_str] = signal_mapping.at(signal_str);
             const auto channel_count_option = "Channels_" + signal_str + ".count";
             const auto channel_count = configuration_->property(channel_count_option, uint64_t(0ULL));
             auto max_sat_count = available_signals.size();

--- a/src/core/receiver/gnss_flowgraph.cc
+++ b/src/core/receiver/gnss_flowgraph.cc
@@ -75,6 +75,22 @@
 
 #define GNSS_SDR_ARRAY_SIGNAL_CONDITIONER_CHANNELS 8
 
+namespace
+{
+const auto signal_mapping = std::unordered_map<std::string, std::pair<std::string, std::string>>{
+    {"1C", {"GPS", "L1"}},
+    {"2S", {"GPS", "L2"}},
+    {"L5", {"GPS", "L5"}},
+    {"1B", {"Galileo", "E1"}},
+    {"5X", {"Galileo", "E5a"}},
+    {"7X", {"Galileo", "E5b"}},
+    {"E6", {"Galileo", "E6"}},
+    {"B1", {"BeiDou", "B1"}},
+    {"B3", {"BeiDou", "B3"}},
+    {"1G", {"Glonass", "L1"}},
+    {"2G", {"Glonass", "L2"}},
+};
+}
 
 GNSSFlowgraph::GNSSFlowgraph(std::shared_ptr<ConfigurationInterface> configuration,
     std::shared_ptr<Concurrent_Queue<pmt::pmt_t>> queue)  // NOLINT(performance-unnecessary-value-param)
@@ -1516,93 +1532,27 @@ int GNSSFlowgraph::assign_channels()
                 }
         }
 
-    if (configuration_->property("Channels_1C.count", uint64_t(0ULL)) > available_GPS_1C_signals_.size() - 1)
+    for (const auto& [signal_str, signal_info] : signal_mapping)
         {
-            help_hint_ += " * The number of GPS L1 channels is set to Channels_1C.count=" + std::to_string(configuration_->property("Channels_1C.count", 0));
-            help_hint_ += " but the maximum number of available GPS satellites is " + std::to_string(available_GPS_1C_signals_.size()) + ".\n";
-            help_hint_ += " Please set Channels_1C.count=" + std::to_string(available_GPS_1C_signals_.size() - 1) + " or lower in your configuration file.\n";
-            top_block_->disconnect_all();
-            return 1;
-        }
-    if (configuration_->property("Channels_2S.count", uint64_t(0ULL)) > available_GPS_2S_signals_.size() - 1)
-        {
-            help_hint_ += " * The number of GPS L2 channels is set to Channels_2S.count=" + std::to_string(configuration_->property("Channels_2S.count", 0));
-            help_hint_ += " but the maximum number of available GPS satellites is " + std::to_string(available_GPS_2S_signals_.size()) + ".\n";
-            help_hint_ += " Please set Channels_2S.count=" + std::to_string(available_GPS_2S_signals_.size() - 1) + " or lower in your configuration file.\n";
-            top_block_->disconnect_all();
-            return 1;
-        }
-    if (configuration_->property("Channels_L5.count", uint64_t(0ULL)) > available_GPS_L5_signals_.size() - 1)
-        {
-            help_hint_ += " * The number of GPS L5 channels is set to Channels_L5.count=" + std::to_string(configuration_->property("Channels_L5.count", 0));
-            help_hint_ += " but the maximum number of available GPS satellites is " + std::to_string(available_GPS_L5_signals_.size()) + ".\n";
-            help_hint_ += " Please set Channels_L5.count=" + std::to_string(available_GPS_L5_signals_.size() - 1) + " or lower in your configuration file.\n";
-            top_block_->disconnect_all();
-            return 1;
-        }
-    if (configuration_->property("Channels_1B.count", uint64_t(0ULL)) > available_GAL_1B_signals_.size() - 1)
-        {
-            help_hint_ += " * The number of Galileo E1 channels is set to Channels_1B.count=" + std::to_string(configuration_->property("Channels_1B.count", 0));
-            help_hint_ += " but the maximum number of available Galileo satellites is " + std::to_string(available_GAL_1B_signals_.size()) + ".\n";
-            help_hint_ += " Please set Channels_1B.count=" + std::to_string(available_GAL_1B_signals_.size()) + " or lower in your configuration file.\n";
-            top_block_->disconnect_all();
-            return 1;
-        }
-    if (configuration_->property("Channels_5X.count", uint64_t(0ULL)) > available_GAL_5X_signals_.size() - 1)
-        {
-            help_hint_ += " * The number of Galileo E5a channels is set to Channels_5X.count=" + std::to_string(configuration_->property("Channels_5X.count", 0));
-            help_hint_ += " but the maximum number of available Galileo satellites is " + std::to_string(available_GAL_5X_signals_.size()) + ".\n";
-            help_hint_ += " Please set Channels_5X.count=" + std::to_string(available_GAL_5X_signals_.size() - 1) + " or lower in your configuration file.\n";
-            top_block_->disconnect_all();
-            return 1;
-        }
-    if (configuration_->property("Channels_7X.count", uint64_t(0ULL)) > available_GAL_7X_signals_.size() - 1)
-        {
-            help_hint_ += " * The number of Galileo E5b channels is set to Channels_7X.count=" + std::to_string(configuration_->property("Channels_7X.count", 0));
-            help_hint_ += " but the maximum number of available Galileo satellites is " + std::to_string(available_GAL_7X_signals_.size()) + ".\n";
-            help_hint_ += " Please set Channels_7X.count=" + std::to_string(available_GAL_7X_signals_.size() - 1) + " or lower in your configuration file.\n";
-            top_block_->disconnect_all();
-            return 1;
-        }
-    if (configuration_->property("Channels_E6.count", uint64_t(0ULL)) > available_GAL_E6_signals_.size() - 1)
-        {
-            help_hint_ += " * The number of Galileo E6 channels is set to Channels_7X.count=" + std::to_string(configuration_->property("Channels_E6.count", 0));
-            help_hint_ += " but the maximum number of available Galileo satellites is " + std::to_string(available_GAL_E6_signals_.size()) + ".\n";
-            help_hint_ += " Please set Channels_E6.count=" + std::to_string(available_GAL_E6_signals_.size() - 1) + " or lower in your configuration file.\n";
-            top_block_->disconnect_all();
-            return 1;
-        }
-    if (configuration_->property("Channels_1G.count", uint64_t(0ULL)) > available_GLO_1G_signals_.size() + 7)  // satellites sharing same frequency number
-        {
-            help_hint_ += " * The number of Glonass L1 channels is set to Channels_1G.count=" + std::to_string(configuration_->property("Channels_1G.count", 0));
-            help_hint_ += " but the maximum number of available Glonass satellites is " + std::to_string(available_GLO_1G_signals_.size() + 8) + ".\n";
-            help_hint_ += " Please set Channels_1G.count=" + std::to_string(available_GLO_1G_signals_.size() + 7) + " or lower in your configuration file.\n";
-            top_block_->disconnect_all();
-            return 1;
-        }
-    if (configuration_->property("Channels_2G.count", uint64_t(0ULL)) > available_GLO_2G_signals_.size() + 7)  // satellites sharing same frequency number
-        {
-            help_hint_ += " * The number of Glonass L2 channels is set to Channels_2G.count=" + std::to_string(configuration_->property("Channels_2G.count", 0));
-            help_hint_ += " but the maximum number of available Glonass satellites is " + std::to_string(available_GLO_2G_signals_.size() + 8) + ".\n";
-            help_hint_ += " Please set Channels_2G.count=" + std::to_string(available_GLO_2G_signals_.size() + 7) + " or lower in your configuration file.\n";
-            top_block_->disconnect_all();
-            return 1;
-        }
-    if (configuration_->property("Channels_B1.count", uint64_t(0ULL)) > available_BDS_B1_signals_.size() - 1)
-        {
-            help_hint_ += " * The number of BeiDou B1 channels is set to Channels_B1.count=" + std::to_string(configuration_->property("Channels_B1.count", 0));
-            help_hint_ += " but the maximum number of available BeiDou satellites is " + std::to_string(available_BDS_B1_signals_.size()) + ".\n";
-            help_hint_ += " Please set Channels_B1.count=" + std::to_string(available_BDS_B1_signals_.size() - 1) + " or lower in your configuration file.\n";
-            top_block_->disconnect_all();
-            return 1;
-        }
-    if (configuration_->property("Channels_B3.count", uint64_t(0ULL)) > available_BDS_B3_signals_.size() - 1)
-        {
-            help_hint_ += " * The number of BeiDou B3 channels is set to Channels_B3.count=" + std::to_string(configuration_->property("Channels_B3.count", 0));
-            help_hint_ += " but the maximum number of available BeiDou satellites is " + std::to_string(available_BDS_B3_signals_.size()) + ".\n";
-            help_hint_ += " Please set Channels_B3.count=" + std::to_string(available_BDS_B3_signals_.size() - 1) + " or lower in your configuration file.\n";
-            top_block_->disconnect_all();
-            return 1;
+            const auto& [gnss_system_str, signal_pretty_str] = signal_info;
+            const auto available_signals = available_signals_map_.at(signal_str);
+            const auto channel_count_option = "Channels_" + signal_str + ".count";
+            const auto channel_count = configuration_->property(channel_count_option, uint64_t(0ULL));
+            auto max_sat_count = available_signals.size();
+
+            if (gnss_system_str == "Glonass")
+                {
+                    max_sat_count += 8;  // satellites sharing same frequency number
+                }
+
+            if (channel_count > max_sat_count - 1)
+                {
+                    help_hint_ += " * The number of " + gnss_system_str + " " + signal_pretty_str + " channels is set to " + channel_count_option + "=" + std::to_string(channel_count);
+                    help_hint_ += " but the maximum number of available " + gnss_system_str + " satellites is " + std::to_string(max_sat_count) + ".\n";
+                    help_hint_ += " Please set " + channel_count_option + "=" + std::to_string(max_sat_count - 1) + " or lower in your configuration file.\n";
+                    top_block_->disconnect_all();
+                    return 1;
+                }
         }
 
     // Assign satellites to channels in the initialization
@@ -1628,84 +1578,9 @@ int GNSSFlowgraph::assign_channels()
                 }
             else
                 {
-                    std::string gnss_system_str;
-                    Gnss_Signal gnss_signal;
-                    switch (mapStringValues_[gnss_signal_str])
-                        {
-                        case evGPS_1C:
-                            gnss_system_str = "GPS";
-                            gnss_signal = Gnss_Signal(Gnss_Satellite(gnss_system_str, sat), gnss_signal_str);
-                            available_GPS_1C_signals_.remove(gnss_signal);
-                            break;
-
-                        case evGPS_2S:
-                            gnss_system_str = "GPS";
-                            gnss_signal = Gnss_Signal(Gnss_Satellite(gnss_system_str, sat), gnss_signal_str);
-                            available_GPS_2S_signals_.remove(gnss_signal);
-                            break;
-
-                        case evGPS_L5:
-                            gnss_system_str = "GPS";
-                            gnss_signal = Gnss_Signal(Gnss_Satellite(gnss_system_str, sat), gnss_signal_str);
-                            available_GPS_L5_signals_.remove(gnss_signal);
-                            break;
-
-                        case evGAL_1B:
-                            gnss_system_str = "Galileo";
-                            gnss_signal = Gnss_Signal(Gnss_Satellite(gnss_system_str, sat), gnss_signal_str);
-                            available_GAL_1B_signals_.remove(gnss_signal);
-                            break;
-
-                        case evGAL_5X:
-                            gnss_system_str = "Galileo";
-                            gnss_signal = Gnss_Signal(Gnss_Satellite(gnss_system_str, sat), gnss_signal_str);
-                            available_GAL_5X_signals_.remove(gnss_signal);
-                            break;
-
-                        case evGAL_7X:
-                            gnss_system_str = "Galileo";
-                            gnss_signal = Gnss_Signal(Gnss_Satellite(gnss_system_str, sat), gnss_signal_str);
-                            available_GAL_7X_signals_.remove(gnss_signal);
-                            break;
-
-                        case evGAL_E6:
-                            gnss_system_str = "Galileo";
-                            gnss_signal = Gnss_Signal(Gnss_Satellite(gnss_system_str, sat), gnss_signal_str);
-                            available_GAL_E6_signals_.remove(gnss_signal);
-                            break;
-
-                        case evGLO_1G:
-                            gnss_system_str = "Glonass";
-                            gnss_signal = Gnss_Signal(Gnss_Satellite(gnss_system_str, sat), gnss_signal_str);
-                            available_GLO_1G_signals_.remove(gnss_signal);
-                            break;
-
-                        case evGLO_2G:
-                            gnss_system_str = "Glonass";
-                            gnss_signal = Gnss_Signal(Gnss_Satellite(gnss_system_str, sat), gnss_signal_str);
-                            available_GLO_2G_signals_.remove(gnss_signal);
-                            break;
-
-                        case evBDS_B1:
-                            gnss_system_str = "Beidou";
-                            gnss_signal = Gnss_Signal(Gnss_Satellite(gnss_system_str, sat), gnss_signal_str);
-                            available_BDS_B1_signals_.remove(gnss_signal);
-                            break;
-
-                        case evBDS_B3:
-                            gnss_system_str = "Beidou";
-                            gnss_signal = Gnss_Signal(Gnss_Satellite(gnss_system_str, sat), gnss_signal_str);
-                            available_BDS_B3_signals_.remove(gnss_signal);
-                            break;
-
-                        default:
-                            LOG(ERROR) << "This should not happen :-(";
-                            gnss_system_str = "GPS";
-                            gnss_signal = Gnss_Signal(Gnss_Satellite(gnss_system_str, sat), gnss_signal_str);
-                            available_GPS_1C_signals_.remove(gnss_signal);
-                            break;
-                        }
-
+                    const auto& [gnss_system_name, _] = signal_mapping.at(gnss_signal_str);
+                    const auto gnss_signal = Gnss_Signal(Gnss_Satellite(gnss_system_name, sat), gnss_signal_str);
+                    available_signals_map_.at(gnss_signal_str).remove(gnss_signal);
                     channels_.at(i)->set_signal(gnss_signal);
                 }
         }
@@ -1753,122 +1628,16 @@ bool GNSSFlowgraph::send_telemetry_msg(const pmt::pmt_t& msg)
 
 void GNSSFlowgraph::push_back_signal(const Gnss_Signal& gs)
 {
-    switch (mapStringValues_[gs.get_signal_str()])
-        {
-        case evGPS_1C:
-            available_GPS_1C_signals_.remove(gs);
-            available_GPS_1C_signals_.push_back(gs);
-            break;
-
-        case evGPS_2S:
-            available_GPS_2S_signals_.remove(gs);
-            available_GPS_2S_signals_.push_back(gs);
-            break;
-
-        case evGPS_L5:
-            available_GPS_L5_signals_.remove(gs);
-            available_GPS_L5_signals_.push_back(gs);
-            break;
-
-        case evGAL_1B:
-            available_GAL_1B_signals_.remove(gs);
-            available_GAL_1B_signals_.push_back(gs);
-            break;
-
-        case evGAL_5X:
-            available_GAL_5X_signals_.remove(gs);
-            available_GAL_5X_signals_.push_back(gs);
-            break;
-
-        case evGAL_7X:
-            available_GAL_7X_signals_.remove(gs);
-            available_GAL_7X_signals_.push_back(gs);
-            break;
-
-        case evGAL_E6:
-            available_GAL_E6_signals_.remove(gs);
-            available_GAL_E6_signals_.push_back(gs);
-            break;
-
-        case evGLO_1G:
-            available_GLO_1G_signals_.remove(gs);
-            available_GLO_1G_signals_.push_back(gs);
-            break;
-
-        case evGLO_2G:
-            available_GLO_2G_signals_.remove(gs);
-            available_GLO_2G_signals_.push_back(gs);
-            break;
-
-        case evBDS_B1:
-            available_BDS_B1_signals_.remove(gs);
-            available_BDS_B1_signals_.push_back(gs);
-            break;
-
-        case evBDS_B3:
-            available_BDS_B3_signals_.remove(gs);
-            available_BDS_B3_signals_.push_back(gs);
-            break;
-
-        default:
-            LOG(ERROR) << "This should not happen :-(";
-            break;
-        }
+    auto& available_signals = available_signals_map_.at(gs.get_signal_str());
+    available_signals.remove(gs);
+    available_signals.push_back(gs);
 }
 
 
 void GNSSFlowgraph::remove_signal(const Gnss_Signal& gs)
 {
-    switch (mapStringValues_[gs.get_signal_str()])
-        {
-        case evGPS_1C:
-            available_GPS_1C_signals_.remove(gs);
-            break;
-
-        case evGPS_2S:
-            available_GPS_2S_signals_.remove(gs);
-            break;
-
-        case evGPS_L5:
-            available_GPS_L5_signals_.remove(gs);
-            break;
-
-        case evGAL_1B:
-            available_GAL_1B_signals_.remove(gs);
-            break;
-
-        case evGAL_5X:
-            available_GAL_5X_signals_.remove(gs);
-            break;
-
-        case evGAL_7X:
-            available_GAL_7X_signals_.remove(gs);
-            break;
-
-        case evGAL_E6:
-            available_GAL_E6_signals_.remove(gs);
-            break;
-
-        case evGLO_1G:
-            available_GLO_1G_signals_.remove(gs);
-            break;
-
-        case evGLO_2G:
-            available_GLO_2G_signals_.remove(gs);
-            break;
-
-        case evBDS_B1:
-            available_BDS_B1_signals_.remove(gs);
-            break;
-
-        case evBDS_B3:
-            available_BDS_B3_signals_.remove(gs);
-            break;
-
-        default:
-            LOG(ERROR) << "This should not happen :-(";
-            break;
-        }
+    auto& available_signals = available_signals_map_.at(gs.get_signal_str());
+    available_signals.remove(gs);
 }
 
 
@@ -2117,64 +1886,26 @@ void GNSSFlowgraph::priorize_satellites(const std::vector<std::pair<int, Gnss_Sa
     Gnss_Signal gs;
     for (const auto& visible_satellite : visible_satellites)
         {
+            std::vector<std::string> signal_str_vector;
+
             if (visible_satellite.second.get_system() == "GPS")
                 {
-                    gs = Gnss_Signal(visible_satellite.second, "1C");
-                    old_size = available_GPS_1C_signals_.size();
-                    available_GPS_1C_signals_.remove(gs);
-                    if (old_size > available_GPS_1C_signals_.size())
-                        {
-                            available_GPS_1C_signals_.push_front(gs);
-                        }
-
-                    gs = Gnss_Signal(visible_satellite.second, "2S");
-                    old_size = available_GPS_2S_signals_.size();
-                    available_GPS_2S_signals_.remove(gs);
-                    if (old_size > available_GPS_2S_signals_.size())
-                        {
-                            available_GPS_2S_signals_.push_front(gs);
-                        }
-
-                    gs = Gnss_Signal(visible_satellite.second, "L5");
-                    old_size = available_GPS_L5_signals_.size();
-                    available_GPS_L5_signals_.remove(gs);
-                    if (old_size > available_GPS_L5_signals_.size())
-                        {
-                            available_GPS_L5_signals_.push_front(gs);
-                        }
+                    signal_str_vector = {"1C", "2S", "L5"};
                 }
             else if (visible_satellite.second.get_system() == "Galileo")
                 {
-                    gs = Gnss_Signal(visible_satellite.second, "1B");
-                    old_size = available_GAL_1B_signals_.size();
-                    available_GAL_1B_signals_.remove(gs);
-                    if (old_size > available_GAL_1B_signals_.size())
-                        {
-                            available_GAL_1B_signals_.push_front(gs);
-                        }
+                    signal_str_vector = {"1B", "5X", "7X", "E6"};
+                }
 
-                    gs = Gnss_Signal(visible_satellite.second, "5X");
-                    old_size = available_GAL_5X_signals_.size();
-                    available_GAL_5X_signals_.remove(gs);
-                    if (old_size > available_GAL_5X_signals_.size())
+            for (const auto& signal_str : signal_str_vector)
+                {
+                    auto& available_signals = available_signals_map_.at(signal_str);
+                    gs = Gnss_Signal(visible_satellite.second, signal_str);
+                    old_size = available_signals.size();
+                    available_signals.remove(gs);
+                    if (old_size > available_signals.size())
                         {
-                            available_GAL_5X_signals_.push_front(gs);
-                        }
-
-                    gs = Gnss_Signal(visible_satellite.second, "7X");
-                    old_size = available_GAL_7X_signals_.size();
-                    available_GAL_7X_signals_.remove(gs);
-                    if (old_size > available_GAL_7X_signals_.size())
-                        {
-                            available_GAL_7X_signals_.push_front(gs);
-                        }
-
-                    gs = Gnss_Signal(visible_satellite.second, "E6");
-                    old_size = available_GAL_E6_signals_.size();
-                    available_GAL_E6_signals_.remove(gs);
-                    if (old_size > available_GAL_E6_signals_.size())
-                        {
-                            available_GAL_E6_signals_.push_front(gs);
+                            available_signals.push_front(gs);
                         }
                 }
         }
@@ -2259,381 +1990,88 @@ std::vector<std::string> GNSSFlowgraph::split_string(const std::string& s, char 
 
 void GNSSFlowgraph::set_signals_list()
 {
-    // Set a sequential list of GNSS satellites
-    std::set<unsigned int>::const_iterator available_gnss_prn_iter;
+    // Glonass removing satellites sharing same frequency number(1 and 5, 2 and 6, 3 and 7, 4 and 6, 11 and 15, 12 and 16, 14 and 18, 17 and 21
+    std::unordered_map<std::string, std::set<unsigned int>> available_prn_map = {
+        {"GPS", {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32}},
+        {"SBAS", {123, 131, 135, 136, 138}},
+        {"Galileo", {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20,
+                        21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36}},
+        {"Glonass", {1, 2, 3, 4, 9, 10, 11, 12, 18, 19, 20, 21, 24}},
+        {"BeiDou", {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20,
+                       21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37,
+                       38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54,
+                       55, 56, 57, 58, 59, 60, 61, 62, 63}},
+    };
 
-    // Create the lists of GNSS satellites
-    std::set<unsigned int> available_gps_prn = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10,
-        11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28,
-        29, 30, 31, 32};
-
-    std::set<unsigned int> available_sbas_prn = {123, 131, 135, 136, 138};
-
-    std::set<unsigned int> available_galileo_prn = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10,
-        11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28,
-        29, 30, 31, 32, 33, 34, 35, 36};
-
-    // Removing satellites sharing same frequency number(1 and 5, 2 and 6, 3 and 7, 4 and 6, 11 and 15, 12 and 16, 14 and 18, 17 and 21
-    std::set<unsigned int> available_glonass_prn = {1, 2, 3, 4, 9, 10, 11, 12, 18, 19, 20, 21, 24};
-
-    std::set<unsigned int> available_beidou_prn = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10,
-        11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29,
-        30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49,
-        50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63};
-
-    std::string sv_list = configuration_->property("Galileo.prns", std::string(""));
-
-    if (!sv_list.empty())
+    for (auto& [gnss_system_str, available_prns] : available_prn_map)
         {
-            // Reset the available prns:
-            std::set<unsigned int> tmp_set;
-            boost::tokenizer<> tok(sv_list);
-            std::transform(tok.begin(), tok.end(), std::inserter(tmp_set, tmp_set.begin()),
-                boost::lexical_cast<unsigned int, std::string>);
+            const auto sv_list = configuration_->property(gnss_system_str + ".prns", std::string(""));
 
-            if (!tmp_set.empty())
+            if (!sv_list.empty())
                 {
-                    available_galileo_prn = std::move(tmp_set);
+                    // Reset the available prns:
+                    std::set<unsigned int> tmp_set;
+                    boost::tokenizer<> tok(sv_list);
+                    std::transform(tok.begin(), tok.end(), std::inserter(tmp_set, tmp_set.begin()),
+                        boost::lexical_cast<unsigned int, std::string>);
+
+                    if (!tmp_set.empty())
+                        {
+                            available_prns = std::move(tmp_set);
+                        }
                 }
-        }
 
-    std::string sv_banned = configuration_->property("GNSS-SDR.Galileo_banned_prns", std::string(""));
-    if (!sv_banned.empty())
-        {
-            std::stringstream ss(sv_banned);
-            while (ss.good())
+            const auto sv_banned = configuration_->property("GNSS-SDR." + gnss_system_str + "_banned_prns", std::string(""));
+            if (!sv_banned.empty())
                 {
-                    std::string substr;
-                    std::getline(ss, substr, ',');
-                    try
+                    std::stringstream ss(sv_banned);
+                    while (ss.good())
                         {
-                            auto banned = static_cast<unsigned int>(std::stoi(substr));
-                            available_galileo_prn.erase(banned);
-                        }
-                    catch (const std::invalid_argument& ia)
-                        {
-                            std::cerr << "Invalid argument at GNSS-SDR.Galileo_banned_prns configuration parameter: " << ia.what() << '\n';
-                        }
-                    catch (const std::out_of_range& oor)
-                        {
-                            std::cerr << "Out of range at GNSS-SDR.Galileo_banned_prns configuration parameter: " << oor.what() << '\n';
+                            std::string substr;
+                            std::getline(ss, substr, ',');
+                            try
+                                {
+                                    const auto banned = static_cast<unsigned int>(std::stoi(substr));
+                                    available_prns.erase(banned);
+                                }
+                            catch (const std::invalid_argument& ia)
+                                {
+                                    std::cerr << "Invalid argument at GNSS-SDR." << gnss_system_str << "_banned_prns configuration parameter: " << ia.what() << '\n';
+                                }
+                            catch (const std::out_of_range& oor)
+                                {
+                                    std::cerr << "Out of range at GNSS-SDR." << gnss_system_str << "_banned_prns configuration parameter: " << oor.what() << '\n';
+                                }
                         }
                 }
         }
 
-    sv_list = configuration_->property("GPS.prns", std::string(""));
-
-    if (!sv_list.empty())
+    for (const auto& [signal_str, signal_info] : signal_mapping)
         {
-            // Reset the available prns:
-            std::set<unsigned int> tmp_set;
-            boost::tokenizer<> tok(sv_list);
-            std::transform(tok.begin(), tok.end(), std::inserter(tmp_set, tmp_set.begin()),
-                boost::lexical_cast<unsigned int, std::string>);
+            const auto& [gnss_system_str, _] = signal_info;
+            const auto channel_count_option = "Channels_" + signal_str + ".count";
 
-            if (!tmp_set.empty())
+            if (configuration_->property(channel_count_option, 0) > 0)
                 {
-                    available_gps_prn = std::move(tmp_set);
-                }
-        }
+                    auto& available_signals = available_signals_map_[signal_str];
 
-    sv_banned = configuration_->property("GNSS-SDR.GPS_banned_prns", std::string(""));
-    if (!sv_banned.empty())
-        {
-            std::stringstream ss(sv_banned);
-            while (ss.good())
-                {
-                    std::string substr;
-                    std::getline(ss, substr, ',');
-                    try
+                    for (const auto& prn : available_prn_map.at(gnss_system_str))
                         {
-                            auto banned = static_cast<unsigned int>(std::stoi(substr));
-                            available_gps_prn.erase(banned);
+                            available_signals.emplace_back(Gnss_Satellite(gnss_system_str, prn), signal_str);
                         }
-                    catch (const std::invalid_argument& ia)
-                        {
-                            std::cerr << "Invalid argument at GNSS-SDR.GPS_banned_prns configuration parameter: " << ia.what() << '\n';
-                        }
-                    catch (const std::out_of_range& oor)
-                        {
-                            std::cerr << "Out of range at GNSS-SDR.GPS_banned_prns configuration parameter: " << oor.what() << '\n';
-                        }
-                }
-        }
-
-    sv_list = configuration_->property("SBAS.prns", std::string(""));
-
-    if (!sv_list.empty())
-        {
-            // Reset the available prns:
-            std::set<unsigned int> tmp_set;
-            boost::tokenizer<> tok(sv_list);
-            std::transform(tok.begin(), tok.end(), std::inserter(tmp_set, tmp_set.begin()),
-                boost::lexical_cast<unsigned int, std::string>);
-
-            if (!tmp_set.empty())
-                {
-                    available_sbas_prn = std::move(tmp_set);
-                }
-        }
-
-    sv_banned = configuration_->property("GNSS-SDR.SBAS_banned_prns", std::string(""));
-    if (!sv_banned.empty())
-        {
-            std::stringstream ss(sv_banned);
-            while (ss.good())
-                {
-                    std::string substr;
-                    std::getline(ss, substr, ',');
-                    try
-                        {
-                            auto banned = static_cast<unsigned int>(std::stoi(substr));
-                            available_sbas_prn.erase(banned);
-                        }
-                    catch (const std::invalid_argument& ia)
-                        {
-                            std::cerr << "Invalid argument at GNSS-SDR.SBAS_banned_prns configuration parameter: " << ia.what() << '\n';
-                        }
-                    catch (const std::out_of_range& oor)
-                        {
-                            std::cerr << "Out of range at GNSS-SDR.SBAS_banned_prns configuration parameter: " << oor.what() << '\n';
-                        }
-                }
-        }
-
-    sv_list = configuration_->property("Glonass.prns", std::string(""));
-
-    if (!sv_list.empty())
-        {
-            // Reset the available prns:
-            std::set<unsigned int> tmp_set;
-            boost::tokenizer<> tok(sv_list);
-            std::transform(tok.begin(), tok.end(), std::inserter(tmp_set, tmp_set.begin()),
-                boost::lexical_cast<unsigned int, std::string>);
-
-            if (!tmp_set.empty())
-                {
-                    available_glonass_prn = std::move(tmp_set);
-                }
-        }
-
-    sv_banned = configuration_->property("GNSS-SDR.Glonass_banned_prns", std::string(""));
-    if (!sv_banned.empty())
-        {
-            std::stringstream ss(sv_banned);
-            while (ss.good())
-                {
-                    std::string substr;
-                    std::getline(ss, substr, ',');
-                    try
-                        {
-                            auto banned = static_cast<unsigned int>(std::stoi(substr));
-                            available_glonass_prn.erase(banned);
-                        }
-                    catch (const std::invalid_argument& ia)
-                        {
-                            std::cerr << "Invalid argument at GNSS-SDR.Glonass_banned_prns configuration parameter: " << ia.what() << '\n';
-                        }
-                    catch (const std::out_of_range& oor)
-                        {
-                            std::cerr << "Out of range at GNSS-SDR.Glonass_banned_prns configuration parameter: " << oor.what() << '\n';
-                        }
-                }
-        }
-
-    sv_list = configuration_->property("Beidou.prns", std::string(""));
-
-    if (!sv_list.empty())
-        {
-            // Reset the available prns:
-            std::set<unsigned int> tmp_set;
-            boost::tokenizer<> tok(sv_list);
-            std::transform(tok.begin(), tok.end(), std::inserter(tmp_set, tmp_set.begin()),
-                boost::lexical_cast<unsigned int, std::string>);
-
-            if (!tmp_set.empty())
-                {
-                    available_beidou_prn = std::move(tmp_set);
-                }
-        }
-
-    sv_banned = configuration_->property("GNSS-SDR.Beidou_banned_prns", std::string(""));
-    if (!sv_banned.empty())
-        {
-            std::stringstream ss(sv_banned);
-            while (ss.good())
-                {
-                    std::string substr;
-                    std::getline(ss, substr, ',');
-                    try
-                        {
-                            auto banned = static_cast<unsigned int>(std::stoi(substr));
-                            available_beidou_prn.erase(banned);
-                        }
-                    catch (const std::invalid_argument& ia)
-                        {
-                            std::cerr << "Invalid argument at GNSS-SDR.Beidou_banned_prns configuration parameter: " << ia.what() << '\n';
-                        }
-                    catch (const std::out_of_range& oor)
-                        {
-                            std::cerr << "Out of range at GNSS-SDR.Beidou_banned_prns configuration parameter: " << oor.what() << '\n';
-                        }
-                }
-        }
-
-    if (configuration_->property("Channels_1C.count", 0) > 0)
-        {
-            // Loop to create GPS L1 C/A signals
-            for (available_gnss_prn_iter = available_gps_prn.cbegin();
-                available_gnss_prn_iter != available_gps_prn.cend();
-                available_gnss_prn_iter++)
-                {
-                    available_GPS_1C_signals_.emplace_back(
-                        Gnss_Satellite(std::string("GPS"), *available_gnss_prn_iter),
-                        std::string("1C"));
-                }
-        }
-
-    if (configuration_->property("Channels_2S.count", 0) > 0)
-        {
-            // Loop to create GPS L2C M signals
-            for (available_gnss_prn_iter = available_gps_prn.cbegin();
-                available_gnss_prn_iter != available_gps_prn.cend();
-                available_gnss_prn_iter++)
-                {
-                    available_GPS_2S_signals_.emplace_back(
-                        Gnss_Satellite(std::string("GPS"), *available_gnss_prn_iter),
-                        std::string("2S"));
-                }
-        }
-
-    if (configuration_->property("Channels_L5.count", 0) > 0)
-        {
-            // Loop to create GPS L5 signals
-            for (available_gnss_prn_iter = available_gps_prn.cbegin();
-                available_gnss_prn_iter != available_gps_prn.cend();
-                available_gnss_prn_iter++)
-                {
-                    available_GPS_L5_signals_.emplace_back(
-                        Gnss_Satellite(std::string("GPS"), *available_gnss_prn_iter),
-                        std::string("L5"));
                 }
         }
 
     if (configuration_->property("Channels_SBAS.count", 0) > 0)
         {
-            // Loop to create SBAS L1 C/A signals
-            for (available_gnss_prn_iter = available_sbas_prn.cbegin();
-                available_gnss_prn_iter != available_sbas_prn.cend();
-                available_gnss_prn_iter++)
-                {
-                    available_SBAS_1C_signals_.emplace_back(
-                        Gnss_Satellite(std::string("SBAS"), *available_gnss_prn_iter),
-                        std::string("1C"));
-                }
-        }
+            const std::string gnss_system_str = "SBAS";
+            const std::string signal_str = "1C";
 
-    if (configuration_->property("Channels_1B.count", 0) > 0)
-        {
-            // Loop to create the list of Galileo E1B signals
-            for (available_gnss_prn_iter = available_galileo_prn.cbegin();
-                available_gnss_prn_iter != available_galileo_prn.cend();
-                available_gnss_prn_iter++)
-                {
-                    available_GAL_1B_signals_.emplace_back(
-                        Gnss_Satellite(std::string("Galileo"), *available_gnss_prn_iter),
-                        std::string("1B"));
-                }
-        }
+            auto& available_signals = available_signals_map_[signal_str];
 
-    if (configuration_->property("Channels_5X.count", 0) > 0)
-        {
-            // Loop to create the list of Galileo E5a signals
-            for (available_gnss_prn_iter = available_galileo_prn.cbegin();
-                available_gnss_prn_iter != available_galileo_prn.cend();
-                available_gnss_prn_iter++)
+            for (const auto& prn : available_prn_map.at(gnss_system_str))
                 {
-                    available_GAL_5X_signals_.emplace_back(
-                        Gnss_Satellite(std::string("Galileo"), *available_gnss_prn_iter),
-                        std::string("5X"));
-                }
-        }
-
-    if (configuration_->property("Channels_7X.count", 0) > 0)
-        {
-            // Loop to create the list of Galileo E5b signals
-            for (available_gnss_prn_iter = available_galileo_prn.cbegin();
-                available_gnss_prn_iter != available_galileo_prn.cend();
-                available_gnss_prn_iter++)
-                {
-                    available_GAL_7X_signals_.emplace_back(
-                        Gnss_Satellite(std::string("Galileo"), *available_gnss_prn_iter),
-                        std::string("7X"));
-                }
-        }
-
-    if (configuration_->property("Channels_E6.count", 0) > 0)
-        {
-            // Loop to create the list of Galileo E6 signals
-            for (available_gnss_prn_iter = available_galileo_prn.cbegin();
-                available_gnss_prn_iter != available_galileo_prn.cend();
-                available_gnss_prn_iter++)
-                {
-                    available_GAL_E6_signals_.emplace_back(
-                        Gnss_Satellite(std::string("Galileo"), *available_gnss_prn_iter),
-                        std::string("E6"));
-                }
-        }
-
-    if (configuration_->property("Channels_1G.count", 0) > 0)
-        {
-            // Loop to create the list of GLONASS L1 C/A signals
-            for (available_gnss_prn_iter = available_glonass_prn.cbegin();
-                available_gnss_prn_iter != available_glonass_prn.cend();
-                available_gnss_prn_iter++)
-                {
-                    available_GLO_1G_signals_.emplace_back(
-                        Gnss_Satellite(std::string("Glonass"), *available_gnss_prn_iter),
-                        std::string("1G"));
-                }
-        }
-
-    if (configuration_->property("Channels_2G.count", 0) > 0)
-        {
-            // Loop to create the list of GLONASS L2 C/A signals
-            for (available_gnss_prn_iter = available_glonass_prn.cbegin();
-                available_gnss_prn_iter != available_glonass_prn.cend();
-                available_gnss_prn_iter++)
-                {
-                    available_GLO_2G_signals_.emplace_back(
-                        Gnss_Satellite(std::string("Glonass"), *available_gnss_prn_iter),
-                        std::string("2G"));
-                }
-        }
-
-    if (configuration_->property("Channels_B1.count", 0) > 0)
-        {
-            // Loop to create the list of BeiDou B1C signals
-            for (available_gnss_prn_iter = available_beidou_prn.cbegin();
-                available_gnss_prn_iter != available_beidou_prn.cend();
-                available_gnss_prn_iter++)
-                {
-                    available_BDS_B1_signals_.emplace_back(
-                        Gnss_Satellite(std::string("Beidou"), *available_gnss_prn_iter),
-                        std::string("B1"));
-                }
-        }
-
-    if (configuration_->property("Channels_B3.count", 0) > 0)
-        {
-            // Loop to create the list of BeiDou B1C signals
-            for (available_gnss_prn_iter = available_beidou_prn.cbegin();
-                available_gnss_prn_iter != available_beidou_prn.cend();
-                available_gnss_prn_iter++)
-                {
-                    available_BDS_B3_signals_.emplace_back(
-                        Gnss_Satellite(std::string("Beidou"), *available_gnss_prn_iter),
-                        std::string("B3"));
+                    available_signals.emplace_back(Gnss_Satellite(gnss_system_str, prn), signal_str);
                 }
         }
 }
@@ -2723,247 +2161,69 @@ Gnss_Signal GNSSFlowgraph::search_next_signal(const std::string& searched_signal
     assistance_available = false;
     Gnss_Signal result{};
     bool found_signal = false;
+    std::string assist_signal = "";
+
     switch (mapStringValues_[searched_signal])
         {
-        case evGPS_1C:
-            // todo: assist the satellite selection with almanac and current PVT here (reuse priorize_satellite function used in control_thread)
-            result = available_GPS_1C_signals_.front();
-            available_GPS_1C_signals_.pop_front();
-            available_GPS_1C_signals_.push_back(result);
-            is_primary_frequency = true;  // indicate that the searched satellite signal belongs to "primary" link (L1, E1, B1, etc..)
-            break;
-
         case evGPS_2S:
-            if (configuration_->property("Channels_1C.count", 0) > 0)
-                {
-                    // 1. Get the current channel status map
-                    std::map<int, std::shared_ptr<Gnss_Synchro>> current_channels_status = channels_status_->get_current_status_map();
-                    // 2. search the currently tracked GPS L1 satellites and assist the GPS L2 acquisition if the satellite is not tracked on L2
-                    for (auto& current_status : current_channels_status)
-                        {
-                            if (std::string(current_status.second->Signal) == "1C")
-                                {
-                                    std::list<Gnss_Signal>::iterator it2;
-                                    it2 = std::find_if(std::begin(available_GPS_2S_signals_), std::end(available_GPS_2S_signals_),
-                                        [&](Gnss_Signal const& sig) { return sig.get_satellite().get_PRN() == current_status.second->PRN; });
-
-                                    if (it2 != available_GPS_2S_signals_.end())
-                                        {
-                                            estimated_doppler = static_cast<float>(current_status.second->Carrier_Doppler_hz);
-                                            RX_time = current_status.second->RX_time;
-                                            // 3. return the GPS L2 satellite and remove it from list
-                                            result = *it2;
-                                            available_GPS_2S_signals_.erase(it2);
-                                            found_signal = true;
-                                            assistance_available = true;
-                                            break;
-                                        }
-                                }
-                        }
-                }
-            // fallback: pick the front satellite because there is no tracked satellites in L1 to assist L2
-            if (found_signal == false)
-                {
-                    result = available_GPS_2S_signals_.front();
-                    available_GPS_2S_signals_.pop_front();
-                    available_GPS_2S_signals_.push_back(result);
-                }
-            break;
-
         case evGPS_L5:
-            if (configuration_->property("Channels_1C.count", 0) > 0)
-                {
-                    // 1. Get the current channel status map
-                    std::map<int, std::shared_ptr<Gnss_Synchro>> current_channels_status = channels_status_->get_current_status_map();
-                    // 2. search the currently tracked GPS L1 satellites and assist the GPS L5 acquisition if the satellite is not tracked on L5
-                    for (auto& current_status : current_channels_status)
-                        {
-                            if (std::string(current_status.second->Signal) == "1C")
-                                {
-                                    std::list<Gnss_Signal>::iterator it2;
-                                    it2 = std::find_if(std::begin(available_GPS_L5_signals_), std::end(available_GPS_L5_signals_),
-                                        [&](Gnss_Signal const& sig) { return sig.get_satellite().get_PRN() == current_status.second->PRN; });
-
-                                    if (it2 != available_GPS_L5_signals_.end())
-                                        {
-                                            estimated_doppler = static_cast<float>(current_status.second->Carrier_Doppler_hz);
-                                            RX_time = current_status.second->RX_time;
-                                            // std::cout << " Channel: " << it->first << " => Doppler: " << estimated_doppler << "[Hz] \n";
-                                            // 3. return the GPS L5 satellite and remove it from list
-                                            result = *it2;
-                                            available_GPS_L5_signals_.erase(it2);
-                                            found_signal = true;
-                                            assistance_available = true;
-                                            break;
-                                        }
-                                }
-                        }
-                }
-            // fallback: pick the front satellite because there is no tracked satellites in L1 to assist L5
-            if (found_signal == false)
-                {
-                    result = available_GPS_L5_signals_.front();
-                    available_GPS_L5_signals_.pop_front();
-                    available_GPS_L5_signals_.push_back(result);
-                }
-            break;
-
-        case evGAL_1B:
-            result = available_GAL_1B_signals_.front();
-            available_GAL_1B_signals_.pop_front();
-            available_GAL_1B_signals_.push_back(result);
-            is_primary_frequency = true;  // indicate that the searched satellite signal belongs to "primary" link (L1, E1, B1, etc..)
+            assist_signal = "1C";
             break;
 
         case evGAL_5X:
-            if (configuration_->property("Channels_1B.count", 0) > 0)
-                {
-                    // 1. Get the current channel status map
-                    std::map<int, std::shared_ptr<Gnss_Synchro>> current_channels_status = channels_status_->get_current_status_map();
-                    // 2. search the currently tracked Galileo E1 satellites and assist the Galileo E5 acquisition if the satellite is not tracked on E5
-                    for (auto& current_status : current_channels_status)
-                        {
-                            if (std::string(current_status.second->Signal) == "1B")
-                                {
-                                    std::list<Gnss_Signal>::iterator it2;
-                                    it2 = std::find_if(std::begin(available_GAL_5X_signals_), std::end(available_GAL_5X_signals_),
-                                        [&](Gnss_Signal const& sig) { return sig.get_satellite().get_PRN() == current_status.second->PRN; });
-
-                                    if (it2 != available_GAL_5X_signals_.end())
-                                        {
-                                            estimated_doppler = static_cast<float>(current_status.second->Carrier_Doppler_hz);
-                                            RX_time = current_status.second->RX_time;
-                                            // std::cout << " Channel: " << it->first << " => Doppler: " << estimated_doppler << "[Hz] \n";
-                                            // 3. return the Gal 5X satellite and remove it from list
-                                            result = *it2;
-                                            available_GAL_5X_signals_.erase(it2);
-                                            found_signal = true;
-                                            assistance_available = true;
-                                            break;
-                                        }
-                                }
-                        }
-                }
-            // fallback: pick the front satellite because there is no tracked satellites in E1 to assist E5
-            if (found_signal == false)
-                {
-                    result = available_GAL_5X_signals_.front();
-                    available_GAL_5X_signals_.pop_front();
-                    available_GAL_5X_signals_.push_back(result);
-                }
-            break;
-
         case evGAL_7X:
-            if (configuration_->property("Channels_1B.count", 0) > 0)
-                {
-                    // 1. Get the current channel status map
-                    std::map<int, std::shared_ptr<Gnss_Synchro>> current_channels_status = channels_status_->get_current_status_map();
-                    // 2. search the currently tracked Galileo E1 satellites and assist the Galileo E5 acquisition if the satellite is not tracked on E5
-                    for (auto& current_status : current_channels_status)
-                        {
-                            if (std::string(current_status.second->Signal) == "1B")
-                                {
-                                    std::list<Gnss_Signal>::iterator it2;
-                                    it2 = std::find_if(std::begin(available_GAL_7X_signals_), std::end(available_GAL_7X_signals_),
-                                        [&](Gnss_Signal const& sig) { return sig.get_satellite().get_PRN() == current_status.second->PRN; });
-
-                                    if (it2 != available_GAL_7X_signals_.end())
-                                        {
-                                            estimated_doppler = static_cast<float>(current_status.second->Carrier_Doppler_hz);
-                                            RX_time = current_status.second->RX_time;
-                                            // std::cout << " Channel: " << it->first << " => Doppler: " << estimated_doppler << "[Hz] \n";
-                                            // 3. return the Gal 7X satellite and remove it from list
-                                            result = *it2;
-                                            available_GAL_7X_signals_.erase(it2);
-                                            found_signal = true;
-                                            assistance_available = true;
-                                            break;
-                                        }
-                                }
-                        }
-                }
-            // fallback: pick the front satellite because there is no tracked satellites in E1 to assist E5
-            if (found_signal == false)
-                {
-                    result = available_GAL_7X_signals_.front();
-                    available_GAL_7X_signals_.pop_front();
-                    available_GAL_7X_signals_.push_back(result);
-                }
-            break;
-
         case evGAL_E6:
-            if (configuration_->property("Channels_1B.count", 0) > 0)
-                {
-                    // 1. Get the current channel status map
-                    std::map<int, std::shared_ptr<Gnss_Synchro>> current_channels_status = channels_status_->get_current_status_map();
-                    // 2. search the currently tracked Galileo E1 satellites and assist the Galileo E5 acquisition if the satellite is not tracked on E5
-                    for (auto& current_status : current_channels_status)
-                        {
-                            if (std::string(current_status.second->Signal) == "1B")
-                                {
-                                    std::list<Gnss_Signal>::iterator it2;
-                                    it2 = std::find_if(std::begin(available_GAL_E6_signals_), std::end(available_GAL_E6_signals_),
-                                        [&](Gnss_Signal const& sig) { return sig.get_satellite().get_PRN() == current_status.second->PRN; });
-
-                                    if (it2 != available_GAL_E6_signals_.end())
-                                        {
-                                            estimated_doppler = static_cast<float>(current_status.second->Carrier_Doppler_hz);
-                                            RX_time = current_status.second->RX_time;
-                                            // std::cout << " Channel: " << it->first << " => Doppler: " << estimated_doppler << "[Hz] \n";
-                                            // 3. return the Gal E6 satellite and remove it from list
-                                            result = *it2;
-                                            available_GAL_E6_signals_.erase(it2);
-                                            found_signal = true;
-                                            assistance_available = true;
-                                            break;
-                                        }
-                                }
-                        }
-                }
-            // fallback: pick the front satellite because there is no tracked satellites in E1 to assist E6
-            if (found_signal == false)
-                {
-                    result = available_GAL_E6_signals_.front();
-                    available_GAL_E6_signals_.pop_front();
-                    available_GAL_E6_signals_.push_back(result);
-                }
+            assist_signal = "1B";
             break;
 
+        case evGPS_1C:
+        case evGAL_1B:
         case evGLO_1G:
-            result = available_GLO_1G_signals_.front();
-            available_GLO_1G_signals_.pop_front();
-            available_GLO_1G_signals_.push_back(result);
-            is_primary_frequency = true;  // indicate that the searched satellite signal belongs to "primary" link (L1, E1, B1, etc..)
-            break;
-
-        case evGLO_2G:
-            result = available_GLO_2G_signals_.front();
-            available_GLO_2G_signals_.pop_front();
-            available_GLO_2G_signals_.push_back(result);
-            break;
-
         case evBDS_B1:
-            result = available_BDS_B1_signals_.front();
-            available_BDS_B1_signals_.pop_front();
-            available_BDS_B1_signals_.push_back(result);
-            is_primary_frequency = true;  // indicate that the searched satellite signal belongs to "primary" link (L1, E1, B1, etc..)
-            break;
-
-        case evBDS_B3:
-            result = available_BDS_B3_signals_.front();
-            available_BDS_B3_signals_.pop_front();
-            available_BDS_B3_signals_.push_back(result);
+            is_primary_frequency = true;
             break;
 
         default:
-            LOG(ERROR) << "This should not happen :-(";
-            if (!available_GPS_1C_signals_.empty())
-                {
-                    result = available_GPS_1C_signals_.front();
-                    available_GPS_1C_signals_.pop_front();
-                    available_GPS_1C_signals_.push_back(result);
-                }
             break;
         }
+
+    if (assist_signal != "")
+        {
+            if (configuration_->property("Channels_" + assist_signal + ".count", 0) > 0)
+                {
+                    // 1. Get the current channel status map
+                    std::map<int, std::shared_ptr<Gnss_Synchro>> current_channels_status = channels_status_->get_current_status_map();
+                    // 2. search the currently tracked primary signal satellites and assist the acquisition if the satellite is not tracked on the assisted signal
+                    for (auto& current_status : current_channels_status)
+                        {
+                            if (std::string(current_status.second->Signal) == assist_signal)
+                                {
+                                    std::list<Gnss_Signal>::iterator it2;
+                                    auto& available_signals = available_signals_map_.at(searched_signal);
+                                    it2 = std::find_if(std::begin(available_signals), std::end(available_signals),
+                                        [&](Gnss_Signal const& sig) { return sig.get_satellite().get_PRN() == current_status.second->PRN; });
+
+                                    if (it2 != available_signals.end())
+                                        {
+                                            estimated_doppler = static_cast<float>(current_status.second->Carrier_Doppler_hz);
+                                            RX_time = current_status.second->RX_time;
+                                            result = *it2;
+                                            available_signals.erase(it2);
+                                            found_signal = true;
+                                            assistance_available = true;
+                                            break;
+                                        }
+                                }
+                        }
+                }
+        }
+
+    if (found_signal == false)
+        {
+            auto& available_signals = available_signals_map_.at(searched_signal);
+            result = available_signals.front();
+            available_signals.pop_front();
+        }
+
     return result;
 }

--- a/src/core/receiver/gnss_flowgraph.cc
+++ b/src/core/receiver/gnss_flowgraph.cc
@@ -77,6 +77,7 @@
 
 namespace
 {
+
 const auto signal_mapping = std::unordered_map<std::string, std::pair<std::string, std::string>>{
     {"1C", {"GPS", "L1"}},
     {"2S", {"GPS", "L2"}},
@@ -90,7 +91,8 @@ const auto signal_mapping = std::unordered_map<std::string, std::pair<std::strin
     {"1G", {"Glonass", "L1"}},
     {"2G", {"Glonass", "L2"}},
 };
-}
+
+}  // namespace
 
 GNSSFlowgraph::GNSSFlowgraph(std::shared_ptr<ConfigurationInterface> configuration,
     std::shared_ptr<Concurrent_Queue<pmt::pmt_t>> queue)  // NOLINT(performance-unnecessary-value-param)

--- a/src/core/receiver/gnss_flowgraph.h
+++ b/src/core/receiver/gnss_flowgraph.h
@@ -40,6 +40,7 @@
 #include <memory>                       // for for shared_ptr, dynamic_pointer_cast
 #include <mutex>                        // for mutex
 #include <string>                       // for string
+#include <unordered_map>                // for unordered_map
 #include <utility>                      // for pair
 #include <vector>                       // for vector
 #if ENABLE_FPGA
@@ -245,18 +246,7 @@ private:
 
     std::vector<unsigned int> channels_state_;
 
-    std::list<Gnss_Signal> available_GPS_1C_signals_;
-    std::list<Gnss_Signal> available_GPS_2S_signals_;
-    std::list<Gnss_Signal> available_GPS_L5_signals_;
-    std::list<Gnss_Signal> available_SBAS_1C_signals_;
-    std::list<Gnss_Signal> available_GAL_1B_signals_;
-    std::list<Gnss_Signal> available_GAL_5X_signals_;
-    std::list<Gnss_Signal> available_GAL_7X_signals_;
-    std::list<Gnss_Signal> available_GAL_E6_signals_;
-    std::list<Gnss_Signal> available_GLO_1G_signals_;
-    std::list<Gnss_Signal> available_GLO_2G_signals_;
-    std::list<Gnss_Signal> available_BDS_B1_signals_;
-    std::list<Gnss_Signal> available_BDS_B3_signals_;
+    std::unordered_map<std::string, std::list<Gnss_Signal>> available_signals_map_;
 
     enum StringValue
     {


### PR DESCRIPTION
Refactor to remove some code duplication within `gnss_flowgraph.cc`.
Move the available PRN lists to a `std::unordered_map` to remove duplicating code for each signal.

The motivation behind this change is to simplify supporting new signals, and to simplify fixing bugs within this file.
Another pull request is coming after this one to fix a bug where a satellite can be tracked multiple times (I want to keep both PRs separated to make the bug fix easier to review).
