### PR TITLE
Cleanup gnss block factory

### DIFF
--- a/src/core/receiver/gnss_block_factory.cc
+++ b/src/core/receiver/gnss_block_factory.cc
@@ -240,6 +240,501 @@ auto findRole(ConfigurationInterface const* configuration, std::string const& ba
         }
     return role;
 };
+
+const auto signal_mapping = std::unordered_map<std::string, std::string>{
+    {"1C", "GPS L1 C/A"},
+    {"2S", "GPS L2C (M)"},
+    {"L5", "GPS L5"},
+    {"1B", "GALILEO E1 B (I/NAV OS)"},
+    {"5X", "GALILEO E5a I (F/NAV OS)"},
+    {"E6", "GALILEO E6 (B/C HAS)"},
+    {"1G", "GLONASS L1 C/A"},
+    {"2G", "GLONASS L2 C/A"},
+    {"B1", "BEIDOU B1I"},
+    {"B3", "BEIDOU B3I"},
+    {"7X", "GALILEO E5b I (I/NAV OS)"},
+};
+
+unsigned int get_channel_count(const ConfigurationInterface* configuration)
+{
+    unsigned int channel_count = 0;
+
+    for (const auto& entry : signal_mapping)
+        {
+            const auto& signal_str = entry.first;
+            channel_count += configuration->property("Channels_" + signal_str + ".count", 0);
+        }
+
+    return channel_count;
+}
+
+template <typename F>
+auto get_block(
+    const ConfigurationInterface* configuration,
+    const std::string& role,
+    unsigned int in_streams,
+    unsigned int out_streams,
+    F get_block_func)
+{
+    const std::string implementation = configuration->property(role + impl_prop, "Wrong"s);
+    auto block = get_block_func(implementation, configuration, role, in_streams, out_streams);
+
+    if (!block)
+        {
+            std::cerr << "Configuration error in " << role << " block: implementation " << (implementation == "Wrong"s ? "not defined."s : implementation + " not available."s) << '\n';
+        }
+
+    return block;
+}
+
+std::unique_ptr<SignalSourceInterface> get_signal_source_block(
+    const std::string& implementation,
+    const ConfigurationInterface* configuration,
+    const std::string& role,
+    unsigned int in_streams,
+    unsigned int out_streams,
+    Concurrent_Queue<pmt::pmt_t>* queue)
+{
+    if (implementation == "Fifo_Signal_Source")
+        {
+            return std::make_unique<FifoSignalSource>(configuration, role, in_streams, out_streams, queue);
+        }
+    else if (implementation == "File_Signal_Source")
+        {
+            return std::make_unique<FileSignalSource>(configuration, role, in_streams, out_streams, queue);
+        }
+    else if (implementation == "File_Timestamp_Signal_Source")
+        {
+            return std::make_unique<FileTimestampSignalSource>(configuration, role, in_streams, out_streams, queue);
+        }
+    else if (implementation == "Multichannel_File_Signal_Source")
+        {
+            return std::make_unique<MultichannelFileSignalSource>(configuration, role, in_streams, out_streams, queue);
+        }
+#if RAW_UDP
+    else if (implementation == "Custom_UDP_Signal_Source")
+        {
+            return std::make_unique<CustomUDPSignalSource>(configuration, role, in_streams, out_streams, queue);
+        }
+#endif
+    else if (implementation == "Nsr_File_Signal_Source")
+        {
+            return std::make_unique<NsrFileSignalSource>(configuration, role, in_streams, out_streams, queue);
+        }
+    else if (implementation == "Two_Bit_Cpx_File_Signal_Source")
+        {
+            return std::make_unique<TwoBitCpxFileSignalSource>(configuration, role, in_streams, out_streams, queue);
+        }
+    else if (implementation == "Four_Bit_Cpx_File_Signal_Source")
+        {
+            return std::make_unique<FourBitCpxFileSignalSource>(configuration, role, in_streams, out_streams, queue);
+        }
+    else if (implementation == "Two_Bit_Packed_File_Signal_Source")
+        {
+            return std::make_unique<TwoBitPackedFileSignalSource>(configuration, role, in_streams, out_streams, queue);
+        }
+    else if (implementation == "Spir_File_Signal_Source")
+        {
+            return std::make_unique<SpirFileSignalSource>(configuration, role, in_streams, out_streams, queue);
+        }
+    else if (implementation == "Spir_GSS6450_File_Signal_Source")
+        {
+            return std::make_unique<SpirGSS6450FileSignalSource>(configuration, role, in_streams, out_streams, queue);
+        }
+    else if (implementation == "RtlTcp_Signal_Source")
+        {
+            return std::make_unique<RtlTcpSignalSource>(configuration, role, in_streams, out_streams, queue);
+        }
+    else if (implementation == "Labsat_Signal_Source")
+        {
+            return std::make_unique<LabsatSignalSource>(configuration, role, in_streams, out_streams, queue);
+        }
+#if UHD_DRIVER
+    else if (implementation == "UHD_Signal_Source")
+        {
+            return std::make_unique<UhdSignalSource>(configuration, role, in_streams, out_streams, queue);
+        }
+#endif
+#if ENABLE_ION_SOURCE
+    else if (implementation == "ION_GSMS_Signal_Source")
+        {
+            return std::make_unique<IONGSMSSignalSource>(configuration, role, in_streams, out_streams, queue);
+        }
+#endif
+#if RAW_ARRAY_DRIVER
+    else if (implementation == "Raw_Array_Signal_Source")
+        {
+            return std::make_unique<RawArraySignalSource>(configuration, role, in_streams, out_streams, queue);
+        }
+#endif
+
+#if OSMOSDR_DRIVER
+    else if (implementation == "Osmosdr_Signal_Source")
+        {
+            return std::make_unique<OsmosdrSignalSource>(configuration, role, in_streams, out_streams, queue);
+        }
+#endif
+
+#if LIMESDR_DRIVER
+    else if (implementation == "Limesdr_Signal_Source")
+        {
+            return std::make_unique<LimesdrSignalSource>(configuration, role, in_streams, out_streams, queue);
+        }
+#endif
+
+#if PLUTOSDR_DRIVER
+    else if (implementation == "Plutosdr_Signal_Source")
+        {
+            return std::make_unique<PlutosdrSignalSource>(configuration, role, in_streams, out_streams, queue);
+        }
+#endif
+#if PLUTOSDR_DRIVER || AD936X_SDR_DRIVER
+    else if (implementation == "Ad936x_Custom_Signal_Source")
+        {
+            return std::make_unique<Ad936xCustomSignalSource>(configuration, role, in_streams, out_streams, queue);
+        }
+#endif
+
+#if FMCOMMS2_DRIVER
+    else if (implementation == "Fmcomms2_Signal_Source")
+        {
+            return std::make_unique<Fmcomms2SignalSource>(configuration, role, in_streams, out_streams, queue);
+        }
+#endif
+
+#if FLEXIBAND_DRIVER
+    else if (implementation == "Flexiband_Signal_Source")
+        {
+            return std::make_unique<FlexibandSignalSource>(configuration, role, in_streams, out_streams, queue);
+        }
+#endif
+
+#if ENABLE_FPGA and AD9361_DRIVER
+    else if (implementation == "ADRV9361_Z7035_Signal_Source_FPGA")
+        {
+            return std::make_unique<Adrv9361z7035SignalSourceFPGA>(configuration, role, in_streams, out_streams, queue);
+        }
+    else if (implementation == "FMCOMMS5_Signal_Source_FPGA")
+        {
+            return std::make_unique<Fmcomms5SignalSourceFPGA>(configuration, role, in_streams, out_streams, queue);
+        }
+#endif
+
+#if ENABLE_FPGA and MAX2771_DRIVER
+    else if (implementation == "MAX2771_EVKIT_Signal_Source_FPGA")
+        {
+            return std::make_unique<MAX2771EVKITSignalSourceFPGA>(configuration, role, in_streams, out_streams, queue);
+        }
+#endif
+
+#if ENABLE_FPGA and DMA_PROXY_DRIVER
+    else if (implementation == "DMA_Signal_Source_FPGA")
+        {
+            return std::make_unique<DMASignalSourceFPGA>(configuration, role, in_streams, out_streams, queue);
+        }
+#endif
+
+#if ZEROMQ_DRIVER
+    else if (implementation == "ZMQ_Signal_Source")
+        {
+            return std::make_unique<ZmqSignalSource>(configuration, role, in_streams, out_streams, queue);
+        }
+#endif
+
+    return nullptr;
+}
+
+std::unique_ptr<AcquisitionInterface> get_acq_block(
+    const std::string& implementation,
+    const ConfigurationInterface* configuration,
+    const std::string& role,
+    unsigned int in_streams,
+    unsigned int out_streams)
+{
+    // ACQUISITION BLOCKS ------------------------------------------------------
+    if (implementation == "GPS_L1_CA_PCPS_Acquisition")
+        {
+            return std::make_unique<GpsL1CaPcpsAcquisition>(configuration, role, in_streams, out_streams);
+        }
+    else if (implementation == "GPS_L1_CA_PCPS_Assisted_Acquisition")
+        {
+            return std::make_unique<GpsL1CaPcpsAssistedAcquisition>(configuration, role, in_streams, out_streams);
+        }
+    else if (implementation == "GPS_L1_CA_PCPS_Tong_Acquisition")
+        {
+            return std::make_unique<GpsL1CaPcpsTongAcquisition>(configuration, role, in_streams, out_streams);
+        }
+    else if (implementation == "GPS_L1_CA_PCPS_Acquisition_Fine_Doppler")
+        {
+            return std::make_unique<GpsL1CaPcpsAcquisitionFineDoppler>(configuration, role, in_streams, out_streams);
+        }
+    else if (implementation == "GPS_L1_CA_PCPS_QuickSync_Acquisition")
+        {
+            return std::make_unique<GpsL1CaPcpsQuickSyncAcquisition>(configuration, role, in_streams, out_streams);
+        }
+    else if (implementation == "GPS_L2_M_PCPS_Acquisition")
+        {
+            return std::make_unique<GpsL2MPcpsAcquisition>(configuration, role, in_streams, out_streams);
+        }
+    else if (implementation == "GPS_L5i_PCPS_Acquisition")
+        {
+            return std::make_unique<GpsL5iPcpsAcquisition>(configuration, role, in_streams, out_streams);
+        }
+    else if (implementation == "Galileo_E1_PCPS_Ambiguous_Acquisition")
+        {
+            return std::make_unique<GalileoE1PcpsAmbiguousAcquisition>(configuration, role, in_streams, out_streams);
+        }
+    else if (implementation == "Galileo_E1_PCPS_8ms_Ambiguous_Acquisition")
+        {
+            return std::make_unique<GalileoE1Pcps8msAmbiguousAcquisition>(configuration, role, in_streams, out_streams);
+        }
+    else if (implementation == "Galileo_E1_PCPS_Tong_Ambiguous_Acquisition")
+        {
+            return std::make_unique<GalileoE1PcpsTongAmbiguousAcquisition>(configuration, role, in_streams, out_streams);
+        }
+    else if (implementation == "Galileo_E1_PCPS_CCCWSR_Ambiguous_Acquisition")
+        {
+            return std::make_unique<GalileoE1PcpsCccwsrAmbiguousAcquisition>(configuration, role, in_streams, out_streams);
+        }
+
+    else if (implementation == "Galileo_E1_PCPS_QuickSync_Ambiguous_Acquisition")
+        {
+            return std::make_unique<GalileoE1PcpsQuickSyncAmbiguousAcquisition>(configuration, role, in_streams, out_streams);
+        }
+    else if (implementation == "Galileo_E5a_Noncoherent_IQ_Acquisition_CAF")
+        {
+            return std::make_unique<GalileoE5aNoncoherentIQAcquisitionCaf>(configuration, role, in_streams, out_streams);
+        }
+    else if (implementation == "Galileo_E5a_Pcps_Acquisition")
+        {
+            return std::make_unique<GalileoE5aPcpsAcquisition>(configuration, role, in_streams, out_streams);
+        }
+    else if (implementation == "Galileo_E5b_PCPS_Acquisition")
+        {
+            return std::make_unique<GalileoE5bPcpsAcquisition>(configuration, role, in_streams, out_streams);
+        }
+    else if (implementation == "Galileo_E6_PCPS_Acquisition")
+        {
+            return std::make_unique<GalileoE6PcpsAcquisition>(configuration, role, in_streams, out_streams);
+        }
+    else if (implementation == "GLONASS_L1_CA_PCPS_Acquisition")
+        {
+            return std::make_unique<GlonassL1CaPcpsAcquisition>(configuration, role, in_streams, out_streams);
+        }
+    else if (implementation == "GLONASS_L2_CA_PCPS_Acquisition")
+        {
+            return std::make_unique<GlonassL2CaPcpsAcquisition>(configuration, role, in_streams, out_streams);
+        }
+    else if (implementation == "BEIDOU_B1I_PCPS_Acquisition")
+        {
+            return std::make_unique<BeidouB1iPcpsAcquisition>(configuration, role, in_streams, out_streams);
+        }
+    else if (implementation == "BEIDOU_B3I_PCPS_Acquisition")
+        {
+            return std::make_unique<BeidouB3iPcpsAcquisition>(configuration, role, in_streams, out_streams);
+        }
+#if OPENCL_BLOCKS
+    else if (implementation == "GPS_L1_CA_PCPS_OpenCl_Acquisition")
+        {
+            return std::make_unique<GpsL1CaPcpsOpenClAcquisition>(configuration, role, in_streams, out_streams);
+        }
+#endif
+#if ENABLE_FPGA
+    else if (implementation == "GPS_L1_CA_PCPS_Acquisition_FPGA")
+        {
+            return std::make_unique<GpsL1CaPcpsAcquisitionFpga>(configuration, role, in_streams, out_streams);
+        }
+    else if (implementation == "Galileo_E1_PCPS_Ambiguous_Acquisition_FPGA")
+        {
+            return std::make_unique<GalileoE1PcpsAmbiguousAcquisitionFpga>(configuration, role, in_streams, out_streams);
+        }
+    else if (implementation == "GPS_L2_M_PCPS_Acquisition_FPGA")
+        {
+            return std::make_unique<GpsL2MPcpsAcquisitionFpga>(configuration, role, in_streams, out_streams);
+        }
+    else if (implementation == "GPS_L5i_PCPS_Acquisition_FPGA")
+        {
+            return std::make_unique<GpsL5iPcpsAcquisitionFpga>(configuration, role, in_streams, out_streams);
+        }
+    else if (implementation == "Galileo_E5a_Pcps_Acquisition_FPGA")
+        {
+            return std::make_unique<GalileoE5aPcpsAcquisitionFpga>(configuration, role, in_streams, out_streams);
+        }
+    else if (implementation == "Galileo_E5b_PCPS_Acquisition_FPGA")
+        {
+            return std::make_unique<GalileoE5bPcpsAcquisitionFpga>(configuration, role, in_streams, out_streams);
+        }
+#endif
+
+    return nullptr;
+}
+
+std::unique_ptr<TrackingInterface> get_trk_block(
+    const std::string& implementation,
+    const ConfigurationInterface* configuration,
+    const std::string& role,
+    unsigned int in_streams,
+    unsigned int out_streams)
+{
+    if (implementation == "GPS_L1_CA_DLL_PLL_Tracking")
+        {
+            return std::make_unique<GpsL1CaDllPllTracking>(configuration, role, in_streams, out_streams);
+        }
+    else if (implementation == "GPS_L1_CA_Gaussian_Tracking")
+        {
+            return std::make_unique<GpsL1CaGaussianTracking>(configuration, role, in_streams, out_streams);
+        }
+    else if (implementation == "GPS_L1_CA_KF_Tracking")
+        {
+            return std::make_unique<GpsL1CaKfTracking>(configuration, role, in_streams, out_streams);
+        }
+    else if (implementation == "GPS_L1_CA_TCP_CONNECTOR_Tracking")
+        {
+            return std::make_unique<GpsL1CaTcpConnectorTracking>(configuration, role, in_streams, out_streams);
+        }
+    else if (implementation == "Galileo_E1_DLL_PLL_VEML_Tracking")
+        {
+            return std::make_unique<GalileoE1DllPllVemlTracking>(configuration, role, in_streams, out_streams);
+        }
+    else if (implementation == "Galileo_E1_TCP_CONNECTOR_Tracking")
+        {
+            return std::make_unique<GalileoE1TcpConnectorTracking>(configuration, role, in_streams, out_streams);
+        }
+    else if (implementation == "Galileo_E5a_DLL_PLL_Tracking")
+        {
+            return std::make_unique<GalileoE5aDllPllTracking>(configuration, role, in_streams, out_streams);
+        }
+    else if (implementation == "Galileo_E5b_DLL_PLL_Tracking")
+        {
+            return std::make_unique<GalileoE5bDllPllTracking>(configuration, role, in_streams, out_streams);
+        }
+    else if (implementation == "Galileo_E6_DLL_PLL_Tracking")
+        {
+            return std::make_unique<GalileoE6DllPllTracking>(configuration, role, in_streams, out_streams);
+        }
+    else if (implementation == "GPS_L2_M_DLL_PLL_Tracking")
+        {
+            return std::make_unique<GpsL2MDllPllTracking>(configuration, role, in_streams, out_streams);
+        }
+    else if ((implementation == "GPS_L5i_DLL_PLL_Tracking") or (implementation == "GPS_L5_DLL_PLL_Tracking"))
+        {
+            return std::make_unique<GpsL5DllPllTracking>(configuration, role, in_streams, out_streams);
+        }
+    else if (implementation == "GLONASS_L1_CA_DLL_PLL_Tracking")
+        {
+            return std::make_unique<GlonassL1CaDllPllTracking>(configuration, role, in_streams, out_streams);
+        }
+    else if (implementation == "GLONASS_L1_CA_DLL_PLL_C_Aid_Tracking")
+        {
+            return std::make_unique<GlonassL1CaDllPllCAidTracking>(configuration, role, in_streams, out_streams);
+        }
+    else if (implementation == "GLONASS_L2_CA_DLL_PLL_Tracking")
+        {
+            return std::make_unique<GlonassL2CaDllPllTracking>(configuration, role, in_streams, out_streams);
+        }
+    else if (implementation == "GLONASS_L2_CA_DLL_PLL_C_Aid_Tracking")
+        {
+            return std::make_unique<GlonassL2CaDllPllCAidTracking>(configuration, role, in_streams, out_streams);
+        }
+    else if (implementation == "BEIDOU_B1I_DLL_PLL_Tracking")
+        {
+            return std::make_unique<BeidouB1iDllPllTracking>(configuration, role, in_streams, out_streams);
+        }
+    else if (implementation == "BEIDOU_B3I_DLL_PLL_Tracking")
+        {
+            return std::make_unique<BeidouB3iDllPllTracking>(configuration, role, in_streams, out_streams);
+        }
+#if CUDA_GPU_ACCEL
+    else if (implementation == "GPS_L1_CA_DLL_PLL_Tracking_GPU")
+        {
+            return std::make_unique<GpsL1CaDllPllTrackingGPU>(configuration, role, in_streams, out_streams);
+        }
+#endif
+#if ENABLE_FPGA
+    else if (implementation == "GPS_L1_CA_DLL_PLL_Tracking_FPGA")
+        {
+            return std::make_unique<GpsL1CaDllPllTrackingFpga>(configuration, role, in_streams, out_streams);
+        }
+    else if (implementation == "Galileo_E1_DLL_PLL_VEML_Tracking_FPGA")
+        {
+            return std::make_unique<GalileoE1DllPllVemlTrackingFpga>(configuration, role, in_streams, out_streams);
+        }
+    else if (implementation == "GPS_L2_M_DLL_PLL_Tracking_FPGA")
+        {
+            return std::make_unique<GpsL2MDllPllTrackingFpga>(configuration, role, in_streams, out_streams);
+        }
+    else if ((implementation == "GPS_L5i_DLL_PLL_Tracking_FPGA") or (implementation == "GPS_L5_DLL_PLL_Tracking_FPGA"))
+        {
+            return std::make_unique<GpsL5DllPllTrackingFpga>(configuration, role, in_streams, out_streams);
+        }
+    else if (implementation == "Galileo_E5a_DLL_PLL_Tracking_FPGA")
+        {
+            return std::make_unique<GalileoE5aDllPllTrackingFpga>(configuration, role, in_streams, out_streams);
+        }
+#endif
+
+    return nullptr;
+}
+
+std::unique_ptr<TelemetryDecoderInterface> get_tlm_block(
+    const std::string& implementation,
+    const ConfigurationInterface* configuration,
+    const std::string& role,
+    unsigned int in_streams,
+    unsigned int out_streams)
+{
+    if (implementation == "GPS_L1_CA_Telemetry_Decoder")
+        {
+            return std::make_unique<GpsL1CaTelemetryDecoder>(configuration, role, in_streams, out_streams);
+        }
+    else if (implementation == "Galileo_E1B_Telemetry_Decoder")
+        {
+            return std::make_unique<GalileoE1BTelemetryDecoder>(configuration, role, in_streams, out_streams);
+        }
+    else if (implementation == "SBAS_L1_Telemetry_Decoder")
+        {
+            return std::make_unique<SbasL1TelemetryDecoder>(configuration, role, in_streams, out_streams);
+        }
+    else if (implementation == "Galileo_E5a_Telemetry_Decoder")
+        {
+            return std::make_unique<GalileoE5aTelemetryDecoder>(configuration, role, in_streams, out_streams);
+        }
+    else if (implementation == "Galileo_E5b_Telemetry_Decoder")
+        {
+            return std::make_unique<GalileoE5bTelemetryDecoder>(configuration, role, in_streams, out_streams);
+        }
+    else if (implementation == "Galileo_E6_Telemetry_Decoder")
+        {
+            return std::make_unique<GalileoE6TelemetryDecoder>(configuration, role, in_streams, out_streams);
+        }
+    else if (implementation == "GPS_L2C_Telemetry_Decoder")
+        {
+            return std::make_unique<GpsL2CTelemetryDecoder>(configuration, role, in_streams, out_streams);
+        }
+    else if (implementation == "GLONASS_L1_CA_Telemetry_Decoder")
+        {
+            return std::make_unique<GlonassL1CaTelemetryDecoder>(configuration, role, in_streams, out_streams);
+        }
+    else if (implementation == "GLONASS_L2_CA_Telemetry_Decoder")
+        {
+            return std::make_unique<GlonassL2CaTelemetryDecoder>(configuration, role, in_streams, out_streams);
+        }
+    else if (implementation == "GPS_L5_Telemetry_Decoder")
+        {
+            return std::make_unique<GpsL5TelemetryDecoder>(configuration, role, in_streams, out_streams);
+        }
+    else if (implementation == "BEIDOU_B1I_Telemetry_Decoder")
+        {
+            return std::make_unique<BeidouB1iTelemetryDecoder>(configuration, role, in_streams, out_streams);
+        }
+    else if (implementation == "BEIDOU_B3I_Telemetry_Decoder")
+        {
+            return std::make_unique<BeidouB3iTelemetryDecoder>(configuration, role, in_streams, out_streams);
+        }
+
+    return nullptr;
+}
+
 }  // namespace
 
 
