### PR TITLE
Fixes and Improvements for Sensor Data Handling

### DIFF
--- a/src/algorithms/libs/CMakeLists.txt
+++ b/src/algorithms/libs/CMakeLists.txt
@@ -74,6 +74,7 @@ set(GNSS_SPLIBS_HEADERS ${GNSS_SPLIBS_HEADERS}
     sensor_data/sensor_data_source_configuration.h
     sensor_data/sensor_data_source.h
     sensor_data/sensor_data_aggregator.h
+    sensor_data/sensor_data_resampler.h
 )
 set(GNSS_SPLIBS_SOURCES ${GNSS_SPLIBS_SOURCES}
     sensor_data/sensor_data_type.cc
@@ -82,6 +83,7 @@ set(GNSS_SPLIBS_SOURCES ${GNSS_SPLIBS_SOURCES}
     sensor_data/sensor_data_source_configuration.cc
     sensor_data/sensor_data_source.cc
     sensor_data/sensor_data_aggregator.cc
+    sensor_data/sensor_data_resampler.cc
 )
 
 if(ENABLE_OPENCL)

--- a/src/algorithms/libs/sensor_data/sensor_data_aggregator.cc
+++ b/src/algorithms/libs/sensor_data/sensor_data_aggregator.cc
@@ -37,6 +37,9 @@ SensorDataAggregator::SensorDataAggregator(const SensorDataSourceConfiguration& 
                         case SensorDataType::F32:
                             f32_data_[required_sensor] = {};
                             break;
+                        case SensorDataType::F64:
+                            f64_data_[required_sensor] = {};
+                            break;
 
                             // More maps to be populated in the future for different types
                             // For now, all supported sensors are represented as f32
@@ -72,6 +75,16 @@ void SensorDataAggregator::update(const std::vector<gr::tag_t>& tags)
             if (not sensor_samples.empty())
                 {
                     SensorDataSample<float> last_sample = sensor_samples.back();
+                    sensor_samples.clear();
+                    sensor_samples.emplace_back(last_sample);
+                }
+        }
+    for (auto& sensor_data : f64_data_)
+        {
+            std::vector<SensorDataSample<double>>& sensor_samples = sensor_data.second;
+            if (not sensor_samples.empty())
+                {
+                    SensorDataSample<double> last_sample = sensor_samples.back();
                     sensor_samples.clear();
                     sensor_samples.emplace_back(last_sample);
                 }
@@ -140,6 +153,56 @@ SensorDataSample<float> SensorDataAggregator::get_average_f32(SensorIdentifier::
 }
 
 
+const std::vector<SensorDataSample<double>>& SensorDataAggregator::get_f64(SensorIdentifier::value_type sensor_id) const
+{
+    // The map is populated on construction with empty vectors for each provided sensor.
+    // If a required sensor is not provided, the error is handled on construction.
+    return f64_data_.at(sensor_id);
+}
+
+
+SensorDataSample<double> SensorDataAggregator::get_last_f64(SensorIdentifier::value_type sensor_id) const
+{
+    // The map is populated on construction with empty vectors for each provided sensor.
+    // If a required sensor is not provided, the error is handled on construction.
+    const std::vector<SensorDataSample<double>> samples = f64_data_.at(sensor_id);
+    if (samples.empty())
+        {
+            return {0, 0};
+        }
+    return samples.back();
+}
+
+SensorDataSample<double> SensorDataAggregator::get_average_f64(SensorIdentifier::value_type sensor_id) const
+{
+    // The map is populated on construction with empty vectors for each provided sensor.
+    // If a required sensor is not provided, the error is handled on construction.
+    const std::vector<SensorDataSample<double>> samples = f64_data_.at(sensor_id);
+    if (samples.empty())
+        {
+            return {0, 0};
+        }
+    double acc = 0.0;
+    double count = 0;
+    bool first = true;
+    for (const auto& sample : samples)
+        {
+            if (first)
+                {
+                    first = false;
+                    continue;
+                }
+            acc += sample.value;
+            ++count;
+        }
+    if (count == 0)
+        {
+            return {samples.back().timestamp, 0};
+        }
+    return {samples.back().timestamp, acc / count};
+}
+
+
 void SensorDataAggregator::append_data(const pmt::pmt_t& data_dict)
 {
     static pmt::pmt_t SAMPLE_STAMP_KEY = pmt::mp(SensorIdentifier::to_string(SensorIdentifier::SAMPLE_STAMP));
@@ -163,6 +226,12 @@ void SensorDataAggregator::append_data(const pmt::pmt_t& data_dict)
                             if (f32_data_.find(sensor_id) != f32_data_.end())
                                 {
                                     f32_data_.at(sensor_id).emplace_back(sample_stamp, pmt::to_float(std::move(val)));
+                                }
+                            break;
+                        case SensorDataType::F64:
+                            if (f64_data_.find(sensor_id) != f64_data_.end())
+                                {
+                                    f64_data_.at(sensor_id).emplace_back(sample_stamp, pmt::to_double(std::move(val)));
                                 }
                             break;
 

--- a/src/algorithms/libs/sensor_data/sensor_data_aggregator.cc
+++ b/src/algorithms/libs/sensor_data/sensor_data_aggregator.cc
@@ -42,7 +42,6 @@ SensorDataAggregator::SensorDataAggregator(const SensorDataSourceConfiguration& 
                             break;
 
                             // More maps to be populated in the future for different types
-                            // For now, all supported sensors are represented as f32
 
                         default:
                             break;
@@ -90,7 +89,6 @@ void SensorDataAggregator::update(const std::vector<gr::tag_t>& tags)
                 }
         }
     // More maps to be cleared in the future for different types
-    // For now, all supported sensors are represented as f32
 
     // Append new data
     for (const auto& sensor_tag : tags)
@@ -236,7 +234,6 @@ void SensorDataAggregator::append_data(const pmt::pmt_t& data_dict)
                             break;
 
                             // More types to be handled in the future for different types
-                            // For now, all supported sensors are represented as f32
 
                         default:
                             break;

--- a/src/algorithms/libs/sensor_data/sensor_data_aggregator.cc
+++ b/src/algorithms/libs/sensor_data/sensor_data_aggregator.cc
@@ -110,6 +110,35 @@ SensorDataSample<float> SensorDataAggregator::get_last_f32(SensorIdentifier::val
     return samples.back();
 }
 
+SensorDataSample<float> SensorDataAggregator::get_average_f32(SensorIdentifier::value_type sensor_id) const
+{
+    // The map is populated on construction with empty vectors for each provided sensor.
+    // If a required sensor is not provided, the error is handled on construction.
+    const std::vector<SensorDataSample<float>> samples = f32_data_.at(sensor_id);
+    if (samples.empty())
+        {
+            return {0, 0};
+        }
+    float acc = 0.0;
+    float count = 0;
+    bool first = true;
+    for (const auto& sample : samples)
+        {
+            if (first)
+                {
+                    first = false;
+                    continue;
+                }
+            acc += sample.value;
+            ++count;
+        }
+    if (count == 0)
+        {
+            return {samples.back().timestamp, 0};
+        }
+    return {samples.back().timestamp, acc / count};
+}
+
 
 void SensorDataAggregator::append_data(const pmt::pmt_t& data_dict)
 {

--- a/src/algorithms/libs/sensor_data/sensor_data_aggregator.h
+++ b/src/algorithms/libs/sensor_data/sensor_data_aggregator.h
@@ -60,14 +60,12 @@ public:
     SensorDataSample<double> get_average_f64(SensorIdentifier::value_type sensor_id) const;
 
     // More getters to be added in the future for different types
-    // For now, all supported sensors are represented as f32
 private:
     void append_data(const pmt::pmt_t& data_dict);
 
     std::unordered_map<SensorIdentifier::value_type, std::vector<SensorDataSample<float>>> f32_data_{};
     std::unordered_map<SensorIdentifier::value_type, std::vector<SensorDataSample<double>>> f64_data_{};
     // More maps to be added in the future for different types
-    // For now, all supported sensors are represented as f32
 };
 
 

--- a/src/algorithms/libs/sensor_data/sensor_data_aggregator.h
+++ b/src/algorithms/libs/sensor_data/sensor_data_aggregator.h
@@ -53,6 +53,7 @@ public:
 
     const std::vector<SensorDataSample<float>>& get_f32(SensorIdentifier::value_type sensor_id) const;
     SensorDataSample<float> get_last_f32(SensorIdentifier::value_type sensor_id) const;
+    SensorDataSample<float> get_average_f32(SensorIdentifier::value_type sensor_id) const;
 
     // More getters to be added in the future for different types
     // For now, all supported sensors are represented as f32

--- a/src/algorithms/libs/sensor_data/sensor_data_aggregator.h
+++ b/src/algorithms/libs/sensor_data/sensor_data_aggregator.h
@@ -55,12 +55,17 @@ public:
     SensorDataSample<float> get_last_f32(SensorIdentifier::value_type sensor_id) const;
     SensorDataSample<float> get_average_f32(SensorIdentifier::value_type sensor_id) const;
 
+    const std::vector<SensorDataSample<double>>& get_f64(SensorIdentifier::value_type sensor_id) const;
+    SensorDataSample<double> get_last_f64(SensorIdentifier::value_type sensor_id) const;
+    SensorDataSample<double> get_average_f64(SensorIdentifier::value_type sensor_id) const;
+
     // More getters to be added in the future for different types
     // For now, all supported sensors are represented as f32
 private:
     void append_data(const pmt::pmt_t& data_dict);
 
     std::unordered_map<SensorIdentifier::value_type, std::vector<SensorDataSample<float>>> f32_data_{};
+    std::unordered_map<SensorIdentifier::value_type, std::vector<SensorDataSample<double>>> f64_data_{};
     // More maps to be added in the future for different types
     // For now, all supported sensors are represented as f32
 };

--- a/src/algorithms/libs/sensor_data/sensor_data_file.cc
+++ b/src/algorithms/libs/sensor_data/sensor_data_file.cc
@@ -33,7 +33,7 @@ SensorDataFile::SensorDataFile(
       offset_in_file_(offset_in_file),
       item_size_(item_size),
       chunks_read_(0),
-      last_sample_stamp_(sample_delay),
+      next_sample_stamp_(sample_delay),
       io_buffer_size_(item_size * IO_BUFFER_MAX_SIZE),
       offset_in_io_buffer_(io_buffer_size_),  // Set to end of buffer so that first look up will trigger a read.
       repeat_(repeat),
@@ -76,10 +76,10 @@ bool SensorDataFile::read_item(std::vector<uint8_t>& buffer)
 
 bool SensorDataFile::read_until_sample(std::size_t end_sample, std::size_t& sample_stamp, std::vector<uint8_t>& buffer)
 {
-    if (last_sample_stamp_ + sample_period_ < end_sample)
+    if (next_sample_stamp_ + sample_period_ < end_sample)
         {
-            last_sample_stamp_ += sample_period_;
-            sample_stamp = last_sample_stamp_;
+            sample_stamp = next_sample_stamp_;
+            next_sample_stamp_ += sample_period_;
             read_item(buffer);
             return true;
         }

--- a/src/algorithms/libs/sensor_data/sensor_data_file.h
+++ b/src/algorithms/libs/sensor_data/sensor_data_file.h
@@ -66,7 +66,7 @@ private:
     std::size_t item_size_;
 
     std::size_t chunks_read_;
-    std::size_t last_sample_stamp_;
+    std::size_t next_sample_stamp_;
     std::vector<uint8_t> io_buffer_;
     std::size_t io_buffer_size_;
     std::size_t offset_in_io_buffer_;

--- a/src/algorithms/libs/sensor_data/sensor_data_resampler.cc
+++ b/src/algorithms/libs/sensor_data/sensor_data_resampler.cc
@@ -1,7 +1,7 @@
 /*!
  * \file sensor_data_resampler.cc
  * \brief  Updates timestamp within sensor data tags. To be used in resampler blocks.
- * \author Victor Castillo, 2024. victorcastilloaguero(at)gmail.com
+ * \author Victor Castillo, 2025. victorcastilloaguero(at)gmail.com
  *
  * -----------------------------------------------------------------------------
  *

--- a/src/algorithms/libs/sensor_data/sensor_data_resampler.cc
+++ b/src/algorithms/libs/sensor_data/sensor_data_resampler.cc
@@ -25,7 +25,9 @@ std::vector<gr::tag_t> resample_sensor_data_tags(const std::vector<gr::tag_t>& t
         {
             if (pmt::dict_has_key(tag.value, SAMPLE_STAMP_KEY))
                 {
-                    auto& new_tag = new_tags.emplace_back();
+                    new_tags.emplace_back();
+                    auto& new_tag = new_tags.back();
+
                     uint64_t sample_stamp = pmt::to_uint64(pmt::dict_ref(tag.value, SAMPLE_STAMP_KEY, pmt::from_uint64(0)));
                     sample_stamp = sample_stamp * freq_out / freq_in;
                     new_tag.offset = tag.offset * freq_out / freq_in;

--- a/src/algorithms/libs/sensor_data/sensor_data_resampler.cc
+++ b/src/algorithms/libs/sensor_data/sensor_data_resampler.cc
@@ -1,0 +1,37 @@
+/*!
+ * \file sensor_data_resampler.cc
+ * \brief  Updates timestamp within sensor data tags. To be used within resampler blocks.
+ * \author Victor Castillo, 2024. victorcastilloaguero(at)gmail.com
+ *
+ * -----------------------------------------------------------------------------
+ *
+ * GNSS-SDR is a Global Navigation Satellite System software-defined receiver.
+ * This file is part of GNSS-SDR.
+ *
+ * Copyright (C) 2025  (see AUTHORS file for a list of contributors)
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ *
+ * -----------------------------------------------------------------------------
+ */
+
+#include "sensor_data_resampler.h"
+#include "sensor_identifier.h"
+
+std::vector<gr::tag_t> resample_sensor_data_tags(const std::vector<gr::tag_t>& tags, double freq_in, double freq_out)
+{
+    static pmt::pmt_t SAMPLE_STAMP_KEY = pmt::mp(SensorIdentifier::to_string(SensorIdentifier::SAMPLE_STAMP));
+    std::vector<gr::tag_t> new_tags{};
+    for (auto& tag : tags)
+        {
+            if (pmt::dict_has_key(tag.value, SAMPLE_STAMP_KEY))
+                {
+                    auto& new_tag = new_tags.emplace_back();
+                    uint64_t sample_stamp = pmt::to_uint64(pmt::dict_ref(tag.value, SAMPLE_STAMP_KEY, pmt::from_uint64(0)));
+                    sample_stamp = sample_stamp * freq_out / freq_in;
+                    new_tag.offset = tag.offset * freq_out / freq_in;
+                    new_tag.key = tag.key;
+                    new_tag.value = pmt::dict_add(tag.value, SAMPLE_STAMP_KEY, pmt::from_uint64(sample_stamp));
+                }
+        }
+    return new_tags;
+}

--- a/src/algorithms/libs/sensor_data/sensor_data_resampler.cc
+++ b/src/algorithms/libs/sensor_data/sensor_data_resampler.cc
@@ -21,7 +21,7 @@ std::vector<gr::tag_t> resample_sensor_data_tags(const std::vector<gr::tag_t>& t
 {
     static pmt::pmt_t SAMPLE_STAMP_KEY = pmt::mp(SensorIdentifier::to_string(SensorIdentifier::SAMPLE_STAMP));
     std::vector<gr::tag_t> new_tags{};
-    for (auto& tag : tags)
+    for (const auto& tag : tags)
         {
             if (pmt::dict_has_key(tag.value, SAMPLE_STAMP_KEY))
                 {

--- a/src/algorithms/libs/sensor_data/sensor_data_resampler.cc
+++ b/src/algorithms/libs/sensor_data/sensor_data_resampler.cc
@@ -1,6 +1,6 @@
 /*!
  * \file sensor_data_resampler.cc
- * \brief  Updates timestamp within sensor data tags. To be used within resampler blocks.
+ * \brief  Updates timestamp within sensor data tags. To be used in resampler blocks.
  * \author Victor Castillo, 2024. victorcastilloaguero(at)gmail.com
  *
  * -----------------------------------------------------------------------------

--- a/src/algorithms/libs/sensor_data/sensor_data_resampler.h
+++ b/src/algorithms/libs/sensor_data/sensor_data_resampler.h
@@ -1,6 +1,6 @@
 /*!
  * \file sensor_data_resampler.h
- * \brief  Updates timestamp within sensor data tags. To be used within resampler blocks.
+ * \brief  Updates timestamp within sensor data tags. To be used in resampler blocks.
  * \author Victor Castillo, 2024. victorcastilloaguero(at)gmail.com
  *
  * -----------------------------------------------------------------------------
@@ -27,6 +27,13 @@
  * \{ */
 
 
+/** \brief Updates timestamp within sensor data tags. To be used in resampler blocks.
+ *
+ *  \param tags Stream tags as retrieved by `get_tags_in_window` or `get_tags_in_range`.
+ *  \param freq_in Input RF sample rate.
+ *  \param freq_out Output RF sample rate.
+ *  \return Stream tags to be added with `add_item_tag`.
+ */
 std::vector<gr::tag_t> resample_sensor_data_tags(const std::vector<gr::tag_t>& tags, double freq_in, double freq_out);
 
 

--- a/src/algorithms/libs/sensor_data/sensor_data_resampler.h
+++ b/src/algorithms/libs/sensor_data/sensor_data_resampler.h
@@ -1,7 +1,7 @@
 /*!
  * \file sensor_data_resampler.h
  * \brief  Updates timestamp within sensor data tags. To be used in resampler blocks.
- * \author Victor Castillo, 2024. victorcastilloaguero(at)gmail.com
+ * \author Victor Castillo, 2025. victorcastilloaguero(at)gmail.com
  *
  * -----------------------------------------------------------------------------
  *

--- a/src/algorithms/libs/sensor_data/sensor_data_resampler.h
+++ b/src/algorithms/libs/sensor_data/sensor_data_resampler.h
@@ -1,0 +1,35 @@
+/*!
+ * \file sensor_data_resampler.h
+ * \brief  Updates timestamp within sensor data tags. To be used within resampler blocks.
+ * \author Victor Castillo, 2024. victorcastilloaguero(at)gmail.com
+ *
+ * -----------------------------------------------------------------------------
+ *
+ * GNSS-SDR is a Global Navigation Satellite System software-defined receiver.
+ * This file is part of GNSS-SDR.
+ *
+ * Copyright (C) 2025  (see AUTHORS file for a list of contributors)
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ *
+ * -----------------------------------------------------------------------------
+ */
+
+
+#ifndef GNSS_SDR_SENSOR_DATA_RESAMPLER_H
+#define GNSS_SDR_SENSOR_DATA_RESAMPLER_H
+
+#include <gnuradio/tags.h>
+#include <vector>
+
+/** \addtogroup Algorithms_Library
+ * \{ */
+/** \addtogroup Algorithm_libs algorithms_libs
+ * \{ */
+
+
+std::vector<gr::tag_t> resample_sensor_data_tags(const std::vector<gr::tag_t>& tags, double freq_in, double freq_out);
+
+
+/** \} */
+/** \} */
+#endif  // GNSS_SDR_SENSOR_DATA_RESAMPLER_H

--- a/src/algorithms/libs/sensor_data/sensor_data_source.cc
+++ b/src/algorithms/libs/sensor_data/sensor_data_source.cc
@@ -115,7 +115,7 @@ int SensorDataSource::work(int noutput_items,
                             pmt::pmt_t value = SensorIdentifier::convert_to_internal_type(sensor.identifier, sensor.type, raw_value);
                             data_tag = pmt::dict_add(data_tag, sensor.tag_key, value);
                         }
-                    add_item_tag(0, sample_stamp, TAG_KEY, data_tag);
+                    add_item_tag(0, nitems_written(0), TAG_KEY, data_tag);
                 }
         }
 

--- a/src/algorithms/libs/sensor_data/sensor_data_source.cc
+++ b/src/algorithms/libs/sensor_data/sensor_data_source.cc
@@ -24,8 +24,6 @@
 #include <absl/log/log.h>
 #endif
 
-using namespace std::string_literals;
-
 SensorDataSource::SensorDataSource(
     const SensorDataSourceConfiguration& configuration,
     const gr::io_signature::sptr& io_signature)

--- a/src/algorithms/libs/sensor_data/sensor_data_source_configuration.cc
+++ b/src/algorithms/libs/sensor_data/sensor_data_source_configuration.cc
@@ -15,6 +15,7 @@
  */
 
 #include "sensor_data_source_configuration.h"
+#include "gnss_sdr_string_literals.h"
 #include <fstream>
 
 #if USE_GLOG_AND_GFLAGS
@@ -22,6 +23,11 @@
 #else
 #include <absl/log/log.h>
 #endif
+
+using namespace std::string_literals;
+
+static std::string CONFIGURATION_ROLE = "SensorData";
+
 
 SensorDataSourceConfiguration::SensorDataSourceConfiguration(const ConfigurationInterface* configuration)
     : enabled_(configuration->property("SensorData.enabled"s, false)), items_per_sample_(1)

--- a/src/algorithms/libs/sensor_data/sensor_data_source_configuration.h
+++ b/src/algorithms/libs/sensor_data/sensor_data_source_configuration.h
@@ -19,7 +19,6 @@
 #define GNSS_SDR_SENSOR_DATA_SOURCE_CONFIGURATION_H
 
 #include "configuration_interface.h"
-#include "gnss_sdr_string_literals.h"
 #include "sensor_data_type.h"
 #include "sensor_identifier.h"
 #include <string>
@@ -29,10 +28,6 @@
  * \{ */
 /** \addtogroup Algorithm_libs algorithms_libs
  * \{ */
-
-using namespace std::string_literals;
-
-static std::string CONFIGURATION_ROLE = "SensorData";
 
 class ConfigurationInterface;
 

--- a/src/algorithms/libs/sensor_data/sensor_identifier.cc
+++ b/src/algorithms/libs/sensor_data/sensor_identifier.cc
@@ -33,6 +33,10 @@ static const ConversionEntry conversion_table[] = {
     {SensorDataType::F64, SensorDataType::F32, [](const pmt::pmt_t& val) { return pmt::from_float(pmt::to_double(val)); }},
     {SensorDataType::I32, SensorDataType::F32, [](const pmt::pmt_t& val) { return pmt::from_float(pmt::to_long(val)); }},
     {SensorDataType::I64, SensorDataType::F32, [](const pmt::pmt_t& val) { return pmt::from_float(pmt::to_long(val)); }},
+    {SensorDataType::F32, SensorDataType::F64, [](const pmt::pmt_t& val) { return pmt::from_double(pmt::to_float(val)); }},
+    {SensorDataType::F64, SensorDataType::F64, [](const pmt::pmt_t& val) { return val; }},
+    {SensorDataType::I32, SensorDataType::F64, [](const pmt::pmt_t& val) { return pmt::from_double(pmt::to_long(val)); }},
+    {SensorDataType::I64, SensorDataType::F64, [](const pmt::pmt_t& val) { return pmt::from_double(pmt::to_long(val)); }},
 };
 
 
@@ -174,7 +178,7 @@ SensorDataType::value_type SensorIdentifier::get_internal_type(value_type sensor
         case IMU_ANG_ACC_X:
         case IMU_ANG_ACC_Y:
         case IMU_ANG_ACC_Z:
-            return SensorDataType::F32;
+            return SensorDataType::F64;
         default:
             return SensorDataType::F32;
         }

--- a/src/algorithms/observables/gnuradio_blocks/hybrid_observables_gs.cc
+++ b/src/algorithms/observables/gnuradio_blocks/hybrid_observables_gs.cc
@@ -661,7 +661,15 @@ void hybrid_observables_gs::set_tag_timestamp_in_sdr_timeframe(const std::vector
 void hybrid_observables_gs::propagate_sensor_data(const std::vector<Gnss_Synchro> &data)
 {
     static pmt::pmt_t SAMPLE_STAMP_KEY = pmt::mp(SensorIdentifier::to_string(SensorIdentifier::SAMPLE_STAMP));
-    uint64_t current_sample = data[0].Tracking_sample_counter * 10;
+    uint64_t current_sample = 0;
+    for (const Gnss_Synchro& item: data)
+        {
+            if (item.Tracking_sample_counter > current_sample)
+                {
+                    current_sample = item.Tracking_sample_counter;
+                }
+        }
+
     if (d_trq_last_sample == 0)
         {
             d_trq_last_sample = current_sample;

--- a/src/algorithms/observables/gnuradio_blocks/hybrid_observables_gs.cc
+++ b/src/algorithms/observables/gnuradio_blocks/hybrid_observables_gs.cc
@@ -23,6 +23,7 @@
 #include "gnss_sdr_filesystem.h"
 #include "gnss_sdr_make_unique.h"
 #include "gnss_synchro.h"
+#include "sensor_data/sensor_identifier.h"
 #include <gnuradio/io_signature.h>
 #include <matio.h>
 #include <pmt/pmt.h>
@@ -657,16 +658,38 @@ void hybrid_observables_gs::set_tag_timestamp_in_sdr_timeframe(const std::vector
         }
 }
 
-void hybrid_observables_gs::propagate_sensor_data()
+void hybrid_observables_gs::propagate_sensor_data(const std::vector<Gnss_Synchro> &data)
 {
+    static pmt::pmt_t SAMPLE_STAMP_KEY = pmt::mp(SensorIdentifier::to_string(SensorIdentifier::SAMPLE_STAMP));
+    uint64_t current_sample = data[0].Tracking_sample_counter * 10;
+    if (d_trq_last_sample == 0)
+        {
+            d_trq_last_sample = current_sample;
+            while (!d_sensor_data_tags.empty())
+                {
+                    d_sensor_data_tags.pop();
+                }
+            return;
+        }
     while (!d_sensor_data_tags.empty())
         {
-            {
-                auto &tag = d_sensor_data_tags.front();
-                add_item_tag(0, this->nitems_written(0) + 1, tag.key, tag.value);
-                d_sensor_data_tags.pop();
-            }
+            auto &tag = d_sensor_data_tags.front();
+            uint64_t tag_sample = pmt::to_uint64(pmt::dict_ref(tag.value, SAMPLE_STAMP_KEY, pmt::from_uint64(0)));
+
+            if (tag_sample <= current_sample)
+                {
+                    if (tag_sample > d_trq_last_sample)
+                        {
+                            add_item_tag(0, this->nitems_written(0) + 1, tag.key, tag.value);
+                        }
+                    d_sensor_data_tags.pop();
+                }
+            else
+                {
+                    break;
+                }
         }
+    d_trq_last_sample = current_sample;
 }
 
 
@@ -685,11 +708,7 @@ int hybrid_observables_gs::general_work(int noutput_items __attribute__((unused)
 
             std::vector<gr::tag_t> tags_vec;
             // Propagate sensor data tags
-            get_tags_in_range(tags_vec, d_nchannels_in - 1, this->nitems_read(d_nchannels_in - 1), this->nitems_read(d_nchannels_in - 1) + 1, pmt::mp("sensor_data"));
-            while (!d_sensor_data_tags.empty())
-                {
-                    d_sensor_data_tags.pop();
-                }
+            get_tags_in_range(tags_vec, d_nchannels_in - 1, this->nitems_read(d_nchannels_in - 1), this->nitems_read(d_nchannels_in - 1) + ninput_items[d_nchannels_in - 1], pmt::mp("sensor_data"));
             for (const auto &tag : tags_vec)
                 {
                     d_sensor_data_tags.emplace(tag);
@@ -818,7 +837,7 @@ int hybrid_observables_gs::general_work(int noutput_items __attribute__((unused)
                 {
                     compute_pranges(epoch_data);
                     set_tag_timestamp_in_sdr_timeframe(epoch_data, d_Rx_clock_buffer.front());
-                    propagate_sensor_data();
+                    propagate_sensor_data(epoch_data);
                 }
 
             // Carrier smoothing (optional)

--- a/src/algorithms/observables/gnuradio_blocks/hybrid_observables_gs.cc
+++ b/src/algorithms/observables/gnuradio_blocks/hybrid_observables_gs.cc
@@ -662,12 +662,9 @@ void hybrid_observables_gs::propagate_sensor_data(const std::vector<Gnss_Synchro
 {
     static pmt::pmt_t SAMPLE_STAMP_KEY = pmt::mp(SensorIdentifier::to_string(SensorIdentifier::SAMPLE_STAMP));
     uint64_t current_sample = 0;
-    for (const Gnss_Synchro& item: data)
+    for (const Gnss_Synchro &item : data)
         {
-            if (item.Tracking_sample_counter > current_sample)
-                {
-                    current_sample = item.Tracking_sample_counter;
-                }
+            current_sample = std::max(current_sample, item.Tracking_sample_counter);
         }
 
     if (d_trq_last_sample == 0)

--- a/src/algorithms/observables/gnuradio_blocks/hybrid_observables_gs.h
+++ b/src/algorithms/observables/gnuradio_blocks/hybrid_observables_gs.h
@@ -94,7 +94,7 @@ private:
     std::queue<GnssTime> d_TimeChannelTagTimestamps;
 
     std::queue<gr::tag_t> d_sensor_data_tags;
-    std::uint64_t d_trq_last_sample;
+    std::uint64_t d_trq_last_sample{0};
 
     std::vector<bool> d_channel_last_pll_lock;
     std::vector<double> d_channel_last_pseudorange_smooth;

--- a/src/algorithms/observables/gnuradio_blocks/hybrid_observables_gs.h
+++ b/src/algorithms/observables/gnuradio_blocks/hybrid_observables_gs.h
@@ -80,7 +80,7 @@ private:
 
     void set_tag_timestamp_in_sdr_timeframe(const std::vector<Gnss_Synchro>& data, uint64_t rx_clock);
 
-    void propagate_sensor_data(const std::vector<Gnss_Synchro> &data);
+    void propagate_sensor_data(const std::vector<Gnss_Synchro>& data);
 
     int32_t save_matfile() const;
 

--- a/src/algorithms/observables/gnuradio_blocks/hybrid_observables_gs.h
+++ b/src/algorithms/observables/gnuradio_blocks/hybrid_observables_gs.h
@@ -80,7 +80,7 @@ private:
 
     void set_tag_timestamp_in_sdr_timeframe(const std::vector<Gnss_Synchro>& data, uint64_t rx_clock);
 
-    void propagate_sensor_data();
+    void propagate_sensor_data(const std::vector<Gnss_Synchro> &data);
 
     int32_t save_matfile() const;
 
@@ -94,6 +94,7 @@ private:
     std::queue<GnssTime> d_TimeChannelTagTimestamps;
 
     std::queue<gr::tag_t> d_sensor_data_tags;
+    std::uint64_t d_trq_last_sample;
 
     std::vector<bool> d_channel_last_pll_lock;
     std::vector<double> d_channel_last_pseudorange_smooth;

--- a/src/algorithms/resampler/gnuradio_blocks/CMakeLists.txt
+++ b/src/algorithms/resampler/gnuradio_blocks/CMakeLists.txt
@@ -41,6 +41,7 @@ target_link_libraries(resampler_gr_blocks
         Gnuradio::runtime
         Boost::headers   # Fix for homebrew
     PRIVATE
+        algorithms_libs
         Volk::volk
 )
 

--- a/src/algorithms/resampler/gnuradio_blocks/direct_resampler_conditioner_cb.cc
+++ b/src/algorithms/resampler/gnuradio_blocks/direct_resampler_conditioner_cb.cc
@@ -18,8 +18,8 @@
 
 
 #include "direct_resampler_conditioner_cb.h"
-#include "../../libs/sensor_data/sensor_data_resampler.h"
-#include "../../libs/sensor_data/sensor_identifier.h"
+#include "sensor_data/sensor_data_resampler.h"
+#include "sensor_data/sensor_identifier.h"
 #include <gnuradio/io_signature.h>
 #include <volk/volk.h>  // for lv_8sc_t
 #include <algorithm>    // for min

--- a/src/algorithms/resampler/gnuradio_blocks/direct_resampler_conditioner_cb.cc
+++ b/src/algorithms/resampler/gnuradio_blocks/direct_resampler_conditioner_cb.cc
@@ -18,6 +18,8 @@
 
 
 #include "direct_resampler_conditioner_cb.h"
+#include "../../libs/sensor_data/sensor_data_resampler.h"
+#include "../../libs/sensor_data/sensor_identifier.h"
 #include <gnuradio/io_signature.h>
 #include <volk/volk.h>  // for lv_8sc_t
 #include <algorithm>    // for min
@@ -58,6 +60,10 @@ direct_resampler_conditioner_cb::direct_resampler_conditioner_cb(
 #else
     this->set_relative_rate(sample_freq_out / sample_freq_in);
 #endif
+
+    // Do not propagate tags, they carry a sample offset that is not properly updated in
+    // this resampler and thus needs manual handling.
+    this->set_tag_propagation_policy(TPP_DONT);
 }
 
 
@@ -110,6 +116,15 @@ int direct_resampler_conditioner_cb::general_work(int noutput_items,
                     lcv++;
                 }
         }
+
+    // Sensor data tag resampling
+    std::vector<gr::tag_t> sensor_tags;
+    this->get_tags_in_window(sensor_tags, 0, 0, std::min(count, ninput_items[0]), pmt::mp("sensor_data"));
+    for (auto &tag : resample_sensor_data_tags(sensor_tags, d_sample_freq_in, d_sample_freq_out))
+        {
+            this->add_item_tag(0, tag);
+        }
+
 
     consume_each(std::min(count, ninput_items[0]));
     return lcv;

--- a/src/algorithms/resampler/gnuradio_blocks/direct_resampler_conditioner_cc.cc
+++ b/src/algorithms/resampler/gnuradio_blocks/direct_resampler_conditioner_cc.cc
@@ -18,8 +18,8 @@
 
 
 #include "direct_resampler_conditioner_cc.h"
-#include "../../libs/sensor_data/sensor_data_resampler.h"
-#include "../../libs/sensor_data/sensor_identifier.h"
+#include "sensor_data/sensor_data_resampler.h"
+#include "sensor_data/sensor_identifier.h"
 #include <gnuradio/io_signature.h>
 #include <volk/volk.h>  // for gr_complex
 #include <algorithm>    // for min

--- a/src/algorithms/resampler/gnuradio_blocks/direct_resampler_conditioner_cc.cc
+++ b/src/algorithms/resampler/gnuradio_blocks/direct_resampler_conditioner_cc.cc
@@ -18,6 +18,8 @@
 
 
 #include "direct_resampler_conditioner_cc.h"
+#include "../../libs/sensor_data/sensor_data_resampler.h"
+#include "../../libs/sensor_data/sensor_identifier.h"
 #include <gnuradio/io_signature.h>
 #include <volk/volk.h>  // for gr_complex
 #include <algorithm>    // for min
@@ -57,6 +59,10 @@ direct_resampler_conditioner_cc::direct_resampler_conditioner_cc(
 #else
     this->set_relative_rate(sample_freq_out / sample_freq_in);
 #endif
+
+    // Do not propagate tags, they carry a sample offset that is not properly updated in
+    // this resampler and thus needs manual handling.
+    this->set_tag_propagation_policy(TPP_DONT);
 }
 
 
@@ -108,6 +114,15 @@ int direct_resampler_conditioner_cc::general_work(int noutput_items,
                     lcv++;
                 }
         }
+
+    // Sensor data tag resampling
+    std::vector<gr::tag_t> sensor_tags;
+    this->get_tags_in_window(sensor_tags, 0, 0, std::min(count, ninput_items[0]), pmt::mp("sensor_data"));
+    for (auto &tag : resample_sensor_data_tags(sensor_tags, d_sample_freq_in, d_sample_freq_out))
+        {
+            this->add_item_tag(0, tag);
+        }
+
 
     consume_each(std::min(count, ninput_items[0]));
     return lcv;

--- a/src/algorithms/resampler/gnuradio_blocks/direct_resampler_conditioner_cs.cc
+++ b/src/algorithms/resampler/gnuradio_blocks/direct_resampler_conditioner_cs.cc
@@ -18,6 +18,8 @@
 
 
 #include "direct_resampler_conditioner_cs.h"
+#include "../../libs/sensor_data/sensor_data_resampler.h"
+#include "../../libs/sensor_data/sensor_identifier.h"
 #include <gnuradio/io_signature.h>
 #include <volk/volk.h>  // for lv_16sc_t
 #include <algorithm>    // for min
@@ -59,6 +61,10 @@ direct_resampler_conditioner_cs::direct_resampler_conditioner_cs(
 #else
     this->set_relative_rate(sample_freq_out / sample_freq_in);
 #endif
+
+    // Do not propagate tags, they carry a sample offset that is not properly updated in
+    // this resampler and thus needs manual handling.
+    this->set_tag_propagation_policy(TPP_DONT);
 }
 
 
@@ -111,6 +117,15 @@ int direct_resampler_conditioner_cs::general_work(int noutput_items,
                     lcv++;
                 }
         }
+
+    // Sensor data tag resampling
+    std::vector<gr::tag_t> sensor_tags;
+    this->get_tags_in_window(sensor_tags, 0, 0, std::min(count, ninput_items[0]), pmt::mp("sensor_data"));
+    for (auto &tag : resample_sensor_data_tags(sensor_tags, d_sample_freq_in, d_sample_freq_out))
+        {
+            this->add_item_tag(0, tag);
+        }
+
 
     consume_each(std::min(count, ninput_items[0]));
     return lcv;

--- a/src/algorithms/resampler/gnuradio_blocks/direct_resampler_conditioner_cs.cc
+++ b/src/algorithms/resampler/gnuradio_blocks/direct_resampler_conditioner_cs.cc
@@ -18,8 +18,8 @@
 
 
 #include "direct_resampler_conditioner_cs.h"
-#include "../../libs/sensor_data/sensor_data_resampler.h"
-#include "../../libs/sensor_data/sensor_identifier.h"
+#include "sensor_data/sensor_data_resampler.h"
+#include "sensor_data/sensor_identifier.h"
 #include <gnuradio/io_signature.h>
 #include <volk/volk.h>  // for lv_16sc_t
 #include <algorithm>    // for min


### PR DESCRIPTION
This PR is part of my [Google Summer of Code 2025 project](https://gist.github.com/castle055/902862007ac1d97f35702bc51347b549).

After spending the summer using the sensor data infrastructure (merged in https://github.com/gnss-sdr/gnss-sdr/pull/894), I have found a few issues with the implementation. This PR solves these issues and also adds a couple minor features.

## Changes

- **ADDED:** `SensorDataType::F64` implements double floating point precision. IMU measurements now default to this data type instead of `F32`.
- **ADDED:** `SensorDataAggregator::get_average_<<type>>(SensorIdentifier)` returns the average among all measurements in the current update cycle.
- **FIX:** Off-by-one error within the `SensorDataFile`. Instead of storing the last RF sample with a measurement, the **next** RF sample to be tagged is stored, shifting all measurement by one period into the past.
- **FIX:** Resampler blocks now update the timestamp stored in each sensor measurement to reflect the interpolation/decimation performed on the RF stream.
- **FIX:** The `HybridObservables` block now delays sensor samples in order to match the delay caused by tracking and telemetry decoding. The delay is not fixed, measurements are pushed into a queue as they arrive from the sample counter block and only released when a channel outputs a `Gnss_Synchro::Tracking_sample_counter` larger than the one stored within the sensor measurement. This means the delay adapts in real time to the computing power available maintaining synchronicity.
- **FIX:** Sometimes the math in `SensorDataSource` added up and sensor measurements where tagged into RF samples that were already gone from the block's buffer. I misunderstood the way GNU Radio handled tags and thought this was okay. In reality, a block can only tag samples while they are in its buffers and so those sensor measurements were being lost. The solution is to tag the measurements to the first RF sample in the buffer, whichever that may be. This should not introduce any timing errors as sensor measurements and `Gnss_Synchro` objects are matched by the timestamp stored inside the sensor measurement, not by the offset of the RF sample being tagged.