### PR TITLE
Fix tracking same PRN multiple times

### DIFF
--- a/src/core/receiver/gnss_flowgraph.cc
+++ b/src/core/receiver/gnss_flowgraph.cc
@@ -2187,6 +2187,14 @@ Gnss_Signal GNSSFlowgraph::search_next_signal(const std::string& searched_signal
     std::string assist_signal = "";
     auto& available_signals = available_signals_map_.at(searched_signal);
 
+    if (available_signals.empty())
+        {
+            const auto& entry = signal_mapping.at(searched_signal);
+            const auto& gnss_system_str = entry.first;
+            const auto& signal_pretty_str = entry.second;
+            throw std::runtime_error("More ACQUISITION channels than PRNs for signal " + gnss_system_str + " " + signal_pretty_str);
+        }
+
     switch (mapStringValues_[searched_signal])
         {
         case evGPS_2S:
@@ -2245,7 +2253,6 @@ Gnss_Signal GNSSFlowgraph::search_next_signal(const std::string& searched_signal
         {
             result = available_signals.front();
             available_signals.pop_front();
-            available_signals.push_back(result);
         }
 
     return result;


### PR DESCRIPTION
It is currently possible to track the same PRN multiple times.
It has more chances of happening when the number of acquisition channels is close to the number of PRN for a given signal. 

This is a bit of a convoluted example in order to reproduce, but if you assign 30 acquisition channels and track GPS L1/CA, it's easy to reproduce:
```
New GPS NAV message received in channel 10: subframe 4 from satellite GPS PRN 11 (Block III) with CN0=54 dB-Hz
New GPS NAV message received in channel 25: subframe 4 from satellite GPS PRN 06 (Block IIF) with CN0=56 dB-Hz
New GPS NAV message received in channel 19: subframe 4 from satellite GPS PRN 09 (Block IIF) with CN0=50 dB-Hz
New GPS NAV message received in channel 24: subframe 4 from satellite GPS PRN 11 (Block III) with CN0=54 dB-Hz
New GPS NAV message received in channel 11: subframe 4 from satellite GPS PRN 04 (Block III) with CN0=47 dB-Hz
New GPS NAV message received in channel 17: subframe 4 from satellite GPS PRN 19 (Block IIR) with CN0=51 dB-Hz
New GPS NAV message received in channel 2: subframe 4 from satellite GPS PRN 29 (Block IIR-M) with CN0=46 dB-Hz
New GPS NAV message received in channel 20: subframe 4 from satellite GPS PRN 12 (Block IIR-M) with CN0=55 dB-Hz
New GPS NAV message received in channel 9: subframe 4 from satellite GPS PRN 04 (Block III) with CN0=47 dB-Hz
New GPS NAV message received in channel 13: subframe 4 from satellite GPS PRN 05 (Block IIR-M) with CN0=51 dB-Hz
New GPS NAV message received in channel 8: subframe 4 from satellite GPS PRN 09 (Block IIF) with CN0=50 dB-Hz
New GPS NAV message received in channel 15: subframe 4 from satellite GPS PRN 05 (Block IIR-M) with CN0=51 dB-Hz
New GPS NAV message received in channel 0: subframe 4 from satellite GPS PRN 25 (Block IIF) with CN0=48 dB-Hz
New GPS NAV message received in channel 7: subframe 4 from satellite GPS PRN 25 (Block IIF) with CN0=48 dB-Hz
New GPS NAV message received in channel 1: subframe 4 from satellite GPS PRN 06 (Block IIF) with CN0=56 dB-Hz
```

When we search for a given PRN, we should not put the PRN back in the available PRN list right away.

Result after the changes:
```
New GPS NAV message received in channel 0: subframe 4 from satellite GPS PRN 06 (Block IIF) with CN0=56 dB-Hz
New GPS NAV message received in channel 16: subframe 4 from satellite GPS PRN 25 (Block IIF) with CN0=48 dB-Hz
New GPS NAV message received in channel 22: subframe 4 from satellite GPS PRN 09 (Block IIF) with CN0=50 dB-Hz
New GPS NAV message received in channel 10: subframe 4 from satellite GPS PRN 05 (Block IIR-M) with CN0=51 dB-Hz
New GPS NAV message received in channel 17: subframe 4 from satellite GPS PRN 12 (Block IIR-M) with CN0=55 dB-Hz
New GPS NAV message received in channel 1: subframe 4 from satellite GPS PRN 20 (Block IIR) with CN0=57 dB-Hz
New GPS NAV message received in channel 12: subframe 4 from satellite GPS PRN 29 (Block IIR-M) with CN0=46 dB-Hz
New GPS NAV message received in channel 20: subframe 4 from satellite GPS PRN 04 (Block III) with CN0=47 dB-Hz
New GPS NAV message received in channel 13: subframe 4 from satellite GPS PRN 11 (Block III) with CN0=54 dB-Hz
New GPS NAV message received in channel 2: subframe 4 from satellite GPS PRN 19 (Block IIR) with CN0=51 dB-Hz
```