@@ -249,8 +744,7 @@ std::unique_ptr<SignalSourceInterface> GNSSBlockFactory::GetSignalSource(
     auto role = findRole(configuration, "SignalSource"s, ID);
     auto implementation = configuration->property(role + impl_prop, ""s);
     LOG(INFO) << "Getting SignalSource " << role << " with implementation " << implementation;
-
-    return dynamic_unique_cast<SignalSourceInterface>(GetBlock(configuration, role, 0, 1, queue));
+    return get_signal_source_block(implementation, configuration, role, 0, 1, queue);
 }
 
 
@@ -267,7 +761,6 @@ std::unique_ptr<GNSSBlockInterface> GNSSBlockFactory::GetSignalConditioner(
     DLOG(INFO) << "role: " << role_conditioner << " (ID=" << ID << ")";
 
     const std::string signal_conditioner = configuration->property(role_conditioner + impl_prop, ""s);
-
     const std::string data_type_adapter = configuration->property(role_datatypeadapter + impl_prop, ""s);
     const std::string input_filter = configuration->property(role_inputfilter + impl_prop, ""s);
     const std::string resampler = configuration->property(role_resampler + impl_prop, ""s);
@@ -297,9 +790,7 @@ std::unique_ptr<GNSSBlockInterface> GNSSBlockFactory::GetSignalConditioner(
                 }
             LOG(INFO) << "Getting " << role_conditioner << " with Pass_Through implementation";
 
-            std::unique_ptr<GNSSBlockInterface> conditioner_ = std::make_unique<Pass_Through>(configuration, role_conditioner, 1, 1);
-
-            return conditioner_;
+            return std::make_unique<Pass_Through>(configuration, role_conditioner, 1, 1);
         }
 
     LOG(INFO) << "Getting " << role_conditioner << " with " << role_datatypeadapter << " implementation: "
