### PR TITLE
Ensure correct file length and sample skip calculations on 32-bit systems by using uint64_t

### DIFF
--- a/src/algorithms/signal_source/adapters/file_source_base.cc
+++ b/src/algorithms/signal_source/adapters/file_source_base.cc
@@ -365,16 +365,16 @@ std::tuple<size_t, bool> FileSourceBase::itemTypeToSize()
 double FileSourceBase::packetsPerSample() const { return 1.0; }
 
 
-size_t FileSourceBase::samplesToSkip() const
+uint64_t FileSourceBase::samplesToSkip() const
 {
-    auto samples_to_skip = size_t(0);
+    auto samples_to_skip = uint64_t(0);
 
     if (seconds_to_skip_ > 0)
         {
             // sampling_frequency is in terms of actual samples (output packets). If this source is
             // compressed, there may be multiple packets per file (read) sample. First compute the
             // actual number of samples to skip (function of time and sample rate)
-            samples_to_skip = static_cast<size_t>(seconds_to_skip_ * sampling_frequency_);
+            samples_to_skip = static_cast<uint64_t>(seconds_to_skip_ * sampling_frequency_);
 
             // convert from sample to input items, scaling this value to input item space
             // (rounding up)
@@ -396,7 +396,7 @@ size_t FileSourceBase::samplesToSkip() const
 }
 
 
-size_t FileSourceBase::computeSamplesInFile() const
+uint64_t FileSourceBase::computeSamplesInFile() const
 {
     auto n_samples = samples();
 
@@ -410,7 +410,7 @@ size_t FileSourceBase::computeSamplesInFile() const
      * A possible solution is to compute the file length in samples using file size, excluding at least
      * the last 2 milliseconds, and enable always the valve block
      */
-    const auto tail = static_cast<size_t>(std::ceil(minimum_tail_s_ * sampling_frequency()));
+    const auto tail = static_cast<uint64_t>(std::ceil(minimum_tail_s_ * sampling_frequency()));
 
     if (tail > size)
         {

--- a/src/algorithms/signal_source/adapters/file_source_base.h
+++ b/src/algorithms/signal_source/adapters/file_source_base.h
@@ -112,10 +112,10 @@ protected:
     virtual double packetsPerSample() const;
 
     //! Compute the number of samples to skip
-    virtual size_t samplesToSkip() const;
+    virtual uint64_t samplesToSkip() const;
 
     //! Compute the number of samples in the file
-    size_t computeSamplesInFile() const;
+    uint64_t computeSamplesInFile() const;
 
     //! Abstracted front-end source. Sub-classes may override if they create specialized chains to
     //! decode source files into a usable format


### PR DESCRIPTION
Ensure correct file length and sample skip calculations on 32-bit systems by using uint64_t
    
On 32-bit architectures, size_t may not be large enough to represent large file sizes or sample counts. This update modifies the file length computation and the return type of samplesToSkip() to use uint64_t, allowing accurate handling of large files and ensuring consistency across platforms.