@@ -310,12 +801,11 @@ std::unique_ptr<GNSSBlockInterface> GNSSBlockFactory::GetSignalConditioner(
     if (signal_conditioner == "Array_Signal_Conditioner")
         {
             // instantiate the array version
-            std::unique_ptr<GNSSBlockInterface> conditioner_ = std::make_unique<ArraySignalConditioner>(
+            return std::make_unique<ArraySignalConditioner>(
                 GetBlock(configuration, role_datatypeadapter, 1, 1),
                 GetBlock(configuration, role_inputfilter, 1, 1),
                 GetBlock(configuration, role_resampler, 1, 1),
                 role_conditioner);
-            return conditioner_;
         }
 
     if (signal_conditioner != "Signal_Conditioner")
@@ -325,12 +815,11 @@ std::unique_ptr<GNSSBlockInterface> GNSSBlockFactory::GetSignalConditioner(
         }
 
     // single-antenna version
-    std::unique_ptr<GNSSBlockInterface> conditioner_ = std::make_unique<SignalConditioner>(
+    return std::make_unique<SignalConditioner>(
         GetBlock(configuration, role_datatypeadapter, 1, 1),
         GetBlock(configuration, role_inputfilter, 1, 1),
         GetBlock(configuration, role_resampler, 1, 1),
         role_conditioner);
-    return conditioner_;
 }
 
 
@@ -344,28 +833,9 @@ std::unique_ptr<GNSSBlockInterface> GNSSBlockFactory::GetObservables(const Confi
             std::cerr << "Error in configuration file: please set Observables.implementation=Hybrid_Observables\n";
             return nullptr;
         }
-    unsigned int Galileo_channels = configuration->property("Channels_1B.count", 0);
-    Galileo_channels += configuration->property("Channels_5X.count", 0);
-    Galileo_channels += configuration->property("Channels_7X.count", 0);
-    Galileo_channels += configuration->property("Channels_E6.count", 0);
-    unsigned int GPS_channels = configuration->property("Channels_1C.count", 0);
-    GPS_channels += configuration->property("Channels_2S.count", 0);
-    GPS_channels += configuration->property("Channels_L5.count", 0);
-    unsigned int Glonass_channels = configuration->property("Channels_1G.count", 0);
-    Glonass_channels += configuration->property("Channels_2G.count", 0);
-    unsigned int Beidou_channels = configuration->property("Channels_B1.count", 0);
-    Beidou_channels += configuration->property("Channels_B3.count", 0);
-    unsigned int extra_channels = 1;  // For monitor channel sample counter
-    return GetBlock(configuration, "Observables",
-        Galileo_channels +
-            GPS_channels +
-            Glonass_channels +
-            Beidou_channels +
-            extra_channels,
-        Galileo_channels +
-            GPS_channels +
-            Glonass_channels +
-            Beidou_channels);
+
+    const auto channel_count = get_channel_count(configuration);
+    return GetBlock(configuration, "Observables", channel_count + 1, channel_count);  // 1 for monitor channel sample counter
 }
 
 
@@ -379,19 +849,9 @@ std::unique_ptr<GNSSBlockInterface> GNSSBlockFactory::GetPVT(const Configuration
             std::cerr << "Error in configuration file: please set PVT.implementation=RTKLIB_PVT\n";
             return nullptr;
         }
-    unsigned int Galileo_channels = configuration->property("Channels_1B.count", 0);
-    Galileo_channels += configuration->property("Channels_5X.count", 0);
-    Galileo_channels += configuration->property("Channels_7X.count", 0);
-    Galileo_channels += configuration->property("Channels_E6.count", 0);
-    unsigned int GPS_channels = configuration->property("Channels_1C.count", 0);
-    GPS_channels += configuration->property("Channels_2S.count", 0);
-    GPS_channels += configuration->property("Channels_L5.count", 0);
-    unsigned int Glonass_channels = configuration->property("Channels_1G.count", 0);
-    Glonass_channels += configuration->property("Channels_2G.count", 0);
-    unsigned int Beidou_channels = configuration->property("Channels_B1.count", 0);
-    Beidou_channels += configuration->property("Channels_B3.count", 0);
-    return GetBlock(configuration, "PVT",
-        Galileo_channels + GPS_channels + Glonass_channels + Beidou_channels, 0);
+
+    const auto channel_count = get_channel_count(configuration);
+    return GetBlock(configuration, "PVT", channel_count, 0);
 }
 
 
@@ -467,180 +927,28 @@ std::unique_ptr<GNSSBlockInterface> GNSSBlockFactory::GetChannel(
 }
 
 
-std::unique_ptr<std::vector<std::unique_ptr<GNSSBlockInterface>>> GNSSBlockFactory::GetChannels(
+std::vector<std::unique_ptr<GNSSBlockInterface>> GNSSBlockFactory::GetChannels(
     const ConfigurationInterface* configuration,
     Concurrent_Queue<pmt::pmt_t>* queue)
 {
     int channel_absolute_id = 0;
+    std::vector<std::unique_ptr<GNSSBlockInterface>> channels(get_channel_count(configuration));
 
-    const unsigned int Channels_1C_count = configuration->property("Channels_1C.count", 0);
-    const unsigned int Channels_1B_count = configuration->property("Channels_1B.count", 0);
-    const unsigned int Channels_1G_count = configuration->property("Channels_1G.count", 0);
-    const unsigned int Channels_2G_count = configuration->property("Channels_2G.count", 0);
-    const unsigned int Channels_2S_count = configuration->property("Channels_2S.count", 0);
-    const unsigned int Channels_5X_count = configuration->property("Channels_5X.count", 0);
-    const unsigned int Channels_L5_count = configuration->property("Channels_L5.count", 0);
-    const unsigned int Channels_B1_count = configuration->property("Channels_B1.count", 0);
-    const unsigned int Channels_B3_count = configuration->property("Channels_B3.count", 0);
-    const unsigned int Channels_7X_count = configuration->property("Channels_7X.count", 0);
-    const unsigned int Channels_E6_count = configuration->property("Channels_E6.count", 0);
-
-    const unsigned int total_channels = Channels_1C_count +
-                                        Channels_1B_count +
-                                        Channels_1G_count +
-                                        Channels_2S_count +
-                                        Channels_2G_count +
-                                        Channels_5X_count +
-                                        Channels_L5_count +
-                                        Channels_B1_count +
-                                        Channels_B3_count +
-                                        Channels_7X_count +
-                                        Channels_E6_count;
-
-    auto channels = std::make_unique<std::vector<std::unique_ptr<GNSSBlockInterface>>>(total_channels);
     try
         {
-            // **************** GPS L1 C/A CHANNELS ****************************
-            LOG(INFO) << "Getting " << Channels_1C_count << " GPS L1 C/A channels";
-
-            for (unsigned int i = 0; i < Channels_1C_count; i++)
+            for (const auto& entry : signal_mapping)
                 {
-                    // Store the channel into the vector of channels
-                    channels->at(channel_absolute_id) = GetChannel(configuration,
-                        std::string("1C"),
-                        channel_absolute_id,
-                        queue);
-                    channel_absolute_id++;
-                }
+                    const auto& signal_str = entry.first;
+                    const auto& signal_pretty_str = entry.second;
+                    const auto channel_count = static_cast<unsigned int>(configuration->property("Channels_" + signal_str + ".count", 0));
+                    LOG(INFO) << "Getting " << channel_count << " " << signal_pretty_str << " channels";
 
-            // **************** GPS L2C (M) CHANNELS ***************************
-            LOG(INFO) << "Getting " << Channels_2S_count << " GPS L2C (M) channels";
-
-            for (unsigned int i = 0; i < Channels_2S_count; i++)
-                {
-                    // Store the channel into the vector of channels
-                    channels->at(channel_absolute_id) = GetChannel(configuration,
-                        std::string("2S"),
-                        channel_absolute_id,
-                        queue);
-                    channel_absolute_id++;
-                }
-
-            // **************** GPS L5 CHANNELS ********************************
-            LOG(INFO) << "Getting " << Channels_L5_count << " GPS L5 channels";
-
-            for (unsigned int i = 0; i < Channels_L5_count; i++)
-                {
-                    // Store the channel into the vector of channels
-                    channels->at(channel_absolute_id) = GetChannel(configuration,
-                        std::string("L5"),
-                        channel_absolute_id,
-                        queue);
-                    channel_absolute_id++;
-                }
-
-            // **************** GALILEO E1 B (I/NAV OS) CHANNELS ***************
-            LOG(INFO) << "Getting " << Channels_1B_count << " GALILEO E1 B (I/NAV OS) channels";
-
-            for (unsigned int i = 0; i < Channels_1B_count; i++)
-                {
-                    // Store the channel into the vector of channels
-                    channels->at(channel_absolute_id) = GetChannel(configuration,
-                        std::string("1B"),
-                        channel_absolute_id,
-                        queue);
-                    channel_absolute_id++;
-                }
-
-            // **************** GALILEO E5a I (F/NAV OS) CHANNELS **************
-            LOG(INFO) << "Getting " << Channels_5X_count << " GALILEO E5a I (F/NAV OS) channels";
-
-            for (unsigned int i = 0; i < Channels_5X_count; i++)
-                {
-                    // Store the channel into the vector of channels
-                    channels->at(channel_absolute_id) = GetChannel(configuration,
-                        std::string("5X"),
-                        channel_absolute_id,
-                        queue);
-                    channel_absolute_id++;
-                }
-
-            // **************** GALILEO E6 (B/C HAS) CHANNELS **************
-            LOG(INFO) << "Getting " << Channels_E6_count << " GALILEO E6 (B/C HAS) channels";
-
-            for (unsigned int i = 0; i < Channels_E6_count; i++)
-                {
-                    // Store the channel into the vector of channels
-                    channels->at(channel_absolute_id) = GetChannel(configuration,
-                        std::string("E6"),
-                        channel_absolute_id,
-                        queue);
-                    channel_absolute_id++;
-                }
-
-            // **************** GLONASS L1 C/A CHANNELS ************************
-            LOG(INFO) << "Getting " << Channels_1G_count << " GLONASS L1 C/A channels";
-
-            for (unsigned int i = 0; i < Channels_1G_count; i++)
-                {
-                    // Store the channel into the vector of channels
-                    channels->at(channel_absolute_id) = GetChannel(configuration,
-                        std::string("1G"),
-                        channel_absolute_id,
-                        queue);
-                    channel_absolute_id++;
-                }
-
-            // **************** GLONASS L2 C/A CHANNELS ************************
-            LOG(INFO) << "Getting " << Channels_2G_count << " GLONASS L2 C/A channels";
-
-            for (unsigned int i = 0; i < Channels_2G_count; i++)
-                {
-                    // Store the channel into the vector of channels
-                    channels->at(channel_absolute_id) = GetChannel(configuration,
-                        std::string("2G"),
-                        channel_absolute_id,
-                        queue);
-                    channel_absolute_id++;
-                }
-
-            // **************** BEIDOU B1I CHANNELS ****************************
-            LOG(INFO) << "Getting " << Channels_B1_count << " BEIDOU B1I channels";
-
-            for (unsigned int i = 0; i < Channels_B1_count; i++)
-                {
-                    // Store the channel into the vector of channels
-                    channels->at(channel_absolute_id) = GetChannel(configuration,
-                        std::string("B1"),
-                        channel_absolute_id,
-                        queue);
-                    channel_absolute_id++;
-                }
-
-            // **************** BEIDOU B3I CHANNELS ****************************
-            LOG(INFO) << "Getting " << Channels_B3_count << " BEIDOU B3I channels";
-
-            for (unsigned int i = 0; i < Channels_B3_count; i++)
-                {
-                    // Store the channel into the vector of channels
-                    channels->at(channel_absolute_id) = GetChannel(configuration,
-                        std::string("B3"),
-                        channel_absolute_id,
-                        queue);
-                    channel_absolute_id++;
-                }
-
-            // **************** GALILEO E5b I (I/NAV OS) CHANNELS **************
-            LOG(INFO) << "Getting " << Channels_7X_count << " GALILEO E5b I (I/NAV OS) channels";
-
-            for (unsigned int i = 0; i < Channels_7X_count; i++)
-                {
-                    // Store the channel into the vector of channels
-                    channels->at(channel_absolute_id) = GetChannel(configuration,
-                        std::string("7X"),
-                        channel_absolute_id,
-                        queue);
-                    channel_absolute_id++;
+                    for (unsigned int i = 0; i < channel_count; i++)
+                        {
+                            // Store the channel into the vector of channels
+                            channels.at(channel_absolute_id) = GetChannel(configuration, signal_str, channel_absolute_id, queue);
+                            ++channel_absolute_id;
+                        }
                 }
         }
     catch (const std::exception& e)
@@ -676,717 +984,111 @@ std::unique_ptr<GNSSBlockInterface> GNSSBlockFactory::GetBlock(
             // PASS THROUGH ------------------------------------------------------------
             if (implementation == "Pass_Through")
                 {
-                    std::unique_ptr<GNSSBlockInterface> block_ = std::make_unique<Pass_Through>(configuration, role, in_streams, out_streams);
-                    block = std::move(block_);
+                    block = std::make_unique<Pass_Through>(configuration, role, in_streams, out_streams);
                 }
 
             // SIGNAL SOURCES ----------------------------------------------------------
-            else if (implementation == "Fifo_Signal_Source")
+            else if ((block = get_signal_source_block(implementation, configuration, role, in_streams, out_streams, queue)))
                 {
-                    std::unique_ptr<GNSSBlockInterface> block_ = std::make_unique<FifoSignalSource>(configuration, role, in_streams,
-                        out_streams, queue);
-                    block = std::move(block_);
                 }
-            else if (implementation == "File_Signal_Source")
-                {
-                    std::unique_ptr<GNSSBlockInterface> block_ = std::make_unique<FileSignalSource>(configuration, role, in_streams,
-                        out_streams, queue);
-                    block = std::move(block_);
-                }
-            else if (implementation == "File_Timestamp_Signal_Source")
-                {
-                    std::unique_ptr<GNSSBlockInterface> block_ = std::make_unique<FileTimestampSignalSource>(configuration, role, in_streams,
-                        out_streams, queue);
-                    block = std::move(block_);
-                }
-            else if (implementation == "Multichannel_File_Signal_Source")
-                {
-                    std::unique_ptr<GNSSBlockInterface> block_ = std::make_unique<MultichannelFileSignalSource>(configuration, role, in_streams,
-                        out_streams, queue);
-                    block = std::move(block_);
-                }
-#if RAW_UDP
-            else if (implementation == "Custom_UDP_Signal_Source")
-                {
-                    std::unique_ptr<GNSSBlockInterface> block_ = std::make_unique<CustomUDPSignalSource>(configuration, role, in_streams,
-                        out_streams, queue);
-                    block = std::move(block_);
-                }
-#endif
-            else if (implementation == "Nsr_File_Signal_Source")
-                {
-                    std::unique_ptr<GNSSBlockInterface> block_ = std::make_unique<NsrFileSignalSource>(configuration, role, in_streams,
-                        out_streams, queue);
-                    block = std::move(block_);
-                }
-            else if (implementation == "Two_Bit_Cpx_File_Signal_Source")
-                {
-                    std::unique_ptr<GNSSBlockInterface> block_ = std::make_unique<TwoBitCpxFileSignalSource>(configuration, role, in_streams,
-                        out_streams, queue);
-                    block = std::move(block_);
-                }
-            else if (implementation == "Four_Bit_Cpx_File_Signal_Source")
-                {
-                    std::unique_ptr<GNSSBlockInterface> block_ = std::make_unique<FourBitCpxFileSignalSource>(configuration, role, in_streams,
-                        out_streams, queue);
-                    block = std::move(block_);
-                }
-            else if (implementation == "Two_Bit_Packed_File_Signal_Source")
-                {
-                    std::unique_ptr<GNSSBlockInterface> block_ = std::make_unique<TwoBitPackedFileSignalSource>(configuration, role, in_streams,
-                        out_streams, queue);
-                    block = std::move(block_);
-                }
-            else if (implementation == "Spir_File_Signal_Source")
-                {
-                    std::unique_ptr<GNSSBlockInterface> block_ = std::make_unique<SpirFileSignalSource>(configuration, role, in_streams,
-                        out_streams, queue);
-                    block = std::move(block_);
-                }
-            else if (implementation == "Spir_GSS6450_File_Signal_Source")
-                {
-                    std::unique_ptr<GNSSBlockInterface> block_ = std::make_unique<SpirGSS6450FileSignalSource>(configuration, role, in_streams,
-                        out_streams, queue);
-                    block = std::move(block_);
-                }
-            else if (implementation == "RtlTcp_Signal_Source")
-                {
-                    std::unique_ptr<GNSSBlockInterface> block_ = std::make_unique<RtlTcpSignalSource>(configuration, role, in_streams,
-                        out_streams, queue);
-                    block = std::move(block_);
-                }
-            else if (implementation == "Labsat_Signal_Source")
-                {
-                    std::unique_ptr<GNSSBlockInterface> block_ = std::make_unique<LabsatSignalSource>(configuration, role, in_streams,
-                        out_streams, queue);
-                    block = std::move(block_);
-                }
-#if UHD_DRIVER
-            else if (implementation == "UHD_Signal_Source")
-                {
-                    std::unique_ptr<GNSSBlockInterface> block_ = std::make_unique<UhdSignalSource>(configuration, role, in_streams,
-                        out_streams, queue);
-                    block = std::move(block_);
-                }
-#endif
-#if ENABLE_ION_SOURCE
-            else if (implementation == "ION_GSMS_Signal_Source")
-                {
-                    std::unique_ptr<GNSSBlockInterface> block_ = std::make_unique<IONGSMSSignalSource>(configuration, role, in_streams,
-                        out_streams, queue);
-                    block = std::move(block_);
-                }
-#endif
-#if RAW_ARRAY_DRIVER
-            else if (implementation == "Raw_Array_Signal_Source")
-                {
-                    std::unique_ptr<GNSSBlockInterface> block_ = std::make_unique<RawArraySignalSource>(configuration, role, in_streams,
-                        out_streams, queue);
-                    block = std::move(block_);
-                }
-#endif
-
-#if OSMOSDR_DRIVER
-            else if (implementation == "Osmosdr_Signal_Source")
-                {
-                    std::unique_ptr<GNSSBlockInterface> block_ = std::make_unique<OsmosdrSignalSource>(configuration, role, in_streams,
-                        out_streams, queue);
-                    block = std::move(block_);
-                }
-#endif
-
-#if LIMESDR_DRIVER
-            else if (implementation == "Limesdr_Signal_Source")
-                {
-                    std::unique_ptr<GNSSBlockInterface>
-                        block_ = std::make_unique<LimesdrSignalSource>(configuration, role, in_streams,
-                            out_streams, queue);
-                    block = std::move(block_);
-                }
-#endif
-
-#if PLUTOSDR_DRIVER
-            else if (implementation == "Plutosdr_Signal_Source")
-                {
-                    std::unique_ptr<GNSSBlockInterface> block_ = std::make_unique<PlutosdrSignalSource>(configuration, role, in_streams,
-                        out_streams, queue);
-                    block = std::move(block_);
-                }
-#endif
-#if PLUTOSDR_DRIVER || AD936X_SDR_DRIVER
-            else if (implementation == "Ad936x_Custom_Signal_Source")
-                {
-                    std::unique_ptr<GNSSBlockInterface> block_ = std::make_unique<Ad936xCustomSignalSource>(configuration, role, in_streams,
-                        out_streams, queue);
-                    block = std::move(block_);
-                }
-#endif
-
-#if FMCOMMS2_DRIVER
-            else if (implementation == "Fmcomms2_Signal_Source")
-                {
-                    std::unique_ptr<GNSSBlockInterface> block_ = std::make_unique<Fmcomms2SignalSource>(configuration, role, in_streams,
-                        out_streams, queue);
-                    block = std::move(block_);
-                }
-#endif
-
-#if FLEXIBAND_DRIVER
-            else if (implementation == "Flexiband_Signal_Source")
-                {
-                    std::unique_ptr<GNSSBlockInterface> block_ = std::make_unique<FlexibandSignalSource>(configuration, role, in_streams,
-                        out_streams, queue);
-                    block = std::move(block_);
-                }
-#endif
-
-#if ENABLE_FPGA and AD9361_DRIVER
-            else if (implementation == "ADRV9361_Z7035_Signal_Source_FPGA")
-                {
-                    std::unique_ptr<GNSSBlockInterface> block_ = std::make_unique<Adrv9361z7035SignalSourceFPGA>(configuration, role, in_streams,
-                        out_streams, queue);
-                    block = std::move(block_);
-                }
-            else if (implementation == "FMCOMMS5_Signal_Source_FPGA")
-                {
-                    std::unique_ptr<GNSSBlockInterface> block_ = std::make_unique<Fmcomms5SignalSourceFPGA>(configuration, role, in_streams,
-                        out_streams, queue);
-                    block = std::move(block_);
-                }
-#endif
-
-#if ENABLE_FPGA and MAX2771_DRIVER
-            else if (implementation == "MAX2771_EVKIT_Signal_Source_FPGA")
-                {
-                    std::unique_ptr<GNSSBlockInterface> block_ = std::make_unique<MAX2771EVKITSignalSourceFPGA>(configuration, role, in_streams,
-                        out_streams, queue);
-                    block = std::move(block_);
-                }
-#endif
-
-#if ENABLE_FPGA and DMA_PROXY_DRIVER
-            else if (implementation == "DMA_Signal_Source_FPGA")
-                {
-                    std::unique_ptr<GNSSBlockInterface> block_ = std::make_unique<DMASignalSourceFPGA>(configuration, role, in_streams,
-                        out_streams, queue);
-                    block = std::move(block_);
-                }
-#endif
-
-#if ZEROMQ_DRIVER
-            else if (implementation == "ZMQ_Signal_Source")
-                {
-                    std::unique_ptr<GNSSBlockInterface> block_ = std::make_unique<ZmqSignalSource>(configuration, role, in_streams,
-                        out_streams, queue);
-                    block = std::move(block_);
-                }
-#endif
-
 
             // DATA TYPE ADAPTER -----------------------------------------------------------
             else if (implementation == "Byte_To_Short")
                 {
-                    std::unique_ptr<GNSSBlockInterface> block_ = std::make_unique<ByteToShort>(configuration, role, in_streams,
-                        out_streams);
-                    block = std::move(block_);
+                    block = std::make_unique<ByteToShort>(configuration, role, in_streams, out_streams);
                 }
             else if (implementation == "Ibyte_To_Cbyte")
                 {
-                    std::unique_ptr<GNSSBlockInterface> block_ = std::make_unique<IbyteToCbyte>(configuration, role, in_streams,
-                        out_streams);
-                    block = std::move(block_);
+                    block = std::make_unique<IbyteToCbyte>(configuration, role, in_streams, out_streams);
                 }
             else if (implementation == "Ibyte_To_Cshort")
                 {
-                    std::unique_ptr<GNSSBlockInterface> block_ = std::make_unique<IbyteToCshort>(configuration, role, in_streams,
-                        out_streams);
-                    block = std::move(block_);
+                    block = std::make_unique<IbyteToCshort>(configuration, role, in_streams, out_streams);
                 }
             else if (implementation == "Ibyte_To_Complex")
                 {
-                    std::unique_ptr<GNSSBlockInterface> block_ = std::make_unique<IbyteToComplex>(configuration, role, in_streams,
-                        out_streams);
-                    block = std::move(block_);
+                    block = std::make_unique<IbyteToComplex>(configuration, role, in_streams, out_streams);
                 }
             else if (implementation == "Ishort_To_Cshort")
                 {
-                    std::unique_ptr<GNSSBlockInterface> block_ = std::make_unique<IshortToCshort>(configuration, role, in_streams,
-                        out_streams);
-                    block = std::move(block_);
+                    block = std::make_unique<IshortToCshort>(configuration, role, in_streams, out_streams);
                 }
             else if (implementation == "Ishort_To_Complex")
                 {
-                    std::unique_ptr<GNSSBlockInterface> block_ = std::make_unique<IshortToComplex>(configuration, role, in_streams,
-                        out_streams);
-                    block = std::move(block_);
+                    block = std::make_unique<IshortToComplex>(configuration, role, in_streams, out_streams);
                 }
             else if (implementation == "Cshort_To_Gr_Complex")
                 {
-                    std::unique_ptr<GNSSBlockInterface> block_ = std::make_unique<CshortToGrComplex>(configuration, role, in_streams,
-                        out_streams);
-                    block = std::move(block_);
+                    block = std::make_unique<CshortToGrComplex>(configuration, role, in_streams, out_streams);
                 }
 
             // INPUT FILTER ------------------------------------------------------------
             else if (implementation == "Fir_Filter")
                 {
-                    std::unique_ptr<GNSSBlockInterface> block_ = std::make_unique<FirFilter>(configuration, role, in_streams,
-                        out_streams);
-                    block = std::move(block_);
+                    block = std::make_unique<FirFilter>(configuration, role, in_streams, out_streams);
                 }
             else if (implementation == "Freq_Xlating_Fir_Filter")
                 {
-                    std::unique_ptr<GNSSBlockInterface> block_ = std::make_unique<FreqXlatingFirFilter>(configuration, role, in_streams,
-                        out_streams);
-                    block = std::move(block_);
+                    block = std::make_unique<FreqXlatingFirFilter>(configuration, role, in_streams, out_streams);
                 }
             else if (implementation == "Beamformer_Filter")
                 {
-                    std::unique_ptr<GNSSBlockInterface> block_ = std::make_unique<BeamformerFilter>(configuration, role, in_streams,
-                        out_streams);
-                    block = std::move(block_);
+                    block = std::make_unique<BeamformerFilter>(configuration, role, in_streams, out_streams);
                 }
             else if (implementation == "Pulse_Blanking_Filter")
                 {
-                    std::unique_ptr<GNSSBlockInterface> block_ = std::make_unique<PulseBlankingFilter>(configuration, role, in_streams,
-                        out_streams);
-                    block = std::move(block_);
+                    block = std::make_unique<PulseBlankingFilter>(configuration, role, in_streams, out_streams);
                 }
             else if (implementation == "Notch_Filter")
                 {
-                    std::unique_ptr<GNSSBlockInterface> block_ = std::make_unique<NotchFilter>(configuration, role, in_streams,
-                        out_streams);
-                    block = std::move(block_);
+                    block = std::make_unique<NotchFilter>(configuration, role, in_streams, out_streams);
                 }
             else if (implementation == "Notch_Filter_Lite")
                 {
-                    std::unique_ptr<GNSSBlockInterface> block_ = std::make_unique<NotchFilterLite>(configuration, role, in_streams,
-                        out_streams);
-                    block = std::move(block_);
+                    block = std::make_unique<NotchFilterLite>(configuration, role, in_streams, out_streams);
                 }
 
             // RESAMPLER ---------------------------------------------------------------
             else if (implementation == "Direct_Resampler")
                 {
-                    std::unique_ptr<GNSSBlockInterface> block_ = std::make_unique<DirectResamplerConditioner>(configuration, role,
-                        in_streams, out_streams);
-                    block = std::move(block_);
+                    block = std::make_unique<DirectResamplerConditioner>(configuration, role, in_streams, out_streams);
                 }
 
             else if ((implementation == "Fractional_Resampler") || (implementation == "Mmse_Resampler"))
                 {
-                    std::unique_ptr<GNSSBlockInterface> block_ = std::make_unique<MmseResamplerConditioner>(configuration, role,
-                        in_streams, out_streams);
-                    block = std::move(block_);
+                    block = std::make_unique<MmseResamplerConditioner>(configuration, role, in_streams, out_streams);
                 }
 
             // ACQUISITION BLOCKS ------------------------------------------------------
-            else if (implementation == "GPS_L1_CA_PCPS_Acquisition")
+            else if ((block = get_acq_block(implementation, configuration, role, in_streams, out_streams)))
                 {
-                    std::unique_ptr<GNSSBlockInterface> block_ = std::make_unique<GpsL1CaPcpsAcquisition>(configuration, role, in_streams,
-                        out_streams);
-                    block = std::move(block_);
                 }
-            else if (implementation == "GPS_L1_CA_PCPS_Assisted_Acquisition")
-                {
-                    std::unique_ptr<GNSSBlockInterface> block_ = std::make_unique<GpsL1CaPcpsAssistedAcquisition>(configuration, role, in_streams,
-                        out_streams);
-                    block = std::move(block_);
-                }
-            else if (implementation == "GPS_L1_CA_PCPS_Tong_Acquisition")
-                {
-                    std::unique_ptr<GNSSBlockInterface> block_ = std::make_unique<GpsL1CaPcpsTongAcquisition>(configuration, role, in_streams,
-                        out_streams);
-                    block = std::move(block_);
-                }
-            else if (implementation == "GPS_L1_CA_PCPS_Acquisition_Fine_Doppler")
-                {
-                    std::unique_ptr<GNSSBlockInterface> block_ = std::make_unique<GpsL1CaPcpsAcquisitionFineDoppler>(configuration, role, in_streams,
-                        out_streams);
-                    block = std::move(block_);
-                }
-            else if (implementation == "GPS_L1_CA_PCPS_QuickSync_Acquisition")
-                {
-                    std::unique_ptr<GNSSBlockInterface> block_ = std::make_unique<GpsL1CaPcpsQuickSyncAcquisition>(configuration, role, in_streams,
-                        out_streams);
-                    block = std::move(block_);
-                }
-            else if (implementation == "GPS_L2_M_PCPS_Acquisition")
-                {
-                    std::unique_ptr<AcquisitionInterface> block_ = std::make_unique<GpsL2MPcpsAcquisition>(configuration, role, in_streams,
-                        out_streams);
-                    block = std::move(block_);
-                }
-            else if (implementation == "GPS_L5i_PCPS_Acquisition")
-                {
-                    std::unique_ptr<AcquisitionInterface> block_ = std::make_unique<GpsL5iPcpsAcquisition>(configuration, role, in_streams,
-                        out_streams);
-                    block = std::move(block_);
-                }
-            else if (implementation == "Galileo_E1_PCPS_Ambiguous_Acquisition")
-                {
-                    std::unique_ptr<GNSSBlockInterface> block_ = std::make_unique<GalileoE1PcpsAmbiguousAcquisition>(configuration, role, in_streams,
-                        out_streams);
-                    block = std::move(block_);
-                }
-            else if (implementation == "Galileo_E1_PCPS_8ms_Ambiguous_Acquisition")
-                {
-                    std::unique_ptr<GNSSBlockInterface> block_ = std::make_unique<GalileoE1Pcps8msAmbiguousAcquisition>(configuration, role, in_streams,
-                        out_streams);
-                    block = std::move(block_);
-                }
-            else if (implementation == "Galileo_E1_PCPS_Tong_Ambiguous_Acquisition")
-                {
-                    std::unique_ptr<GNSSBlockInterface> block_ = std::make_unique<GalileoE1PcpsTongAmbiguousAcquisition>(configuration, role, in_streams,
-                        out_streams);
-                    block = std::move(block_);
-                }
-            else if (implementation == "Galileo_E1_PCPS_CCCWSR_Ambiguous_Acquisition")
-                {
-                    std::unique_ptr<GNSSBlockInterface> block_ = std::make_unique<GalileoE1PcpsCccwsrAmbiguousAcquisition>(configuration, role, in_streams,
-                        out_streams);
-                    block = std::move(block_);
-                }
-            else if (implementation == "Galileo_E1_PCPS_QuickSync_Ambiguous_Acquisition")
-                {
-                    std::unique_ptr<GNSSBlockInterface> block_ = std::make_unique<GalileoE1PcpsQuickSyncAmbiguousAcquisition>(configuration, role, in_streams,
-                        out_streams);
-                    block = std::move(block_);
-                }
-            else if (implementation == "Galileo_E5a_Noncoherent_IQ_Acquisition_CAF")
-                {
-                    std::unique_ptr<GNSSBlockInterface> block_ = std::make_unique<GalileoE5aNoncoherentIQAcquisitionCaf>(configuration, role, in_streams,
-                        out_streams);
-                    block = std::move(block_);
-                }
-            else if (implementation == "Galileo_E5a_Pcps_Acquisition")
-                {
-                    std::unique_ptr<GNSSBlockInterface> block_ = std::make_unique<GalileoE5aPcpsAcquisition>(configuration, role, in_streams,
-                        out_streams);
-                    block = std::move(block_);
-                }
-            else if (implementation == "Galileo_E5b_PCPS_Acquisition")
-                {
-                    std::unique_ptr<GNSSBlockInterface> block_ = std::make_unique<GalileoE5bPcpsAcquisition>(configuration, role, in_streams,
-                        out_streams);
-                    block = std::move(block_);
-                }
-            else if (implementation == "Galileo_E6_PCPS_Acquisition")
-                {
-                    std::unique_ptr<GNSSBlockInterface> block_ = std::make_unique<GalileoE6PcpsAcquisition>(configuration, role, in_streams,
-                        out_streams);
-                    block = std::move(block_);
-                }
-            else if (implementation == "GLONASS_L1_CA_PCPS_Acquisition")
-                {
-                    std::unique_ptr<AcquisitionInterface> block_ = std::make_unique<GlonassL1CaPcpsAcquisition>(configuration, role, in_streams,
-                        out_streams);
-                    block = std::move(block_);
-                }
-            else if (implementation == "GLONASS_L2_CA_PCPS_Acquisition")
-                {
-                    std::unique_ptr<AcquisitionInterface> block_ = std::make_unique<GlonassL2CaPcpsAcquisition>(configuration, role, in_streams,
-                        out_streams);
-                    block = std::move(block_);
-                }
-            else if (implementation == "BEIDOU_B1I_PCPS_Acquisition")
-                {
-                    std::unique_ptr<AcquisitionInterface> block_ = std::make_unique<BeidouB1iPcpsAcquisition>(configuration, role, in_streams,
-                        out_streams);
-                    block = std::move(block_);
-                }
-            else if (implementation == "BEIDOU_B3I_PCPS_Acquisition")
-                {
-                    std::unique_ptr<AcquisitionInterface> block_ = std::make_unique<BeidouB3iPcpsAcquisition>(configuration, role, in_streams,
-                        out_streams);
-                    block = std::move(block_);
-                }
-#if OPENCL_BLOCKS
-            else if (implementation == "GPS_L1_CA_PCPS_OpenCl_Acquisition")
-                {
-                    std::unique_ptr<GNSSBlockInterface> block_ = std::make_unique<GpsL1CaPcpsOpenClAcquisition>(configuration, role, in_streams,
-                        out_streams);
-                    block = std::move(block_);
-                }
-#endif
-#if ENABLE_FPGA
-            else if (implementation == "GPS_L1_CA_PCPS_Acquisition_FPGA")
-                {
-                    std::unique_ptr<GNSSBlockInterface> block_ = std::make_unique<GpsL1CaPcpsAcquisitionFpga>(configuration, role, in_streams,
-                        out_streams);
-                    block = std::move(block_);
-                }
-            else if (implementation == "Galileo_E1_PCPS_Ambiguous_Acquisition_FPGA")
-                {
-                    std::unique_ptr<GNSSBlockInterface> block_ = std::make_unique<GalileoE1PcpsAmbiguousAcquisitionFpga>(configuration, role, in_streams,
-                        out_streams);
-                    block = std::move(block_);
-                }
-            else if (implementation == "GPS_L2_M_PCPS_Acquisition_FPGA")
-                {
-                    std::unique_ptr<GNSSBlockInterface> block_ = std::make_unique<GpsL2MPcpsAcquisitionFpga>(configuration, role, in_streams,
-                        out_streams);
-                    block = std::move(block_);
-                }
-            else if (implementation == "GPS_L5i_PCPS_Acquisition_FPGA")
-                {
-                    std::unique_ptr<AcquisitionInterface> block_ = std::make_unique<GpsL5iPcpsAcquisitionFpga>(configuration, role, in_streams,
-                        out_streams);
-                    block = std::move(block_);
-                }
-            else if (implementation == "Galileo_E5a_Pcps_Acquisition_FPGA")
-                {
-                    std::unique_ptr<GNSSBlockInterface> block_ = std::make_unique<GalileoE5aPcpsAcquisitionFpga>(configuration, role, in_streams,
-                        out_streams);
-                    block = std::move(block_);
-                }
-            else if (implementation == "Galileo_E5b_PCPS_Acquisition_FPGA")
-                {
-                    std::unique_ptr<AcquisitionInterface> block_ = std::make_unique<GalileoE5bPcpsAcquisitionFpga>(configuration, role, in_streams,
-                        out_streams);
-                    block = std::move(block_);
-                }
-#endif
 
             // TRACKING BLOCKS ---------------------------------------------------------
-            else if (implementation == "GPS_L1_CA_DLL_PLL_Tracking")
+            else if ((block = get_trk_block(implementation, configuration, role, in_streams, out_streams)))
                 {
-                    std::unique_ptr<GNSSBlockInterface> block_ = std::make_unique<GpsL1CaDllPllTracking>(configuration, role, in_streams,
-                        out_streams);
-                    block = std::move(block_);
                 }
-            else if (implementation == "GPS_L1_CA_Gaussian_Tracking")
-                {
-                    std::unique_ptr<GNSSBlockInterface> block_ = std::make_unique<GpsL1CaGaussianTracking>(configuration, role, in_streams,
-                        out_streams);
-                    block = std::move(block_);
-                }
-            else if (implementation == "GPS_L1_CA_KF_Tracking")
-                {
-                    std::unique_ptr<GNSSBlockInterface> block_ = std::make_unique<GpsL1CaKfTracking>(configuration, role, in_streams,
-                        out_streams);
-                    block = std::move(block_);
-                }
-            else if (implementation == "GPS_L1_CA_TCP_CONNECTOR_Tracking")
-                {
-                    std::unique_ptr<GNSSBlockInterface> block_ = std::make_unique<GpsL1CaTcpConnectorTracking>(configuration, role, in_streams,
-                        out_streams);
-                    block = std::move(block_);
-                }
-            else if (implementation == "GPS_L2_M_DLL_PLL_Tracking")
-                {
-                    std::unique_ptr<GNSSBlockInterface> block_ = std::make_unique<GpsL2MDllPllTracking>(configuration, role, in_streams,
-                        out_streams);
-                    block = std::move(block_);
-                }
-            else if ((implementation == "GPS_L5i_DLL_PLL_Tracking") or (implementation == "GPS_L5_DLL_PLL_Tracking"))
-                {
-                    std::unique_ptr<GNSSBlockInterface> block_ = std::make_unique<GpsL5DllPllTracking>(configuration, role, in_streams,
-                        out_streams);
-                    block = std::move(block_);
-                }
-            else if (implementation == "Galileo_E1_DLL_PLL_VEML_Tracking")
-                {
-                    std::unique_ptr<GNSSBlockInterface> block_ = std::make_unique<GalileoE1DllPllVemlTracking>(configuration, role, in_streams,
-                        out_streams);
-                    block = std::move(block_);
-                }
-            else if (implementation == "Galileo_E1_TCP_CONNECTOR_Tracking")
-                {
-                    std::unique_ptr<GNSSBlockInterface> block_ = std::make_unique<GalileoE1TcpConnectorTracking>(configuration, role, in_streams,
-                        out_streams);
-                    block = std::move(block_);
-                }
-            else if (implementation == "Galileo_E5a_DLL_PLL_Tracking")
-                {
-                    std::unique_ptr<GNSSBlockInterface> block_ = std::make_unique<GalileoE5aDllPllTracking>(configuration, role, in_streams,
-                        out_streams);
-                    block = std::move(block_);
-                }
-            else if (implementation == "Galileo_E5b_DLL_PLL_Tracking")
-                {
-                    std::unique_ptr<GNSSBlockInterface> block_ = std::make_unique<GalileoE5bDllPllTracking>(configuration, role, in_streams,
-                        out_streams);
-                    block = std::move(block_);
-                }
-            else if (implementation == "Galileo_E6_DLL_PLL_Tracking")
-                {
-                    std::unique_ptr<GNSSBlockInterface> block_ = std::make_unique<GalileoE6DllPllTracking>(configuration, role, in_streams,
-                        out_streams);
-                    block = std::move(block_);
-                }
-            else if (implementation == "GLONASS_L1_CA_DLL_PLL_Tracking")
-                {
-                    std::unique_ptr<GNSSBlockInterface> block_ = std::make_unique<GlonassL1CaDllPllTracking>(configuration, role, in_streams,
-                        out_streams);
-                    block = std::move(block_);
-                }
-            else if (implementation == "GLONASS_L1_CA_DLL_PLL_C_Aid_Tracking")
-                {
-                    std::unique_ptr<GNSSBlockInterface> block_ = std::make_unique<GlonassL1CaDllPllCAidTracking>(configuration, role, in_streams,
-                        out_streams);
-                    block = std::move(block_);
-                }
-            else if (implementation == "GLONASS_L2_CA_DLL_PLL_Tracking")
-                {
-                    std::unique_ptr<GNSSBlockInterface> block_ = std::make_unique<GlonassL2CaDllPllTracking>(configuration, role, in_streams,
-                        out_streams);
-                    block = std::move(block_);
-                }
-            else if (implementation == "GLONASS_L2_CA_DLL_PLL_C_Aid_Tracking")
-                {
-                    std::unique_ptr<GNSSBlockInterface> block_ = std::make_unique<GlonassL2CaDllPllCAidTracking>(configuration, role, in_streams,
-                        out_streams);
-                    block = std::move(block_);
-                }
-            else if (implementation == "BEIDOU_B1I_DLL_PLL_Tracking")
-                {
-                    std::unique_ptr<GNSSBlockInterface> block_ = std::make_unique<BeidouB1iDllPllTracking>(configuration, role, in_streams,
-                        out_streams);
-                    block = std::move(block_);
-                }
-            else if (implementation == "BEIDOU_B3I_DLL_PLL_Tracking")
-                {
-                    std::unique_ptr<GNSSBlockInterface> block_ = std::make_unique<BeidouB3iDllPllTracking>(configuration, role, in_streams,
-                        out_streams);
-                    block = std::move(block_);
-                }
-#if CUDA_GPU_ACCEL
-            else if (implementation == "GPS_L1_CA_DLL_PLL_Tracking_GPU")
-                {
-                    std::unique_ptr<GNSSBlockInterface> block_ = std::make_unique<GpsL1CaDllPllTrackingGPU>(configuration, role, in_streams,
-                        out_streams);
-                    block = std::move(block_);
-                }
-#endif
-#if ENABLE_FPGA
-            else if (implementation == "GPS_L1_CA_DLL_PLL_Tracking_FPGA")
-                {
-                    std::unique_ptr<TrackingInterface> block_ = std::make_unique<GpsL1CaDllPllTrackingFpga>(configuration, role, in_streams,
-                        out_streams);
-                    block = std::move(block_);
-                }
-            else if (implementation == "Galileo_E1_DLL_PLL_VEML_Tracking_FPGA")
-                {
-                    std::unique_ptr<TrackingInterface> block_ = std::make_unique<GalileoE1DllPllVemlTrackingFpga>(configuration, role, in_streams,
-                        out_streams);
-                    block = std::move(block_);
-                }
-            else if (implementation == "GPS_L2_M_DLL_PLL_Tracking_FPGA")
-                {
-                    std::unique_ptr<GNSSBlockInterface> block_ = std::make_unique<GpsL2MDllPllTrackingFpga>(configuration, role, in_streams,
-                        out_streams);
-                    block = std::move(block_);
-                }
-            else if ((implementation == "GPS_L5i_DLL_PLL_Tracking_FPGA") or (implementation == "GPS_L5_DLL_PLL_Tracking_FPGA"))
-                {
-                    std::unique_ptr<GNSSBlockInterface> block_ = std::make_unique<GpsL5DllPllTrackingFpga>(configuration, role, in_streams,
-                        out_streams);
-                    block = std::move(block_);
-                }
-            else if (implementation == "Galileo_E5a_DLL_PLL_Tracking_FPGA")
-                {
-                    std::unique_ptr<GNSSBlockInterface> block_ = std::make_unique<GalileoE5aDllPllTrackingFpga>(configuration, role, in_streams,
-                        out_streams);
-                    block = std::move(block_);
-                }
-#endif
 
             // TELEMETRY DECODERS ------------------------------------------------------
-            else if (implementation == "GPS_L1_CA_Telemetry_Decoder")
+            else if ((block = get_tlm_block(implementation, configuration, role, in_streams, out_streams)))
                 {
-                    std::unique_ptr<GNSSBlockInterface> block_ = std::make_unique<GpsL1CaTelemetryDecoder>(configuration, role, in_streams,
-                        out_streams);
-                    block = std::move(block_);
-                }
-            else if (implementation == "GPS_L2C_Telemetry_Decoder")
-                {
-                    std::unique_ptr<GNSSBlockInterface> block_ = std::make_unique<GpsL2CTelemetryDecoder>(configuration, role, in_streams,
-                        out_streams);
-                    block = std::move(block_);
-                }
-            else if (implementation == "GPS_L5_Telemetry_Decoder")
-                {
-                    std::unique_ptr<GNSSBlockInterface> block_ = std::make_unique<GpsL5TelemetryDecoder>(configuration, role, in_streams,
-                        out_streams);
-                    block = std::move(block_);
-                }
-            else if (implementation == "SBAS_L1_Telemetry_Decoder")
-                {
-                    std::unique_ptr<GNSSBlockInterface> block_ = std::make_unique<SbasL1TelemetryDecoder>(configuration, role, in_streams,
-                        out_streams);
-                    block = std::move(block_);
-                }
-            else if (implementation == "Galileo_E1B_Telemetry_Decoder")
-                {
-                    std::unique_ptr<GNSSBlockInterface> block_ = std::make_unique<GalileoE1BTelemetryDecoder>(configuration, role, in_streams,
-                        out_streams);
-                    block = std::move(block_);
-                }
-            else if (implementation == "Galileo_E5a_Telemetry_Decoder")
-                {
-                    std::unique_ptr<GNSSBlockInterface> block_ = std::make_unique<GalileoE5aTelemetryDecoder>(configuration, role, in_streams,
-                        out_streams);
-                    block = std::move(block_);
-                }
-            else if (implementation == "Galileo_E5b_Telemetry_Decoder")
-                {
-                    std::unique_ptr<GNSSBlockInterface> block_ = std::make_unique<GalileoE5bTelemetryDecoder>(configuration, role, in_streams,
-                        out_streams);
-                    block = std::move(block_);
-                }
-            else if (implementation == "Galileo_E6_Telemetry_Decoder")
-                {
-                    std::unique_ptr<GNSSBlockInterface> block_ = std::make_unique<GalileoE6TelemetryDecoder>(configuration, role, in_streams,
-                        out_streams);
-                    block = std::move(block_);
-                }
-            else if (implementation == "GLONASS_L1_CA_Telemetry_Decoder")
-                {
-                    std::unique_ptr<GNSSBlockInterface> block_ = std::make_unique<GlonassL1CaTelemetryDecoder>(configuration, role, in_streams,
-                        out_streams);
-                    block = std::move(block_);
-                }
-            else if (implementation == "GLONASS_L2_CA_Telemetry_Decoder")
-                {
-                    std::unique_ptr<GNSSBlockInterface> block_ = std::make_unique<GlonassL2CaTelemetryDecoder>(configuration, role, in_streams,
-                        out_streams);
-                    block = std::move(block_);
-                }
-            else if (implementation == "BEIDOU_B1I_Telemetry_Decoder")
-                {
-                    std::unique_ptr<GNSSBlockInterface> block_ = std::make_unique<BeidouB1iTelemetryDecoder>(configuration, role, in_streams,
-                        out_streams);
-                    block = std::move(block_);
-                }
-            else if (implementation == "BEIDOU_B3I_Telemetry_Decoder")
-                {
-                    std::unique_ptr<GNSSBlockInterface> block_ = std::make_unique<BeidouB3iTelemetryDecoder>(configuration, role, in_streams,
-                        out_streams);
-                    block = std::move(block_);
                 }
 
             // OBSERVABLES -------------------------------------------------------------
             else if ((implementation == "Hybrid_Observables") || (implementation == "GPS_L1_CA_Observables") || (implementation == "GPS_L2C_Observables") ||
                      (implementation == "Galileo_E5A_Observables"))
                 {
-                    std::unique_ptr<GNSSBlockInterface> block_ = std::make_unique<HybridObservables>(configuration, role, in_streams,
-                        out_streams);
-                    block = std::move(block_);
+                    block = std::make_unique<HybridObservables>(configuration, role, in_streams, out_streams);
                 }
 
             // PVT ---------------------------------------------------------------------
             else if ((implementation == "RTKLIB_PVT") || (implementation == "GPS_L1_CA_PVT") || (implementation == "Galileo_E1_PVT") || (implementation == "Hybrid_PVT"))
                 {
-                    std::unique_ptr<GNSSBlockInterface> block_ = std::make_unique<Rtklib_Pvt>(configuration, role, in_streams,
-                        out_streams);
-                    block = std::move(block_);
+                    block = std::make_unique<Rtklib_Pvt>(configuration, role, in_streams, out_streams);
                 }
-
             else
                 {
                     std::cerr << "Configuration error in " << role << " block: implementation " + implementation + " is not available.\n"s;
-                    block = nullptr;
                 }
         }
     catch (const std::exception& e)
@@ -1401,197 +1103,13 @@ std::unique_ptr<GNSSBlockInterface> GNSSBlockFactory::GetBlock(
 }
 
 
-/*
- *
- * PLEASE ADD YOUR NEW BLOCK HERE!!
- *
- * Not very elegant, Acq, Trk and Tlm blocks must be added here, too.
- * To be improved!
- */
 std::unique_ptr<AcquisitionInterface> GNSSBlockFactory::GetAcqBlock(
     const ConfigurationInterface* configuration,
     const std::string& role,
     unsigned int in_streams,
     unsigned int out_streams)
 {
-    std::unique_ptr<AcquisitionInterface> block;
-    const std::string implementation = configuration->property(role + impl_prop, "Wrong"s);
-
-    // ACQUISITION BLOCKS ------------------------------------------------------
-    if (implementation == "GPS_L1_CA_PCPS_Acquisition")
-        {
-            std::unique_ptr<AcquisitionInterface> block_ = std::make_unique<GpsL1CaPcpsAcquisition>(configuration, role, in_streams,
-                out_streams);
-            block = std::move(block_);
-        }
-    else if (implementation == "GPS_L1_CA_PCPS_Assisted_Acquisition")
-        {
-            std::unique_ptr<AcquisitionInterface> block_ = std::make_unique<GpsL1CaPcpsAssistedAcquisition>(configuration, role, in_streams,
-                out_streams);
-            block = std::move(block_);
-        }
-    else if (implementation == "GPS_L1_CA_PCPS_Tong_Acquisition")
-        {
-            std::unique_ptr<AcquisitionInterface> block_ = std::make_unique<GpsL1CaPcpsTongAcquisition>(configuration, role, in_streams,
-                out_streams);
-            block = std::move(block_);
-        }
-    else if (implementation == "GPS_L1_CA_PCPS_Acquisition_Fine_Doppler")
-        {
-            std::unique_ptr<AcquisitionInterface> block_ = std::make_unique<GpsL1CaPcpsAcquisitionFineDoppler>(configuration, role, in_streams,
-                out_streams);
-            block = std::move(block_);
-        }
-    else if (implementation == "GPS_L1_CA_PCPS_QuickSync_Acquisition")
-        {
-            std::unique_ptr<AcquisitionInterface> block_ = std::make_unique<GpsL1CaPcpsQuickSyncAcquisition>(configuration, role, in_streams,
-                out_streams);
-            block = std::move(block_);
-        }
-    else if (implementation == "GPS_L2_M_PCPS_Acquisition")
-        {
-            std::unique_ptr<AcquisitionInterface> block_ = std::make_unique<GpsL2MPcpsAcquisition>(configuration, role, in_streams,
-                out_streams);
-            block = std::move(block_);
-        }
-    else if (implementation == "GPS_L5i_PCPS_Acquisition")
-        {
-            std::unique_ptr<AcquisitionInterface> block_ = std::make_unique<GpsL5iPcpsAcquisition>(configuration, role, in_streams,
-                out_streams);
-            block = std::move(block_);
-        }
-    else if (implementation == "Galileo_E1_PCPS_Ambiguous_Acquisition")
-        {
-            std::unique_ptr<AcquisitionInterface> block_ = std::make_unique<GalileoE1PcpsAmbiguousAcquisition>(configuration, role, in_streams,
-                out_streams);
-            block = std::move(block_);
-        }
-    else if (implementation == "Galileo_E1_PCPS_8ms_Ambiguous_Acquisition")
-        {
-            std::unique_ptr<AcquisitionInterface> block_ = std::make_unique<GalileoE1Pcps8msAmbiguousAcquisition>(configuration, role, in_streams,
-                out_streams);
-            block = std::move(block_);
-        }
-    else if (implementation == "Galileo_E1_PCPS_Tong_Ambiguous_Acquisition")
-        {
-            std::unique_ptr<AcquisitionInterface> block_ = std::make_unique<GalileoE1PcpsTongAmbiguousAcquisition>(configuration, role, in_streams,
-                out_streams);
-            block = std::move(block_);
-        }
-    else if (implementation == "Galileo_E1_PCPS_CCCWSR_Ambiguous_Acquisition")
-        {
-            std::unique_ptr<AcquisitionInterface> block_ = std::make_unique<GalileoE1PcpsCccwsrAmbiguousAcquisition>(configuration, role, in_streams,
-                out_streams);
-            block = std::move(block_);
-        }
-
-    else if (implementation == "Galileo_E1_PCPS_QuickSync_Ambiguous_Acquisition")
-        {
-            std::unique_ptr<AcquisitionInterface> block_ = std::make_unique<GalileoE1PcpsQuickSyncAmbiguousAcquisition>(configuration, role, in_streams,
-                out_streams);
-            block = std::move(block_);
-        }
-    else if (implementation == "Galileo_E5a_Noncoherent_IQ_Acquisition_CAF")
-        {
-            std::unique_ptr<AcquisitionInterface> block_ = std::make_unique<GalileoE5aNoncoherentIQAcquisitionCaf>(configuration, role, in_streams,
-                out_streams);
-            block = std::move(block_);
-        }
-    else if (implementation == "Galileo_E5a_Pcps_Acquisition")
-        {
-            std::unique_ptr<AcquisitionInterface> block_ = std::make_unique<GalileoE5aPcpsAcquisition>(configuration, role, in_streams,
-                out_streams);
-            block = std::move(block_);
-        }
-    else if (implementation == "Galileo_E5b_PCPS_Acquisition")
-        {
-            std::unique_ptr<AcquisitionInterface> block_ = std::make_unique<GalileoE5bPcpsAcquisition>(configuration, role, in_streams,
-                out_streams);
-            block = std::move(block_);
-        }
-    else if (implementation == "Galileo_E6_PCPS_Acquisition")
-        {
-            std::unique_ptr<AcquisitionInterface> block_ = std::make_unique<GalileoE6PcpsAcquisition>(configuration, role, in_streams,
-                out_streams);
-            block = std::move(block_);
-        }
-    else if (implementation == "GLONASS_L1_CA_PCPS_Acquisition")
-        {
-            std::unique_ptr<AcquisitionInterface> block_ = std::make_unique<GlonassL1CaPcpsAcquisition>(configuration, role, in_streams,
-                out_streams);
-            block = std::move(block_);
-        }
-    else if (implementation == "GLONASS_L2_CA_PCPS_Acquisition")
-        {
-            std::unique_ptr<AcquisitionInterface> block_ = std::make_unique<GlonassL2CaPcpsAcquisition>(configuration, role, in_streams,
-                out_streams);
-            block = std::move(block_);
-        }
-    else if (implementation == "BEIDOU_B1I_PCPS_Acquisition")
-        {
-            std::unique_ptr<AcquisitionInterface> block_ = std::make_unique<BeidouB1iPcpsAcquisition>(configuration, role, in_streams,
-                out_streams);
-            block = std::move(block_);
-        }
-    else if (implementation == "BEIDOU_B3I_PCPS_Acquisition")
-        {
-            std::unique_ptr<AcquisitionInterface> block_ = std::make_unique<BeidouB3iPcpsAcquisition>(configuration, role, in_streams,
-                out_streams);
-            block = std::move(block_);
-        }
-#if OPENCL_BLOCKS
-    else if (implementation == "GPS_L1_CA_PCPS_OpenCl_Acquisition")
-        {
-            std::unique_ptr<AcquisitionInterface> block_ = std::make_unique<GpsL1CaPcpsOpenClAcquisition>(configuration, role, in_streams,
-                out_streams);
-            block = std::move(block_);
-        }
-#endif
-#if ENABLE_FPGA
-    else if (implementation == "GPS_L1_CA_PCPS_Acquisition_FPGA")
-        {
-            std::unique_ptr<AcquisitionInterface> block_ = std::make_unique<GpsL1CaPcpsAcquisitionFpga>(configuration, role, in_streams,
-                out_streams);
-            block = std::move(block_);
-        }
-    else if (implementation == "Galileo_E1_PCPS_Ambiguous_Acquisition_FPGA")
-        {
-            std::unique_ptr<AcquisitionInterface> block_ = std::make_unique<GalileoE1PcpsAmbiguousAcquisitionFpga>(configuration, role, in_streams,
-                out_streams);
-            block = std::move(block_);
-        }
-    else if (implementation == "GPS_L2_M_PCPS_Acquisition_FPGA")
-        {
-            std::unique_ptr<AcquisitionInterface> block_ = std::make_unique<GpsL2MPcpsAcquisitionFpga>(configuration, role, in_streams,
-                out_streams);
-            block = std::move(block_);
-        }
-    else if (implementation == "GPS_L5i_PCPS_Acquisition_FPGA")
-        {
-            std::unique_ptr<AcquisitionInterface> block_ = std::make_unique<GpsL5iPcpsAcquisitionFpga>(configuration, role, in_streams,
-                out_streams);
-            block = std::move(block_);
-        }
-    else if (implementation == "Galileo_E5a_Pcps_Acquisition_FPGA")
-        {
-            std::unique_ptr<AcquisitionInterface> block_ = std::make_unique<GalileoE5aPcpsAcquisitionFpga>(configuration, role, in_streams,
-                out_streams);
-            block = std::move(block_);
-        }
-    else if (implementation == "Galileo_E5b_PCPS_Acquisition_FPGA")
-        {
-            std::unique_ptr<AcquisitionInterface> block_ = std::make_unique<GalileoE5bPcpsAcquisitionFpga>(configuration, role, in_streams,
-                out_streams);
-            block = std::move(block_);
-        }
-#endif
-
-    else
-        {
-            std::cerr << "Configuration error in " << role << " block: implementation " << (implementation == "Wrong"s ? "not defined."s : implementation + " not available."s) << '\n';
-            block = nullptr;
-        }
-    return block;
+    return get_block(configuration, role, in_streams, out_streams, get_acq_block);
 }
 
 
@@ -1601,158 +1119,7 @@ std::unique_ptr<TrackingInterface> GNSSBlockFactory::GetTrkBlock(
     unsigned int in_streams,
     unsigned int out_streams)
 {
-    std::unique_ptr<TrackingInterface> block;
-    const std::string implementation = configuration->property(role + impl_prop, "Wrong"s);
-
-    // TRACKING BLOCKS ---------------------------------------------------------
-    if (implementation == "GPS_L1_CA_DLL_PLL_Tracking")
-        {
-            std::unique_ptr<TrackingInterface> block_ = std::make_unique<GpsL1CaDllPllTracking>(configuration, role, in_streams,
-                out_streams);
-            block = std::move(block_);
-        }
-    else if (implementation == "GPS_L1_CA_Gaussian_Tracking")
-        {
-            std::unique_ptr<TrackingInterface> block_ = std::make_unique<GpsL1CaGaussianTracking>(configuration, role, in_streams,
-                out_streams);
-            block = std::move(block_);
-        }
-    else if (implementation == "GPS_L1_CA_KF_Tracking")
-        {
-            std::unique_ptr<TrackingInterface> block_ = std::make_unique<GpsL1CaKfTracking>(configuration, role, in_streams,
-                out_streams);
-            block = std::move(block_);
-        }
-    else if (implementation == "GPS_L1_CA_TCP_CONNECTOR_Tracking")
-        {
-            std::unique_ptr<TrackingInterface> block_ = std::make_unique<GpsL1CaTcpConnectorTracking>(configuration, role, in_streams,
-                out_streams);
-            block = std::move(block_);
-        }
-    else if (implementation == "Galileo_E1_DLL_PLL_VEML_Tracking")
-        {
-            std::unique_ptr<TrackingInterface> block_ = std::make_unique<GalileoE1DllPllVemlTracking>(configuration, role, in_streams,
-                out_streams);
-            block = std::move(block_);
-        }
-    else if (implementation == "Galileo_E1_TCP_CONNECTOR_Tracking")
-        {
-            std::unique_ptr<TrackingInterface> block_ = std::make_unique<GalileoE1TcpConnectorTracking>(configuration, role, in_streams,
-                out_streams);
-            block = std::move(block_);
-        }
-    else if (implementation == "Galileo_E5a_DLL_PLL_Tracking")
-        {
-            std::unique_ptr<TrackingInterface> block_ = std::make_unique<GalileoE5aDllPllTracking>(configuration, role, in_streams,
-                out_streams);
-            block = std::move(block_);
-        }
-    else if (implementation == "Galileo_E5b_DLL_PLL_Tracking")
-        {
-            std::unique_ptr<TrackingInterface> block_ = std::make_unique<GalileoE5bDllPllTracking>(configuration, role, in_streams,
-                out_streams);
-            block = std::move(block_);
-        }
-    else if (implementation == "Galileo_E6_DLL_PLL_Tracking")
-        {
-            std::unique_ptr<TrackingInterface> block_ = std::make_unique<GalileoE6DllPllTracking>(configuration, role, in_streams,
-                out_streams);
-            block = std::move(block_);
-        }
-    else if (implementation == "GPS_L2_M_DLL_PLL_Tracking")
-        {
-            std::unique_ptr<TrackingInterface> block_ = std::make_unique<GpsL2MDllPllTracking>(configuration, role, in_streams,
-                out_streams);
-            block = std::move(block_);
-        }
-    else if ((implementation == "GPS_L5i_DLL_PLL_Tracking") or (implementation == "GPS_L5_DLL_PLL_Tracking"))
-        {
-            std::unique_ptr<TrackingInterface> block_ = std::make_unique<GpsL5DllPllTracking>(configuration, role, in_streams,
-                out_streams);
-            block = std::move(block_);
-        }
-    else if (implementation == "GLONASS_L1_CA_DLL_PLL_Tracking")
-        {
-            std::unique_ptr<TrackingInterface> block_ = std::make_unique<GlonassL1CaDllPllTracking>(configuration, role, in_streams,
-                out_streams);
-            block = std::move(block_);
-        }
-    else if (implementation == "GLONASS_L1_CA_DLL_PLL_C_Aid_Tracking")
-        {
-            std::unique_ptr<TrackingInterface> block_ = std::make_unique<GlonassL1CaDllPllCAidTracking>(configuration, role, in_streams,
-                out_streams);
-            block = std::move(block_);
-        }
-    else if (implementation == "GLONASS_L2_CA_DLL_PLL_Tracking")
-        {
-            std::unique_ptr<TrackingInterface> block_ = std::make_unique<GlonassL2CaDllPllTracking>(configuration, role, in_streams,
-                out_streams);
-            block = std::move(block_);
-        }
-    else if (implementation == "GLONASS_L2_CA_DLL_PLL_C_Aid_Tracking")
-        {
-            std::unique_ptr<TrackingInterface> block_ = std::make_unique<GlonassL2CaDllPllCAidTracking>(configuration, role, in_streams,
-                out_streams);
-            block = std::move(block_);
-        }
-    else if (implementation == "BEIDOU_B1I_DLL_PLL_Tracking")
-        {
-            std::unique_ptr<TrackingInterface> block_ = std::make_unique<BeidouB1iDllPllTracking>(configuration, role, in_streams,
-                out_streams);
-            block = std::move(block_);
-        }
-    else if (implementation == "BEIDOU_B3I_DLL_PLL_Tracking")
-        {
-            std::unique_ptr<TrackingInterface> block_ = std::make_unique<BeidouB3iDllPllTracking>(configuration, role, in_streams,
-                out_streams);
-            block = std::move(block_);
-        }
-#if CUDA_GPU_ACCEL
-    else if (implementation == "GPS_L1_CA_DLL_PLL_Tracking_GPU")
-        {
-            std::unique_ptr<TrackingInterface> block_ = std::make_unique<GpsL1CaDllPllTrackingGPU>(configuration, role, in_streams,
-                out_streams);
-            block = std::move(block_);
-        }
-#endif
-#if ENABLE_FPGA
-    else if (implementation == "GPS_L1_CA_DLL_PLL_Tracking_FPGA")
-        {
-            std::unique_ptr<TrackingInterface> block_ = std::make_unique<GpsL1CaDllPllTrackingFpga>(configuration, role, in_streams,
-                out_streams);
-            block = std::move(block_);
-        }
-    else if (implementation == "Galileo_E1_DLL_PLL_VEML_Tracking_FPGA")
-        {
-            std::unique_ptr<TrackingInterface> block_ = std::make_unique<GalileoE1DllPllVemlTrackingFpga>(configuration, role, in_streams,
-                out_streams);
-            block = std::move(block_);
-        }
-    else if (implementation == "GPS_L2_M_DLL_PLL_Tracking_FPGA")
-        {
-            std::unique_ptr<TrackingInterface> block_ = std::make_unique<GpsL2MDllPllTrackingFpga>(configuration, role, in_streams,
-                out_streams);
-            block = std::move(block_);
-        }
-    else if ((implementation == "GPS_L5i_DLL_PLL_Tracking_FPGA") or (implementation == "GPS_L5_DLL_PLL_Tracking_FPGA"))
-        {
-            std::unique_ptr<TrackingInterface> block_ = std::make_unique<GpsL5DllPllTrackingFpga>(configuration, role, in_streams,
-                out_streams);
-            block = std::move(block_);
-        }
-    else if (implementation == "Galileo_E5a_DLL_PLL_Tracking_FPGA")
-        {
-            std::unique_ptr<TrackingInterface> block_ = std::make_unique<GalileoE5aDllPllTrackingFpga>(configuration, role, in_streams,
-                out_streams);
-            block = std::move(block_);
-        }
-#endif
-    else
-        {
-            std::cerr << "Configuration error in " << role << " block: implementation " << (implementation == "Wrong"s ? "not defined."s : implementation + " not available."s) << '\n';
-            block = nullptr;
-        }
-    return block;
+    return get_block(configuration, role, in_streams, out_streams, get_trk_block);
 }
 
 
@@ -1762,88 +1129,5 @@ std::unique_ptr<TelemetryDecoderInterface> GNSSBlockFactory::GetTlmBlock(
     unsigned int in_streams,
     unsigned int out_streams)
 {
-    std::unique_ptr<TelemetryDecoderInterface> block;
-    const std::string implementation = configuration->property(role + impl_prop, "Wrong"s);
-
-    // TELEMETRY DECODERS ------------------------------------------------------
-    if (implementation == "GPS_L1_CA_Telemetry_Decoder")
-        {
-            std::unique_ptr<TelemetryDecoderInterface> block_ = std::make_unique<GpsL1CaTelemetryDecoder>(configuration, role, in_streams,
-                out_streams);
-            block = std::move(block_);
-        }
-    else if (implementation == "Galileo_E1B_Telemetry_Decoder")
-        {
-            std::unique_ptr<TelemetryDecoderInterface> block_ = std::make_unique<GalileoE1BTelemetryDecoder>(configuration, role, in_streams,
-                out_streams);
-            block = std::move(block_);
-        }
-    else if (implementation == "SBAS_L1_Telemetry_Decoder")
-        {
-            std::unique_ptr<TelemetryDecoderInterface> block_ = std::make_unique<SbasL1TelemetryDecoder>(configuration, role, in_streams,
-                out_streams);
-            block = std::move(block_);
-        }
-    else if (implementation == "Galileo_E5a_Telemetry_Decoder")
-        {
-            std::unique_ptr<TelemetryDecoderInterface> block_ = std::make_unique<GalileoE5aTelemetryDecoder>(configuration, role, in_streams,
-                out_streams);
-            block = std::move(block_);
-        }
-    else if (implementation == "Galileo_E5b_Telemetry_Decoder")
-        {
-            std::unique_ptr<TelemetryDecoderInterface> block_ = std::make_unique<GalileoE5bTelemetryDecoder>(configuration, role, in_streams,
-                out_streams);
-            block = std::move(block_);
-        }
-    else if (implementation == "Galileo_E6_Telemetry_Decoder")
-        {
-            std::unique_ptr<TelemetryDecoderInterface> block_ = std::make_unique<GalileoE6TelemetryDecoder>(configuration, role, in_streams,
-                out_streams);
-            block = std::move(block_);
-        }
-    else if (implementation == "GPS_L2C_Telemetry_Decoder")
-        {
-            std::unique_ptr<TelemetryDecoderInterface> block_ = std::make_unique<GpsL2CTelemetryDecoder>(configuration, role, in_streams,
-                out_streams);
-            block = std::move(block_);
-        }
-    else if (implementation == "GLONASS_L1_CA_Telemetry_Decoder")
-        {
-            std::unique_ptr<TelemetryDecoderInterface> block_ = std::make_unique<GlonassL1CaTelemetryDecoder>(configuration, role, in_streams,
-                out_streams);
-            block = std::move(block_);
-        }
-    else if (implementation == "GLONASS_L2_CA_Telemetry_Decoder")
-        {
-            std::unique_ptr<TelemetryDecoderInterface> block_ = std::make_unique<GlonassL2CaTelemetryDecoder>(configuration, role, in_streams,
-                out_streams);
-            block = std::move(block_);
-        }
-    else if (implementation == "GPS_L5_Telemetry_Decoder")
-        {
-            std::unique_ptr<TelemetryDecoderInterface> block_ = std::make_unique<GpsL5TelemetryDecoder>(configuration, role, in_streams,
-                out_streams);
-            block = std::move(block_);
-        }
-    else if (implementation == "BEIDOU_B1I_Telemetry_Decoder")
-        {
-            std::unique_ptr<TelemetryDecoderInterface> block_ = std::make_unique<BeidouB1iTelemetryDecoder>(configuration, role, in_streams,
-                out_streams);
-            block = std::move(block_);
-        }
-    else if (implementation == "BEIDOU_B3I_Telemetry_Decoder")
-        {
-            std::unique_ptr<TelemetryDecoderInterface> block_ = std::make_unique<BeidouB3iTelemetryDecoder>(configuration, role, in_streams,
-                out_streams);
-            block = std::move(block_);
-        }
-
-    else
-        {
-            std::cerr << "Configuration error in " << role << " block: implementation " << (implementation == "Wrong"s ? "not defined."s : implementation + " not available."s) << '\n';
-            block = nullptr;
-        }
-
-    return block;
+    return get_block(configuration, role, in_streams, out_streams, get_tlm_block);
 }

--- a/src/core/receiver/gnss_block_factory.cc
+++ b/src/core/receiver/gnss_block_factory.cc
@@ -241,7 +241,7 @@ auto findRole(ConfigurationInterface const* configuration, std::string const& ba
     return role;
 };
 
-const auto signal_mapping = std::unordered_map<std::string, std::string>{
+const auto signal_mapping = std::vector<std::pair<std::string, std::string>>{
     {"1C", "GPS L1 C/A"},
     {"2S", "GPS L2C (M)"},
     {"L5", "GPS L5"},

--- a/src/core/receiver/gnss_block_factory.h
+++ b/src/core/receiver/gnss_block_factory.h
@@ -57,7 +57,7 @@ public:
 
     std::unique_ptr<GNSSBlockInterface> GetSignalConditioner(const ConfigurationInterface* configuration, int ID = -1);
 
-    std::unique_ptr<std::vector<std::unique_ptr<GNSSBlockInterface>>> GetChannels(const ConfigurationInterface* configuration,
+    std::vector<std::unique_ptr<GNSSBlockInterface>> GetChannels(const ConfigurationInterface* configuration,
         Concurrent_Queue<pmt::pmt_t>* queue);
 
     std::unique_ptr<GNSSBlockInterface> GetObservables(const ConfigurationInterface* configuration);

--- a/src/core/receiver/gnss_flowgraph.cc
+++ b/src/core/receiver/gnss_flowgraph.cc
@@ -212,10 +212,10 @@ void GNSSFlowgraph::init()
 
     auto channels = block_factory->GetChannels(configuration_.get(), queue_.get());
 
-    channels_count_ = static_cast<int>(channels->size());
+    channels_count_ = static_cast<int>(channels.size());
     for (int i = 0; i < channels_count_; i++)
         {
-            std::shared_ptr<GNSSBlockInterface> chan_ = std::move(channels->at(i));
+            std::shared_ptr<GNSSBlockInterface> chan_ = std::move(channels.at(i));
             channels_.push_back(std::dynamic_pointer_cast<ChannelInterface>(chan_));
         }
 

--- a/tests/unit-tests/control-plane/gnss_block_factory_test.cc
+++ b/tests/unit-tests/control-plane/gnss_block_factory_test.cc
@@ -394,9 +394,9 @@ TEST(GNSSBlockFactoryTest, InstantiateChannels)
     configuration->set_property("TelemetryDecoder_1C.implementation", "GPS_L1_CA_Telemetry_Decoder");
     std::shared_ptr<Concurrent_Queue<pmt::pmt_t>> queue = std::make_shared<Concurrent_Queue<pmt::pmt_t>>();
     std::unique_ptr<GNSSBlockFactory> factory = std::make_unique<GNSSBlockFactory>();
-    std::unique_ptr<std::vector<std::unique_ptr<GNSSBlockInterface>>> channels = factory->GetChannels(configuration.get(), queue.get());
-    EXPECT_EQ(static_cast<unsigned int>(2), channels->size());
-    channels->erase(channels->begin(), channels->end());
+    std::vector<std::unique_ptr<GNSSBlockInterface>> channels = factory->GetChannels(configuration.get(), queue.get());
+    EXPECT_EQ(static_cast<unsigned int>(2), channels.size());
+    channels.erase(channels.begin(), channels.end());
 }
 
 


### PR DESCRIPTION
Updating `gnss_block_factory.cc` is error prone since you have to add your implementations in two places for Acquisition, Tracking and Telemetry, with this change it is only required to do it once, removing code duplication.

Also I do not see a point in creating a temporary `block_` variable to then assign it to `block`, and that change alone removes hundreds of lines of code.

Finally `std::unique_ptr<std::vector<...>>` doesn't make sense, `std::vector<...>` is already using an internal pointer, this is just unnecessary indirection.