### PR TITLE
RVV Implementations for VOLK GNSS-SDR Kernels

### DIFF
--- a/src/algorithms/libs/volk_gnsssdr_module/volk_gnsssdr/kernels/volk_gnsssdr/volk_gnsssdr_16i_resamplerxnpuppet_16i.h
+++ b/src/algorithms/libs/volk_gnsssdr_module/volk_gnsssdr/kernels/volk_gnsssdr/volk_gnsssdr_16i_resamplerxnpuppet_16i.h
@@ -264,4 +264,34 @@ static inline void volk_gnsssdr_16i_resamplerxnpuppet_16i_neon(int16_t* result, 
 
 #endif
 
+
+#ifdef LV_HAVE_RVV
+static inline void volk_gnsssdr_16i_resamplerxnpuppet_16i_rvv(int16_t* result, const int16_t* local_code, unsigned int num_points)
+{
+    int code_length_chips = 2046;
+    float code_phase_step_chips = ((float)(code_length_chips) + 0.1) / ((float)num_points);
+    int num_out_vectors = 3;
+    float rem_code_phase_chips = -0.234;
+    int n;
+    float shifts_chips[3] = {-0.1, 0.0, 0.1};
+    int16_t** result_aux = (int16_t**)volk_gnsssdr_malloc(sizeof(int16_t*) * num_out_vectors, volk_gnsssdr_get_alignment());
+
+    for (n = 0; n < num_out_vectors; n++)
+        {
+            result_aux[n] = (int16_t*)volk_gnsssdr_malloc(sizeof(int16_t) * num_points, volk_gnsssdr_get_alignment());
+        }
+
+    volk_gnsssdr_16i_xn_resampler_16i_xn_rvv(result_aux, local_code, rem_code_phase_chips, code_phase_step_chips, shifts_chips, code_length_chips, num_out_vectors, num_points);
+
+    memcpy((int16_t*)result, (int16_t*)result_aux[0], sizeof(int16_t) * num_points);
+
+    for (n = 0; n < num_out_vectors; n++)
+        {
+            volk_gnsssdr_free(result_aux[n]);
+        }
+    volk_gnsssdr_free(result_aux);
+}
+
+#endif
+
 #endif  // INCLUDED_volk_gnsssdr_16i_resamplerpuppet_16i_H

--- a/src/algorithms/libs/volk_gnsssdr_module/volk_gnsssdr/kernels/volk_gnsssdr/volk_gnsssdr_16i_xn_resampler_16i_xn.h
+++ b/src/algorithms/libs/volk_gnsssdr_module/volk_gnsssdr/kernels/volk_gnsssdr/volk_gnsssdr_16i_xn_resampler_16i_xn.h
@@ -630,7 +630,7 @@ static inline void volk_gnsssdr_16i_xn_resampler_16i_xn_rvv(int16_t** result, co
                     vuint32m8_t iVal = __riscv_vadd_vx_u32m8(idVal, currI, vl);
                     vfloat32m8_t floatIVal = __riscv_vfcvt_f_xu_v_f32m8(iVal, vl);
 
-                    // iterIndex[i] = floatIVal[i] * code_phase_step_chips
+                    // iterIndex[i] = floatI[i] * code_phase_step_chips
                     vfloat32m8_t iterIndexVal = __riscv_vfmul_vf_f32m8(floatIVal, code_phase_step_chips, vl);
 
                     // overflowIndex[i] = (int) floor(iterIndex[i] + constIndexShift)
@@ -659,7 +659,7 @@ static inline void volk_gnsssdr_16i_xn_resampler_16i_xn_rvv(int16_t** result, co
                     __riscv_vse16_v_i16m4(outPtr, outVal, vl);
 
                     // In looping, decrement the number of
-                    // elements left and increment stripmining pointers
+                    // elements left and increment stripmining variables
                     // by the number of elements processed
                 }
         }

--- a/src/algorithms/libs/volk_gnsssdr_module/volk_gnsssdr/kernels/volk_gnsssdr/volk_gnsssdr_16i_xn_resampler_16i_xn.h
+++ b/src/algorithms/libs/volk_gnsssdr_module/volk_gnsssdr/kernels/volk_gnsssdr/volk_gnsssdr_16i_xn_resampler_16i_xn.h
@@ -599,37 +599,25 @@ static inline void volk_gnsssdr_16i_xn_resampler_16i_xn_neon(int16_t** result, c
 
 #ifdef LV_HAVE_RVV
 #include <riscv_vector.h>
+
 static inline void volk_gnsssdr_16i_xn_resampler_16i_xn_rvv(int16_t** result, const int16_t* local_code, float rem_code_phase_chips, float code_phase_step_chips, float* shifts_chips, unsigned int code_length_chips, int num_out_vectors, unsigned int num_points)
 {
+    // Initialize reference pointer, as stays same across loops
+    const int16_t* inPtr = local_code;
 
     for (int current_correlator_tap = 0; current_correlator_tap < num_out_vectors; current_correlator_tap++)
         {
-            // Stores address offsets from `local_code` to load from and
-            // then store in `result[current_correlator_tap]`
-            unsigned int offsetBuffer[num_points];
-
-            for (int i = 0; i < num_points; i++)
-                {
-                    // resample code for current tap
-                    int local_code_chip_index = (int)floor(code_phase_step_chips * (float)i + shifts_chips[current_correlator_tap] - rem_code_phase_chips);
-                    // Take into account that in multitap correlators, the shifts can be negative!
-                    if (local_code_chip_index < 0) local_code_chip_index += (int)code_length_chips * (abs(local_code_chip_index) / code_length_chips + 1);
-                    local_code_chip_index = local_code_chip_index % code_length_chips;
-
-                    // `local_code_chip_index` should be some positive, valid
-                    // index to `local_code`
-                    // Convert from index to raw address offset
-                    offsetBuffer[i] = (unsigned int) (local_code_chip_index * 2);
-                }
-
             size_t n = num_points;
 
-            // Initialize pointers to track progress as stripmine
-            int16_t* outPtr = result[current_correlator_tap];
-            const int16_t* inPtr = local_code;
-            const unsigned int* offsetPtr = (const unsigned int*) offsetBuffer;
+            const float constIndexShift = shifts_chips[current_correlator_tap] - rem_code_phase_chips;
 
-            for (size_t vl; n > 0; n -= vl, outPtr += vl, offsetPtr += vl)
+            // Initialize pointer, counter to track progress as stripmine
+            int16_t* outPtr = result[current_correlator_tap];
+            // Simulates how, compared to generic implementation, `i` continues
+            // increasing across different vector computatation batches
+            unsigned int currI = 0;
+
+            for (size_t vl; n > 0; n -= vl, outPtr += vl, currI += vl)
                 {
                     // Use LMUL of 4 since EEW/SEW of indexed load is 2,
                     // meaning that to use u32 as indices to load
@@ -637,8 +625,31 @@ static inline void volk_gnsssdr_16i_xn_resampler_16i_xn_rvv(int16_t** result, co
                     // Record how many data elements will actually be processed
                     vl = __riscv_vsetvl_e16m4(n);
 
-                    // Load offset[0..vl)
-                    vuint32m8_t offsetVal = __riscv_vle32_v_u32m8(offsetPtr, vl);
+                    // floatI[i] = (float) (i + currI)
+                    vuint32m8_t idVal = __riscv_vid_v_u32m8(vl);
+                    vuint32m8_t iVal = __riscv_vadd_vx_u32m8(idVal, currI, vl);
+                    vfloat32m8_t floatIVal = __riscv_vfcvt_f_xu_v_f32m8(iVal, vl);
+
+                    // iterIndex[i] = floatIVal[i] * code_phase_step_chips
+                    vfloat32m8_t iterIndexVal = __riscv_vfmul_vf_f32m8(floatIVal, code_phase_step_chips, vl);
+
+                    // overflowIndex[i] = (int) floor(iterIndex[i] + constIndexShift)
+                    vfloat32m8_t shiftedIndexVal = __riscv_vfadd_vf_f32m8(iterIndexVal, constIndexShift, vl);
+                    vint32m8_t overflowIndexVal = __riscv_vfcvt_x_f_v_i32m8_rm(shiftedIndexVal, __RISCV_FRM_RDN, vl);
+
+                    // Wrap to valid index in `local_code`, handling negative values
+                    // index[i] = ( code_length_chips + ( overflowIndex[i] % code_length_chips ) ) % code_length_chips
+                    vint32m8_t indexVal = __riscv_vrem_vx_i32m8(overflowIndexVal, code_length_chips, vl);
+                    indexVal = __riscv_vadd_vx_i32m8(indexVal, code_length_chips, vl);
+                    indexVal = __riscv_vrem_vx_i32m8(indexVal, code_length_chips, vl);
+
+                    // After above, should now be guaranteed positive and valid index
+                    // finalIndex[i] = (unsigned int) index[i];
+                    vuint32m8_t finalIndexVal = __riscv_vreinterpret_v_i32m8_u32m8(indexVal);
+
+                    // Convert to address offset
+                    // offset[i] = finalIndex[i] * sizeof(int16_t)
+                    vuint32m8_t offsetVal = __riscv_vmul_vx_u32m8(finalIndexVal, sizeof(int16_t), vl);
 
                     // This indexed load is unordered to hopefully boost run time
                     // out[i] = in[offset[i]]

--- a/src/algorithms/libs/volk_gnsssdr_module/volk_gnsssdr/kernels/volk_gnsssdr/volk_gnsssdr_16i_xn_resampler_16i_xn.h
+++ b/src/algorithms/libs/volk_gnsssdr_module/volk_gnsssdr/kernels/volk_gnsssdr/volk_gnsssdr_16i_xn_resampler_16i_xn.h
@@ -594,8 +594,66 @@ static inline void volk_gnsssdr_16i_xn_resampler_16i_xn_neon(int16_t** result, c
         }
 }
 
-
 #endif
 
+
+#ifdef LV_HAVE_RVV
+#include <riscv_vector.h>
+static inline void volk_gnsssdr_16i_xn_resampler_16i_xn_rvv(int16_t** result, const int16_t* local_code, float rem_code_phase_chips, float code_phase_step_chips, float* shifts_chips, unsigned int code_length_chips, int num_out_vectors, unsigned int num_points)
+{
+
+    for (int current_correlator_tap = 0; current_correlator_tap < num_out_vectors; current_correlator_tap++)
+        {
+            // Stores address offsets from `local_code` to load from and
+            // then store in `result[current_correlator_tap]`
+            unsigned int offsetBuffer[num_points];
+
+            for (int i = 0; i < num_points; i++)
+                {
+                    // resample code for current tap
+                    int local_code_chip_index = (int)floor(code_phase_step_chips * (float)i + shifts_chips[current_correlator_tap] - rem_code_phase_chips);
+                    // Take into account that in multitap correlators, the shifts can be negative!
+                    if (local_code_chip_index < 0) local_code_chip_index += (int)code_length_chips * (abs(local_code_chip_index) / code_length_chips + 1);
+                    local_code_chip_index = local_code_chip_index % code_length_chips;
+
+                    // `local_code_chip_index` should be some positive, valid
+                    // index to `local_code`
+                    // Convert from index to raw address offset
+                    offsetBuffer[i] = (unsigned int) (local_code_chip_index * 2);
+                }
+
+            size_t n = num_points;
+
+            // Initialize pointers to track progress as stripmine
+            int16_t* outPtr = result[current_correlator_tap];
+            const int16_t* inPtr = local_code;
+            const unsigned int* offsetPtr = (const unsigned int*) offsetBuffer;
+
+            for (size_t vl; n > 0; n -= vl, outPtr += vl, offsetPtr += vl)
+                {
+                    // Use LMUL of 4 since EEW/SEW of indexed load is 2,
+                    // meaning that to use u32 as indices to load
+                    // i16m4, index vector needs to be u32m8
+                    // Record how many data elements will actually be processed
+                    vl = __riscv_vsetvl_e16m4(n);
+
+                    // Load offset[0..vl)
+                    vuint32m8_t offsetVal = __riscv_vle32_v_u32m8(offsetPtr, vl);
+
+                    // This indexed load is unordered to hopefully boost run time
+                    // out[i] = in[offset[i]]
+                    vint16m4_t outVal = __riscv_vluxei32_v_i16m4(inPtr, offsetVal, vl);
+
+                    // Store out[0..vl)
+                    __riscv_vse16_v_i16m4(outPtr, outVal, vl);
+
+                    // In looping, decrement the number of
+                    // elements left and increment stripmining pointers
+                    // by the number of elements processed
+                }
+        }
+}
+
+#endif /* LV_HAVE_RVV */
 
 #endif /*INCLUDED_volk_gnsssdr_16i_xn_resampler_16i_xn_H*/

--- a/src/algorithms/libs/volk_gnsssdr_module/volk_gnsssdr/kernels/volk_gnsssdr/volk_gnsssdr_16ic_16i_rotator_dot_prod_16ic_xn.h
+++ b/src/algorithms/libs/volk_gnsssdr_module/volk_gnsssdr/kernels/volk_gnsssdr/volk_gnsssdr_16ic_16i_rotator_dot_prod_16ic_xn.h
@@ -791,24 +791,22 @@ static inline void volk_gnsssdr_16ic_16i_rotator_dot_prod_16ic_xn_rvv(lv_16sc_t*
     size_t ROTATOR_RELOAD = 256;
 
     // Initialize reference pointers of compatible type that will not be stripmined
-    float* phasePtr = (float*) phase;
+    float* phasePtr = (float*)phase;
 
     // Initialize pointers of compatible type to track progress as stripmine
-    short* outPtr = (short*) result;
-    const short* comPtr = (const short*) in_common;
-    const short** inPtrBuf = (const short**) volk_gnsssdr_malloc(
-        num_a_vectors * sizeof(*in_a), volk_gnsssdr_get_alignment()
-    );
+    short* outPtr = (short*)result;
+    const short* comPtr = (const short*)in_common;
+    const short** inPtrBuf = (const short**)volk_gnsssdr_malloc(num_a_vectors * sizeof(*in_a), volk_gnsssdr_get_alignment());
 
     for (int n_vec = 0; n_vec < num_a_vectors; n_vec++)
-    {
-        // Initialize `out` to zero
-        result[n_vec] = lv_cmake(0, 0);
+        {
+            // Initialize `out` to zero
+            result[n_vec] = lv_cmake(0, 0);
 
-        // Create copies in case pointers within `in_a` are not meant to be modified
-        // (in which case function signature should be `const short* const* in_a`)
-        inPtrBuf[n_vec] = in_a[n_vec];
-    }
+            // Create copies in case pointers within `in_a` are not meant to be modified
+            // (in which case function signature should be `const short* const* in_a`)
+            inPtrBuf[n_vec] = in_a[n_vec];
+        }
 
     for (int _ = 0; _ < num_points / ROTATOR_RELOAD; _++)
         {
@@ -882,8 +880,8 @@ static inline void volk_gnsssdr_16ic_16i_rotator_dot_prod_16ic_xn_rvv(lv_16sc_t*
                             vint16m2_t outImagVal = __riscv_vmul_vv_i16m2(inVal, comProdImagVal, vl);
 
                             // Load accumulator
-                            vint32m1_t accRealVal = __riscv_vmv_s_x_i32m1((int) outPtr[2 * n_vec], 1);
-                            vint32m1_t accImagVal = __riscv_vmv_s_x_i32m1((int) outPtr[2 * n_vec + 1], 1);
+                            vint32m1_t accRealVal = __riscv_vmv_s_x_i32m1((int)outPtr[2 * n_vec], 1);
+                            vint32m1_t accImagVal = __riscv_vmv_s_x_i32m1((int)outPtr[2 * n_vec + 1], 1);
 
                             // acc[0] = sum( acc[0], out[0..vl) )
                             accRealVal = __riscv_vwredsum_vs_i16m2_i32m1(outRealVal, accRealVal, vl);
@@ -898,8 +896,8 @@ static inline void volk_gnsssdr_16ic_16i_rotator_dot_prod_16ic_xn_rvv(lv_16sc_t*
                             accImagVal = __riscv_vmax_vx_i32m1(accImagVal, -32768, 1);
 
                             // Store acc[0]
-                            outPtr[2 * n_vec] = (short) __riscv_vmv_x_s_i32m1_i32(accRealVal);
-                            outPtr[2 * n_vec + 1] = (short) __riscv_vmv_x_s_i32m1_i32(accImagVal);
+                            outPtr[2 * n_vec] = (short)__riscv_vmv_x_s_i32m1_i32(accRealVal);
+                            outPtr[2 * n_vec + 1] = (short)__riscv_vmv_x_s_i32m1_i32(accImagVal);
 
                             // Increment this pointer
                             inPtrBuf[n_vec] += vl;
@@ -918,7 +916,7 @@ static inline void volk_gnsssdr_16ic_16i_rotator_dot_prod_16ic_xn_rvv(lv_16sc_t*
                     // elements left and increment the pointers
                     // by the number of elements processed
                 }
-            // Regenerate phase
+                // Regenerate phase
 #ifdef __cplusplus
             (*phase) /= std::abs((*phase));
 #else
@@ -996,8 +994,8 @@ static inline void volk_gnsssdr_16ic_16i_rotator_dot_prod_16ic_xn_rvv(lv_16sc_t*
                     vint16m2_t outImagVal = __riscv_vmul_vv_i16m2(inVal, comProdImagVal, vl);
 
                     // Load accumulator
-                    vint32m1_t accRealVal = __riscv_vmv_s_x_i32m1((int) outPtr[2 * n_vec], 1);
-                    vint32m1_t accImagVal = __riscv_vmv_s_x_i32m1((int) outPtr[2 * n_vec + 1], 1);
+                    vint32m1_t accRealVal = __riscv_vmv_s_x_i32m1((int)outPtr[2 * n_vec], 1);
+                    vint32m1_t accImagVal = __riscv_vmv_s_x_i32m1((int)outPtr[2 * n_vec + 1], 1);
 
                     // acc[0] = sum( acc[0], out[0..vl) )
                     accRealVal = __riscv_vwredsum_vs_i16m2_i32m1(outRealVal, accRealVal, vl);
@@ -1012,8 +1010,8 @@ static inline void volk_gnsssdr_16ic_16i_rotator_dot_prod_16ic_xn_rvv(lv_16sc_t*
                     accImagVal = __riscv_vmax_vx_i32m1(accImagVal, -32768, 1);
 
                     // Store acc[0]
-                    outPtr[2 * n_vec] = (short) __riscv_vmv_x_s_i32m1_i32(accRealVal);
-                    outPtr[2 * n_vec + 1] = (short) __riscv_vmv_x_s_i32m1_i32(accImagVal);
+                    outPtr[2 * n_vec] = (short)__riscv_vmv_x_s_i32m1_i32(accRealVal);
+                    outPtr[2 * n_vec + 1] = (short)__riscv_vmv_x_s_i32m1_i32(accImagVal);
 
                     // Increment this pointer
                     inPtrBuf[n_vec] += vl;

--- a/src/algorithms/libs/volk_gnsssdr_module/volk_gnsssdr/kernels/volk_gnsssdr/volk_gnsssdr_16ic_16i_rotator_dot_prod_16ic_xn.h
+++ b/src/algorithms/libs/volk_gnsssdr_module/volk_gnsssdr/kernels/volk_gnsssdr/volk_gnsssdr_16ic_16i_rotator_dot_prod_16ic_xn.h
@@ -782,4 +782,260 @@ static inline void volk_gnsssdr_16ic_16i_rotator_dot_prod_16ic_xn_u_avx2(lv_16sc
 }
 #endif /* LV_HAVE_AVX2 */
 
+
+#ifdef LV_HAVE_RVV
+#include <riscv_vector.h>
+
+static inline void volk_gnsssdr_16ic_16i_rotator_dot_prod_16ic_xn_rvv(lv_16sc_t* result, const lv_16sc_t* in_common, const lv_32fc_t phase_inc, lv_32fc_t* phase, const int16_t** in_a, int num_a_vectors, unsigned int num_points)
+{
+    size_t ROTATOR_RELOAD = 256;
+
+    // Initialize reference pointers of compatible type that will not be stripmined
+    float* phasePtr = (float*) phase;
+
+    // Initialize pointers of compatible type to track progress as stripmine
+    short* outPtr = (short*) result;
+    const short* comPtr = (const short*) in_common;
+    const short** inPtrBuf = (const short**) volk_gnsssdr_malloc(
+        num_a_vectors * sizeof(*in_a), volk_gnsssdr_get_alignment()
+    );
+
+    for (int n_vec = 0; n_vec < num_a_vectors; n_vec++)
+    {
+        // Initialize `out` to zero
+        result[n_vec] = lv_cmake(0, 0);
+
+        // Create copies in case pointers within `in_a` are not meant to be modified
+        // (in which case function signature should be `const short* const* in_a`)
+        inPtrBuf[n_vec] = in_a[n_vec];
+    }
+
+    for (int _ = 0; _ < num_points / ROTATOR_RELOAD; _++)
+        {
+            size_t n = ROTATOR_RELOAD;
+
+            for (size_t vl; n > 0; n -= vl, comPtr += vl * 2)
+                {
+                    // Record how many elements will actually be processed
+                    vl = __riscv_vsetvl_e16m2(n);
+
+                    // Splat phase
+                    vfloat32m4_t phaseRealVal = __riscv_vfmv_v_f_f32m4(phasePtr[0], vl);
+                    vfloat32m4_t phaseImagVal = __riscv_vfmv_v_f_f32m4(phasePtr[1], vl);
+
+                    // Splat phaseInc
+                    vfloat32m4_t phaseIncRealVal = __riscv_vfmv_v_f_f32m4(lv_creal(phase_inc), vl);
+                    vfloat32m4_t phaseIncImagVal = __riscv_vfmv_v_f_f32m4(lv_cimag(phase_inc), vl);
+
+                    // iter[i] = i
+                    vuint32m4_t iterVal = __riscv_vid_v_u32m4(vl);
+
+                    // phase[i] = phase[i] * ( phaseInc[i] ^ i )
+                    for (int j = 1; j < vl; j++)
+                        {
+                            vbool8_t maskVal = __riscv_vmsgtu_vx_u32m4_b8(iterVal, 0, vl);
+
+                            // Initialize as copies of phase so that can target masked
+                            // operations onto these copies instead of the original vectors
+                            vfloat32m4_t prodRealVal = phaseRealVal;
+                            vfloat32m4_t prodImagVal = phaseImagVal;
+
+                            // For more details on cross product,
+                            // check `volk_gnsssdr_8ic_x2_multiply_8ic_rvv`,
+                            // for instance
+                            prodRealVal = __riscv_vfmul_vv_f32m4_mu(maskVal, prodRealVal, phaseRealVal, phaseIncRealVal, vl);
+                            prodRealVal = __riscv_vfnmsac_vv_f32m4_mu(maskVal, prodRealVal, phaseImagVal, phaseIncImagVal, vl);
+                            prodImagVal = __riscv_vfmul_vv_f32m4_mu(maskVal, prodImagVal, phaseRealVal, phaseIncImagVal, vl);
+                            prodImagVal = __riscv_vfmacc_vv_f32m4_mu(maskVal, prodImagVal, phaseImagVal, phaseIncRealVal, vl);
+
+                            phaseRealVal = prodRealVal;
+                            phaseImagVal = prodImagVal;
+
+                            iterVal = __riscv_vsub_vx_u32m4_mu(maskVal, iterVal, iterVal, 1, vl);
+                        }
+
+                    // Load com[0..vl)
+                    vint16m2x2_t comVal = __riscv_vlseg2e16_v_i16m2x2(comPtr, vl);
+                    vint16m2_t comRealVal = __riscv_vget_v_i16m2x2_i16m2(comVal, 0);
+                    vint16m2_t comImagVal = __riscv_vget_v_i16m2x2_i16m2(comVal, 1);
+
+                    // w(ide)ComProd[i] = ( (float) com[i] ) * phase[i]
+                    vfloat32m4_t fComRealVal = __riscv_vfwcvt_f_x_v_f32m4(comRealVal, vl);
+                    vfloat32m4_t fComImagVal = __riscv_vfwcvt_f_x_v_f32m4(comImagVal, vl);
+
+                    vfloat32m4_t wComProdRealVal = __riscv_vfmul_vv_f32m4(fComRealVal, phaseRealVal, vl);
+                    wComProdRealVal = __riscv_vfnmsac_vv_f32m4(wComProdRealVal, fComImagVal, phaseImagVal, vl);
+                    vfloat32m4_t wComProdImagVal = __riscv_vfmul_vv_f32m4(fComRealVal, phaseImagVal, vl);
+                    wComProdImagVal = __riscv_vfmacc_vv_f32m4(wComProdImagVal, fComImagVal, phaseRealVal, vl);
+
+                    // comProd[i] = (int16_t) wComProd[i]
+                    vint16m2_t comProdRealVal = __riscv_vfncvt_x_f_w_i16m2(wComProdRealVal, vl);
+                    vint16m2_t comProdImagVal = __riscv_vfncvt_x_f_w_i16m2(wComProdImagVal, vl);
+
+                    for (int n_vec = 0; n_vec < num_a_vectors; n_vec++)
+                        {
+                            // Load in[0..vl)
+                            vint16m2_t inVal = __riscv_vle16_v_i16m2(inPtrBuf[n_vec], vl);
+
+                            // out[i] = in[i] * comProd[i]
+                            vint16m2_t outRealVal = __riscv_vmul_vv_i16m2(inVal, comProdRealVal, vl);
+                            vint16m2_t outImagVal = __riscv_vmul_vv_i16m2(inVal, comProdImagVal, vl);
+
+                            // Load accumulator
+                            vint32m1_t accRealVal = __riscv_vmv_s_x_i32m1((int) outPtr[2 * n_vec], 1);
+                            vint32m1_t accImagVal = __riscv_vmv_s_x_i32m1((int) outPtr[2 * n_vec + 1], 1);
+
+                            // acc[0] = sum( acc[0], out[0..vl) )
+                            accRealVal = __riscv_vwredsum_vs_i16m2_i32m1(outRealVal, accRealVal, vl);
+                            accImagVal = __riscv_vwredsum_vs_i16m2_i32m1(outImagVal, accImagVal, vl);
+
+                            // Technically could give a different result than saturating
+                            // one at a time, due to ordering differences
+                            // Saturate within 16 bits
+                            accRealVal = __riscv_vmin_vx_i32m1(accRealVal, 32767, 1);
+                            accRealVal = __riscv_vmax_vx_i32m1(accRealVal, -32768, 1);
+                            accImagVal = __riscv_vmin_vx_i32m1(accImagVal, 32767, 1);
+                            accImagVal = __riscv_vmax_vx_i32m1(accImagVal, -32768, 1);
+
+                            // Store acc[0]
+                            outPtr[2 * n_vec] = (short) __riscv_vmv_x_s_i32m1_i32(accRealVal);
+                            outPtr[2 * n_vec + 1] = (short) __riscv_vmv_x_s_i32m1_i32(accImagVal);
+
+                            // Increment this pointer
+                            inPtrBuf[n_vec] += vl;
+                        }
+
+                    // Store phase[vl - 1]
+                    phaseRealVal = __riscv_vslidedown_vx_f32m4(phaseRealVal, vl - 1, vl);
+                    phasePtr[0] = __riscv_vfmv_f_s_f32m4_f32(phaseRealVal);
+                    phaseImagVal = __riscv_vslidedown_vx_f32m4(phaseImagVal, vl - 1, vl);
+                    phasePtr[1] = __riscv_vfmv_f_s_f32m4_f32(phaseImagVal);
+
+                    // Account for multiplication after last calculation
+                    (*phase) *= phase_inc;
+
+                    // In looping, decrement the number of
+                    // elements left and increment the pointers
+                    // by the number of elements processed
+                }
+            // Regenerate phase
+#ifdef __cplusplus
+            (*phase) /= std::abs((*phase));
+#else
+            (*phase) /= hypotf(lv_creal(*phase), lv_cimag(*phase));
+#endif
+        }
+
+    size_t n = num_points % ROTATOR_RELOAD;
+
+    for (size_t vl; n > 0; n -= vl, comPtr += vl * 2)
+        {
+            // Record how many elements will actually be processed
+            vl = __riscv_vsetvl_e16m2(n);
+
+            // Splat phase
+            vfloat32m4_t phaseRealVal = __riscv_vfmv_v_f_f32m4(phasePtr[0], vl);
+            vfloat32m4_t phaseImagVal = __riscv_vfmv_v_f_f32m4(phasePtr[1], vl);
+
+            // Splat phaseInc
+            vfloat32m4_t phaseIncRealVal = __riscv_vfmv_v_f_f32m4(lv_creal(phase_inc), vl);
+            vfloat32m4_t phaseIncImagVal = __riscv_vfmv_v_f_f32m4(lv_cimag(phase_inc), vl);
+
+            // iter[i] = i
+            vuint32m4_t iterVal = __riscv_vid_v_u32m4(vl);
+
+            // phase[i] = phase[i] * ( phaseInc[i] ^ i )
+            for (int j = 1; j < vl; j++)
+                {
+                    vbool8_t maskVal = __riscv_vmsgtu_vx_u32m4_b8(iterVal, 0, vl);
+
+                    // Initialize as copies of phase so that can target masked
+                    // operations onto these copies instead of the original vectors
+                    vfloat32m4_t prodRealVal = phaseRealVal;
+                    vfloat32m4_t prodImagVal = phaseImagVal;
+
+                    // For more details on cross product,
+                    // check `volk_gnsssdr_8ic_x2_multiply_8ic_rvv`,
+                    // for instance
+                    prodRealVal = __riscv_vfmul_vv_f32m4_mu(maskVal, prodRealVal, phaseRealVal, phaseIncRealVal, vl);
+                    prodRealVal = __riscv_vfnmsac_vv_f32m4_mu(maskVal, prodRealVal, phaseImagVal, phaseIncImagVal, vl);
+                    prodImagVal = __riscv_vfmul_vv_f32m4_mu(maskVal, prodImagVal, phaseRealVal, phaseIncImagVal, vl);
+                    prodImagVal = __riscv_vfmacc_vv_f32m4_mu(maskVal, prodImagVal, phaseImagVal, phaseIncRealVal, vl);
+
+                    phaseRealVal = prodRealVal;
+                    phaseImagVal = prodImagVal;
+
+                    iterVal = __riscv_vsub_vx_u32m4_mu(maskVal, iterVal, iterVal, 1, vl);
+                }
+
+            // Load com[0..vl)
+            vint16m2x2_t comVal = __riscv_vlseg2e16_v_i16m2x2(comPtr, vl);
+            vint16m2_t comRealVal = __riscv_vget_v_i16m2x2_i16m2(comVal, 0);
+            vint16m2_t comImagVal = __riscv_vget_v_i16m2x2_i16m2(comVal, 1);
+
+            // w(ide)ComProd[i] = ( (float) com[i] ) * phase[i]
+            vfloat32m4_t fComRealVal = __riscv_vfwcvt_f_x_v_f32m4(comRealVal, vl);
+            vfloat32m4_t fComImagVal = __riscv_vfwcvt_f_x_v_f32m4(comImagVal, vl);
+
+            vfloat32m4_t wComProdRealVal = __riscv_vfmul_vv_f32m4(fComRealVal, phaseRealVal, vl);
+            wComProdRealVal = __riscv_vfnmsac_vv_f32m4(wComProdRealVal, fComImagVal, phaseImagVal, vl);
+            vfloat32m4_t wComProdImagVal = __riscv_vfmul_vv_f32m4(fComRealVal, phaseImagVal, vl);
+            wComProdImagVal = __riscv_vfmacc_vv_f32m4(wComProdImagVal, fComImagVal, phaseRealVal, vl);
+
+            // comProd[i] = (int16_t) wComProd[i]
+            vint16m2_t comProdRealVal = __riscv_vfncvt_x_f_w_i16m2(wComProdRealVal, vl);
+            vint16m2_t comProdImagVal = __riscv_vfncvt_x_f_w_i16m2(wComProdImagVal, vl);
+
+            for (int n_vec = 0; n_vec < num_a_vectors; n_vec++)
+                {
+                    // Load in[0..vl)
+                    vint16m2_t inVal = __riscv_vle16_v_i16m2(inPtrBuf[n_vec], vl);
+
+                    // out[i] = in[i] * comProd[i]
+                    vint16m2_t outRealVal = __riscv_vmul_vv_i16m2(inVal, comProdRealVal, vl);
+                    vint16m2_t outImagVal = __riscv_vmul_vv_i16m2(inVal, comProdImagVal, vl);
+
+                    // Load accumulator
+                    vint32m1_t accRealVal = __riscv_vmv_s_x_i32m1((int) outPtr[2 * n_vec], 1);
+                    vint32m1_t accImagVal = __riscv_vmv_s_x_i32m1((int) outPtr[2 * n_vec + 1], 1);
+
+                    // acc[0] = sum( acc[0], out[0..vl) )
+                    accRealVal = __riscv_vwredsum_vs_i16m2_i32m1(outRealVal, accRealVal, vl);
+                    accImagVal = __riscv_vwredsum_vs_i16m2_i32m1(outImagVal, accImagVal, vl);
+
+                    // Technically could give a different result than saturating
+                    // one at a time, due to ordering differences
+                    // Saturate within 16 bits
+                    accRealVal = __riscv_vmin_vx_i32m1(accRealVal, 32767, 1);
+                    accRealVal = __riscv_vmax_vx_i32m1(accRealVal, -32768, 1);
+                    accImagVal = __riscv_vmin_vx_i32m1(accImagVal, 32767, 1);
+                    accImagVal = __riscv_vmax_vx_i32m1(accImagVal, -32768, 1);
+
+                    // Store acc[0]
+                    outPtr[2 * n_vec] = (short) __riscv_vmv_x_s_i32m1_i32(accRealVal);
+                    outPtr[2 * n_vec + 1] = (short) __riscv_vmv_x_s_i32m1_i32(accImagVal);
+
+                    // Increment this pointer
+                    inPtrBuf[n_vec] += vl;
+                }
+
+            // Store phase[vl - 1]
+            phaseRealVal = __riscv_vslidedown_vx_f32m4(phaseRealVal, vl - 1, vl);
+            phasePtr[0] = __riscv_vfmv_f_s_f32m4_f32(phaseRealVal);
+            phaseImagVal = __riscv_vslidedown_vx_f32m4(phaseImagVal, vl - 1, vl);
+            phasePtr[1] = __riscv_vfmv_f_s_f32m4_f32(phaseImagVal);
+
+            // Account for multiplication after last calculation
+            (*phase) *= phase_inc;
+
+            // In looping, decrement the number of
+            // elements left and increment the pointers
+            // by the number of elements processed
+        }
+
+    // Don't leak memory!
+    volk_gnsssdr_free(inPtrBuf);
+}
+#endif /* LV_HAVE_RVV */
+
 #endif /* INCLUDED_volk_gnsssdr_16ic_16i_dot_prod_16ic_xn_H */

--- a/src/algorithms/libs/volk_gnsssdr_module/volk_gnsssdr/kernels/volk_gnsssdr/volk_gnsssdr_16ic_16i_rotator_dotprodxnpuppet_16ic.h
+++ b/src/algorithms/libs/volk_gnsssdr_module/volk_gnsssdr/kernels/volk_gnsssdr/volk_gnsssdr_16ic_16i_rotator_dotprodxnpuppet_16ic.h
@@ -210,4 +210,35 @@ static inline void volk_gnsssdr_16ic_16i_rotator_dotprodxnpuppet_16ic_u_avx2(lv_
 #endif  // AVX2
 
 
+#ifdef LV_HAVE_RVV
+static inline void volk_gnsssdr_16ic_16i_rotator_dotprodxnpuppet_16ic_rvv(lv_16sc_t* result, const lv_16sc_t* local_code, const lv_16sc_t* in, unsigned int num_points)
+{
+    // phases must be normalized. Phase rotator expects a complex exponential input!
+    float rem_carrier_phase_in_rad = 0.345;
+    float phase_step_rad = 0.1;
+    lv_32fc_t phase[1];
+    phase[0] = lv_cmake(cos(rem_carrier_phase_in_rad), sin(rem_carrier_phase_in_rad));
+    lv_32fc_t phase_inc[1];
+    phase_inc[0] = lv_cmake(cos(phase_step_rad), sin(phase_step_rad));
+    int n;
+    int num_a_vectors = 3;
+    int16_t** in_a = (int16_t**)volk_gnsssdr_malloc(sizeof(int16_t*) * num_a_vectors, volk_gnsssdr_get_alignment());
+    for (n = 0; n < num_a_vectors; n++)
+        {
+            in_a[n] = (int16_t*)volk_gnsssdr_malloc(sizeof(int16_t) * num_points, volk_gnsssdr_get_alignment());
+            memcpy((int16_t*)in_a[n], (int16_t*)in, sizeof(int16_t) * num_points);
+        }
+
+    volk_gnsssdr_16ic_16i_rotator_dot_prod_16ic_xn_rvv(result, local_code, phase_inc[0], phase, (const int16_t**)in_a, num_a_vectors, num_points);
+
+    for (n = 0; n < num_a_vectors; n++)
+        {
+            volk_gnsssdr_free(in_a[n]);
+        }
+    volk_gnsssdr_free(in_a);
+}
+
+#endif  // RVV
+
+
 #endif  // INCLUDED_volk_gnsssdr_16ic_16i_rotator_dotprodxnpuppet_16ic_H

--- a/src/algorithms/libs/volk_gnsssdr_module/volk_gnsssdr/kernels/volk_gnsssdr/volk_gnsssdr_16ic_conjugate_16ic.h
+++ b/src/algorithms/libs/volk_gnsssdr_module/volk_gnsssdr/kernels/volk_gnsssdr/volk_gnsssdr_16ic_conjugate_16ic.h
@@ -212,10 +212,7 @@ static inline void volk_gnsssdr_16ic_conjugate_16ic_rvv(lv_16sc_t* cVector, cons
             vint16m4_t negImagVal = __riscv_vneg_v_i16m4(aImagVal, vl);
 
             // Store aReal[0..vl), negImag[0..vl)
-            vint16m4x2_t cVal = __riscv_vset_v_i16m4_i16m4x2(
-                __riscv_vundefined_i16m4x2(), 0, aRealVal
-            );
-            cVal = __riscv_vset_v_i16m4_i16m4x2(cVal, 1, negImagVal);
+            vint16m4x2_t cVal = __riscv_vcreate_v_i16m4x2(aRealVal, negImagVal);
             __riscv_vsseg2e16_v_i16m4x2(cPtr, cVal, vl);
 
             // In looping, decrease the number of

--- a/src/algorithms/libs/volk_gnsssdr_module/volk_gnsssdr/kernels/volk_gnsssdr/volk_gnsssdr_16ic_conjugate_16ic.h
+++ b/src/algorithms/libs/volk_gnsssdr_module/volk_gnsssdr/kernels/volk_gnsssdr/volk_gnsssdr_16ic_conjugate_16ic.h
@@ -195,8 +195,8 @@ static inline void volk_gnsssdr_16ic_conjugate_16ic_rvv(lv_16sc_t* cVector, cons
     size_t n = num_points;
 
     // Initialize pointers to keep track as stripmine
-    short* cPtr = (short*) cVector;
-    const short* aPtr = (short*) aVector;
+    short* cPtr = (short*)cVector;
+    const short* aPtr = (short*)aVector;
 
     for (size_t vl; n > 0; n -= vl, cPtr += vl * 2, aPtr += vl * 2)
         {

--- a/src/algorithms/libs/volk_gnsssdr_module/volk_gnsssdr/kernels/volk_gnsssdr/volk_gnsssdr_16ic_conjugate_16ic.h
+++ b/src/algorithms/libs/volk_gnsssdr_module/volk_gnsssdr/kernels/volk_gnsssdr/volk_gnsssdr_16ic_conjugate_16ic.h
@@ -186,4 +186,45 @@ static inline void volk_gnsssdr_16ic_conjugate_16ic_u_avx2(lv_16sc_t* cVector, c
 }
 #endif /* LV_HAVE_AVX2 */
 
+
+#ifdef LV_HAVE_RVV
+#include <riscv_vector.h>
+
+static inline void volk_gnsssdr_16ic_conjugate_16ic_rvv(lv_16sc_t* cVector, const lv_16sc_t* aVector, unsigned int num_points)
+{
+    size_t n = num_points;
+
+    // Initialize pointers to keep track as stripmine
+    short* cPtr = (short*) cVector;
+    const short* aPtr = (short*) aVector;
+
+    for (size_t vl; n > 0; n -= vl, cPtr += vl * 2, aPtr += vl * 2)
+        {
+            // Record number of elements that will actually be processed
+            vl = __riscv_vsetvl_e16m4(n);
+
+            // Load aReal[0..vl), aImag[0..vl)
+            vint16m4x2_t aVal = __riscv_vlseg2e16_v_i16m4x2(aPtr, vl);
+            vint16m4_t aRealVal = __riscv_vget_v_i16m4x2_i16m4(aVal, 0);
+            vint16m4_t aImagVal = __riscv_vget_v_i16m4x2_i16m4(aVal, 1);
+
+            // negImag[i] = -aImag[i]
+            vint16m4_t negImagVal = __riscv_vneg_v_i16m4(aImagVal, vl);
+
+            // Store aReal[0..vl), negImag[0..vl)
+            vint16m4x2_t cVal = __riscv_vset_v_i16m4_i16m4x2(
+                __riscv_vundefined_i16m4x2(), 0, aRealVal
+            );
+            cVal = __riscv_vset_v_i16m4_i16m4x2(cVal, 1, negImagVal);
+            __riscv_vsseg2e16_v_i16m4x2(cPtr, cVal, vl);
+
+            // In looping, decrease the number of
+            // elements left and increase the pointers
+            // by the number of elements processed,
+            // taking into account how each complex number
+            // stored in `cPtr` and `aPtr` is two 2-byte ints
+        }
+}
+#endif /* LV_HAVE_RVV */
+
 #endif /* INCLUDED_volk_gnsssdr_16ic_conjugate_16ic_H */

--- a/src/algorithms/libs/volk_gnsssdr_module/volk_gnsssdr/kernels/volk_gnsssdr/volk_gnsssdr_16ic_convert_32fc.h
+++ b/src/algorithms/libs/volk_gnsssdr_module/volk_gnsssdr/kernels/volk_gnsssdr/volk_gnsssdr_16ic_convert_32fc.h
@@ -265,4 +265,49 @@ static inline void volk_gnsssdr_16ic_convert_32fc_neon(lv_32fc_t* outputVector, 
 }
 #endif /* LV_HAVE_NEON */
 
+#ifdef LV_HAVE_RVV
+#include <riscv_vector.h>
+
+static inline void volk_gnsssdr_16ic_convert_32fc_rvv(lv_32fc_t* outputVector, const lv_16sc_t* inputVector, unsigned int num_points)
+{
+    size_t n = num_points;
+
+    // Initialize pointers to keep track as stripmine
+    float* outPtr = (float*) outputVector;
+    const short* inPtr = (const short*) inputVector;
+
+    for (size_t vl; n > 0; n -= vl, outPtr += vl * 2, inPtr += vl * 2)
+        {
+            // Record how many elements will actually be processed
+            // Only use a EMUL of 2 so that when widen, EMUL = 4
+            // which still allows a segment store with NFIELDS = 2
+            vl = __riscv_vsetvl_e16m2(n);
+
+            // Load inReal[0..vl), inImag[0..vl)
+            vint16m2x2_t inVal = __riscv_vlseg2e16_v_i16m2x2(inPtr, vl);
+            vint16m2_t inRealVal = __riscv_vget_v_i16m2x2_i16m2(inVal, 0);
+            vint16m2_t inImagVal = __riscv_vget_v_i16m2x2_i16m2(inVal, 1);
+
+            // outReal[i] = (float) inReal[i]
+            // outImag[i] = (float) inImag[i]
+            vfloat32m4_t outRealVal = __riscv_vfwcvt_f_x_v_f32m4(inRealVal, vl);
+            vfloat32m4_t outImagVal = __riscv_vfwcvt_f_x_v_f32m4(inImagVal, vl);
+
+            // Store outReal[0..vl), outImag[0..vl)
+            vfloat32m4x2_t outVal = __riscv_vset_v_f32m4_f32m4x2(
+                __riscv_vundefined_f32m4x2(), 0, outRealVal
+            );
+            outVal = __riscv_vset_v_f32m4_f32m4x2(outVal, 1, outImagVal);
+            __riscv_vsseg2e32_v_f32m4x2(outPtr, outVal, vl);
+
+            // In looping, decrement the number
+            // elements left and increment the pointers
+            // by the number of elements processed,
+            // taking into account how the `vl` complex
+            // numbers are each stored as two numbers
+            // of their corresponding size
+        }
+}
+#endif /* LV_HAVE_RVV */
+
 #endif /* INCLUDED_volk_gnsssdr_32fc_convert_16ic_H */

--- a/src/algorithms/libs/volk_gnsssdr_module/volk_gnsssdr/kernels/volk_gnsssdr/volk_gnsssdr_16ic_convert_32fc.h
+++ b/src/algorithms/libs/volk_gnsssdr_module/volk_gnsssdr/kernels/volk_gnsssdr/volk_gnsssdr_16ic_convert_32fc.h
@@ -270,35 +270,30 @@ static inline void volk_gnsssdr_16ic_convert_32fc_neon(lv_32fc_t* outputVector, 
 
 static inline void volk_gnsssdr_16ic_convert_32fc_rvv(lv_32fc_t* outputVector, const lv_16sc_t* inputVector, unsigned int num_points)
 {
-    size_t n = num_points;
+    // Will be converting by number, with each
+    // complex number containing two component numbers
+    size_t n = num_points * 2;
 
     // Initialize pointers to keep track as stripmine
     float* outPtr = (float*) outputVector;
     const short* inPtr = (const short*) inputVector;
 
-    for (size_t vl; n > 0; n -= vl, outPtr += vl * 2, inPtr += vl * 2)
+    for (size_t vl; n > 0; n -= vl, outPtr += vl, inPtr += vl)
         {
             // Record how many elements will actually be processed
-            // Only use a EMUL of 2 so that when widen, EMUL = 4
-            // which still allows a segment store with NFIELDS = 2
-            vl = __riscv_vsetvl_e16m2(n);
+            // Only use a EMUL of 4 so that when widen, EMUL = 8
+            vl = __riscv_vsetvl_e16m4(n);
 
-            // Load inReal[0..vl), inImag[0..vl)
-            vint16m2x2_t inVal = __riscv_vlseg2e16_v_i16m2x2(inPtr, vl);
-            vint16m2_t inRealVal = __riscv_vget_v_i16m2x2_i16m2(inVal, 0);
-            vint16m2_t inImagVal = __riscv_vget_v_i16m2x2_i16m2(inVal, 1);
+            // Don't have to segment store/load since converting
+            // both real and imaginary components
+            // Load in[0..vl)
+            vint16m4_t inVal = __riscv_vle16_v_i16m4(inPtr, vl);
 
-            // outReal[i] = (float) inReal[i]
-            // outImag[i] = (float) inImag[i]
-            vfloat32m4_t outRealVal = __riscv_vfwcvt_f_x_v_f32m4(inRealVal, vl);
-            vfloat32m4_t outImagVal = __riscv_vfwcvt_f_x_v_f32m4(inImagVal, vl);
+            // out[i] = (float) in[i]
+            vfloat32m8_t outVal = __riscv_vfwcvt_f_x_v_f32m8(inVal, vl);
 
-            // Store outReal[0..vl), outImag[0..vl)
-            vfloat32m4x2_t outVal = __riscv_vset_v_f32m4_f32m4x2(
-                __riscv_vundefined_f32m4x2(), 0, outRealVal
-            );
-            outVal = __riscv_vset_v_f32m4_f32m4x2(outVal, 1, outImagVal);
-            __riscv_vsseg2e32_v_f32m4x2(outPtr, outVal, vl);
+            // Store out[0..vl)
+            __riscv_vse32_v_f32m8(outPtr, outVal, vl);
 
             // In looping, decrement the number
             // elements left and increment the pointers

--- a/src/algorithms/libs/volk_gnsssdr_module/volk_gnsssdr/kernels/volk_gnsssdr/volk_gnsssdr_16ic_convert_32fc.h
+++ b/src/algorithms/libs/volk_gnsssdr_module/volk_gnsssdr/kernels/volk_gnsssdr/volk_gnsssdr_16ic_convert_32fc.h
@@ -275,8 +275,8 @@ static inline void volk_gnsssdr_16ic_convert_32fc_rvv(lv_32fc_t* outputVector, c
     size_t n = num_points * 2;
 
     // Initialize pointers to keep track as stripmine
-    float* outPtr = (float*) outputVector;
-    const short* inPtr = (const short*) inputVector;
+    float* outPtr = (float*)outputVector;
+    const short* inPtr = (const short*)inputVector;
 
     for (size_t vl; n > 0; n -= vl, outPtr += vl, inPtr += vl)
         {

--- a/src/algorithms/libs/volk_gnsssdr_module/volk_gnsssdr/kernels/volk_gnsssdr/volk_gnsssdr_16ic_resampler_fast_16ic.h
+++ b/src/algorithms/libs/volk_gnsssdr_module/volk_gnsssdr/kernels/volk_gnsssdr/volk_gnsssdr_16ic_resampler_fast_16ic.h
@@ -330,4 +330,85 @@ static inline void volk_gnsssdr_16ic_resampler_fast_16ic_neon(lv_16sc_t* result,
 
 #endif /* LV_HAVE_NEON */
 
+
+#ifdef LV_HAVE_RVV
+#include <riscv_vector.h>
+
+static inline void volk_gnsssdr_16ic_resampler_fast_16ic_rvv(lv_16sc_t* result, const lv_16sc_t* local_code, float rem_code_phase_chips, float code_phase_step_chips, int code_length_chips, unsigned int num_output_samples)
+{
+    // To make easier to work with in RVV, just interpret the two 16-bit components
+    // of each complex number as a single 32-bit number to move around
+
+    // Initialize reference pointer, as stays same and not stripmined
+    const int* inPtr = (const int*) local_code;
+
+    size_t n = num_output_samples;
+
+    const float constIndexShift = rem_code_phase_chips;
+
+    // Initialize pointer to track progress as stripmine
+    int* outPtr = (int*) result;
+    // Simulates how, compared to generic implementation, `i` continues
+    // increasing across different vector computation batches
+    unsigned int currI = 0;
+
+    for (size_t vl; n > 0; n -= vl, outPtr += vl, currI += vl)
+        {
+            // Record how many elements will actually be processed
+            vl = __riscv_vsetvl_e32m8(n);
+
+            // floatI[i] = (float) (i + currI);
+            vuint32m8_t idVal = __riscv_vid_v_u32m8(vl);
+            vuint32m8_t iVal = __riscv_vadd_vx_u32m8(idVal, currI, vl);
+            vfloat32m8_t floatIVal = __riscv_vfcvt_f_xu_v_f32m8(iVal, vl);
+
+            // iterIndex[i] = floatI[i] * code_phase_step_chips
+            vfloat32m8_t iterIndexVal = __riscv_vfmul_vf_f32m8(floatIVal, code_phase_step_chips, vl);
+
+            // overflowIndex[i] = (int) floor(iterIndex[i] + constIndexShift)
+            vfloat32m8_t shiftedIndexVal = __riscv_vfadd_vf_f32m8(iterIndexVal, constIndexShift, vl);
+            vint32m8_t overflowIndexVal = __riscv_vfcvt_x_f_v_i32m8_rm(shiftedIndexVal, __RISCV_FRM_RDN, vl);
+
+            // Note on performance: Could technically do a "nested ternary" here,
+            // where only check the second conditional for an element if the first conditional
+            // was false. This would increase performance only in cases where both the
+            // microarchitecture is actually able to optimize masked vector functions AND
+            // there are enough negative indices that the skipped comparisons make up for
+            // the additional mask inversion instruction. At this point, seems like optimizing
+            // for pennies, so did not implement this and went for the clearer approach below
+
+            // Wrap to valid index in `local_code`, given that phase cannot be more
+            // than twice of `code_length_chips`, positive or negative
+            // index[i] = overflowIndex[i]
+            // index[i] = index[i] < 0 ? index[i] + code_length_chips : index[i]
+            // index[i] = index[i] > (code_length_chips - 1) ? index[i] - code_length_chips : index[i]
+            vint32m8_t indexVal = overflowIndexVal;
+            vbool4_t indexMaskVal = __riscv_vmslt_vx_i32m8_b4(indexVal, 0, vl);
+            indexVal = __riscv_vadd_vx_i32m8_mu(indexMaskVal, indexVal, indexVal, code_length_chips, vl);
+            indexMaskVal = __riscv_vmsgt_vx_i32m8_b4(indexVal, code_length_chips - 1, vl);
+            indexVal = __riscv_vsub_vx_i32m8_mu(indexMaskVal, indexVal, indexVal, code_length_chips, vl);
+
+            // After above, should now be guaranteed positive and valid index
+            // finalIndex[i] = (unsigned int) index[i]
+            vuint32m8_t finalIndexVal = __riscv_vreinterpret_v_i32m8_u32m8(indexVal);
+
+            // Convert to address offset
+            // offset[i] = finalIndex[i] * sizeof(lv_16sc_t)
+            vuint32m8_t offsetVal = __riscv_vmul_vx_u32m8(finalIndexVal, sizeof(lv_16sc_t), vl);
+
+            // This indexed load is unordered to hopefully boost run time
+            // out[i] = in[offset[i]]
+            vint32m8_t outVal = __riscv_vluxei32_v_i32m8(inPtr, offsetVal, vl);
+
+            // Store out[0..vl)
+            __riscv_vse32_v_i32m8(outPtr, outVal, vl);
+
+            // In looping, decrement the number of
+            // elements left and increment stripmining variables
+            // by the number of elements processed
+        }
+}
+
+#endif /* LV_HAVE_RVV */
+
 #endif /* INCLUDED_volk_gnsssdr_16ic_resampler_fast_16ic_H */

--- a/src/algorithms/libs/volk_gnsssdr_module/volk_gnsssdr/kernels/volk_gnsssdr/volk_gnsssdr_16ic_resampler_fast_16ic.h
+++ b/src/algorithms/libs/volk_gnsssdr_module/volk_gnsssdr/kernels/volk_gnsssdr/volk_gnsssdr_16ic_resampler_fast_16ic.h
@@ -340,14 +340,14 @@ static inline void volk_gnsssdr_16ic_resampler_fast_16ic_rvv(lv_16sc_t* result, 
     // of each complex number as a single 32-bit number to move around
 
     // Initialize reference pointer, as stays same and not stripmined
-    const int* inPtr = (const int*) local_code;
+    const int* inPtr = (const int*)local_code;
 
     size_t n = num_output_samples;
 
     const float constIndexShift = rem_code_phase_chips;
 
     // Initialize pointer to track progress as stripmine
-    int* outPtr = (int*) result;
+    int* outPtr = (int*)result;
     // Simulates how, compared to generic implementation, `i` continues
     // increasing across different vector computation batches
     unsigned int currI = 0;

--- a/src/algorithms/libs/volk_gnsssdr_module/volk_gnsssdr/kernels/volk_gnsssdr/volk_gnsssdr_16ic_resamplerfastpuppet_16ic.h
+++ b/src/algorithms/libs/volk_gnsssdr_module/volk_gnsssdr/kernels/volk_gnsssdr/volk_gnsssdr_16ic_resamplerfastpuppet_16ic.h
@@ -70,4 +70,16 @@ static inline void volk_gnsssdr_16ic_resamplerfastpuppet_16ic_neon(lv_16sc_t* re
 
 #endif /* LV_HAVE_NEON */
 
+#ifdef LV_HAVE_RVV
+
+static inline void volk_gnsssdr_16ic_resamplerfastpuppet_16ic_rvv(lv_16sc_t* result, const lv_16sc_t* local_code, unsigned int num_points)
+{
+    float rem_code_phase_chips = -0.123;
+    float code_phase_step_chips = 0.1;
+    int code_length_chips = 1023;
+    volk_gnsssdr_16ic_resampler_fast_16ic_rvv(result, local_code, rem_code_phase_chips, code_phase_step_chips, code_length_chips, num_points);
+}
+
+#endif /* LV_HAVE_RVV */
+
 #endif  // INCLUDED_volk_gnsssdr_16ic_resamplerfastpuppet_16ic_H

--- a/src/algorithms/libs/volk_gnsssdr_module/volk_gnsssdr/kernels/volk_gnsssdr/volk_gnsssdr_16ic_resamplerfastxnpuppet_16ic.h
+++ b/src/algorithms/libs/volk_gnsssdr_module/volk_gnsssdr/kernels/volk_gnsssdr/volk_gnsssdr_16ic_resamplerfastxnpuppet_16ic.h
@@ -143,4 +143,33 @@ static inline void volk_gnsssdr_16ic_resamplerfastxnpuppet_16ic_neon(lv_16sc_t* 
 #endif
 
 
+#ifdef LV_HAVE_RVV
+static inline void volk_gnsssdr_16ic_resamplerfastxnpuppet_16ic_rvv(lv_16sc_t* result, const lv_16sc_t* local_code, unsigned int num_points)
+{
+    float code_phase_step_chips = 0.1;
+    int code_length_chips = 2046;
+    int num_out_vectors = 3;
+    int n;
+    float* rem_code_phase_chips = (float*)volk_gnsssdr_malloc(sizeof(float) * num_out_vectors, volk_gnsssdr_get_alignment());
+    lv_16sc_t** result_aux = (lv_16sc_t**)volk_gnsssdr_malloc(sizeof(lv_16sc_t*) * num_out_vectors, volk_gnsssdr_get_alignment());
+
+    for (n = 0; n < num_out_vectors; n++)
+        {
+            rem_code_phase_chips[n] = -0.234;
+            result_aux[n] = (lv_16sc_t*)volk_gnsssdr_malloc(sizeof(lv_16sc_t) * num_points, volk_gnsssdr_get_alignment());
+        }
+    volk_gnsssdr_16ic_xn_resampler_fast_16ic_xn_rvv(result_aux, local_code, rem_code_phase_chips, code_phase_step_chips, code_length_chips, num_out_vectors, num_points);
+
+    memcpy(result, result_aux[0], sizeof(lv_16sc_t) * num_points);
+    volk_gnsssdr_free(rem_code_phase_chips);
+    for (n = 0; n < num_out_vectors; n++)
+        {
+            volk_gnsssdr_free(result_aux[n]);
+        }
+    volk_gnsssdr_free(result_aux);
+}
+
+#endif
+
+
 #endif  // INCLUDED_volk_gnsssdr_16ic_resamplerpuppet_16ic_H

--- a/src/algorithms/libs/volk_gnsssdr_module/volk_gnsssdr/kernels/volk_gnsssdr/volk_gnsssdr_16ic_resamplerxnpuppet_16ic.h
+++ b/src/algorithms/libs/volk_gnsssdr_module/volk_gnsssdr/kernels/volk_gnsssdr/volk_gnsssdr_16ic_resamplerxnpuppet_16ic.h
@@ -265,4 +265,34 @@ static inline void volk_gnsssdr_16ic_resamplerxnpuppet_16ic_neon(lv_16sc_t* resu
 
 #endif
 
+
+#ifdef LV_HAVE_RVV
+static inline void volk_gnsssdr_16ic_resamplerxnpuppet_16ic_rvv(lv_16sc_t* result, const lv_16sc_t* local_code, unsigned int num_points)
+{
+    int code_length_chips = 2046;
+    float code_phase_step_chips = ((float)(code_length_chips) + 0.1) / ((float)num_points);
+    int num_out_vectors = 3;
+    float rem_code_phase_chips = -0.234;
+    int n;
+    float shifts_chips[3] = {-0.1, 0.0, 0.1};
+    lv_16sc_t** result_aux = (lv_16sc_t**)volk_gnsssdr_malloc(sizeof(lv_16sc_t*) * num_out_vectors, volk_gnsssdr_get_alignment());
+
+    for (n = 0; n < num_out_vectors; n++)
+        {
+            result_aux[n] = (lv_16sc_t*)volk_gnsssdr_malloc(sizeof(lv_16sc_t) * num_points, volk_gnsssdr_get_alignment());
+        }
+
+    volk_gnsssdr_16ic_xn_resampler_16ic_xn_rvv(result_aux, local_code, rem_code_phase_chips, code_phase_step_chips, shifts_chips, code_length_chips, num_out_vectors, num_points);
+
+    memcpy((lv_16sc_t*)result, (lv_16sc_t*)result_aux[0], sizeof(lv_16sc_t) * num_points);
+
+    for (n = 0; n < num_out_vectors; n++)
+        {
+            volk_gnsssdr_free(result_aux[n]);
+        }
+    volk_gnsssdr_free(result_aux);
+}
+
+#endif
+
 #endif  // INCLUDED_volk_gnsssdr_16ic_resamplerpuppet_16ic_H

--- a/src/algorithms/libs/volk_gnsssdr_module/volk_gnsssdr/kernels/volk_gnsssdr/volk_gnsssdr_16ic_rotatorpuppet_16ic.h
+++ b/src/algorithms/libs/volk_gnsssdr_module/volk_gnsssdr/kernels/volk_gnsssdr/volk_gnsssdr_16ic_rotatorpuppet_16ic.h
@@ -155,4 +155,20 @@ static inline void volk_gnsssdr_16ic_rotatorpuppet_16ic_neon_reload(lv_16sc_t* o
 #endif /* LV_HAVE_NEON */
 
 
+#ifdef LV_HAVE_RVV
+static inline void volk_gnsssdr_16ic_rotatorpuppet_16ic_rvv(lv_16sc_t* outVector, const lv_16sc_t* inVector, unsigned int num_points)
+{
+    // phases must be normalized. Phase rotator expects a complex exponential input!
+    float rem_carrier_phase_in_rad = 0.345;
+    float phase_step_rad = 0.123;
+    lv_32fc_t phase[1];
+    phase[0] = lv_cmake(cos(rem_carrier_phase_in_rad), -sin(rem_carrier_phase_in_rad));
+    lv_32fc_t phase_inc[1];
+    phase_inc[0] = lv_cmake(cos(phase_step_rad), -sin(phase_step_rad));
+    volk_gnsssdr_16ic_s32fc_x2_rotator_16ic_rvv(outVector, inVector, &phase_inc[0], phase, num_points);
+}
+
+#endif /* LV_HAVE_RVV */
+
+
 #endif /* INCLUDED_volk_gnsssdr_16ic_rotatorpuppet_16ic_H */

--- a/src/algorithms/libs/volk_gnsssdr_module/volk_gnsssdr/kernels/volk_gnsssdr/volk_gnsssdr_16ic_s32fc_x2_rotator_16ic.h
+++ b/src/algorithms/libs/volk_gnsssdr_module/volk_gnsssdr/kernels/volk_gnsssdr/volk_gnsssdr_16ic_s32fc_x2_rotator_16ic.h
@@ -969,12 +969,12 @@ static inline void volk_gnsssdr_16ic_s32fc_x2_rotator_16ic_rvv(lv_16sc_t* outVec
     size_t ROTATOR_RELOAD = 512;
 
     // Initialize reference pointers of compatible type that will not be stripmined
-    float* phasePtr = (float*) phase;
-    float* phaseIncPtr = (float*) phase_inc;
+    float* phasePtr = (float*)phase;
+    float* phaseIncPtr = (float*)phase_inc;
 
     // Initialize pointers of compatible type to track progress as stripmine
-    short* outPtr = (short*) outVector;
-    const short* inPtr = (const short*) inVector;
+    short* outPtr = (short*)outVector;
+    const short* inPtr = (const short*)inVector;
 
     for (int _ = 0; _ < num_points / ROTATOR_RELOAD; _++)
         {
@@ -1058,7 +1058,7 @@ static inline void volk_gnsssdr_16ic_s32fc_x2_rotator_16ic_rvv(lv_16sc_t* outVec
                     // numbers are each stored as two 16-bit numbers
                 }
 
-            // Regenerate phase
+                // Regenerate phase
 #ifdef __cplusplus
             (*phase) /= std::abs((*phase));
 #else

--- a/src/algorithms/libs/volk_gnsssdr_module/volk_gnsssdr/kernels/volk_gnsssdr/volk_gnsssdr_16ic_s32fc_x2_rotator_16ic.h
+++ b/src/algorithms/libs/volk_gnsssdr_module/volk_gnsssdr/kernels/volk_gnsssdr/volk_gnsssdr_16ic_s32fc_x2_rotator_16ic.h
@@ -960,4 +960,193 @@ static inline void volk_gnsssdr_16ic_s32fc_x2_rotator_16ic_neon_reload(lv_16sc_t
 
 #endif /* LV_HAVE_NEON */
 
+
+#ifdef LV_HAVE_RVV
+#include <riscv_vector.h>
+
+static inline void volk_gnsssdr_16ic_s32fc_x2_rotator_16ic_rvv(lv_16sc_t* outVector, const lv_16sc_t* inVector, const lv_32fc_t* phase_inc, lv_32fc_t* phase, unsigned int num_points)
+{
+    size_t ROTATOR_RELOAD = 512;
+
+    // Initialize reference pointers of compatible type that will not be stripmined
+    float* phasePtr = (float*) phase;
+    float* phaseIncPtr = (float*) phase_inc;
+
+    // Initialize pointers of compatible type to track progress as stripmine
+    short* outPtr = (short*) outVector;
+    const short* inPtr = (const short*) inVector;
+
+    for (int _ = 0; _ < num_points / ROTATOR_RELOAD; _++)
+        {
+            size_t n = ROTATOR_RELOAD;
+
+            for (size_t vl; n > 0; n -= vl, outPtr += vl * 2, inPtr += vl * 2)
+                {
+                    // Record how many elements will actually be processed
+                    vl = __riscv_vsetvl_e16m2(n);
+
+                    // Splat phase
+                    vfloat32m4_t phaseRealVal = __riscv_vfmv_v_f_f32m4(phasePtr[0], vl);
+                    vfloat32m4_t phaseImagVal = __riscv_vfmv_v_f_f32m4(phasePtr[1], vl);
+
+                    // Splat phaseInc
+                    vfloat32m4_t phaseIncRealVal = __riscv_vfmv_v_f_f32m4(phaseIncPtr[0], vl);
+                    vfloat32m4_t phaseIncImagVal = __riscv_vfmv_v_f_f32m4(phaseIncPtr[1], vl);
+
+                    // iter[i] = i
+                    vuint32m4_t iterVal = __riscv_vid_v_u32m4(vl);
+
+                    // phase[i] = phase[i] * ( phaseInc[i] ^ i )
+                    for (int j = 1; j < vl; j++)
+                        {
+                            vbool8_t maskVal = __riscv_vmsgtu_vx_u32m4_b8(iterVal, 0, vl);
+
+                            // Initialize as copies of phase so that can target masked
+                            // operations onto these copies instead of the original vectors
+                            vfloat32m4_t prodRealVal = phaseRealVal;
+                            vfloat32m4_t prodImagVal = phaseImagVal;
+
+                            // For more details on cross product,
+                            // check `volk_gnsssdr_8ic_x2_multiply_8ic_rvv`,
+                            // for instance
+                            prodRealVal = __riscv_vfmul_vv_f32m4_mu(maskVal, prodRealVal, phaseRealVal, phaseIncRealVal, vl);
+                            prodRealVal = __riscv_vfnmsac_vv_f32m4_mu(maskVal, prodRealVal, phaseImagVal, phaseIncImagVal, vl);
+                            prodImagVal = __riscv_vfmul_vv_f32m4_mu(maskVal, prodImagVal, phaseRealVal, phaseIncImagVal, vl);
+                            prodImagVal = __riscv_vfmacc_vv_f32m4_mu(maskVal, prodImagVal, phaseImagVal, phaseIncRealVal, vl);
+
+                            phaseRealVal = prodRealVal;
+                            phaseImagVal = prodImagVal;
+
+                            iterVal = __riscv_vsub_vx_u32m4_mu(maskVal, iterVal, iterVal, 1, vl);
+                        }
+
+                    // Load inReal[0..vl), inImag[0..vl)
+                    vint16m2x2_t inVal = __riscv_vlseg2e16_v_i16m2x2(inPtr, vl);
+                    vint16m2_t inRealVal = __riscv_vget_v_i16m2x2_i16m2(inVal, 0);
+                    vint16m2_t inImagVal = __riscv_vget_v_i16m2x2_i16m2(inVal, 1);
+
+                    // w(ide)Out[i] = ( (float) in[i] ) * phase[i]
+                    vfloat32m4_t fInRealVal = __riscv_vfwcvt_f_x_v_f32m4(inRealVal, vl);
+                    vfloat32m4_t fInImagVal = __riscv_vfwcvt_f_x_v_f32m4(inImagVal, vl);
+
+                    vfloat32m4_t wOutRealVal = __riscv_vfmul_vv_f32m4(fInRealVal, phaseRealVal, vl);
+                    wOutRealVal = __riscv_vfnmsac_vv_f32m4(wOutRealVal, fInImagVal, phaseImagVal, vl);
+                    vfloat32m4_t wOutImagVal = __riscv_vfmul_vv_f32m4(fInRealVal, phaseImagVal, vl);
+                    wOutImagVal = __riscv_vfmacc_vv_f32m4(wOutImagVal, fInImagVal, phaseRealVal, vl);
+
+                    // out[i] = (int16_t) wOut[i]
+                    vint16m2_t outRealVal = __riscv_vfncvt_x_f_w_i16m2(wOutRealVal, vl);
+                    vint16m2_t outImagVal = __riscv_vfncvt_x_f_w_i16m2(wOutImagVal, vl);
+
+                    // Store out[0..vl)
+                    vint16m2x2_t outVal = __riscv_vcreate_v_i16m2x2(outRealVal, outImagVal);
+                    __riscv_vsseg2e16_v_i16m2x2(outPtr, outVal, vl);
+
+                    // Store phase[vl - 1]
+                    phaseRealVal = __riscv_vslidedown_vx_f32m4(phaseRealVal, vl - 1, vl);
+                    phasePtr[0] = __riscv_vfmv_f_s_f32m4_f32(phaseRealVal);
+                    phaseImagVal = __riscv_vslidedown_vx_f32m4(phaseImagVal, vl - 1, vl);
+                    phasePtr[1] = __riscv_vfmv_f_s_f32m4_f32(phaseImagVal);
+
+                    // Account for multiplication after last calculation
+                    (*phase) *= *phase_inc;
+
+                    // In looping, decrement the number of
+                    // elements left and increment the pointers
+                    // by the number of elements processed,
+                    // taking into account how the `vl` complex
+                    // numbers are each stored as two 16-bit numbers
+                }
+
+            // Regenerate phase
+#ifdef __cplusplus
+            (*phase) /= std::abs((*phase));
+#else
+            (*phase) /= hypotf(lv_creal(*phase), lv_cimag(*phase));
+#endif
+        }
+
+    size_t n = num_points % ROTATOR_RELOAD;
+
+    for (size_t vl; n > 0; n -= vl, outPtr += vl * 2, inPtr += vl * 2)
+        {
+            // Record how many elements will actually be processed
+            vl = __riscv_vsetvl_e16m2(n);
+
+            // Splat phase
+            vfloat32m4_t phaseRealVal = __riscv_vfmv_v_f_f32m4(phasePtr[0], vl);
+            vfloat32m4_t phaseImagVal = __riscv_vfmv_v_f_f32m4(phasePtr[1], vl);
+
+            // Splat phaseInc
+            vfloat32m4_t phaseIncRealVal = __riscv_vfmv_v_f_f32m4(phaseIncPtr[0], vl);
+            vfloat32m4_t phaseIncImagVal = __riscv_vfmv_v_f_f32m4(phaseIncPtr[1], vl);
+
+            // iter[i] = i
+            vuint32m4_t iterVal = __riscv_vid_v_u32m4(vl);
+
+            // phase[i] = phase[i] * ( phaseInc[i] ^ i )
+            for (int j = 1; j < vl; j++)
+                {
+                    vbool8_t maskVal = __riscv_vmsgtu_vx_u32m4_b8(iterVal, 0, vl);
+
+                    // Initialize as copies of phase so that can target masked
+                    // operations onto these copies instead of the original vectors
+                    vfloat32m4_t prodRealVal = phaseRealVal;
+                    vfloat32m4_t prodImagVal = phaseImagVal;
+
+                    // For more details on cross product,
+                    // check `volk_gnsssdr_8ic_x2_multiply_8ic_rvv`,
+                    // for instance
+                    prodRealVal = __riscv_vfmul_vv_f32m4_mu(maskVal, prodRealVal, phaseRealVal, phaseIncRealVal, vl);
+                    prodRealVal = __riscv_vfnmsac_vv_f32m4_mu(maskVal, prodRealVal, phaseImagVal, phaseIncImagVal, vl);
+                    prodImagVal = __riscv_vfmul_vv_f32m4_mu(maskVal, prodImagVal, phaseRealVal, phaseIncImagVal, vl);
+                    prodImagVal = __riscv_vfmacc_vv_f32m4_mu(maskVal, prodImagVal, phaseImagVal, phaseIncRealVal, vl);
+
+                    phaseRealVal = prodRealVal;
+                    phaseImagVal = prodImagVal;
+
+                    iterVal = __riscv_vsub_vx_u32m4_mu(maskVal, iterVal, iterVal, 1, vl);
+                }
+
+            // Load inReal[0..vl), inImag[0..vl)
+            vint16m2x2_t inVal = __riscv_vlseg2e16_v_i16m2x2(inPtr, vl);
+            vint16m2_t inRealVal = __riscv_vget_v_i16m2x2_i16m2(inVal, 0);
+            vint16m2_t inImagVal = __riscv_vget_v_i16m2x2_i16m2(inVal, 1);
+
+            // w(ide)Out[i] = ( (float) in[i] ) * phase[i]
+            vfloat32m4_t fInRealVal = __riscv_vfwcvt_f_x_v_f32m4(inRealVal, vl);
+            vfloat32m4_t fInImagVal = __riscv_vfwcvt_f_x_v_f32m4(inImagVal, vl);
+
+            vfloat32m4_t wOutRealVal = __riscv_vfmul_vv_f32m4(fInRealVal, phaseRealVal, vl);
+            wOutRealVal = __riscv_vfnmsac_vv_f32m4(wOutRealVal, fInImagVal, phaseImagVal, vl);
+            vfloat32m4_t wOutImagVal = __riscv_vfmul_vv_f32m4(fInRealVal, phaseImagVal, vl);
+            wOutImagVal = __riscv_vfmacc_vv_f32m4(wOutImagVal, fInImagVal, phaseRealVal, vl);
+
+            // out[i] = (int16_t) wOut[i]
+            vint16m2_t outRealVal = __riscv_vfncvt_x_f_w_i16m2(wOutRealVal, vl);
+            vint16m2_t outImagVal = __riscv_vfncvt_x_f_w_i16m2(wOutImagVal, vl);
+
+            // Store out[0..vl)
+            vint16m2x2_t outVal = __riscv_vcreate_v_i16m2x2(outRealVal, outImagVal);
+            __riscv_vsseg2e16_v_i16m2x2(outPtr, outVal, vl);
+
+            // Store phase[vl - 1]
+            phaseRealVal = __riscv_vslidedown_vx_f32m4(phaseRealVal, vl - 1, vl);
+            phasePtr[0] = __riscv_vfmv_f_s_f32m4_f32(phaseRealVal);
+            phaseImagVal = __riscv_vslidedown_vx_f32m4(phaseImagVal, vl - 1, vl);
+            phasePtr[1] = __riscv_vfmv_f_s_f32m4_f32(phaseImagVal);
+
+            // Account for multiplication after last calculation
+            (*phase) *= *phase_inc;
+
+            // In looping, decrement the number of
+            // elements left and increment the pointers
+            // by the number of elements processed,
+            // taking into account how the `vl` complex
+            // numbers are each stored as two 16-bit numbers
+        }
+}
+
+#endif /* LV_HAVE_RVV */
+
 #endif /* INCLUDED_volk_gnsssdr_16ic_s32fc_x2_rotator_16ic_H */

--- a/src/algorithms/libs/volk_gnsssdr_module/volk_gnsssdr/kernels/volk_gnsssdr/volk_gnsssdr_16ic_x2_dot_prod_16ic.h
+++ b/src/algorithms/libs/volk_gnsssdr_module/volk_gnsssdr/kernels/volk_gnsssdr/volk_gnsssdr_16ic_x2_dot_prod_16ic.h
@@ -565,11 +565,11 @@ static inline void volk_gnsssdr_16ic_x2_dot_prod_16ic_rvv(lv_16sc_t* result, con
 
     // Explicitly cast in order to directly fill
     // with calculated values
-    short* resPtr = (short*) result;
+    short* resPtr = (short*)result;
 
     // Initialize pointers to track progress as stripmine
-    const short* aPtr = (const short*) in_a;
-    const short* bPtr = (const short*) in_b;
+    const short* aPtr = (const short*)in_a;
+    const short* bPtr = (const short*)in_b;
 
     // Use 32-bit accumulator in order to saturate
     // to 16 bits
@@ -623,9 +623,9 @@ static inline void volk_gnsssdr_16ic_x2_dot_prod_16ic_rvv(lv_16sc_t* result, con
         }
 
     // Real part of resultant complex number
-    resPtr[0] = (short) __riscv_vmv_x_s_i32m1_i32(accRealVal);
+    resPtr[0] = (short)__riscv_vmv_x_s_i32m1_i32(accRealVal);
     // Imaginary part of resultant complex number
-    resPtr[1] = (short) __riscv_vmv_x_s_i32m1_i32(accImagVal);
+    resPtr[1] = (short)__riscv_vmv_x_s_i32m1_i32(accImagVal);
 }
 #endif /* LV_HAVE_RVV */
 

--- a/src/algorithms/libs/volk_gnsssdr_module/volk_gnsssdr/kernels/volk_gnsssdr/volk_gnsssdr_16ic_x2_dot_prod_16ic.h
+++ b/src/algorithms/libs/volk_gnsssdr_module/volk_gnsssdr/kernels/volk_gnsssdr/volk_gnsssdr_16ic_x2_dot_prod_16ic.h
@@ -555,4 +555,78 @@ static inline void volk_gnsssdr_16ic_x2_dot_prod_16ic_neon_optvma(lv_16sc_t* out
 
 #endif /* LV_HAVE_NEON */
 
+
+#ifdef LV_HAVE_RVV
+#include <riscv_vector.h>
+
+static inline void volk_gnsssdr_16ic_x2_dot_prod_16ic_rvv(lv_16sc_t* result, const lv_16sc_t* in_a, const lv_16sc_t* in_b, unsigned int num_points)
+{
+    size_t n = num_points;
+
+    // Explicitly cast in order to directly fill
+    // with calculated values
+    short* resPtr = (short*) result;
+
+    // Initialize pointers to track progress as stripmine
+    const short* aPtr = (const short*) in_a;
+    const short* bPtr = (const short*) in_b;
+
+    // Use 32-bit accumulator in order to saturate
+    // to 16 bits
+    // accReal[0] = 0
+    vint32m1_t accRealVal = __riscv_vmv_s_x_i32m1(0, 1);
+    // accImag[0] = 0
+    vint32m1_t accImagVal = __riscv_vmv_s_x_i32m1(0, 1);
+
+    for (size_t vl; n > 0; n -= vl, aPtr += vl * 2, bPtr += vl * 2)
+        {
+            // Record how many elements will actually be processed
+            vl = __riscv_vsetvl_e16m4(n);
+
+            // Load aReal[0..vl), aImag[0..vl)
+            vint16m4x2_t aVal = __riscv_vlseg2e16_v_i16m4x2(aPtr, vl);
+            vint16m4_t aRealVal = __riscv_vget_v_i16m4x2_i16m4(aVal, 0);
+            vint16m4_t aImagVal = __riscv_vget_v_i16m4x2_i16m4(aVal, 1);
+
+            // Load bReal[0..vl), bImag[0..vl)
+            vint16m4x2_t bVal = __riscv_vlseg2e16_v_i16m4x2(bPtr, vl);
+            vint16m4_t bRealVal = __riscv_vget_v_i16m4x2_i16m4(bVal, 0);
+            vint16m4_t bImagVal = __riscv_vget_v_i16m4x2_i16m4(bVal, 1);
+
+            // outReal[i] = -(aImag[i] * bImag[i]) + aReal[i] * bReal[i]
+            vint16m4_t outRealVal = __riscv_vmul_vv_i16m4(aRealVal, bRealVal, vl);
+            outRealVal = __riscv_vnmsac_vv_i16m4(outRealVal, aImagVal, bImagVal, vl);
+
+            // accReal[0] = sum( accReal[0], outReal[0..vl) )
+            accRealVal = __riscv_vwredsum_vs_i16m4_i32m1(outRealVal, accRealVal, vl);
+
+            // Saturate accReal[0] within 16 bits
+            accRealVal = __riscv_vmin_vx_i32m1(accRealVal, 32767, 1);
+            accRealVal = __riscv_vmax_vx_i32m1(accRealVal, -32768, 1);
+
+            // outImag[i] = (aImag[i] * bReal[i]) + aReal[i] * bImag[i]
+            vint16m4_t outImagVal = __riscv_vmul_vv_i16m4(aRealVal, bImagVal, vl);
+            outImagVal = __riscv_vmacc_vv_i16m4(outImagVal, aImagVal, bRealVal, vl);
+
+            // accImag[0] = sum( accImag[0], outImag[0..vl) )
+            accImagVal = __riscv_vwredsum_vs_i16m4_i32m1(outImagVal, accImagVal, vl);
+
+            // Saturate accImag[0] within 16 bits
+            accImagVal = __riscv_vmin_vx_i32m1(accImagVal, 32767, 1);
+            accImagVal = __riscv_vmax_vx_i32m1(accImagVal, -32768, 1);
+
+            // In looping, decrement the number of
+            // elements left and increment the pointers
+            // by the number of elements processed,
+            // taking into account how the `vl` complex
+            // numbers are each stored as 2 `short`s
+        }
+
+    // Real part of resultant complex number
+    resPtr[0] = (short) __riscv_vmv_x_s_i32m1_i32(accRealVal);
+    // Imaginary part of resultant complex number
+    resPtr[1] = (short) __riscv_vmv_x_s_i32m1_i32(accImagVal);
+}
+#endif /* LV_HAVE_RVV */
+
 #endif /* INCLUDED_volk_gnsssdr_16ic_x2_dot_prod_16ic_H */

--- a/src/algorithms/libs/volk_gnsssdr_module/volk_gnsssdr/kernels/volk_gnsssdr/volk_gnsssdr_16ic_x2_dot_prod_16ic_xn.h
+++ b/src/algorithms/libs/volk_gnsssdr_module/volk_gnsssdr/kernels/volk_gnsssdr/volk_gnsssdr_16ic_x2_dot_prod_16ic_xn.h
@@ -722,4 +722,80 @@ static inline void volk_gnsssdr_16ic_x2_dot_prod_16ic_xn_neon_optvma(lv_16sc_t* 
 }
 #endif /* LV_HAVE_NEON */
 
+
+#ifdef LV_HAVE_RVV
+#include <riscv_vector.h>
+
+static inline void volk_gnsssdr_16ic_x2_dot_prod_16ic_xn_rvv(lv_16sc_t* result, const lv_16sc_t* in_common, const lv_16sc_t** in_a, int num_a_vectors, unsigned int num_points) {
+    int n_vec = num_a_vectors;
+
+    for (int i = 0; i < n_vec; i++)
+        {
+            size_t n = num_points;
+
+            short* resPtr = (short*) &result[i];
+
+            // Initialize pointers to track progress as stripmine
+            const short* comPtr = (const short*) in_common;
+            const short* aPtr = (const short*) in_a[i];
+
+            // Use 32-bit accumulator in order to saturate
+            // to 16 bits
+            // accReal[0] = 0
+            vint32m1_t accRealVal = __riscv_vmv_s_x_i32m1(0, 1);
+            // accImag[0] = 0
+            vint32m1_t accImagVal = __riscv_vmv_s_x_i32m1(0, 1);
+
+            for (size_t vl; n > 0; n -= vl, comPtr += vl * 2, aPtr += vl * 2)
+                {
+                    // Record how many elements will actually be processed
+                    vl = __riscv_vsetvl_e16m4(n);
+
+                    // Load comReal[0..vl), comImag[0..vl)
+                    vint16m4x2_t comVal = __riscv_vlseg2e16_v_i16m4x2(comPtr, vl);
+                    vint16m4_t comRealVal = __riscv_vget_v_i16m4x2_i16m4(comVal, 0);
+                    vint16m4_t comImagVal = __riscv_vget_v_i16m4x2_i16m4(comVal, 1);
+
+                    // Load aReal[0..vl), aImag[0..vl)
+                    vint16m4x2_t aVal = __riscv_vlseg2e16_v_i16m4x2(aPtr, vl);
+                    vint16m4_t aRealVal = __riscv_vget_v_i16m4x2_i16m4(aVal, 0);
+                    vint16m4_t aImagVal = __riscv_vget_v_i16m4x2_i16m4(aVal, 1);
+
+                    // outReal[i] = -(comImag[i] * aImag[i]) + comReal[i] * aReal[i]
+                    vint16m4_t outRealVal = __riscv_vmul_vv_i16m4(comRealVal, aRealVal, vl);
+                    outRealVal = __riscv_vnmsac_vv_i16m4(outRealVal, comImagVal, aImagVal, vl);
+
+                    // accReal[0] = sum( accReal[0], outReal[0..vl) )
+                    accRealVal = __riscv_vwredsum_vs_i16m4_i32m1(outRealVal, accRealVal, vl);
+
+                    // Saturate accReal[0] within 16 bits
+                    accRealVal = __riscv_vmin_vx_i32m1(accRealVal, 32767, 1);
+                    accRealVal = __riscv_vmax_vx_i32m1(accRealVal, -32768, 1);
+
+                    // outImag[i] = (comImag[i] * aReal[i]) + comReal[i] * aImag[i]
+                    vint16m4_t outImagVal = __riscv_vmul_vv_i16m4(comRealVal, aImagVal, vl);
+                    outImagVal = __riscv_vmacc_vv_i16m4(outImagVal, comImagVal, aRealVal, vl);
+
+                    // accImag[0] = sum( accImag[0], outImag[0..vl) )
+                    accImagVal = __riscv_vwredsum_vs_i16m4_i32m1(outImagVal, accImagVal, vl);
+
+                    // Saturate accImag[0] within 16 bits
+                    accImagVal = __riscv_vmin_vx_i32m1(accImagVal, 32767, 1);
+                    accImagVal = __riscv_vmax_vx_i32m1(accImagVal, -32768, 1);
+
+                    // In looping, decrement the number of
+                    // elements left and increment the pointers
+                    // by the number of elements processed,
+                    // taking into account how the `vl` complex
+                    // numbers are each stored as 2 `short`s
+                }
+
+            // Real part of resultant complex number
+            resPtr[0] = (short) __riscv_vmv_x_s_i32m1_i32(accRealVal);
+            // Imaginary part of resultant complex number
+            resPtr[1] = (short) __riscv_vmv_x_s_i32m1_i32(accImagVal);
+        }
+}
+#endif /* LV_HAVE_RVV */
+
 #endif /* INCLUDED_volk_gnsssdr_16ic_xn_dot_prod_16ic_xn_H */

--- a/src/algorithms/libs/volk_gnsssdr_module/volk_gnsssdr/kernels/volk_gnsssdr/volk_gnsssdr_16ic_x2_dot_prod_16ic_xn.h
+++ b/src/algorithms/libs/volk_gnsssdr_module/volk_gnsssdr/kernels/volk_gnsssdr/volk_gnsssdr_16ic_x2_dot_prod_16ic_xn.h
@@ -726,18 +726,19 @@ static inline void volk_gnsssdr_16ic_x2_dot_prod_16ic_xn_neon_optvma(lv_16sc_t* 
 #ifdef LV_HAVE_RVV
 #include <riscv_vector.h>
 
-static inline void volk_gnsssdr_16ic_x2_dot_prod_16ic_xn_rvv(lv_16sc_t* result, const lv_16sc_t* in_common, const lv_16sc_t** in_a, int num_a_vectors, unsigned int num_points) {
+static inline void volk_gnsssdr_16ic_x2_dot_prod_16ic_xn_rvv(lv_16sc_t* result, const lv_16sc_t* in_common, const lv_16sc_t** in_a, int num_a_vectors, unsigned int num_points)
+{
     int n_vec = num_a_vectors;
 
     for (int i = 0; i < n_vec; i++)
         {
             size_t n = num_points;
 
-            short* resPtr = (short*) &result[i];
+            short* resPtr = (short*)&result[i];
 
             // Initialize pointers to track progress as stripmine
-            const short* comPtr = (const short*) in_common;
-            const short* aPtr = (const short*) in_a[i];
+            const short* comPtr = (const short*)in_common;
+            const short* aPtr = (const short*)in_a[i];
 
             // Use 32-bit accumulator in order to saturate
             // to 16 bits
@@ -791,9 +792,9 @@ static inline void volk_gnsssdr_16ic_x2_dot_prod_16ic_xn_rvv(lv_16sc_t* result, 
                 }
 
             // Real part of resultant complex number
-            resPtr[0] = (short) __riscv_vmv_x_s_i32m1_i32(accRealVal);
+            resPtr[0] = (short)__riscv_vmv_x_s_i32m1_i32(accRealVal);
             // Imaginary part of resultant complex number
-            resPtr[1] = (short) __riscv_vmv_x_s_i32m1_i32(accImagVal);
+            resPtr[1] = (short)__riscv_vmv_x_s_i32m1_i32(accImagVal);
         }
 }
 #endif /* LV_HAVE_RVV */

--- a/src/algorithms/libs/volk_gnsssdr_module/volk_gnsssdr/kernels/volk_gnsssdr/volk_gnsssdr_16ic_x2_dotprodxnpuppet_16ic.h
+++ b/src/algorithms/libs/volk_gnsssdr_module/volk_gnsssdr/kernels/volk_gnsssdr/volk_gnsssdr_16ic_x2_dotprodxnpuppet_16ic.h
@@ -247,4 +247,27 @@ static inline void volk_gnsssdr_16ic_x2_dotprodxnpuppet_16ic_neon_optvma(lv_16sc
 
 #endif  // NEON
 
+
+#ifdef LV_HAVE_RVV
+static inline void volk_gnsssdr_16ic_x2_dotprodxnpuppet_16ic_rvv(lv_16sc_t* result, const lv_16sc_t* local_code, const lv_16sc_t* in, unsigned int num_points)
+{
+    int num_a_vectors = 3;
+    lv_16sc_t** in_a = (lv_16sc_t**)volk_gnsssdr_malloc(sizeof(lv_16sc_t*) * num_a_vectors, volk_gnsssdr_get_alignment());
+    int n;
+    for (n = 0; n < num_a_vectors; n++)
+        {
+            in_a[n] = (lv_16sc_t*)volk_gnsssdr_malloc(sizeof(lv_16sc_t) * num_points, volk_gnsssdr_get_alignment());
+            memcpy((lv_16sc_t*)in_a[n], (lv_16sc_t*)in, sizeof(lv_16sc_t) * num_points);
+        }
+
+    volk_gnsssdr_16ic_x2_dot_prod_16ic_xn_rvv(result, local_code, (const lv_16sc_t**)in_a, num_a_vectors, num_points);
+
+    for (n = 0; n < num_a_vectors; n++)
+        {
+            volk_gnsssdr_free(in_a[n]);
+        }
+    volk_gnsssdr_free(in_a);
+}
+#endif /* LV_HAVE_RVV */
+
 #endif  // INCLUDED_volk_gnsssdr_16ic_x2_dotprodxnpuppet_16ic_H

--- a/src/algorithms/libs/volk_gnsssdr_module/volk_gnsssdr/kernels/volk_gnsssdr/volk_gnsssdr_16ic_x2_multiply_16ic.h
+++ b/src/algorithms/libs/volk_gnsssdr_module/volk_gnsssdr/kernels/volk_gnsssdr/volk_gnsssdr_16ic_x2_multiply_16ic.h
@@ -335,9 +335,9 @@ static inline void volk_gnsssdr_16ic_x2_multiply_16ic_rvv(lv_16sc_t* result, con
     size_t n = num_points;
 
     // Initialize pointers to keep track as stripmine
-    short* resPtr = (short*) result;
-    const short* aPtr = (const short*) in_a;
-    const short* bPtr = (const short*) in_b;
+    short* resPtr = (short*)result;
+    const short* aPtr = (const short*)in_a;
+    const short* bPtr = (const short*)in_b;
 
     for (size_t vl; n > 0; n -= vl, resPtr += vl * 2, aPtr += vl * 2, bPtr += vl * 2)
         {

--- a/src/algorithms/libs/volk_gnsssdr_module/volk_gnsssdr/kernels/volk_gnsssdr/volk_gnsssdr_16ic_x2_multiply_16ic.h
+++ b/src/algorithms/libs/volk_gnsssdr_module/volk_gnsssdr/kernels/volk_gnsssdr/volk_gnsssdr_16ic_x2_multiply_16ic.h
@@ -367,10 +367,7 @@ static inline void volk_gnsssdr_16ic_x2_multiply_16ic_rvv(lv_16sc_t* result, con
             resImagVal = __riscv_vmacc_vv_i16m4(resImagVal, aImagVal, bRealVal, vl);
 
             // Store resReal[0..vl), resImag[0..vl)
-            vint16m4x2_t resVal = __riscv_vset_v_i16m4_i16m4x2(
-                __riscv_vundefined_i16m4x2(), 0, resRealVal
-            );
-            resVal = __riscv_vset_v_i16m4_i16m4x2(resVal, 1, resImagVal);
+            vint16m4x2_t resVal = __riscv_vcreate_v_i16m4x2(resRealVal, resImagVal);
             __riscv_vsseg2e16_v_i16m4x2(resPtr, resVal, vl);
 
             // In looping, decrement the number of

--- a/src/algorithms/libs/volk_gnsssdr_module/volk_gnsssdr/kernels/volk_gnsssdr/volk_gnsssdr_16ic_x2_multiply_16ic.h
+++ b/src/algorithms/libs/volk_gnsssdr_module/volk_gnsssdr/kernels/volk_gnsssdr/volk_gnsssdr_16ic_x2_multiply_16ic.h
@@ -326,4 +326,61 @@ static inline void volk_gnsssdr_16ic_x2_multiply_16ic_neon(lv_16sc_t* out, const
 }
 #endif /* LV_HAVE_NEON*/
 
+
+#ifdef LV_HAVE_RVV
+#include <riscv_vector.h>
+
+static inline void volk_gnsssdr_16ic_x2_multiply_16ic_rvv(lv_16sc_t* result, const lv_16sc_t* in_a, const lv_16sc_t* in_b, unsigned int num_points)
+{
+    size_t n = num_points;
+
+    // Initialize pointers to keep track as stripmine
+    short* resPtr = (short*) result;
+    const short* aPtr = (const short*) in_a;
+    const short* bPtr = (const short*) in_b;
+
+    for (size_t vl; n > 0; n -= vl, resPtr += vl * 2, aPtr += vl * 2, bPtr += vl * 2)
+        {
+            // Record how many elements that will actually be processed
+            vl = __riscv_vsetvl_e16m4(n);
+
+            // Load aReal[0..vl), aImag[0..vl)
+            vint16m4x2_t aVal = __riscv_vlseg2e16_v_i16m4x2(aPtr, vl);
+            vint16m4_t aRealVal = __riscv_vget_v_i16m4x2_i16m4(aVal, 0);
+            vint16m4_t aImagVal = __riscv_vget_v_i16m4x2_i16m4(aVal, 1);
+
+            // Load bReal[0..vl), bImag[0..vl)
+            vint16m4x2_t bVal = __riscv_vlseg2e16_v_i16m4x2(bPtr, vl);
+            vint16m4_t bRealVal = __riscv_vget_v_i16m4x2_i16m4(bVal, 0);
+            vint16m4_t bImagVal = __riscv_vget_v_i16m4x2_i16m4(bVal, 1);
+
+            // resReal[i] = aReal[i] * bReal[i]
+            vint16m4_t resRealVal = __riscv_vmul_vv_i16m4(aRealVal, bRealVal, vl);
+
+            // resReal[i] = -(aImag[i] * bImag[i]) + resReal[i]
+            resRealVal = __riscv_vnmsac_vv_i16m4(resRealVal, aImagVal, bImagVal, vl);
+
+            // resImag[i] = aReal[i] * bImag[i]
+            vint16m4_t resImagVal = __riscv_vmul_vv_i16m4(aRealVal, bImagVal, vl);
+
+            // resImag[i] = (aImag[i] * bReal[i]) + resImag[i]
+            resImagVal = __riscv_vmacc_vv_i16m4(resImagVal, aImagVal, bRealVal, vl);
+
+            // Store resReal[0..vl), resImag[0..vl)
+            vint16m4x2_t resVal = __riscv_vset_v_i16m4_i16m4x2(
+                __riscv_vundefined_i16m4x2(), 0, resRealVal
+            );
+            resVal = __riscv_vset_v_i16m4_i16m4x2(resVal, 1, resImagVal);
+            __riscv_vsseg2e16_v_i16m4x2(resPtr, resVal, vl);
+
+            // In looping, decrement the number of
+            // elements left and increment the pointers
+            // by the numebr of elements processed,
+            // taking into account how the `vl` complex
+            // numbers are each stored as 2 `short`s
+        }
+}
+
+#endif /* LV_HAVE_RVV */
+
 #endif /* INCLUDED_volk_gnsssdr_16ic_x2_multiply_16ic_H */

--- a/src/algorithms/libs/volk_gnsssdr_module/volk_gnsssdr/kernels/volk_gnsssdr/volk_gnsssdr_16ic_x2_rotator_dot_prod_16ic_xn.h
+++ b/src/algorithms/libs/volk_gnsssdr_module/volk_gnsssdr/kernels/volk_gnsssdr/volk_gnsssdr_16ic_x2_rotator_dot_prod_16ic_xn.h
@@ -1860,4 +1860,271 @@ static inline void volk_gnsssdr_16ic_x2_rotator_dot_prod_16ic_xn_neon_optvma(lv_
 
 #endif /* LV_HAVE_NEON */
 
+
+#ifdef LV_HAVE_RVV
+#include <riscv_vector.h>
+
+static inline void volk_gnsssdr_16ic_x2_rotator_dot_prod_16ic_xn_rvv(lv_16sc_t* result, const lv_16sc_t* in_common, const lv_32fc_t phase_inc, lv_32fc_t* phase, const lv_16sc_t** in_a, int num_a_vectors, unsigned int num_points)
+{
+    size_t ROTATOR_RELOAD = 256;
+
+    // Initialize reference pointers of compatible type that will not be stripmined
+    float* phasePtr = (float*) phase;
+
+    // Initialize pointers of compatible type to track progress as stripmine
+    short* outPtr = (short*) result;
+    const short* comPtr = (const short*) in_common;
+    const short** inPtrBuf = (const short**) volk_gnsssdr_malloc(
+        num_a_vectors * sizeof(*in_a), volk_gnsssdr_get_alignment()
+    );
+
+    for (int n_vec = 0; n_vec < num_a_vectors; n_vec++)
+    {
+        // Initialize `out` to zero
+        result[n_vec] = lv_cmake(0, 0);
+
+        // Treat complex number as struct containting
+        // two 16-bit integers
+        inPtrBuf[n_vec] = (const short*) in_a[n_vec];
+    }
+
+    for (int _ = 0; _ < num_points / ROTATOR_RELOAD; _++)
+        {
+            size_t n = ROTATOR_RELOAD;
+
+            for (size_t vl; n > 0; n -= vl, comPtr += vl * 2)
+                {
+                    // Record how many elements will actually be processed
+                    vl = __riscv_vsetvl_e16m2(n);
+
+                    // Splat phase
+                    vfloat32m4_t phaseRealVal = __riscv_vfmv_v_f_f32m4(phasePtr[0], vl);
+                    vfloat32m4_t phaseImagVal = __riscv_vfmv_v_f_f32m4(phasePtr[1], vl);
+
+                    // Splat phaseInc
+                    vfloat32m4_t phaseIncRealVal = __riscv_vfmv_v_f_f32m4(lv_creal(phase_inc), vl);
+                    vfloat32m4_t phaseIncImagVal = __riscv_vfmv_v_f_f32m4(lv_cimag(phase_inc), vl);
+
+                    // iter[i] = i
+                    vuint32m4_t iterVal = __riscv_vid_v_u32m4(vl);
+
+                    // phase[i] = phase[i] * ( phaseInc[i] ^ i )
+                    for (int j = 1; j < vl; j++)
+                        {
+                            vbool8_t maskVal = __riscv_vmsgtu_vx_u32m4_b8(iterVal, 0, vl);
+
+                            // Initialize as copies of phase so that can target masked
+                            // operations onto these copies instead of the original vectors
+                            vfloat32m4_t prodRealVal = phaseRealVal;
+                            vfloat32m4_t prodImagVal = phaseImagVal;
+
+                            // For more details on cross product,
+                            // check `volk_gnsssdr_8ic_x2_multiply_8ic_rvv`,
+                            // for instance
+                            prodRealVal = __riscv_vfmul_vv_f32m4_mu(maskVal, prodRealVal, phaseRealVal, phaseIncRealVal, vl);
+                            prodRealVal = __riscv_vfnmsac_vv_f32m4_mu(maskVal, prodRealVal, phaseImagVal, phaseIncImagVal, vl);
+                            prodImagVal = __riscv_vfmul_vv_f32m4_mu(maskVal, prodImagVal, phaseRealVal, phaseIncImagVal, vl);
+                            prodImagVal = __riscv_vfmacc_vv_f32m4_mu(maskVal, prodImagVal, phaseImagVal, phaseIncRealVal, vl);
+
+                            phaseRealVal = prodRealVal;
+                            phaseImagVal = prodImagVal;
+
+                            iterVal = __riscv_vsub_vx_u32m4_mu(maskVal, iterVal, iterVal, 1, vl);
+                        }
+
+                    // Load com[0..vl)
+                    vint16m2x2_t comVal = __riscv_vlseg2e16_v_i16m2x2(comPtr, vl);
+                    vint16m2_t comRealVal = __riscv_vget_v_i16m2x2_i16m2(comVal, 0);
+                    vint16m2_t comImagVal = __riscv_vget_v_i16m2x2_i16m2(comVal, 1);
+
+                    // w(ide)ComProd[i] = ( (float) com[i] ) * phase[i]
+                    vfloat32m4_t fComRealVal = __riscv_vfwcvt_f_x_v_f32m4(comRealVal, vl);
+                    vfloat32m4_t fComImagVal = __riscv_vfwcvt_f_x_v_f32m4(comImagVal, vl);
+
+                    vfloat32m4_t wComProdRealVal = __riscv_vfmul_vv_f32m4(fComRealVal, phaseRealVal, vl);
+                    wComProdRealVal = __riscv_vfnmsac_vv_f32m4(wComProdRealVal, fComImagVal, phaseImagVal, vl);
+                    vfloat32m4_t wComProdImagVal = __riscv_vfmul_vv_f32m4(fComRealVal, phaseImagVal, vl);
+                    wComProdImagVal = __riscv_vfmacc_vv_f32m4(wComProdImagVal, fComImagVal, phaseRealVal, vl);
+
+                    // comProd[i] = (int16_t) wComProd[i]
+                    vint16m2_t comProdRealVal = __riscv_vfncvt_x_f_w_i16m2(wComProdRealVal, vl);
+                    vint16m2_t comProdImagVal = __riscv_vfncvt_x_f_w_i16m2(wComProdImagVal, vl);
+
+                    for (int n_vec = 0; n_vec < num_a_vectors; n_vec++)
+                        {
+                            // Load in[0..vl)
+                            vint16m2x2_t inVal = __riscv_vlseg2e16_v_i16m2x2(inPtrBuf[n_vec], vl);
+                            vint16m2_t inRealVal = __riscv_vget_v_i16m2x2_i16m2(inVal, 0);
+                            vint16m2_t inImagVal = __riscv_vget_v_i16m2x2_i16m2(inVal, 1);
+
+                            // out[i] = in[i] * comProd[i]
+                            vint16m2_t outRealVal = __riscv_vmul_vv_i16m2(inRealVal, comProdRealVal, vl);
+                            outRealVal = __riscv_vnmsac_vv_i16m2(outRealVal, inImagVal, comProdImagVal, vl);
+                            vint16m2_t outImagVal = __riscv_vmul_vv_i16m2(inRealVal, comProdImagVal, vl);
+                            outImagVal = __riscv_vmacc_vv_i16m2(outImagVal, inImagVal, comProdRealVal, vl);
+
+                            // Load accumulator
+                            vint32m1_t accRealVal = __riscv_vmv_s_x_i32m1((int) outPtr[2 * n_vec], 1);
+                            vint32m1_t accImagVal = __riscv_vmv_s_x_i32m1((int) outPtr[2 * n_vec + 1], 1);
+
+                            // acc[0] = sum( acc[0], out[0..vl) )
+                            accRealVal = __riscv_vwredsum_vs_i16m2_i32m1(outRealVal, accRealVal, vl);
+                            accImagVal = __riscv_vwredsum_vs_i16m2_i32m1(outImagVal, accImagVal, vl);
+
+                            // Technically could give a different result than saturating
+                            // one at a time, due to ordering differences
+                            // Saturate within 16 bits
+                            accRealVal = __riscv_vmin_vx_i32m1(accRealVal, 32767, 1);
+                            accRealVal = __riscv_vmax_vx_i32m1(accRealVal, -32768, 1);
+                            accImagVal = __riscv_vmin_vx_i32m1(accImagVal, 32767, 1);
+                            accImagVal = __riscv_vmax_vx_i32m1(accImagVal, -32768, 1);
+
+                            // Store acc[0]
+                            outPtr[2 * n_vec] = (short) __riscv_vmv_x_s_i32m1_i32(accRealVal);
+                            outPtr[2 * n_vec + 1] = (short) __riscv_vmv_x_s_i32m1_i32(accImagVal);
+
+                            // Increment this pointer, accounting how each complex
+                            // element is two 16-bit integer numbers
+                            inPtrBuf[n_vec] += vl * 2;
+                        }
+
+                    // Store phase[vl - 1]
+                    phaseRealVal = __riscv_vslidedown_vx_f32m4(phaseRealVal, vl - 1, vl);
+                    phasePtr[0] = __riscv_vfmv_f_s_f32m4_f32(phaseRealVal);
+                    phaseImagVal = __riscv_vslidedown_vx_f32m4(phaseImagVal, vl - 1, vl);
+                    phasePtr[1] = __riscv_vfmv_f_s_f32m4_f32(phaseImagVal);
+
+                    // Account for multiplication after last calculation
+                    (*phase) *= phase_inc;
+
+                    // In looping, decrement the number of
+                    // elements left and increment the pointers
+                    // by the number of elements processed
+                }
+            // Regenerate phase
+#ifdef __cplusplus
+            (*phase) /= std::abs((*phase));
+#else
+            (*phase) /= hypotf(lv_creal(*phase), lv_cimag(*phase));
+#endif
+        }
+
+    size_t n = num_points % ROTATOR_RELOAD;
+
+    for (size_t vl; n > 0; n -= vl, comPtr += vl * 2)
+        {
+            // Record how many elements will actually be processed
+            vl = __riscv_vsetvl_e16m2(n);
+
+            // Splat phase
+            vfloat32m4_t phaseRealVal = __riscv_vfmv_v_f_f32m4(phasePtr[0], vl);
+            vfloat32m4_t phaseImagVal = __riscv_vfmv_v_f_f32m4(phasePtr[1], vl);
+
+            // Splat phaseInc
+            vfloat32m4_t phaseIncRealVal = __riscv_vfmv_v_f_f32m4(lv_creal(phase_inc), vl);
+            vfloat32m4_t phaseIncImagVal = __riscv_vfmv_v_f_f32m4(lv_cimag(phase_inc), vl);
+
+            // iter[i] = i
+            vuint32m4_t iterVal = __riscv_vid_v_u32m4(vl);
+
+            // phase[i] = phase[i] * ( phaseInc[i] ^ i )
+            for (int j = 1; j < vl; j++)
+                {
+                    vbool8_t maskVal = __riscv_vmsgtu_vx_u32m4_b8(iterVal, 0, vl);
+
+                    // Initialize as copies of phase so that can target masked
+                    // operations onto these copies instead of the original vectors
+                    vfloat32m4_t prodRealVal = phaseRealVal;
+                    vfloat32m4_t prodImagVal = phaseImagVal;
+
+                    // For more details on cross product,
+                    // check `volk_gnsssdr_8ic_x2_multiply_8ic_rvv`,
+                    // for instance
+                    prodRealVal = __riscv_vfmul_vv_f32m4_mu(maskVal, prodRealVal, phaseRealVal, phaseIncRealVal, vl);
+                    prodRealVal = __riscv_vfnmsac_vv_f32m4_mu(maskVal, prodRealVal, phaseImagVal, phaseIncImagVal, vl);
+                    prodImagVal = __riscv_vfmul_vv_f32m4_mu(maskVal, prodImagVal, phaseRealVal, phaseIncImagVal, vl);
+                    prodImagVal = __riscv_vfmacc_vv_f32m4_mu(maskVal, prodImagVal, phaseImagVal, phaseIncRealVal, vl);
+
+                    phaseRealVal = prodRealVal;
+                    phaseImagVal = prodImagVal;
+
+                    iterVal = __riscv_vsub_vx_u32m4_mu(maskVal, iterVal, iterVal, 1, vl);
+                }
+
+            // Load com[0..vl)
+            vint16m2x2_t comVal = __riscv_vlseg2e16_v_i16m2x2(comPtr, vl);
+            vint16m2_t comRealVal = __riscv_vget_v_i16m2x2_i16m2(comVal, 0);
+            vint16m2_t comImagVal = __riscv_vget_v_i16m2x2_i16m2(comVal, 1);
+
+            // w(ide)ComProd[i] = ( (float) com[i] ) * phase[i]
+            vfloat32m4_t fComRealVal = __riscv_vfwcvt_f_x_v_f32m4(comRealVal, vl);
+            vfloat32m4_t fComImagVal = __riscv_vfwcvt_f_x_v_f32m4(comImagVal, vl);
+
+            vfloat32m4_t wComProdRealVal = __riscv_vfmul_vv_f32m4(fComRealVal, phaseRealVal, vl);
+            wComProdRealVal = __riscv_vfnmsac_vv_f32m4(wComProdRealVal, fComImagVal, phaseImagVal, vl);
+            vfloat32m4_t wComProdImagVal = __riscv_vfmul_vv_f32m4(fComRealVal, phaseImagVal, vl);
+            wComProdImagVal = __riscv_vfmacc_vv_f32m4(wComProdImagVal, fComImagVal, phaseRealVal, vl);
+
+            // comProd[i] = (int16_t) wComProd[i]
+            vint16m2_t comProdRealVal = __riscv_vfncvt_x_f_w_i16m2(wComProdRealVal, vl);
+            vint16m2_t comProdImagVal = __riscv_vfncvt_x_f_w_i16m2(wComProdImagVal, vl);
+
+            for (int n_vec = 0; n_vec < num_a_vectors; n_vec++)
+                {
+                    // Load in[0..vl)
+                    vint16m2x2_t inVal = __riscv_vlseg2e16_v_i16m2x2(inPtrBuf[n_vec], vl);
+                    vint16m2_t inRealVal = __riscv_vget_v_i16m2x2_i16m2(inVal, 0);
+                    vint16m2_t inImagVal = __riscv_vget_v_i16m2x2_i16m2(inVal, 1);
+
+                    // out[i] = in[i] * comProd[i]
+                    vint16m2_t outRealVal = __riscv_vmul_vv_i16m2(inRealVal, comProdRealVal, vl);
+                    outRealVal = __riscv_vnmsac_vv_i16m2(outRealVal, inImagVal, comProdImagVal, vl);
+                    vint16m2_t outImagVal = __riscv_vmul_vv_i16m2(inRealVal, comProdImagVal, vl);
+                    outImagVal = __riscv_vmacc_vv_i16m2(outImagVal, inImagVal, comProdRealVal, vl);
+
+                    // Load accumulator
+                    vint32m1_t accRealVal = __riscv_vmv_s_x_i32m1((int) outPtr[2 * n_vec], 1);
+                    vint32m1_t accImagVal = __riscv_vmv_s_x_i32m1((int) outPtr[2 * n_vec + 1], 1);
+
+                    // acc[0] = sum( acc[0], out[0..vl) )
+                    accRealVal = __riscv_vwredsum_vs_i16m2_i32m1(outRealVal, accRealVal, vl);
+                    accImagVal = __riscv_vwredsum_vs_i16m2_i32m1(outImagVal, accImagVal, vl);
+
+                    // Technically could give a different result than saturating
+                    // one at a time, due to ordering differences
+                    // Saturate within 16 bits
+                    accRealVal = __riscv_vmin_vx_i32m1(accRealVal, 32767, 1);
+                    accRealVal = __riscv_vmax_vx_i32m1(accRealVal, -32768, 1);
+                    accImagVal = __riscv_vmin_vx_i32m1(accImagVal, 32767, 1);
+                    accImagVal = __riscv_vmax_vx_i32m1(accImagVal, -32768, 1);
+
+                    // Store acc[0]
+                    outPtr[2 * n_vec] = (short) __riscv_vmv_x_s_i32m1_i32(accRealVal);
+                    outPtr[2 * n_vec + 1] = (short) __riscv_vmv_x_s_i32m1_i32(accImagVal);
+
+                    // Increment this pointer, accounting how each complex
+                    // element is two 16-bit integer numbers
+                    inPtrBuf[n_vec] += vl * 2;
+                }
+
+            // Store phase[vl - 1]
+            phaseRealVal = __riscv_vslidedown_vx_f32m4(phaseRealVal, vl - 1, vl);
+            phasePtr[0] = __riscv_vfmv_f_s_f32m4_f32(phaseRealVal);
+            phaseImagVal = __riscv_vslidedown_vx_f32m4(phaseImagVal, vl - 1, vl);
+            phasePtr[1] = __riscv_vfmv_f_s_f32m4_f32(phaseImagVal);
+
+            // Account for multiplication after last calculation
+            (*phase) *= phase_inc;
+
+            // In looping, decrement the number of
+            // elements left and increment the pointers
+            // by the number of elements processed
+        }
+
+    // Don't leak memory!
+    volk_gnsssdr_free(inPtrBuf);
+}
+
+#endif /* LV_HAVE_RVV */
+
 #endif /* INCLUDED_volk_gnsssdr_16ic_x2_dot_prod_16ic_xn_H */

--- a/src/algorithms/libs/volk_gnsssdr_module/volk_gnsssdr/kernels/volk_gnsssdr/volk_gnsssdr_16ic_x2_rotator_dot_prod_16ic_xn.h
+++ b/src/algorithms/libs/volk_gnsssdr_module/volk_gnsssdr/kernels/volk_gnsssdr/volk_gnsssdr_16ic_x2_rotator_dot_prod_16ic_xn.h
@@ -1869,24 +1869,23 @@ static inline void volk_gnsssdr_16ic_x2_rotator_dot_prod_16ic_xn_rvv(lv_16sc_t* 
     size_t ROTATOR_RELOAD = 256;
 
     // Initialize reference pointers of compatible type that will not be stripmined
-    float* phasePtr = (float*) phase;
+    float* phasePtr = (float*)phase;
 
     // Initialize pointers of compatible type to track progress as stripmine
-    short* outPtr = (short*) result;
-    const short* comPtr = (const short*) in_common;
-    const short** inPtrBuf = (const short**) volk_gnsssdr_malloc(
-        num_a_vectors * sizeof(*in_a), volk_gnsssdr_get_alignment()
-    );
+    short* outPtr = (short*)result;
+    const short* comPtr = (const short*)in_common;
+    const short** inPtrBuf = (const short**)volk_gnsssdr_malloc(
+        num_a_vectors * sizeof(*in_a), volk_gnsssdr_get_alignment());
 
     for (int n_vec = 0; n_vec < num_a_vectors; n_vec++)
-    {
-        // Initialize `out` to zero
-        result[n_vec] = lv_cmake(0, 0);
+        {
+            // Initialize `out` to zero
+            result[n_vec] = lv_cmake(0, 0);
 
-        // Treat complex number as struct containting
-        // two 16-bit integers
-        inPtrBuf[n_vec] = (const short*) in_a[n_vec];
-    }
+            // Treat complex number as struct containting
+            // two 16-bit integers
+            inPtrBuf[n_vec] = (const short*)in_a[n_vec];
+        }
 
     for (int _ = 0; _ < num_points / ROTATOR_RELOAD; _++)
         {
@@ -1964,8 +1963,8 @@ static inline void volk_gnsssdr_16ic_x2_rotator_dot_prod_16ic_xn_rvv(lv_16sc_t* 
                             outImagVal = __riscv_vmacc_vv_i16m2(outImagVal, inImagVal, comProdRealVal, vl);
 
                             // Load accumulator
-                            vint32m1_t accRealVal = __riscv_vmv_s_x_i32m1((int) outPtr[2 * n_vec], 1);
-                            vint32m1_t accImagVal = __riscv_vmv_s_x_i32m1((int) outPtr[2 * n_vec + 1], 1);
+                            vint32m1_t accRealVal = __riscv_vmv_s_x_i32m1((int)outPtr[2 * n_vec], 1);
+                            vint32m1_t accImagVal = __riscv_vmv_s_x_i32m1((int)outPtr[2 * n_vec + 1], 1);
 
                             // acc[0] = sum( acc[0], out[0..vl) )
                             accRealVal = __riscv_vwredsum_vs_i16m2_i32m1(outRealVal, accRealVal, vl);
@@ -1980,8 +1979,8 @@ static inline void volk_gnsssdr_16ic_x2_rotator_dot_prod_16ic_xn_rvv(lv_16sc_t* 
                             accImagVal = __riscv_vmax_vx_i32m1(accImagVal, -32768, 1);
 
                             // Store acc[0]
-                            outPtr[2 * n_vec] = (short) __riscv_vmv_x_s_i32m1_i32(accRealVal);
-                            outPtr[2 * n_vec + 1] = (short) __riscv_vmv_x_s_i32m1_i32(accImagVal);
+                            outPtr[2 * n_vec] = (short)__riscv_vmv_x_s_i32m1_i32(accRealVal);
+                            outPtr[2 * n_vec + 1] = (short)__riscv_vmv_x_s_i32m1_i32(accImagVal);
 
                             // Increment this pointer, accounting how each complex
                             // element is two 16-bit integer numbers
@@ -2001,7 +2000,7 @@ static inline void volk_gnsssdr_16ic_x2_rotator_dot_prod_16ic_xn_rvv(lv_16sc_t* 
                     // elements left and increment the pointers
                     // by the number of elements processed
                 }
-            // Regenerate phase
+                // Regenerate phase
 #ifdef __cplusplus
             (*phase) /= std::abs((*phase));
 #else
@@ -2083,8 +2082,8 @@ static inline void volk_gnsssdr_16ic_x2_rotator_dot_prod_16ic_xn_rvv(lv_16sc_t* 
                     outImagVal = __riscv_vmacc_vv_i16m2(outImagVal, inImagVal, comProdRealVal, vl);
 
                     // Load accumulator
-                    vint32m1_t accRealVal = __riscv_vmv_s_x_i32m1((int) outPtr[2 * n_vec], 1);
-                    vint32m1_t accImagVal = __riscv_vmv_s_x_i32m1((int) outPtr[2 * n_vec + 1], 1);
+                    vint32m1_t accRealVal = __riscv_vmv_s_x_i32m1((int)outPtr[2 * n_vec], 1);
+                    vint32m1_t accImagVal = __riscv_vmv_s_x_i32m1((int)outPtr[2 * n_vec + 1], 1);
 
                     // acc[0] = sum( acc[0], out[0..vl) )
                     accRealVal = __riscv_vwredsum_vs_i16m2_i32m1(outRealVal, accRealVal, vl);
@@ -2099,8 +2098,8 @@ static inline void volk_gnsssdr_16ic_x2_rotator_dot_prod_16ic_xn_rvv(lv_16sc_t* 
                     accImagVal = __riscv_vmax_vx_i32m1(accImagVal, -32768, 1);
 
                     // Store acc[0]
-                    outPtr[2 * n_vec] = (short) __riscv_vmv_x_s_i32m1_i32(accRealVal);
-                    outPtr[2 * n_vec + 1] = (short) __riscv_vmv_x_s_i32m1_i32(accImagVal);
+                    outPtr[2 * n_vec] = (short)__riscv_vmv_x_s_i32m1_i32(accRealVal);
+                    outPtr[2 * n_vec + 1] = (short)__riscv_vmv_x_s_i32m1_i32(accImagVal);
 
                     // Increment this pointer, accounting how each complex
                     // element is two 16-bit integer numbers

--- a/src/algorithms/libs/volk_gnsssdr_module/volk_gnsssdr/kernels/volk_gnsssdr/volk_gnsssdr_16ic_x2_rotator_dotprodxnpuppet_16ic.h
+++ b/src/algorithms/libs/volk_gnsssdr_module/volk_gnsssdr/kernels/volk_gnsssdr/volk_gnsssdr_16ic_x2_rotator_dotprodxnpuppet_16ic.h
@@ -364,4 +364,35 @@ static inline void volk_gnsssdr_16ic_x2_rotator_dotprodxnpuppet_16ic_neon_vma(lv
 
 #endif  // NEON
 
+
+#ifdef LV_HAVE_RVV
+static inline void volk_gnsssdr_16ic_x2_rotator_dotprodxnpuppet_16ic_rvv(lv_16sc_t* result, const lv_16sc_t* local_code, const lv_16sc_t* in, unsigned int num_points)
+{
+    // phases must be normalized. Phase rotator expects a complex exponential input!
+    float rem_carrier_phase_in_rad = 0.345;
+    float phase_step_rad = 0.1;
+    lv_32fc_t phase[1];
+    phase[0] = lv_cmake(cos(rem_carrier_phase_in_rad), sin(rem_carrier_phase_in_rad));
+    lv_32fc_t phase_inc[1];
+    phase_inc[0] = lv_cmake(cos(phase_step_rad), sin(phase_step_rad));
+    int n;
+    int num_a_vectors = 3;
+    lv_16sc_t** in_a = (lv_16sc_t**)volk_gnsssdr_malloc(sizeof(lv_16sc_t*) * num_a_vectors, volk_gnsssdr_get_alignment());
+    for (n = 0; n < num_a_vectors; n++)
+        {
+            in_a[n] = (lv_16sc_t*)volk_gnsssdr_malloc(sizeof(lv_16sc_t) * num_points, volk_gnsssdr_get_alignment());
+            memcpy((lv_16sc_t*)in_a[n], (lv_16sc_t*)in, sizeof(lv_16sc_t) * num_points);
+        }
+
+    volk_gnsssdr_16ic_x2_rotator_dot_prod_16ic_xn_rvv(result, local_code, phase_inc[0], phase, (const lv_16sc_t**)in_a, num_a_vectors, num_points);
+
+    for (n = 0; n < num_a_vectors; n++)
+        {
+            volk_gnsssdr_free(in_a[n]);
+        }
+    volk_gnsssdr_free(in_a);
+}
+
+#endif  // RVV
+
 #endif  // INCLUDED_volk_gnsssdr_16ic_x2_rotator_dotprodxnpuppet_16ic_H

--- a/src/algorithms/libs/volk_gnsssdr_module/volk_gnsssdr/kernels/volk_gnsssdr/volk_gnsssdr_16ic_xn_resampler_16ic_xn.h
+++ b/src/algorithms/libs/volk_gnsssdr_module/volk_gnsssdr/kernels/volk_gnsssdr/volk_gnsssdr_16ic_xn_resampler_16ic_xn.h
@@ -604,50 +604,53 @@ static inline void volk_gnsssdr_16ic_xn_resampler_16ic_xn_rvv(lv_16sc_t** result
     // To make easier to work with in RVV, just interpret the two 16-bit components
     // of each complex number as a single 32-bit number to move around
 
-    for (int current_correlator_tap = 0; current_correlator_tap < num_out_vectors; current_correlator_tap++) {
-        // Stores address offsets from `local_code` to load from and
-        // then store in `result[current_correlator_tap]`
-        unsigned int offsetBuffer[num_points];
+    for (int current_correlator_tap = 0; current_correlator_tap < num_out_vectors; current_correlator_tap++)
+        {
+            // Stores address offsets from `local_code` to load from and
+            // then store in `result[current_correlator_tap]`
+            unsigned int offsetBuffer[num_points];
 
-        for (int i = 0; i < num_points; i++) {
-            // resample code for current tap
-            int local_code_chip_index = (int)floor(code_phase_step_chips * (float)i + shifts_chips[current_correlator_tap] - rem_code_phase_chips);
-            // Take into account that in multitap correlators, the shifts can be negative!
-            if (local_code_chip_index < 0) local_code_chip_index += (int)code_length_chips * (abs(local_code_chip_index) / code_length_chips + 1);
-            local_code_chip_index = local_code_chip_index % code_length_chips;
+            for (int i = 0; i < num_points; i++)
+                {
+                    // resample code for current tap
+                    int local_code_chip_index = (int)floor(code_phase_step_chips * (float)i + shifts_chips[current_correlator_tap] - rem_code_phase_chips);
+                    // Take into account that in multitap correlators, the shifts can be negative!
+                    if (local_code_chip_index < 0) local_code_chip_index += (int)code_length_chips * (abs(local_code_chip_index) / code_length_chips + 1);
+                    local_code_chip_index = local_code_chip_index % code_length_chips;
 
-            // `local_code_chip_index` should be some positive, valid
-            // index to `local_code`
-            // Convert from index to raw address offset
-            offsetBuffer[i] = (unsigned int) (local_code_chip_index * 4);
+                    // `local_code_chip_index` should be some positive, valid
+                    // index to `local_code`
+                    // Convert from index to raw address offset
+                    offsetBuffer[i] = (unsigned int) (local_code_chip_index * 4);
+                }
+
+            size_t n = num_points;
+
+            // Initialize pointers to track progress as stripmine
+            int* outPtr = (int*) result[current_correlator_tap];
+            const int* inPtr = (const int*) local_code;
+            const unsigned int* offsetPtr = (const unsigned int*) offsetBuffer;
+
+            for (size_t vl; n > 0; n -= vl, outPtr += vl, offsetPtr += vl)
+                {
+                    // Record how many elements will actually be processed
+                    vl = __riscv_vsetvl_e32m8(n);
+
+                    // Load offset[0..vl)
+                    vuint32m8_t offsetVal = __riscv_vle32_v_u32m8(offsetPtr, vl);
+
+                    // This indexed load is unordered to hopefully boost run time
+                    // out[i] = in[offset[i]]
+                    vint32m8_t outVal = __riscv_vluxei32_v_i32m8(inPtr, offsetVal, vl);
+
+                    // Store out[0..vl)
+                    __riscv_vse32_v_i32m8(outPtr, outVal, vl);
+
+                    // In looping, decrement the number of
+                    // elements left and increment stripmining pointers
+                    // by the number of elements processed
+                }
         }
-
-        size_t n = num_points;
-
-        // Initialize pointers to track progress as stripmine
-        int* outPtr = (int*) result[current_correlator_tap];
-        const int* inPtr = (const int*) local_code;
-        const unsigned int* offsetPtr = (const unsigned int*) offsetBuffer;
-
-        for (size_t vl; n > 0; n -= vl, outPtr += vl, offsetPtr += vl) {
-            // Record how many elements will actually be processed
-            vl = __riscv_vsetvl_e32m8(n);
-
-            // Load offset[0..vl)
-            vuint32m8_t offsetVal = __riscv_vle32_v_u32m8(offsetPtr, vl);
-
-            // This indexed load is unordered to hopefully boost run time
-            // out[i] = in[offset[i]]
-            vint32m8_t outVal = __riscv_vluxei32_v_i32m8(inPtr, offsetVal, vl);
-
-            // Store out[0..vl)
-            __riscv_vse32_v_i32m8(outPtr, outVal, vl);
-
-            // In looping, decrement the number of
-            // elements left and increment stripmining pointers
-            // by the number of elements processed
-        }
-    }
 }
 
 #endif

--- a/src/algorithms/libs/volk_gnsssdr_module/volk_gnsssdr/kernels/volk_gnsssdr/volk_gnsssdr_16ic_xn_resampler_16ic_xn.h
+++ b/src/algorithms/libs/volk_gnsssdr_module/volk_gnsssdr/kernels/volk_gnsssdr/volk_gnsssdr_16ic_xn_resampler_16ic_xn.h
@@ -629,7 +629,7 @@ static inline void volk_gnsssdr_16ic_xn_resampler_16ic_xn_rvv(lv_16sc_t** result
                     vuint32m8_t iVal = __riscv_vadd_vx_u32m8(idVal, currI, vl);
                     vfloat32m8_t floatIVal = __riscv_vfcvt_f_xu_v_f32m8(iVal, vl);
 
-                    // iterIndex[i] = floatIVal[i] * code_phase_step_chips
+                    // iterIndex[i] = floatI[i] * code_phase_step_chips
                     vfloat32m8_t iterIndexVal = __riscv_vfmul_vf_f32m8(floatIVal, code_phase_step_chips, vl);
 
                     // overflowIndex[i] = (int) floor(iterIndex[i] + constIndexShift)
@@ -647,7 +647,7 @@ static inline void volk_gnsssdr_16ic_xn_resampler_16ic_xn_rvv(lv_16sc_t** result
                     vuint32m8_t finalIndexVal = __riscv_vreinterpret_v_i32m8_u32m8(indexVal);
 
                     // Convert to address offset
-                    // offset[i] = finalIndex[i] * sizeof(float)
+                    // offset[i] = finalIndex[i] * sizeof(lv_16sc_t)
                     vuint32m8_t offsetVal = __riscv_vmul_vx_u32m8(finalIndexVal, sizeof(lv_16sc_t), vl);
 
                     // This indexed load is unordered to hopefully boost run time
@@ -658,7 +658,7 @@ static inline void volk_gnsssdr_16ic_xn_resampler_16ic_xn_rvv(lv_16sc_t** result
                     __riscv_vse32_v_i32m8(outPtr, outVal, vl);
 
                     // In looping, decrement the number of
-                    // elements left and increment stripmining pointers
+                    // elements left and increment stripmining variables
                     // by the number of elements processed
                 }
         }

--- a/src/algorithms/libs/volk_gnsssdr_module/volk_gnsssdr/kernels/volk_gnsssdr/volk_gnsssdr_16ic_xn_resampler_16ic_xn.h
+++ b/src/algorithms/libs/volk_gnsssdr_module/volk_gnsssdr/kernels/volk_gnsssdr/volk_gnsssdr_16ic_xn_resampler_16ic_xn.h
@@ -605,7 +605,7 @@ static inline void volk_gnsssdr_16ic_xn_resampler_16ic_xn_rvv(lv_16sc_t** result
     // of each complex number as a single 32-bit number to move around
 
     // Initialize reference pointer, as stays same across loops
-    const int* inPtr = (const int*) local_code;
+    const int* inPtr = (const int*)local_code;
 
     for (int current_correlator_tap = 0; current_correlator_tap < num_out_vectors; current_correlator_tap++)
         {
@@ -614,7 +614,7 @@ static inline void volk_gnsssdr_16ic_xn_resampler_16ic_xn_rvv(lv_16sc_t** result
             const float constIndexShift = shifts_chips[current_correlator_tap] - rem_code_phase_chips;
 
             // Initialize pointers to track progress as stripmine
-            int* outPtr = (int*) result[current_correlator_tap];
+            int* outPtr = (int*)result[current_correlator_tap];
             // Simulates how, compared to generic implementation, `i` continues
             // increasing across different vector computatation batches
             unsigned int currI = 0;

--- a/src/algorithms/libs/volk_gnsssdr_module/volk_gnsssdr/kernels/volk_gnsssdr/volk_gnsssdr_16ic_xn_resampler_16ic_xn.h
+++ b/src/algorithms/libs/volk_gnsssdr_module/volk_gnsssdr/kernels/volk_gnsssdr/volk_gnsssdr_16ic_xn_resampler_16ic_xn.h
@@ -604,40 +604,51 @@ static inline void volk_gnsssdr_16ic_xn_resampler_16ic_xn_rvv(lv_16sc_t** result
     // To make easier to work with in RVV, just interpret the two 16-bit components
     // of each complex number as a single 32-bit number to move around
 
+    // Initialize reference pointer, as stays same across loops
+    const int* inPtr = (const int*) local_code;
+
     for (int current_correlator_tap = 0; current_correlator_tap < num_out_vectors; current_correlator_tap++)
         {
-            // Stores address offsets from `local_code` to load from and
-            // then store in `result[current_correlator_tap]`
-            unsigned int offsetBuffer[num_points];
-
-            for (int i = 0; i < num_points; i++)
-                {
-                    // resample code for current tap
-                    int local_code_chip_index = (int)floor(code_phase_step_chips * (float)i + shifts_chips[current_correlator_tap] - rem_code_phase_chips);
-                    // Take into account that in multitap correlators, the shifts can be negative!
-                    if (local_code_chip_index < 0) local_code_chip_index += (int)code_length_chips * (abs(local_code_chip_index) / code_length_chips + 1);
-                    local_code_chip_index = local_code_chip_index % code_length_chips;
-
-                    // `local_code_chip_index` should be some positive, valid
-                    // index to `local_code`
-                    // Convert from index to raw address offset
-                    offsetBuffer[i] = (unsigned int) (local_code_chip_index * 4);
-                }
-
             size_t n = num_points;
+
+            const float constIndexShift = shifts_chips[current_correlator_tap] - rem_code_phase_chips;
 
             // Initialize pointers to track progress as stripmine
             int* outPtr = (int*) result[current_correlator_tap];
-            const int* inPtr = (const int*) local_code;
-            const unsigned int* offsetPtr = (const unsigned int*) offsetBuffer;
+            // Simulates how, compared to generic implementation, `i` continues
+            // increasing across different vector computatation batches
+            unsigned int currI = 0;
 
-            for (size_t vl; n > 0; n -= vl, outPtr += vl, offsetPtr += vl)
+            for (size_t vl; n > 0; n -= vl, outPtr += vl, currI += vl)
                 {
-                    // Record how many elements will actually be processed
+                    // Record how many data elements will actually be processed
                     vl = __riscv_vsetvl_e32m8(n);
 
-                    // Load offset[0..vl)
-                    vuint32m8_t offsetVal = __riscv_vle32_v_u32m8(offsetPtr, vl);
+                    // floatI[i] = (float) (i + currI)
+                    vuint32m8_t idVal = __riscv_vid_v_u32m8(vl);
+                    vuint32m8_t iVal = __riscv_vadd_vx_u32m8(idVal, currI, vl);
+                    vfloat32m8_t floatIVal = __riscv_vfcvt_f_xu_v_f32m8(iVal, vl);
+
+                    // iterIndex[i] = floatIVal[i] * code_phase_step_chips
+                    vfloat32m8_t iterIndexVal = __riscv_vfmul_vf_f32m8(floatIVal, code_phase_step_chips, vl);
+
+                    // overflowIndex[i] = (int) floor(iterIndex[i] + constIndexShift)
+                    vfloat32m8_t shiftedIndexVal = __riscv_vfadd_vf_f32m8(iterIndexVal, constIndexShift, vl);
+                    vint32m8_t overflowIndexVal = __riscv_vfcvt_x_f_v_i32m8_rm(shiftedIndexVal, __RISCV_FRM_RDN, vl);
+
+                    // Wrap to valid index in `local_code`, handling negative values
+                    // index[i] = ( code_length_chips + ( overflowIndex[i] % code_length_chips ) ) % code_length_chips
+                    vint32m8_t indexVal = __riscv_vrem_vx_i32m8(overflowIndexVal, code_length_chips, vl);
+                    indexVal = __riscv_vadd_vx_i32m8(indexVal, code_length_chips, vl);
+                    indexVal = __riscv_vrem_vx_i32m8(indexVal, code_length_chips, vl);
+
+                    // After above, should now be guaranteed positive and valid index
+                    // finalIndex[i] = (unsigned int) index[i];
+                    vuint32m8_t finalIndexVal = __riscv_vreinterpret_v_i32m8_u32m8(indexVal);
+
+                    // Convert to address offset
+                    // offset[i] = finalIndex[i] * sizeof(float)
+                    vuint32m8_t offsetVal = __riscv_vmul_vx_u32m8(finalIndexVal, sizeof(lv_16sc_t), vl);
 
                     // This indexed load is unordered to hopefully boost run time
                     // out[i] = in[offset[i]]

--- a/src/algorithms/libs/volk_gnsssdr_module/volk_gnsssdr/kernels/volk_gnsssdr/volk_gnsssdr_16ic_xn_resampler_16ic_xn.h
+++ b/src/algorithms/libs/volk_gnsssdr_module/volk_gnsssdr/kernels/volk_gnsssdr/volk_gnsssdr_16ic_xn_resampler_16ic_xn.h
@@ -593,6 +593,62 @@ static inline void volk_gnsssdr_16ic_xn_resampler_16ic_xn_neon(lv_16sc_t** resul
         }
 }
 
+#endif
+
+
+#ifdef LV_HAVE_RVV
+#include <riscv_vector.h>
+
+static inline void volk_gnsssdr_16ic_xn_resampler_16ic_xn_rvv(lv_16sc_t** result, const lv_16sc_t* local_code, float rem_code_phase_chips, float code_phase_step_chips, float* shifts_chips, unsigned int code_length_chips, int num_out_vectors, unsigned int num_points)
+{
+    // To make easier to work with in RVV, just interpret the two 16-bit components
+    // of each complex number as a single 32-bit number to move around
+
+    for (int current_correlator_tap = 0; current_correlator_tap < num_out_vectors; current_correlator_tap++) {
+        // Stores address offsets from `local_code` to load from and
+        // then store in `result[current_correlator_tap]`
+        unsigned int offsetBuffer[num_points];
+
+        for (int i = 0; i < num_points; i++) {
+            // resample code for current tap
+            int local_code_chip_index = (int)floor(code_phase_step_chips * (float)i + shifts_chips[current_correlator_tap] - rem_code_phase_chips);
+            // Take into account that in multitap correlators, the shifts can be negative!
+            if (local_code_chip_index < 0) local_code_chip_index += (int)code_length_chips * (abs(local_code_chip_index) / code_length_chips + 1);
+            local_code_chip_index = local_code_chip_index % code_length_chips;
+
+            // `local_code_chip_index` should be some positive, valid
+            // index to `local_code`
+            // Convert from index to raw address offset
+            offsetBuffer[i] = (unsigned int) (local_code_chip_index * 4);
+        }
+
+        size_t n = num_points;
+
+        // Initialize pointers to track progress as stripmine
+        int* outPtr = (int*) result[current_correlator_tap];
+        const int* inPtr = (const int*) local_code;
+        const unsigned int* offsetPtr = (const unsigned int*) offsetBuffer;
+
+        for (size_t vl; n > 0; n -= vl, outPtr += vl, offsetPtr += vl) {
+            // Record how many elements will actually be processed
+            vl = __riscv_vsetvl_e32m8(n);
+
+            // Load offset[0..vl)
+            vuint32m8_t offsetVal = __riscv_vle32_v_u32m8(offsetPtr, vl);
+
+            // This indexed load is unordered to hopefully boost run time
+            // out[i] = in[offset[i]]
+            vint32m8_t outVal = __riscv_vluxei32_v_i32m8(inPtr, offsetVal, vl);
+
+            // Store out[0..vl)
+            __riscv_vse32_v_i32m8(outPtr, outVal, vl);
+
+            // In looping, decrement the number of
+            // elements left and increment stripmining pointers
+            // by the number of elements processed
+        }
+    }
+}
 
 #endif
 

--- a/src/algorithms/libs/volk_gnsssdr_module/volk_gnsssdr/kernels/volk_gnsssdr/volk_gnsssdr_16ic_xn_resampler_fast_16ic_xn.h
+++ b/src/algorithms/libs/volk_gnsssdr_module/volk_gnsssdr/kernels/volk_gnsssdr/volk_gnsssdr_16ic_xn_resampler_fast_16ic_xn.h
@@ -382,10 +382,10 @@ static inline void volk_gnsssdr_16ic_xn_resampler_fast_16ic_xn_rvv(lv_16sc_t** r
     // of each complex number as a single 32-bit number to move around
 
     // Initialize reference pointer, as stays same and not stripmined
-    const int* inPtr = (const int*) local_code;
+    const int* inPtr = (const int*)local_code;
 
     // Initialize variable to clearer, applicable type
-    int code_len = (int) code_length_chips;
+    int code_len = (int)code_length_chips;
 
     for (int current_vector = 0; current_vector < num_out_vectors; current_vector++)
         {
@@ -394,7 +394,7 @@ static inline void volk_gnsssdr_16ic_xn_resampler_fast_16ic_xn_rvv(lv_16sc_t** r
             const float constIndexShift = rem_code_phase_chips[current_vector];
 
             // Initialize pointer to track progress as stripmine
-            int* outPtr = (int*) result[current_vector];
+            int* outPtr = (int*)result[current_vector];
             // Simulates how, compared to generic implementation, `i` continues
             // increasing across different vector computation batches
             unsigned int currI = 0;

--- a/src/algorithms/libs/volk_gnsssdr_module/volk_gnsssdr/kernels/volk_gnsssdr/volk_gnsssdr_16ic_xn_resampler_fast_16ic_xn.h
+++ b/src/algorithms/libs/volk_gnsssdr_module/volk_gnsssdr/kernels/volk_gnsssdr/volk_gnsssdr_16ic_xn_resampler_fast_16ic_xn.h
@@ -372,4 +372,91 @@ static inline void volk_gnsssdr_16ic_xn_resampler_fast_16ic_xn_neon(lv_16sc_t** 
 
 #endif /* LV_HAVE_NEON */
 
+
+#ifdef LV_HAVE_RVV
+#include <riscv_vector.h>
+
+static inline void volk_gnsssdr_16ic_xn_resampler_fast_16ic_xn_rvv(lv_16sc_t** result, const lv_16sc_t* local_code, float* rem_code_phase_chips, float code_phase_step_chips, unsigned int code_length_chips, int num_out_vectors, unsigned int num_out_samples)
+{
+    // To make easier to work with in RVV, just interpret the two 16-bit components
+    // of each complex number as a single 32-bit number to move around
+
+    // Initialize reference pointer, as stays same and not stripmined
+    const int* inPtr = (const int*) local_code;
+
+    // Initialize variable to clearer, applicable type
+    int code_len = (int) code_length_chips;
+
+    for (int current_vector = 0; current_vector < num_out_vectors; current_vector++)
+        {
+            size_t n = num_out_samples;
+
+            const float constIndexShift = rem_code_phase_chips[current_vector];
+
+            // Initialize pointer to track progress as stripmine
+            int* outPtr = (int*) result[current_vector];
+            // Simulates how, compared to generic implementation, `i` continues
+            // increasing across different vector computation batches
+            unsigned int currI = 0;
+
+            for (size_t vl; n > 0; n -= vl, outPtr += vl, currI += vl)
+                {
+                    // Record how many elements will actually be processed
+                    vl = __riscv_vsetvl_e32m8(n);
+
+                    // floatI[i] = (float) (i + currI);
+                    vuint32m8_t idVal = __riscv_vid_v_u32m8(vl);
+                    vuint32m8_t iVal = __riscv_vadd_vx_u32m8(idVal, currI, vl);
+                    vfloat32m8_t floatIVal = __riscv_vfcvt_f_xu_v_f32m8(iVal, vl);
+
+                    // iterIndex[i] = floatI[i] * code_phase_step_chips
+                    vfloat32m8_t iterIndexVal = __riscv_vfmul_vf_f32m8(floatIVal, code_phase_step_chips, vl);
+
+                    // overflowIndex[i] = (int) floor(iterIndex[i] + constIndexShift)
+                    vfloat32m8_t shiftedIndexVal = __riscv_vfadd_vf_f32m8(iterIndexVal, constIndexShift, vl);
+                    vint32m8_t overflowIndexVal = __riscv_vfcvt_x_f_v_i32m8_rm(shiftedIndexVal, __RISCV_FRM_RDN, vl);
+
+                    // Note on performance: Could technically do a "nested ternary" here,
+                    // where only check the second conditional for an element if the first conditional
+                    // was false. This would increase performance only in cases where both the
+                    // microarchitecture is actually able to optimize masked vector functions AND
+                    // there are enough negative indices that the skipped comparisons make up for
+                    // the additional mask inversion instruction. At this point, seems like optimizing
+                    // for pennies, so did not implement this and went for the clearer approach below
+
+                    // Wrap to valid index in `local_code`, given that phase cannot be more
+                    // than twice of `code_length_chips`, positive or negative
+                    // index[i] = overflowIndex[i]
+                    // index[i] = index[i] < 0 ? index[i] + code_len : index[i]
+                    // index[i] = index[i] > (code_len - 1) ? index[i] - code_len : index[i]
+                    vint32m8_t indexVal = overflowIndexVal;
+                    vbool4_t indexMaskVal = __riscv_vmslt_vx_i32m8_b4(indexVal, 0, vl);
+                    indexVal = __riscv_vadd_vx_i32m8_mu(indexMaskVal, indexVal, indexVal, code_len, vl);
+                    indexMaskVal = __riscv_vmsgt_vx_i32m8_b4(indexVal, code_len - 1, vl);
+                    indexVal = __riscv_vsub_vx_i32m8_mu(indexMaskVal, indexVal, indexVal, code_len, vl);
+
+                    // After above, should now be guaranteed positive and valid index
+                    // finalIndex[i] = (unsigned int) index[i]
+                    vuint32m8_t finalIndexVal = __riscv_vreinterpret_v_i32m8_u32m8(indexVal);
+
+                    // Convert to address offset
+                    // offset[i] = finalIndex[i] * sizeof(lv_16sc_t)
+                    vuint32m8_t offsetVal = __riscv_vmul_vx_u32m8(finalIndexVal, sizeof(lv_16sc_t), vl);
+
+                    // This indexed load is unordered to hopefully boost run time
+                    // out[i] = in[offset[i]]
+                    vint32m8_t outVal = __riscv_vluxei32_v_i32m8(inPtr, offsetVal, vl);
+
+                    // Store out[0..vl)
+                    __riscv_vse32_v_i32m8(outPtr, outVal, vl);
+
+                    // In looping, decrement the number of
+                    // elements left and increment stripmining variables
+                    // by the number of elements processed
+                }
+        }
+}
+
+#endif /* LV_HAVE_RVV */
+
 #endif /* INCLUDED_volk_gnsssdr_16ic_xn_resampler_fast_16ic_xn_H */

--- a/src/algorithms/libs/volk_gnsssdr_module/volk_gnsssdr/kernels/volk_gnsssdr/volk_gnsssdr_32f_high_dynamics_resamplerxnpuppet_32f.h
+++ b/src/algorithms/libs/volk_gnsssdr_module/volk_gnsssdr/kernels/volk_gnsssdr/volk_gnsssdr_32f_high_dynamics_resamplerxnpuppet_32f.h
@@ -244,4 +244,34 @@ static inline void volk_gnsssdr_32f_high_dynamics_resamplerxnpuppet_32f_u_avx(fl
 #endif
 
 
+#ifdef LV_HAVE_RVV
+static inline void volk_gnsssdr_32f_high_dynamics_resamplerxnpuppet_32f_rvv(float* result, const float* local_code, unsigned int num_points)
+{
+    int code_length_chips = 2046;
+    float code_phase_step_chips = ((float)(code_length_chips) + 0.1) / ((float)num_points);
+    int num_out_vectors = 3;
+    float rem_code_phase_chips = -0.8234;
+    float code_phase_rate_step_chips = 1.0 / powf(2.0, 33.0);
+    int n;
+    float shifts_chips[3] = {-0.1, 0.0, 0.1};
+
+    float** result_aux = (float**)volk_gnsssdr_malloc(sizeof(float*) * num_out_vectors, volk_gnsssdr_get_alignment());
+    for (n = 0; n < num_out_vectors; n++)
+        {
+            result_aux[n] = (float*)volk_gnsssdr_malloc(sizeof(float) * num_points, volk_gnsssdr_get_alignment());
+        }
+
+    volk_gnsssdr_32f_xn_high_dynamics_resampler_32f_xn_rvv(result_aux, local_code, rem_code_phase_chips, code_phase_step_chips, code_phase_rate_step_chips, shifts_chips, code_length_chips, num_out_vectors, num_points);
+
+    memcpy((float*)result, (float*)result_aux[0], sizeof(float) * num_points);
+
+    for (n = 0; n < num_out_vectors; n++)
+        {
+            volk_gnsssdr_free(result_aux[n]);
+        }
+    volk_gnsssdr_free(result_aux);
+}
+#endif
+
+
 #endif  // INCLUDED_volk_gnsssdr_32f_high_dynamics_resamplerpuppet_32f_H

--- a/src/algorithms/libs/volk_gnsssdr_module/volk_gnsssdr/kernels/volk_gnsssdr/volk_gnsssdr_32f_resamplerxnpuppet_32f.h
+++ b/src/algorithms/libs/volk_gnsssdr_module/volk_gnsssdr/kernels/volk_gnsssdr/volk_gnsssdr_32f_resamplerxnpuppet_32f.h
@@ -260,4 +260,32 @@ static inline void volk_gnsssdr_32f_resamplerxnpuppet_32f_neon(float* result, co
 }
 #endif
 
+#ifdef LV_HAVE_RVV
+static inline void volk_gnsssdr_32f_resamplerxnpuppet_32f_rvv(float* result, const float* local_code, unsigned int num_points)
+{
+    int code_length_chips = 2046;
+    float code_phase_step_chips = ((float)(code_length_chips) + 0.1) / ((float)num_points);
+    int num_out_vectors = 3;
+    float rem_code_phase_chips = -0.234;
+    int n;
+    float shifts_chips[3] = {-0.1, 0.0, 0.1};
+
+    float** result_aux = (float**)volk_gnsssdr_malloc(sizeof(float*) * num_out_vectors, volk_gnsssdr_get_alignment());
+    for (n = 0; n < num_out_vectors; n++)
+        {
+            result_aux[n] = (float*)volk_gnsssdr_malloc(sizeof(float) * num_points, volk_gnsssdr_get_alignment());
+        }
+
+    volk_gnsssdr_32f_xn_resampler_32f_xn_rvv(result_aux, local_code, rem_code_phase_chips, code_phase_step_chips, shifts_chips, code_length_chips, num_out_vectors, num_points);
+
+    memcpy((float*)result, (float*)result_aux[0], sizeof(float) * num_points);
+
+    for (n = 0; n < num_out_vectors; n++)
+        {
+            volk_gnsssdr_free(result_aux[n]);
+        }
+    volk_gnsssdr_free(result_aux);
+}
+#endif
+
 #endif  // INCLUDED_volk_gnsssdr_32f_resamplerpuppet_32f_H

--- a/src/algorithms/libs/volk_gnsssdr_module/volk_gnsssdr/kernels/volk_gnsssdr/volk_gnsssdr_32f_sincos_32fc.h
+++ b/src/algorithms/libs/volk_gnsssdr_module/volk_gnsssdr/kernels/volk_gnsssdr/volk_gnsssdr_32f_sincos_32fc.h
@@ -734,4 +734,133 @@ static inline void volk_gnsssdr_32f_sincos_32fc_neon(lv_32fc_t* out, const float
 #endif /* LV_HAVE_NEON  */
 
 
+#ifdef LV_HAVE_RVV
+#include <riscv_vector.h>
+
+// Reverse-engineered from NEON implementation
+static inline void volk_gnsssdr_32f_sincos_32fc_rvv(lv_32fc_t* out, const float* in, unsigned int num_points)
+{
+    // Copied from other implementations, specifically NEON
+    const float c_minus_cephes_DP1 = -0.78515625;
+    const float c_minus_cephes_DP2 = -2.4187564849853515625e-4;
+    const float c_minus_cephes_DP3 = -3.77489497744594108e-8;
+    const float c_sincof_p0 = -1.9515295891E-4;
+    const float c_sincof_p1 = 8.3321608736E-3;
+    const float c_sincof_p2 = -1.6666654611E-1;
+    const float c_coscof_p0 = 2.443315711809948E-005;
+    const float c_coscof_p1 = -1.388731625493765E-003;
+    const float c_coscof_p2 = 4.166664568298827E-002;
+    const float c_cephes_FOPI = 1.27323954473516;
+
+    size_t n = num_points;
+
+    // Initialize pointers to keep track as stripmine
+    float* outPtr = (float*) out;
+    const float* inPtr = in;
+
+    for (size_t vl; n > 0; n -= vl, outPtr += vl * 2, inPtr += vl)
+        {
+            // Record how many elements will actually be processed
+            vl = __riscv_vsetvl_e32m4(n);
+
+            // Load in[0..vl)
+            vfloat32m4_t inVal = __riscv_vle32_v_f32m4(inPtr, vl);
+
+            // Save initial signs
+            // signMask[i] = in[i] < 0
+            vbool8_t signMask = __riscv_vmflt_vf_f32m4_b8(inVal, (float) 0, vl);
+
+            // x[i] = |in[i]|
+            vfloat32m4_t xVal = __riscv_vfabs_v_f32m4(inVal, vl);
+
+            // y[i] = (4/PI) * x[i]
+            vfloat32m4_t yVal = __riscv_vfmul_vf_f32m4(xVal, c_cephes_FOPI, vl);
+
+            // Quantize (reduce) y into discrete chunks to approximate into,
+            // and use the integer version to do some neat bit masking in order
+            // to encode sin/cos signs
+            // reduced[i] = ( ((unsigned int) y[i] + 1) / 2 ) * 2 = ((unsigned int) y[i] + 1) & ~1
+            vuint32m4_t reducedVal = __riscv_vfcvt_xu_f_v_u32m4(yVal, vl);
+            reducedVal = __riscv_vadd_vx_u32m4(reducedVal, 1, vl);
+            reducedVal = __riscv_vand_vx_u32m4(reducedVal, ~1, vl);
+
+            // Save which polynomial should be used
+            // polyMask[i] = reduced[i] & 2 != 0
+            vuint32m4_t polyTempVal = __riscv_vand_vx_u32m4(reducedVal, 2, vl);
+            vbool8_t polyMask = __riscv_vmsne_vx_u32m4_b8(polyTempVal, 0, vl);
+
+            // Save sign value for sin, cos, encoded within LSB 3:1
+            // sinSignMask[i] = signMask[i] ^ ( reduced[i] & 4 != 0 )
+            vuint32m4_t sinSignTempVal = __riscv_vand_vx_u32m4(reducedVal, 4, vl);
+            vbool8_t sinSignMask = __riscv_vmsne_vx_u32m4_b8(sinSignTempVal, 0, vl);
+            sinSignMask = __riscv_vmxor_mm_b8(signMask, sinSignMask, vl);
+
+            // Encoded the opposite to sinSignMask, i.e. 0 is positive for cosSignMask
+            // cosSignMask[i] = ( reduced[i] - 2 ) & 4 != 0
+            vuint32m4_t cosSignTempVal = __riscv_vsub_vx_u32m4(reducedVal, 2, vl);
+            cosSignTempVal = __riscv_vand_vx_u32m4(cosSignTempVal, 4, vl);
+            vbool8_t cosSignMask = __riscv_vmsne_vx_u32m4_b8(cosSignTempVal, 0, vl);
+
+            // reducedY[i] = (float) reduced[i]
+            vfloat32m4_t reducedYVal = __riscv_vfcvt_f_xu_v_f32m4(reducedVal, vl);
+
+            // The magic pass: "Extended precision modular arithmetic"
+            // x[i] = ((in[i] + reducedY[i] * -DP1) + reducedY[i] * -DP2) + reducedY[i] * -DP3;
+            vfloat32m4_t xmm1Val = __riscv_vfmul_vf_f32m4(reducedYVal, c_minus_cephes_DP1, vl);
+            xVal = __riscv_vfadd_vv_f32m4(xVal, xmm1Val, vl);
+            vfloat32m4_t xmm2Val = __riscv_vfmul_vf_f32m4(reducedYVal, c_minus_cephes_DP2, vl);
+            xVal = __riscv_vfadd_vv_f32m4(xVal, xmm2Val, vl);
+            vfloat32m4_t xmm3Val = __riscv_vfmul_vf_f32m4(reducedYVal, c_minus_cephes_DP3, vl);
+            xVal = __riscv_vfadd_vv_f32m4(xVal, xmm3Val, vl);
+
+            // Calculate both polynomials; one for 0 <= x <= PI / 4,
+            //  other for PI / 4 <= x <= PI / 2
+            vfloat32m4_t xSqVal = __riscv_vfmul_vv_f32m4(xVal, xVal, vl);
+
+            vfloat32m4_t y1Val = __riscv_vfmul_vf_f32m4(xSqVal, c_coscof_p0, vl);
+            y1Val = __riscv_vfadd_vf_f32m4(y1Val, c_coscof_p1, vl);
+            y1Val = __riscv_vfmul_vv_f32m4(y1Val, xSqVal, vl);
+            y1Val = __riscv_vfadd_vf_f32m4(y1Val, c_coscof_p2, vl);
+            y1Val = __riscv_vfmul_vv_f32m4(y1Val, xSqVal, vl);
+            y1Val = __riscv_vfmul_vv_f32m4(y1Val, xSqVal, vl);
+            y1Val = __riscv_vfsub_vv_f32m4(y1Val, __riscv_vfmul_vf_f32m4(xSqVal, 0.5f, vl), vl);
+            y1Val = __riscv_vfadd_vf_f32m4(y1Val, 1, vl);
+
+            vfloat32m4_t y2Val = __riscv_vfmul_vf_f32m4(xSqVal, c_sincof_p0, vl);
+            y2Val = __riscv_vfadd_vf_f32m4(y2Val, c_sincof_p1, vl);
+            y2Val = __riscv_vfmul_vv_f32m4(y2Val, xSqVal, vl);
+            y2Val = __riscv_vfadd_vf_f32m4(y2Val, c_sincof_p2, vl);
+            y2Val = __riscv_vfmul_vv_f32m4(y2Val, xSqVal, vl);
+            y2Val = __riscv_vfmul_vv_f32m4(y2Val, xVal, vl);
+            y2Val = __riscv_vfadd_vv_f32m4(y2Val, xVal, vl);
+
+            // Output results
+            // sin[i] = polyMask ? y1[i] : y2[i]
+            // cos[i] = polyMask ? y2[i] : y1[i]
+            vfloat32m4_t sinVal = __riscv_vmerge_vvm_f32m4(y2Val, y1Val, polyMask, vl);
+            vfloat32m4_t cosVal = __riscv_vmerge_vvm_f32m4(y1Val, y2Val, polyMask, vl);
+
+            // outImag[i] = sinSignMask ? -sin[i] : sin[i]
+            // outReal[i] = cosSignMask ? cos[i] : -cos[i]
+            vfloat32m4_t outImagVal = __riscv_vmerge_vvm_f32m4(
+                sinVal, __riscv_vfneg_v_f32m4(sinVal, vl), sinSignMask, vl
+            );
+            vfloat32m4_t outRealVal = __riscv_vmerge_vvm_f32m4(
+                __riscv_vfneg_v_f32m4(cosVal, vl), cosVal, cosSignMask, vl
+            );
+
+            // Store out[0..vl)
+            vfloat32m4x2_t outVal = __riscv_vcreate_v_f32m4x2(outRealVal, outImagVal);
+            __riscv_vsseg2e32_v_f32m4x2(outPtr, outVal, vl);
+
+            // In looping, decrement the number of
+            // elements left and increment the pointers
+            // by the number of elements processed,
+            // taking into account how the output `vl` 
+            // complex numbers are stored as 2 `float`s
+        }
+}
+
+#endif /* LV_HAVE_RVV */
+
 #endif /* INCLUDED_volk_gnsssdr_32f_sincos_32fc_H  */

--- a/src/algorithms/libs/volk_gnsssdr_module/volk_gnsssdr/kernels/volk_gnsssdr/volk_gnsssdr_32f_sincos_32fc.h
+++ b/src/algorithms/libs/volk_gnsssdr_module/volk_gnsssdr/kernels/volk_gnsssdr/volk_gnsssdr_32f_sincos_32fc.h
@@ -755,7 +755,7 @@ static inline void volk_gnsssdr_32f_sincos_32fc_rvv(lv_32fc_t* out, const float*
     size_t n = num_points;
 
     // Initialize pointers to keep track as stripmine
-    float* outPtr = (float*) out;
+    float* outPtr = (float*)out;
     const float* inPtr = in;
 
     for (size_t vl; n > 0; n -= vl, outPtr += vl * 2, inPtr += vl)
@@ -768,7 +768,7 @@ static inline void volk_gnsssdr_32f_sincos_32fc_rvv(lv_32fc_t* out, const float*
 
             // Save initial signs
             // signMask[i] = in[i] < 0
-            vbool8_t signMask = __riscv_vmflt_vf_f32m4_b8(inVal, (float) 0, vl);
+            vbool8_t signMask = __riscv_vmflt_vf_f32m4_b8(inVal, (float)0, vl);
 
             // x[i] = |in[i]|
             vfloat32m4_t xVal = __riscv_vfabs_v_f32m4(inVal, vl);
@@ -843,11 +843,9 @@ static inline void volk_gnsssdr_32f_sincos_32fc_rvv(lv_32fc_t* out, const float*
             // outImag[i] = sinSignMask ? -sin[i] : sin[i]
             // outReal[i] = cosSignMask ? cos[i] : -cos[i]
             vfloat32m4_t outImagVal = __riscv_vmerge_vvm_f32m4(
-                sinVal, __riscv_vfneg_v_f32m4(sinVal, vl), sinSignMask, vl
-            );
+                sinVal, __riscv_vfneg_v_f32m4(sinVal, vl), sinSignMask, vl);
             vfloat32m4_t outRealVal = __riscv_vmerge_vvm_f32m4(
-                __riscv_vfneg_v_f32m4(cosVal, vl), cosVal, cosSignMask, vl
-            );
+                __riscv_vfneg_v_f32m4(cosVal, vl), cosVal, cosSignMask, vl);
 
             // Store out[0..vl)
             vfloat32m4x2_t outVal = __riscv_vcreate_v_f32m4x2(outRealVal, outImagVal);
@@ -856,7 +854,7 @@ static inline void volk_gnsssdr_32f_sincos_32fc_rvv(lv_32fc_t* out, const float*
             // In looping, decrement the number of
             // elements left and increment the pointers
             // by the number of elements processed,
-            // taking into account how the output `vl` 
+            // taking into account how the output `vl`
             // complex numbers are stored as 2 `float`s
         }
 }

--- a/src/algorithms/libs/volk_gnsssdr_module/volk_gnsssdr/kernels/volk_gnsssdr/volk_gnsssdr_32f_xn_high_dynamics_resampler_32f_xn.h
+++ b/src/algorithms/libs/volk_gnsssdr_module/volk_gnsssdr/kernels/volk_gnsssdr/volk_gnsssdr_32f_xn_high_dynamics_resampler_32f_xn.h
@@ -78,7 +78,7 @@ static inline void volk_gnsssdr_32f_xn_high_dynamics_resampler_32f_xn_generic(fl
             if (local_code_chip_index < 0) local_code_chip_index += (int)code_length_chips * (abs(local_code_chip_index) / code_length_chips + 1);
             local_code_chip_index = local_code_chip_index % code_length_chips;
             result[0][n] = local_code[local_code_chip_index];
-       }
+        }
 
     // adjacent correlators
     unsigned int shift_samples = 0;

--- a/src/algorithms/libs/volk_gnsssdr_module/volk_gnsssdr/kernels/volk_gnsssdr/volk_gnsssdr_32f_xn_high_dynamics_resampler_32f_xn.h
+++ b/src/algorithms/libs/volk_gnsssdr_module/volk_gnsssdr/kernels/volk_gnsssdr/volk_gnsssdr_32f_xn_high_dynamics_resampler_32f_xn.h
@@ -78,7 +78,7 @@ static inline void volk_gnsssdr_32f_xn_high_dynamics_resampler_32f_xn_generic(fl
             if (local_code_chip_index < 0) local_code_chip_index += (int)code_length_chips * (abs(local_code_chip_index) / code_length_chips + 1);
             local_code_chip_index = local_code_chip_index % code_length_chips;
             result[0][n] = local_code[local_code_chip_index];
-        }
+       }
 
     // adjacent correlators
     unsigned int shift_samples = 0;
@@ -685,5 +685,85 @@ static inline void volk_gnsssdr_32f_xn_high_dynamics_resampler_32f_xn_u_avx(floa
 // }
 //
 // #endif
+
+
+#ifdef LV_HAVE_RVV
+#include <riscv_vector.h>
+
+static inline void volk_gnsssdr_32f_xn_high_dynamics_resampler_32f_xn_rvv(float** result, const float* local_code, float rem_code_phase_chips, float code_phase_step_chips, float code_phase_rate_step_chips, float* shifts_chips, unsigned int code_length_chips, int num_out_vectors, unsigned int num_points)
+{
+    // To make easier to work with in RVV, just interpret the two 32-bit components
+    // of each complex number as a single 64-bit number to move around
+
+    // Initialize reference pointer, as don't stripmine through
+    const float* inPtr = local_code;
+
+    size_t n = num_points;
+
+    const float constIndexShift = shifts_chips[0] - rem_code_phase_chips;
+
+    // Initialize pointers to track progress as stripmine
+    float* outPtr = result[0];
+    // Simulates how, compared to generic implementation, `i` continues
+    // increasing across different vector computatation batches
+    unsigned int currI = 0;
+
+    for (size_t vl; n > 0; n -= vl, outPtr += vl, currI += vl)
+        {
+            // Record how many data elements will actually be processed
+            vl = __riscv_vsetvl_e32m8(n);
+
+            // floatI[i] = (float) (i + currI)
+            vuint32m8_t idVal = __riscv_vid_v_u32m8(vl);
+            vuint32m8_t iVal = __riscv_vadd_vx_u32m8(idVal, currI, vl);
+            vfloat32m8_t floatIVal = __riscv_vfcvt_f_xu_v_f32m8(iVal, vl);
+
+            // iterIndex[i] = floatI[i] * code_phase_step_chips + (floatI[i] * floatI[i])
+            // iterIndex[i] = +(( floatI[i] ^ 2 ) * code_phase_rate_step_chips) + iterIndex[i]
+            vfloat32m8_t iterIndexVal = __riscv_vfmul_vf_f32m8(floatIVal, code_phase_step_chips, vl);
+            vfloat32m8_t floatISqVal = __riscv_vfmul_vv_f32m8(floatIVal, floatIVal, vl);
+            iterIndexVal = __riscv_vfmacc_vf_f32m8(iterIndexVal, code_phase_rate_step_chips, floatISqVal, vl);
+
+            // overflowIndex[i] = (int) floor(iterIndex[i] + constIndexShift)
+            vfloat32m8_t shiftedIndexVal = __riscv_vfadd_vf_f32m8(iterIndexVal, constIndexShift, vl);
+            vint32m8_t overflowIndexVal = __riscv_vfcvt_x_f_v_i32m8_rm(shiftedIndexVal, __RISCV_FRM_RDN, vl);
+
+            // Wrap to valid index in `local_code`, handling negative values
+            // index[i] = ( code_length_chips + ( overflowIndex[i] % code_length_chips ) ) % code_length_chips
+            vint32m8_t indexVal = __riscv_vrem_vx_i32m8(overflowIndexVal, code_length_chips, vl);
+            indexVal = __riscv_vadd_vx_i32m8(indexVal, code_length_chips, vl);
+            indexVal = __riscv_vrem_vx_i32m8(indexVal, code_length_chips, vl);
+
+            // After above, should now be guaranteed positive and valid index
+            // finalIndex[i] = (unsigned int) index[i];
+            vuint32m8_t finalIndexVal = __riscv_vreinterpret_v_i32m8_u32m8(indexVal);
+
+            // Convert to address offset
+            // offset[i] = finalIndex[i] * sizeof(float)
+            vuint32m8_t offsetVal = __riscv_vmul_vx_u32m8(finalIndexVal, sizeof(float), vl);
+
+            // This indexed load is unordered to hopefully boost run time
+            // out[i] = in[offset[i]]
+            vfloat32m8_t outVal = __riscv_vluxei32_v_f32m8(inPtr, offsetVal, vl);
+
+            // Store out[0..vl)
+            __riscv_vse32_v_f32m8(outPtr, outVal, vl);
+
+            // In looping, decrement the number of
+            // elements left and increment stripmining variables
+            // by the number of elements processed
+        }
+
+    // adjacent correlators
+    unsigned int shift_samples = 0;
+    for (int current_correlator_tap = 1; current_correlator_tap < num_out_vectors; current_correlator_tap++)
+        {
+            shift_samples += (int)round((shifts_chips[current_correlator_tap] - shifts_chips[current_correlator_tap - 1]) / code_phase_step_chips);
+            memcpy(&result[current_correlator_tap][0], &result[0][shift_samples], (num_points - shift_samples) * sizeof(float));
+            memcpy(&result[current_correlator_tap][num_points - shift_samples], &result[0][0], shift_samples * sizeof(float));
+        }
+}
+
+#endif
 
 #endif /* INCLUDED_volk_gnsssdr_32f_xn_high_dynamics_resampler_32f_xn_H */

--- a/src/algorithms/libs/volk_gnsssdr_module/volk_gnsssdr/kernels/volk_gnsssdr/volk_gnsssdr_32f_xn_resampler_32f_xn.h
+++ b/src/algorithms/libs/volk_gnsssdr_module/volk_gnsssdr/kernels/volk_gnsssdr/volk_gnsssdr_32f_xn_resampler_32f_xn.h
@@ -605,40 +605,51 @@ static inline void volk_gnsssdr_32f_xn_resampler_32f_xn_neon(float** result, con
 
 static inline void volk_gnsssdr_32f_xn_resampler_32f_xn_rvv(float** result, const float* local_code, float rem_code_phase_chips, float code_phase_step_chips, float* shifts_chips, unsigned int code_length_chips, int num_out_vectors, unsigned int num_points)
 {
+    // Initialize reference pointer, as stays same across loops
+    const float* inPtr = local_code;
+
     for (int current_correlator_tap = 0; current_correlator_tap < num_out_vectors; current_correlator_tap++)
         {
-            // Stores address offsets from `local_code` to load from and
-            // then store in `result[current_correlator_tap]`
-            unsigned int offsetBuffer[num_points];
-
-            for (int i = 0; i < num_points; i++)
-                {
-                    // resample code for current tap
-                    int local_code_chip_index = (int)floor(code_phase_step_chips * (float)i + shifts_chips[current_correlator_tap] - rem_code_phase_chips);
-                    // Take into account that in multitap correlators, the shifts can be negative!
-                    if (local_code_chip_index < 0) local_code_chip_index += (int)code_length_chips * (abs(local_code_chip_index) / code_length_chips + 1);
-                    local_code_chip_index = local_code_chip_index % code_length_chips;
-
-                    // `local_code_chip_index` should be some positive, valid
-                    // index to `local_code`
-                    // Convert from index to raw address offset
-                    offsetBuffer[i] = (unsigned int) (local_code_chip_index * 4);
-                }
-
             size_t n = num_points;
+
+            const float constIndexShift = shifts_chips[current_correlator_tap] - rem_code_phase_chips;
 
             // Initialize pointers to track progress as stripmine
             float* outPtr = result[current_correlator_tap];
-            const float* inPtr = local_code;
-            const unsigned int* offsetPtr = (const unsigned int*) offsetBuffer;
+            // Simulates how, compared to generic implementation, `i` continues
+            // increasing across different vector computatation batches
+            unsigned int currI = 0;
 
-            for (size_t vl; n > 0; n -= vl, outPtr += vl, offsetPtr += vl)
+            for (size_t vl; n > 0; n -= vl, outPtr += vl, currI += vl)
                 {
                     // Record how many data elements will actually be processed
                     vl = __riscv_vsetvl_e32m8(n);
 
-                    // Load offset[0..vl)
-                    vuint32m8_t offsetVal = __riscv_vle32_v_u32m8(offsetPtr, vl);
+                    // floatI[i] = (float) (i + currI)
+                    vuint32m8_t idVal = __riscv_vid_v_u32m8(vl);
+                    vuint32m8_t iVal = __riscv_vadd_vx_u32m8(idVal, currI, vl);
+                    vfloat32m8_t floatIVal = __riscv_vfcvt_f_xu_v_f32m8(iVal, vl);
+
+                    // iterIndex[i] = floatIVal[i] * code_phase_step_chips
+                    vfloat32m8_t iterIndexVal = __riscv_vfmul_vf_f32m8(floatIVal, code_phase_step_chips, vl);
+
+                    // overflowIndex[i] = (int) floor(iterIndex[i] + constIndexShift)
+                    vfloat32m8_t shiftedIndexVal = __riscv_vfadd_vf_f32m8(iterIndexVal, constIndexShift, vl);
+                    vint32m8_t overflowIndexVal = __riscv_vfcvt_x_f_v_i32m8_rm(shiftedIndexVal, __RISCV_FRM_RDN, vl);
+
+                    // Wrap to valid index in `local_code`, handling negative values
+                    // index[i] = ( code_length_chips + ( overflowIndex[i] % code_length_chips ) ) % code_length_chips
+                    vint32m8_t indexVal = __riscv_vrem_vx_i32m8(overflowIndexVal, code_length_chips, vl);
+                    indexVal = __riscv_vadd_vx_i32m8(indexVal, code_length_chips, vl);
+                    indexVal = __riscv_vrem_vx_i32m8(indexVal, code_length_chips, vl);
+
+                    // After above, should now be guaranteed positive and valid index
+                    // finalIndex[i] = (unsigned int) index[i];
+                    vuint32m8_t finalIndexVal = __riscv_vreinterpret_v_i32m8_u32m8(indexVal);
+
+                    // Convert to address offset
+                    // offset[i] = finalIndex[i] * sizeof(float)
+                    vuint32m8_t offsetVal = __riscv_vmul_vx_u32m8(finalIndexVal, sizeof(float), vl);
 
                     // This indexed load is unordered to hopefully boost run time
                     // out[i] = in[offset[i]]

--- a/src/algorithms/libs/volk_gnsssdr_module/volk_gnsssdr/kernels/volk_gnsssdr/volk_gnsssdr_32f_xn_resampler_32f_xn.h
+++ b/src/algorithms/libs/volk_gnsssdr_module/volk_gnsssdr/kernels/volk_gnsssdr/volk_gnsssdr_32f_xn_resampler_32f_xn.h
@@ -630,7 +630,7 @@ static inline void volk_gnsssdr_32f_xn_resampler_32f_xn_rvv(float** result, cons
                     vuint32m8_t iVal = __riscv_vadd_vx_u32m8(idVal, currI, vl);
                     vfloat32m8_t floatIVal = __riscv_vfcvt_f_xu_v_f32m8(iVal, vl);
 
-                    // iterIndex[i] = floatIVal[i] * code_phase_step_chips
+                    // iterIndex[i] = floatI[i] * code_phase_step_chips
                     vfloat32m8_t iterIndexVal = __riscv_vfmul_vf_f32m8(floatIVal, code_phase_step_chips, vl);
 
                     // overflowIndex[i] = (int) floor(iterIndex[i] + constIndexShift)
@@ -659,7 +659,7 @@ static inline void volk_gnsssdr_32f_xn_resampler_32f_xn_rvv(float** result, cons
                     __riscv_vse32_v_f32m8(outPtr, outVal, vl);
 
                     // In looping, decrement the number of
-                    // elements left and increment stripmining pointers
+                    // elements left and increment stripmining variables
                     // by the number of elements processed
                 }
         }

--- a/src/algorithms/libs/volk_gnsssdr_module/volk_gnsssdr/kernels/volk_gnsssdr/volk_gnsssdr_32f_xn_resampler_32f_xn.h
+++ b/src/algorithms/libs/volk_gnsssdr_module/volk_gnsssdr/kernels/volk_gnsssdr/volk_gnsssdr_32f_xn_resampler_32f_xn.h
@@ -599,4 +599,60 @@ static inline void volk_gnsssdr_32f_xn_resampler_32f_xn_neon(float** result, con
 
 #endif
 
+
+#ifdef LV_HAVE_RVV
+#include <riscv_vector.h>
+
+static inline void volk_gnsssdr_32f_xn_resampler_32f_xn_rvv(float** result, const float* local_code, float rem_code_phase_chips, float code_phase_step_chips, float* shifts_chips, unsigned int code_length_chips, int num_out_vectors, unsigned int num_points)
+{
+    for (int current_correlator_tap = 0; current_correlator_tap < num_out_vectors; current_correlator_tap++)
+        {
+            // Stores address offsets from `local_code` to load from and
+            // then store in `result[current_correlator_tap]`
+            unsigned int offsetBuffer[num_points];
+
+            for (int i = 0; i < num_points; i++)
+                {
+                    // resample code for current tap
+                    int local_code_chip_index = (int)floor(code_phase_step_chips * (float)i + shifts_chips[current_correlator_tap] - rem_code_phase_chips);
+                    // Take into account that in multitap correlators, the shifts can be negative!
+                    if (local_code_chip_index < 0) local_code_chip_index += (int)code_length_chips * (abs(local_code_chip_index) / code_length_chips + 1);
+                    local_code_chip_index = local_code_chip_index % code_length_chips;
+
+                    // `local_code_chip_index` should be some positive, valid
+                    // index to `local_code`
+                    // Convert from index to raw address offset
+                    offsetBuffer[i] = (unsigned int) (local_code_chip_index * 4);
+                }
+
+            size_t n = num_points;
+
+            // Initialize pointers to track progress as stripmine
+            float* outPtr = result[current_correlator_tap];
+            const float* inPtr = local_code;
+            const unsigned int* offsetPtr = (const unsigned int*) offsetBuffer;
+
+            for (size_t vl; n > 0; n -= vl, outPtr += vl, offsetPtr += vl)
+                {
+                    // Record how many data elements will actually be processed
+                    vl = __riscv_vsetvl_e32m8(n);
+
+                    // Load offset[0..vl)
+                    vuint32m8_t offsetVal = __riscv_vle32_v_u32m8(offsetPtr, vl);
+
+                    // This indexed load is unordered to hopefully boost run time
+                    // out[i] = in[offset[i]]
+                    vfloat32m8_t outVal = __riscv_vluxei32_v_f32m8(inPtr, offsetVal, vl);
+
+                    // Store out[0..vl)
+                    __riscv_vse32_v_f32m8(outPtr, outVal, vl);
+
+                    // In looping, decrement the number of
+                    // elements left and increment stripmining pointers
+                    // by the number of elements processed
+                }
+        }
+}
+#endif /* LV_HAVE_RVV */
+
 #endif /*INCLUDED_volk_gnsssdr_32f_xn_resampler_32f_xn_H*/

--- a/src/algorithms/libs/volk_gnsssdr_module/volk_gnsssdr/kernels/volk_gnsssdr/volk_gnsssdr_32fc_32f_rotator_dot_prod_32fc_xn.h
+++ b/src/algorithms/libs/volk_gnsssdr_module/volk_gnsssdr/kernels/volk_gnsssdr/volk_gnsssdr_32fc_32f_rotator_dot_prod_32fc_xn.h
@@ -483,4 +483,229 @@ static inline void volk_gnsssdr_32fc_32f_rotator_dot_prod_32fc_xn_a_avx(lv_32fc_
 
 #endif /* LV_HAVE_AVX */
 
+
+#ifdef LV_HAVE_RVV
+#include <riscv_vector.h>
+
+static inline void volk_gnsssdr_32fc_32f_rotator_dot_prod_32fc_xn_rvv(lv_32fc_t* result, const lv_32fc_t* in_common, const lv_32fc_t phase_inc, lv_32fc_t* phase, const float** in_a, int num_a_vectors, unsigned int num_points)
+{
+    size_t ROTATOR_RELOAD = 256;
+
+    // Initialize reference pointers of compatible type that will not be stripmined
+    float* phasePtr = (float*) phase;
+
+    // Initialize pointers of compatible type to track progress as stripmine
+    float* outPtr = (float*) result;
+    const float* comPtr = (const float*) in_common;
+    const float** inPtrBuf = (const float**) volk_gnsssdr_malloc(
+        num_a_vectors * sizeof(*in_a), volk_gnsssdr_get_alignment()
+    );
+
+    for (int n_vec = 0; n_vec < num_a_vectors; n_vec++)
+    {
+        // Initialize `out` to zero
+        result[n_vec] = lv_cmake(0.0f, 0.0f);
+
+        // Treat complex number as struct containting
+        // two 16-bit integers
+        inPtrBuf[n_vec] = in_a[n_vec];
+    }
+
+    for (int _ = 0; _ < num_points / ROTATOR_RELOAD; _++)
+        {
+            size_t n = ROTATOR_RELOAD;
+
+            for (size_t vl; n > 0; n -= vl, comPtr += vl * 2)
+                {
+                    // Record how many elements will actually be processed
+                    vl = __riscv_vsetvl_e32m4(n);
+
+                    // Splat phase
+                    vfloat32m4_t phaseRealVal = __riscv_vfmv_v_f_f32m4(phasePtr[0], vl);
+                    vfloat32m4_t phaseImagVal = __riscv_vfmv_v_f_f32m4(phasePtr[1], vl);
+
+                    // Splat phaseInc
+                    vfloat32m4_t phaseIncRealVal = __riscv_vfmv_v_f_f32m4(lv_creal(phase_inc), vl);
+                    vfloat32m4_t phaseIncImagVal = __riscv_vfmv_v_f_f32m4(lv_cimag(phase_inc), vl);
+
+                    // iter[i] = i
+                    vuint32m4_t iterVal = __riscv_vid_v_u32m4(vl);
+
+                    // phase[i] = phase[i] * ( phaseInc[i] ^ i )
+                    for (int j = 1; j < vl; j++)
+                        {
+                            vbool8_t maskVal = __riscv_vmsgtu_vx_u32m4_b8(iterVal, 0, vl);
+
+                            // Initialize as copies of phase so that can target masked
+                            // operations onto these copies instead of the original vectors
+                            vfloat32m4_t prodRealVal = phaseRealVal;
+                            vfloat32m4_t prodImagVal = phaseImagVal;
+
+                            // For more details on cross product,
+                            // check `volk_gnsssdr_8ic_x2_multiply_8ic_rvv`,
+                            // for instance
+                            prodRealVal = __riscv_vfmul_vv_f32m4_mu(maskVal, prodRealVal, phaseRealVal, phaseIncRealVal, vl);
+                            prodRealVal = __riscv_vfnmsac_vv_f32m4_mu(maskVal, prodRealVal, phaseImagVal, phaseIncImagVal, vl);
+                            prodImagVal = __riscv_vfmul_vv_f32m4_mu(maskVal, prodImagVal, phaseRealVal, phaseIncImagVal, vl);
+                            prodImagVal = __riscv_vfmacc_vv_f32m4_mu(maskVal, prodImagVal, phaseImagVal, phaseIncRealVal, vl);
+
+                            phaseRealVal = prodRealVal;
+                            phaseImagVal = prodImagVal;
+
+                            iterVal = __riscv_vsub_vx_u32m4_mu(maskVal, iterVal, iterVal, 1, vl);
+                        }
+
+                    // Load com[0..vl)
+                    vfloat32m4x2_t comVal = __riscv_vlseg2e32_v_f32m4x2(comPtr, vl);
+                    vfloat32m4_t comRealVal = __riscv_vget_v_f32m4x2_f32m4(comVal, 0);
+                    vfloat32m4_t comImagVal = __riscv_vget_v_f32m4x2_f32m4(comVal, 1);
+
+                    vfloat32m4_t comProdRealVal = __riscv_vfmul_vv_f32m4(comRealVal, phaseRealVal, vl);
+                    comProdRealVal = __riscv_vfnmsac_vv_f32m4(comProdRealVal, comImagVal, phaseImagVal, vl);
+                    vfloat32m4_t comProdImagVal = __riscv_vfmul_vv_f32m4(comRealVal, phaseImagVal, vl);
+                    comProdImagVal = __riscv_vfmacc_vv_f32m4(comProdImagVal, comImagVal, phaseRealVal, vl);
+
+                    for (int n_vec = 0; n_vec < num_a_vectors; n_vec++)
+                        {
+                            // Load in[0..vl)
+                            vfloat32m4_t inVal = __riscv_vle32_v_f32m4(inPtrBuf[n_vec], vl);
+
+                            // out[i] = in[i] * comProd[i]
+                            vfloat32m4_t outRealVal = __riscv_vfmul_vv_f32m4(inVal, comProdRealVal, vl);
+                            vfloat32m4_t outImagVal = __riscv_vfmul_vv_f32m4(inVal, comProdImagVal, vl);
+
+                            // Load accumulator
+                            vfloat32m1_t accRealVal = __riscv_vfmv_s_f_f32m1(outPtr[2 * n_vec], 1);
+                            vfloat32m1_t accImagVal = __riscv_vfmv_s_f_f32m1(outPtr[2 * n_vec + 1], 1);
+
+                            // acc[0] = sum( acc[0], out[0..vl) )
+                            accRealVal = __riscv_vfredosum_vs_f32m4_f32m1(outRealVal, accRealVal, vl);
+                            accImagVal = __riscv_vfredosum_vs_f32m4_f32m1(outImagVal, accImagVal, vl);
+
+                            // Store acc[0]
+                            outPtr[2 * n_vec] = __riscv_vfmv_f_s_f32m1_f32(accRealVal);
+                            outPtr[2 * n_vec + 1] = __riscv_vfmv_f_s_f32m1_f32(accImagVal);
+
+                            // Increment this pointer
+                            inPtrBuf[n_vec] += vl;
+                        }
+
+                    // Store phase[vl - 1]
+                    phaseRealVal = __riscv_vslidedown_vx_f32m4(phaseRealVal, vl - 1, vl);
+                    phasePtr[0] = __riscv_vfmv_f_s_f32m4_f32(phaseRealVal);
+                    phaseImagVal = __riscv_vslidedown_vx_f32m4(phaseImagVal, vl - 1, vl);
+                    phasePtr[1] = __riscv_vfmv_f_s_f32m4_f32(phaseImagVal);
+
+                    // Account for multiplication after last calculation
+                    (*phase) *= phase_inc;
+
+                    // In looping, decrement the number of
+                    // elements left and increment the pointers
+                    // by the number of elements processed
+            }
+            // Regenerate phase
+#ifdef __cplusplus
+            (*phase) /= std::abs((*phase));
+#else
+            (*phase) /= hypotf(lv_creal(*phase), lv_cimag(*phase));
+#endif
+        }
+
+    size_t n = num_points % ROTATOR_RELOAD;
+
+    for (size_t vl; n > 0; n -= vl, comPtr += vl * 2)
+        {
+            // Record how many elements will actually be processed
+            vl = __riscv_vsetvl_e32m4(n);
+
+            // Splat phase
+            vfloat32m4_t phaseRealVal = __riscv_vfmv_v_f_f32m4(phasePtr[0], vl);
+            vfloat32m4_t phaseImagVal = __riscv_vfmv_v_f_f32m4(phasePtr[1], vl);
+
+            // Splat phaseInc
+            vfloat32m4_t phaseIncRealVal = __riscv_vfmv_v_f_f32m4(lv_creal(phase_inc), vl);
+            vfloat32m4_t phaseIncImagVal = __riscv_vfmv_v_f_f32m4(lv_cimag(phase_inc), vl);
+
+            // iter[i] = i
+            vuint32m4_t iterVal = __riscv_vid_v_u32m4(vl);
+
+            // phase[i] = phase[i] * ( phaseInc[i] ^ i )
+            for (int j = 1; j < vl; j++)
+                {
+                    vbool8_t maskVal = __riscv_vmsgtu_vx_u32m4_b8(iterVal, 0, vl);
+
+                    // Initialize as copies of phase so that can target masked
+                    // operations onto these copies instead of the original vectors
+                    vfloat32m4_t prodRealVal = phaseRealVal;
+                    vfloat32m4_t prodImagVal = phaseImagVal;
+
+                    // For more details on cross product,
+                    // check `volk_gnsssdr_8ic_x2_multiply_8ic_rvv`,
+                    // for instance
+                    prodRealVal = __riscv_vfmul_vv_f32m4_mu(maskVal, prodRealVal, phaseRealVal, phaseIncRealVal, vl);
+                    prodRealVal = __riscv_vfnmsac_vv_f32m4_mu(maskVal, prodRealVal, phaseImagVal, phaseIncImagVal, vl);
+                    prodImagVal = __riscv_vfmul_vv_f32m4_mu(maskVal, prodImagVal, phaseRealVal, phaseIncImagVal, vl);
+                    prodImagVal = __riscv_vfmacc_vv_f32m4_mu(maskVal, prodImagVal, phaseImagVal, phaseIncRealVal, vl);
+
+                    phaseRealVal = prodRealVal;
+                    phaseImagVal = prodImagVal;
+
+                    iterVal = __riscv_vsub_vx_u32m4_mu(maskVal, iterVal, iterVal, 1, vl);
+                }
+
+            // Load com[0..vl)
+            vfloat32m4x2_t comVal = __riscv_vlseg2e32_v_f32m4x2(comPtr, vl);
+            vfloat32m4_t comRealVal = __riscv_vget_v_f32m4x2_f32m4(comVal, 0);
+            vfloat32m4_t comImagVal = __riscv_vget_v_f32m4x2_f32m4(comVal, 1);
+
+            vfloat32m4_t comProdRealVal = __riscv_vfmul_vv_f32m4(comRealVal, phaseRealVal, vl);
+            comProdRealVal = __riscv_vfnmsac_vv_f32m4(comProdRealVal, comImagVal, phaseImagVal, vl);
+            vfloat32m4_t comProdImagVal = __riscv_vfmul_vv_f32m4(comRealVal, phaseImagVal, vl);
+            comProdImagVal = __riscv_vfmacc_vv_f32m4(comProdImagVal, comImagVal, phaseRealVal, vl);
+
+            for (int n_vec = 0; n_vec < num_a_vectors; n_vec++)
+                {
+                    // Load in[0..vl)
+                    vfloat32m4_t inVal = __riscv_vle32_v_f32m4(inPtrBuf[n_vec], vl);
+
+                    // out[i] = in[i] * comProd[i]
+                    vfloat32m4_t outRealVal = __riscv_vfmul_vv_f32m4(inVal, comProdRealVal, vl);
+                    vfloat32m4_t outImagVal = __riscv_vfmul_vv_f32m4(inVal, comProdImagVal, vl);
+
+                    // Load accumulator
+                    vfloat32m1_t accRealVal = __riscv_vfmv_s_f_f32m1(outPtr[2 * n_vec], 1);
+                    vfloat32m1_t accImagVal = __riscv_vfmv_s_f_f32m1(outPtr[2 * n_vec + 1], 1);
+
+                    // acc[0] = sum( acc[0], out[0..vl) )
+                    accRealVal = __riscv_vfredosum_vs_f32m4_f32m1(outRealVal, accRealVal, vl);
+                    accImagVal = __riscv_vfredosum_vs_f32m4_f32m1(outImagVal, accImagVal, vl);
+
+                    // Store acc[0]
+                    outPtr[2 * n_vec] = __riscv_vfmv_f_s_f32m1_f32(accRealVal);
+                    outPtr[2 * n_vec + 1] = __riscv_vfmv_f_s_f32m1_f32(accImagVal);
+
+                    // Increment this pointer
+                    inPtrBuf[n_vec] += vl;
+                }
+
+            // Store phase[vl - 1]
+            phaseRealVal = __riscv_vslidedown_vx_f32m4(phaseRealVal, vl - 1, vl);
+            phasePtr[0] = __riscv_vfmv_f_s_f32m4_f32(phaseRealVal);
+            phaseImagVal = __riscv_vslidedown_vx_f32m4(phaseImagVal, vl - 1, vl);
+            phasePtr[1] = __riscv_vfmv_f_s_f32m4_f32(phaseImagVal);
+
+            // Account for multiplication after last calculation
+            (*phase) *= phase_inc;
+
+            // In looping, decrement the number of
+            // elements left and increment the pointers
+            // by the number of elements processed
+        }
+
+    // Don't leak memory!
+    volk_gnsssdr_free(inPtrBuf);
+}
+
+#endif /* LV_HAVE_RVV */
+
 #endif /* INCLUDED_volk_gnsssdr_32fc_32f_rotator_dot_prod_32fc_xn_H */

--- a/src/algorithms/libs/volk_gnsssdr_module/volk_gnsssdr/kernels/volk_gnsssdr/volk_gnsssdr_32fc_32f_rotator_dot_prod_32fc_xn.h
+++ b/src/algorithms/libs/volk_gnsssdr_module/volk_gnsssdr/kernels/volk_gnsssdr/volk_gnsssdr_32fc_32f_rotator_dot_prod_32fc_xn.h
@@ -492,24 +492,23 @@ static inline void volk_gnsssdr_32fc_32f_rotator_dot_prod_32fc_xn_rvv(lv_32fc_t*
     size_t ROTATOR_RELOAD = 256;
 
     // Initialize reference pointers of compatible type that will not be stripmined
-    float* phasePtr = (float*) phase;
+    float* phasePtr = (float*)phase;
 
     // Initialize pointers of compatible type to track progress as stripmine
-    float* outPtr = (float*) result;
-    const float* comPtr = (const float*) in_common;
-    const float** inPtrBuf = (const float**) volk_gnsssdr_malloc(
-        num_a_vectors * sizeof(*in_a), volk_gnsssdr_get_alignment()
-    );
+    float* outPtr = (float*)result;
+    const float* comPtr = (const float*)in_common;
+    const float** inPtrBuf = (const float**)volk_gnsssdr_malloc(
+        num_a_vectors * sizeof(*in_a), volk_gnsssdr_get_alignment());
 
     for (int n_vec = 0; n_vec < num_a_vectors; n_vec++)
-    {
-        // Initialize `out` to zero
-        result[n_vec] = lv_cmake(0.0f, 0.0f);
+        {
+            // Initialize `out` to zero
+            result[n_vec] = lv_cmake(0.0f, 0.0f);
 
-        // Treat complex number as struct containting
-        // two 16-bit integers
-        inPtrBuf[n_vec] = in_a[n_vec];
-    }
+            // Treat complex number as struct containting
+            // two 16-bit integers
+            inPtrBuf[n_vec] = in_a[n_vec];
+        }
 
     for (int _ = 0; _ < num_points / ROTATOR_RELOAD; _++)
         {
@@ -602,8 +601,8 @@ static inline void volk_gnsssdr_32fc_32f_rotator_dot_prod_32fc_xn_rvv(lv_32fc_t*
                     // In looping, decrement the number of
                     // elements left and increment the pointers
                     // by the number of elements processed
-            }
-            // Regenerate phase
+                }
+                // Regenerate phase
 #ifdef __cplusplus
             (*phase) /= std::abs((*phase));
 #else

--- a/src/algorithms/libs/volk_gnsssdr_module/volk_gnsssdr/kernels/volk_gnsssdr/volk_gnsssdr_32fc_32f_rotator_dotprodxnpuppet_32fc.h
+++ b/src/algorithms/libs/volk_gnsssdr_module/volk_gnsssdr/kernels/volk_gnsssdr/volk_gnsssdr_32fc_32f_rotator_dotprodxnpuppet_32fc.h
@@ -150,4 +150,35 @@ static inline void volk_gnsssdr_32fc_32f_rotator_dotprodxnpuppet_32fc_a_avx(lv_3
 
 #endif  // AVX
 
+
+#ifdef LV_HAVE_RVV
+static inline void volk_gnsssdr_32fc_32f_rotator_dotprodxnpuppet_32fc_rvv(lv_32fc_t* result, const lv_32fc_t* local_code, const float* in, unsigned int num_points)
+{
+    // phases must be normalized. Phase rotator expects a complex exponential input!
+    float rem_carrier_phase_in_rad = 0.25;
+    float phase_step_rad = 0.1;
+    lv_32fc_t phase[1];
+    phase[0] = lv_cmake(cos(rem_carrier_phase_in_rad), sin(rem_carrier_phase_in_rad));
+    lv_32fc_t phase_inc[1];
+    phase_inc[0] = lv_cmake(cos(phase_step_rad), sin(phase_step_rad));
+    int n;
+    int num_a_vectors = 3;
+    float** in_a = (float**)volk_gnsssdr_malloc(sizeof(float*) * num_a_vectors, volk_gnsssdr_get_alignment());
+    for (n = 0; n < num_a_vectors; n++)
+        {
+            in_a[n] = (float*)volk_gnsssdr_malloc(sizeof(float) * num_points, volk_gnsssdr_get_alignment());
+            memcpy((float*)in_a[n], (float*)in, sizeof(float) * num_points);
+        }
+
+    volk_gnsssdr_32fc_32f_rotator_dot_prod_32fc_xn_rvv(result, local_code, phase_inc[0], phase, (const float**)in_a, num_a_vectors, num_points);
+
+    for (n = 0; n < num_a_vectors; n++)
+        {
+            volk_gnsssdr_free(in_a[n]);
+        }
+    volk_gnsssdr_free(in_a);
+}
+
+#endif  // RVV
+
 #endif  // INCLUDED_volk_gnsssdr_32fc_32f_rotator_dotprodxnpuppet_32fc_H

--- a/src/algorithms/libs/volk_gnsssdr_module/volk_gnsssdr/kernels/volk_gnsssdr/volk_gnsssdr_32fc_convert_16ic.h
+++ b/src/algorithms/libs/volk_gnsssdr_module/volk_gnsssdr/kernels/volk_gnsssdr/volk_gnsssdr_32fc_convert_16ic.h
@@ -471,8 +471,8 @@ static inline void volk_gnsssdr_32fc_convert_16ic_rvv(lv_16sc_t* outputVector, c
     size_t n = num_points * 2;
 
     // Initialize pointers to keep track as stripmine
-    short* outPtr = (short*) outputVector;
-    const float* inPtr = (const float*) inputVector;
+    short* outPtr = (short*)outputVector;
+    const float* inPtr = (const float*)inputVector;
 
     for (size_t vl; n > 0; n -= vl, outPtr += vl, inPtr += vl)
         {
@@ -485,8 +485,8 @@ static inline void volk_gnsssdr_32fc_convert_16ic_rvv(lv_16sc_t* outputVector, c
             vfloat32m8_t inVal = __riscv_vle32_v_f32m8(inPtr, vl);
 
             // Saturate in[i] to 16 bits
-            inVal = __riscv_vfmin_vf_f32m8(inVal, (float) 32767, vl);
-            inVal = __riscv_vfmax_vf_f32m8(inVal, (float) -32768, vl);
+            inVal = __riscv_vfmin_vf_f32m8(inVal, (float)32767, vl);
+            inVal = __riscv_vfmax_vf_f32m8(inVal, (float)-32768, vl);
 
             // out[i] = (short) in[i]
             vint16m4_t outVal = __riscv_vfncvt_x_f_w_i16m4(inVal, vl);

--- a/src/algorithms/libs/volk_gnsssdr_module/volk_gnsssdr/kernels/volk_gnsssdr/volk_gnsssdr_32fc_convert_16ic.h
+++ b/src/algorithms/libs/volk_gnsssdr_module/volk_gnsssdr/kernels/volk_gnsssdr/volk_gnsssdr_32fc_convert_16ic.h
@@ -461,4 +461,48 @@ static inline void volk_gnsssdr_32fc_convert_16ic_generic(lv_16sc_t* outputVecto
 }
 #endif /* LV_HAVE_GENERIC */
 
+#ifdef LV_HAVE_RVV
+#include <riscv_vector.h>
+
+static inline void volk_gnsssdr_32fc_convert_16ic_rvv(lv_16sc_t* outputVector, const lv_32fc_t* inputVector, unsigned int num_points)
+{
+    size_t n = num_points;
+
+    // Initialize pointers to keep track as stripmine
+    short* outPtr = (short*) outputVector;
+    const float* inPtr = (const float*) inputVector;
+
+    for (size_t vl; n > 0; n -= vl, outPtr += vl * 2, inPtr += vl * 2)
+        {
+            // Record how many elements will actually be processed
+            vl = __riscv_vsetvl_e32m4(n);
+
+            // Load inReal[0..vl), inImag[0..vl)
+            vfloat32m4x2_t inVal = __riscv_vlseg2e32_v_f32m4x2(inPtr, vl);
+            vfloat32m4_t inRealVal = __riscv_vget_v_f32m4x2_f32m4(inVal, 0);
+            vfloat32m4_t inImagVal = __riscv_vget_v_f32m4x2_f32m4(inVal, 1);
+
+            // outReal[i] = (short) inReal[i]
+            vint16m2_t outRealVal = __riscv_vfncvt_x_f_w_i16m2(inRealVal, vl);
+
+            // outImag[i] = (short) inImag[i]
+            vint16m2_t outImagVal = __riscv_vfncvt_x_f_w_i16m2(inImagVal, vl);
+
+            // Store outReal[0..vl), outImag[0..vl)
+            vint16m2x2_t outVal = __riscv_vset_v_i16m2_i16m2x2(
+                __riscv_vundefined_i16m2x2(), 0, outRealVal
+            );
+            outVal = __riscv_vset_v_i16m2_i16m2x2(outVal, 1, outImagVal);
+            __riscv_vsseg2e16_v_i16m2x2(outPtr, outVal, vl);
+
+            // In looping, decrement the number of
+            // elements left and increment the pointers
+            // by the number of elements processed,
+            // accounting how the `vl` complex numbers
+            // are each stored as two numbers of their
+            // corresponding size.
+        }
+}
+#endif /* LV_HAVE_RVV */
+
 #endif /* INCLUDED_volk_gnsssdr_32fc_convert_16ic_H */

--- a/src/algorithms/libs/volk_gnsssdr_module/volk_gnsssdr/kernels/volk_gnsssdr/volk_gnsssdr_32fc_convert_16ic.h
+++ b/src/algorithms/libs/volk_gnsssdr_module/volk_gnsssdr/kernels/volk_gnsssdr/volk_gnsssdr_32fc_convert_16ic.h
@@ -482,6 +482,12 @@ static inline void volk_gnsssdr_32fc_convert_16ic_rvv(lv_16sc_t* outputVector, c
             vfloat32m4_t inRealVal = __riscv_vget_v_f32m4x2_f32m4(inVal, 0);
             vfloat32m4_t inImagVal = __riscv_vget_v_f32m4x2_f32m4(inVal, 1);
 
+            // Saturate inReal[i], inImag[i] to 16 bits
+            inRealVal = __riscv_vfmin_vf_f32m4(inRealVal, (float) 32767, vl);
+            inRealVal = __riscv_vfmax_vf_f32m4(inRealVal, (float) -32768, vl);
+            inImagVal = __riscv_vfmin_vf_f32m4(inImagVal, (float) 32767, vl);
+            inImagVal = __riscv_vfmax_vf_f32m4(inImagVal, (float) -32768, vl);
+
             // outReal[i] = (short) inReal[i]
             vint16m2_t outRealVal = __riscv_vfncvt_x_f_w_i16m2(inRealVal, vl);
 

--- a/src/algorithms/libs/volk_gnsssdr_module/volk_gnsssdr/kernels/volk_gnsssdr/volk_gnsssdr_32fc_convert_16ic.h
+++ b/src/algorithms/libs/volk_gnsssdr_module/volk_gnsssdr/kernels/volk_gnsssdr/volk_gnsssdr_32fc_convert_16ic.h
@@ -466,40 +466,33 @@ static inline void volk_gnsssdr_32fc_convert_16ic_generic(lv_16sc_t* outputVecto
 
 static inline void volk_gnsssdr_32fc_convert_16ic_rvv(lv_16sc_t* outputVector, const lv_32fc_t* inputVector, unsigned int num_points)
 {
-    size_t n = num_points;
+    // Will be converting by number, with each
+    // complex number containing two component numbers
+    size_t n = num_points * 2;
 
     // Initialize pointers to keep track as stripmine
     short* outPtr = (short*) outputVector;
     const float* inPtr = (const float*) inputVector;
 
-    for (size_t vl; n > 0; n -= vl, outPtr += vl * 2, inPtr += vl * 2)
+    for (size_t vl; n > 0; n -= vl, outPtr += vl, inPtr += vl)
         {
             // Record how many elements will actually be processed
-            vl = __riscv_vsetvl_e32m4(n);
+            vl = __riscv_vsetvl_e32m8(n);
 
-            // Load inReal[0..vl), inImag[0..vl)
-            vfloat32m4x2_t inVal = __riscv_vlseg2e32_v_f32m4x2(inPtr, vl);
-            vfloat32m4_t inRealVal = __riscv_vget_v_f32m4x2_f32m4(inVal, 0);
-            vfloat32m4_t inImagVal = __riscv_vget_v_f32m4x2_f32m4(inVal, 1);
+            // Don't have to segment load/store since converting
+            // both real and imaginary components
+            // Load in[0..vl)
+            vfloat32m8_t inVal = __riscv_vle32_v_f32m8(inPtr, vl);
 
-            // Saturate inReal[i], inImag[i] to 16 bits
-            inRealVal = __riscv_vfmin_vf_f32m4(inRealVal, (float) 32767, vl);
-            inRealVal = __riscv_vfmax_vf_f32m4(inRealVal, (float) -32768, vl);
-            inImagVal = __riscv_vfmin_vf_f32m4(inImagVal, (float) 32767, vl);
-            inImagVal = __riscv_vfmax_vf_f32m4(inImagVal, (float) -32768, vl);
+            // Saturate in[i] to 16 bits
+            inVal = __riscv_vfmin_vf_f32m8(inVal, (float) 32767, vl);
+            inVal = __riscv_vfmax_vf_f32m8(inVal, (float) -32768, vl);
 
-            // outReal[i] = (short) inReal[i]
-            vint16m2_t outRealVal = __riscv_vfncvt_x_f_w_i16m2(inRealVal, vl);
+            // out[i] = (short) in[i]
+            vint16m4_t outVal = __riscv_vfncvt_x_f_w_i16m4(inVal, vl);
 
-            // outImag[i] = (short) inImag[i]
-            vint16m2_t outImagVal = __riscv_vfncvt_x_f_w_i16m2(inImagVal, vl);
-
-            // Store outReal[0..vl), outImag[0..vl)
-            vint16m2x2_t outVal = __riscv_vset_v_i16m2_i16m2x2(
-                __riscv_vundefined_i16m2x2(), 0, outRealVal
-            );
-            outVal = __riscv_vset_v_i16m2_i16m2x2(outVal, 1, outImagVal);
-            __riscv_vsseg2e16_v_i16m2x2(outPtr, outVal, vl);
+            // Store out[0..vl)
+            __riscv_vse16_v_i16m4(outPtr, outVal, vl);
 
             // In looping, decrement the number of
             // elements left and increment the pointers

--- a/src/algorithms/libs/volk_gnsssdr_module/volk_gnsssdr/kernels/volk_gnsssdr/volk_gnsssdr_32fc_convert_8ic.h
+++ b/src/algorithms/libs/volk_gnsssdr_module/volk_gnsssdr/kernels/volk_gnsssdr/volk_gnsssdr_32fc_convert_8ic.h
@@ -457,7 +457,9 @@ static inline void volk_gnsssdr_32fc_convert_8ic_neon(lv_8sc_t* outputVector, co
 
 static inline void volk_gnsssdr_32fc_convert_8ic_rvv(lv_8sc_t* outputVector, const lv_32fc_t* inputVector, unsigned int num_points)
 {
-    size_t n = num_points;
+    // Will be converting by number, with each
+    // complex number containing two component numbers
+    size_t n = num_points * 2;
 
     // Initialize pointers to keep track as stripmine
     // Assuming `signed char` is intended, as `char`'s
@@ -465,42 +467,31 @@ static inline void volk_gnsssdr_32fc_convert_8ic_rvv(lv_8sc_t* outputVector, con
     signed char* outPtr = (signed char*) outputVector;
     const float* inPtr = (const float*) inputVector;
 
-    for (size_t vl; n > 0; n -= vl, outPtr += vl * 2, inPtr += vl * 2)
+    for (size_t vl; n > 0; n -= vl, outPtr += vl, inPtr += vl)
         {
             // Record how many elements will actually be processed
-            vl = __riscv_vsetvl_e32m4(n);
+            vl = __riscv_vsetvl_e32m8(n);
 
-            // Load inReal[0..vl), inImag[0..vl)
-            vfloat32m4x2_t inVal = __riscv_vlseg2e32_v_f32m4x2(inPtr, vl);
-            vfloat32m4_t inRealVal = __riscv_vget_v_f32m4x2_f32m4(inVal, 0);
-            vfloat32m4_t inImagVal = __riscv_vget_v_f32m4x2_f32m4(inVal, 1);
+            // Don't have to segment load/store since converting
+            // both real and imaginary components
+            // Load in[0..vl)
+            vfloat32m8_t inVal = __riscv_vle32_v_f32m8(inPtr, vl);
 
             // For some reason, generic implementation
             // multiplies float by `INT8_MAX` before converting
-            // tmpReal[i], tmpImag[i] *= INT8_MAX
-            vfloat32m4_t tmp32RealVal = __riscv_vfmul_vf_f32m4(inRealVal, (float) 127, vl);
-            vfloat32m4_t tmp32ImagVal = __riscv_vfmul_vf_f32m4(inImagVal, (float) 127, vl);
+            // tmp[i] *= INT8_MAX
+            vfloat32m8_t tmp32Val = __riscv_vfmul_vf_f32m8(inVal, (float) 127, vl);
 
-            // Saturate tmpReal[i], tmpImag[i] to 8 bits
-            tmp32RealVal = __riscv_vfmin_vf_f32m4(tmp32RealVal, (float) 127, vl);
-            tmp32RealVal = __riscv_vfmax_vf_f32m4(tmp32RealVal, (float) -128, vl);
-            tmp32ImagVal = __riscv_vfmin_vf_f32m4(tmp32ImagVal, (float) 127, vl);
-            tmp32ImagVal = __riscv_vfmax_vf_f32m4(tmp32ImagVal, (float) -128, vl);
+            // Saturate tmp[i] to 8 bits
+            tmp32Val = __riscv_vfmin_vf_f32m8(tmp32Val, (float) 127, vl);
+            tmp32Val = __riscv_vfmax_vf_f32m8(tmp32Val, (float) -128, vl);
 
-            // outReal[i] = (signed char) tmpReal[i]
-            vint16m2_t tmp16RealVal = __riscv_vfncvt_x_f_w_i16m2(tmp32RealVal, vl);
-            vint8m1_t outRealVal = __riscv_vncvt_x_x_w_i8m1(tmp16RealVal, vl);
+            // out[i] = (signed char) tmp[i]
+            vint16m4_t tmp16Val = __riscv_vfncvt_x_f_w_i16m4(tmp32Val, vl);
+            vint8m2_t outVal = __riscv_vncvt_x_x_w_i8m2(tmp16Val, vl);
 
-            // outImag[i] = (signed char) tmpImag[i]
-            vint16m2_t tmp16ImagVal = __riscv_vfncvt_x_f_w_i16m2(tmp32ImagVal, vl);
-            vint8m1_t outImagVal = __riscv_vncvt_x_x_w_i8m1(tmp16ImagVal, vl);
-
-            // Store outReal[0..vl), outImag[0..vl)
-            vint8m1x2_t outVal = __riscv_vset_v_i8m1_i8m1x2(
-                __riscv_vundefined_i8m1x2(), 0, outRealVal
-            );
-            outVal = __riscv_vset_v_i8m1_i8m1x2(outVal, 1, outImagVal);
-            __riscv_vsseg2e8_v_i8m1x2(outPtr, outVal, vl);
+            // Store out[0..vl)
+            __riscv_vse8_v_i8m2(outPtr, outVal, vl);
 
             // In looping, decrement the number of
             // elements left and increment the pointers

--- a/src/algorithms/libs/volk_gnsssdr_module/volk_gnsssdr/kernels/volk_gnsssdr/volk_gnsssdr_32fc_convert_8ic.h
+++ b/src/algorithms/libs/volk_gnsssdr_module/volk_gnsssdr/kernels/volk_gnsssdr/volk_gnsssdr_32fc_convert_8ic.h
@@ -452,4 +452,58 @@ static inline void volk_gnsssdr_32fc_convert_8ic_neon(lv_8sc_t* outputVector, co
 
 #endif /* LV_HAVE_NEON */
 
+#ifdef LV_HAVE_RVV
+#include <riscv_vector.h>
+
+static inline void volk_gnsssdr_32fc_convert_8ic_rvv(lv_8sc_t* outputVector, const lv_32fc_t* inputVector, unsigned int num_points)
+{
+    size_t n = num_points;
+
+    // Initialize pointers to keep track as stripmine
+    // Assuming `signed char` is intended, as `char`'s
+    // signedness is implementation-based
+    signed char* outPtr = (signed char*) outputVector;
+    const float* inPtr = (const float*) inputVector;
+
+    for (size_t vl; n > 0; n -= vl, outPtr += vl * 2, inPtr += vl * 2)
+        {
+            // Record how many elements will actually be processed
+            vl = __riscv_vsetvl_e32m4(n);
+
+            // Load inReal[0..vl), inImag[0..vl)
+            vfloat32m4x2_t inVal = __riscv_vlseg2e32_v_f32m4x2(inPtr, vl);
+            vfloat32m4_t inRealVal = __riscv_vget_v_f32m4x2_f32m4(inVal, 0);
+            vfloat32m4_t inImagVal = __riscv_vget_v_f32m4x2_f32m4(inVal, 1);
+
+            // For some reason, generic implementation
+            // multiplies float by `INT8_MAX` before converting
+            // tmpReal[i], tmpImag[i] *= INT8_MAX
+            vfloat32m4_t tmp32RealVal = __riscv_vfmul_vf_f32m4(inRealVal, (float) 127, vl);
+            vfloat32m4_t tmp32ImagVal = __riscv_vfmul_vf_f32m4(inImagVal, (float) 127, vl);
+
+            // outReal[i] = (signed char) tmpReal[i]
+            vint16m2_t tmp16RealVal = __riscv_vfncvt_x_f_w_i16m2(tmp32RealVal, vl);
+            vint8m1_t outRealVal = __riscv_vncvt_x_x_w_i8m1(tmp16RealVal, vl);
+
+            // outImag[i] = (signed char) tmpImag[i]
+            vint16m2_t tmp16ImagVal = __riscv_vfncvt_x_f_w_i16m2(tmp32ImagVal, vl);
+            vint8m1_t outImagVal = __riscv_vncvt_x_x_w_i8m1(tmp16ImagVal, vl);
+
+            // Store outReal[0..vl), outImag[0..vl)
+            vint8m1x2_t outVal = __riscv_vset_v_i8m1_i8m1x2(
+                __riscv_vundefined_i8m1x2(), 0, outRealVal
+            );
+            outVal = __riscv_vset_v_i8m1_i8m1x2(outVal, 1, outImagVal);
+            __riscv_vsseg2e8_v_i8m1x2(outPtr, outVal, vl);
+
+            // In looping, decrement the number of
+            // elements left and increment the pointers
+            // by the number of elements processed,
+            // accounting how the `vl` complex numbers
+            // are each stored as two numbers of their
+            // corresponding size.
+        }
+}
+#endif /* LV_HAVE_RVV */
+
 #endif /* INCLUDED_volk_gnsssdr_32fc_convert_8ic_H */

--- a/src/algorithms/libs/volk_gnsssdr_module/volk_gnsssdr/kernels/volk_gnsssdr/volk_gnsssdr_32fc_convert_8ic.h
+++ b/src/algorithms/libs/volk_gnsssdr_module/volk_gnsssdr/kernels/volk_gnsssdr/volk_gnsssdr_32fc_convert_8ic.h
@@ -464,8 +464,8 @@ static inline void volk_gnsssdr_32fc_convert_8ic_rvv(lv_8sc_t* outputVector, con
     // Initialize pointers to keep track as stripmine
     // Assuming `signed char` is intended, as `char`'s
     // signedness is implementation-based
-    signed char* outPtr = (signed char*) outputVector;
-    const float* inPtr = (const float*) inputVector;
+    signed char* outPtr = (signed char*)outputVector;
+    const float* inPtr = (const float*)inputVector;
 
     for (size_t vl; n > 0; n -= vl, outPtr += vl, inPtr += vl)
         {
@@ -480,11 +480,11 @@ static inline void volk_gnsssdr_32fc_convert_8ic_rvv(lv_8sc_t* outputVector, con
             // For some reason, generic implementation
             // multiplies float by `INT8_MAX` before converting
             // tmp[i] *= INT8_MAX
-            vfloat32m8_t tmp32Val = __riscv_vfmul_vf_f32m8(inVal, (float) 127, vl);
+            vfloat32m8_t tmp32Val = __riscv_vfmul_vf_f32m8(inVal, (float)127, vl);
 
             // Saturate tmp[i] to 8 bits
-            tmp32Val = __riscv_vfmin_vf_f32m8(tmp32Val, (float) 127, vl);
-            tmp32Val = __riscv_vfmax_vf_f32m8(tmp32Val, (float) -128, vl);
+            tmp32Val = __riscv_vfmin_vf_f32m8(tmp32Val, (float)127, vl);
+            tmp32Val = __riscv_vfmax_vf_f32m8(tmp32Val, (float)-128, vl);
 
             // out[i] = (signed char) tmp[i]
             vint16m4_t tmp16Val = __riscv_vfncvt_x_f_w_i16m4(tmp32Val, vl);

--- a/src/algorithms/libs/volk_gnsssdr_module/volk_gnsssdr/kernels/volk_gnsssdr/volk_gnsssdr_32fc_convert_8ic.h
+++ b/src/algorithms/libs/volk_gnsssdr_module/volk_gnsssdr/kernels/volk_gnsssdr/volk_gnsssdr_32fc_convert_8ic.h
@@ -481,6 +481,12 @@ static inline void volk_gnsssdr_32fc_convert_8ic_rvv(lv_8sc_t* outputVector, con
             vfloat32m4_t tmp32RealVal = __riscv_vfmul_vf_f32m4(inRealVal, (float) 127, vl);
             vfloat32m4_t tmp32ImagVal = __riscv_vfmul_vf_f32m4(inImagVal, (float) 127, vl);
 
+            // Saturate tmpReal[i], tmpImag[i] to 8 bits
+            tmp32RealVal = __riscv_vfmin_vf_f32m4(tmp32RealVal, (float) 127, vl);
+            tmp32RealVal = __riscv_vfmax_vf_f32m4(tmp32RealVal, (float) -128, vl);
+            tmp32ImagVal = __riscv_vfmin_vf_f32m4(tmp32ImagVal, (float) 127, vl);
+            tmp32ImagVal = __riscv_vfmax_vf_f32m4(tmp32ImagVal, (float) -128, vl);
+
             // outReal[i] = (signed char) tmpReal[i]
             vint16m2_t tmp16RealVal = __riscv_vfncvt_x_f_w_i16m2(tmp32RealVal, vl);
             vint8m1_t outRealVal = __riscv_vncvt_x_x_w_i8m1(tmp16RealVal, vl);

--- a/src/algorithms/libs/volk_gnsssdr_module/volk_gnsssdr/kernels/volk_gnsssdr/volk_gnsssdr_32fc_resamplerxnpuppet_32fc.h
+++ b/src/algorithms/libs/volk_gnsssdr_module/volk_gnsssdr/kernels/volk_gnsssdr/volk_gnsssdr_32fc_resamplerxnpuppet_32fc.h
@@ -320,4 +320,33 @@ static inline void volk_gnsssdr_32fc_resamplerxnpuppet_32fc_neon(lv_32fc_t* resu
 }
 #endif
 
+
+#ifdef LV_HAVE_RVV
+static inline void volk_gnsssdr_32fc_resamplerxnpuppet_32fc_rvv(lv_32fc_t* result, const lv_32fc_t* local_code, unsigned int num_points)
+{
+    int code_length_chips = 2046;
+    float code_phase_step_chips = ((float)(code_length_chips) + 0.1) / ((float)num_points);
+    int num_out_vectors = 3;
+    float rem_code_phase_chips = -0.234;
+    int n;
+    float shifts_chips[3] = {-0.1, 0.0, 0.1};
+
+    lv_32fc_t** result_aux = (lv_32fc_t**)volk_gnsssdr_malloc(sizeof(lv_32fc_t*) * num_out_vectors, volk_gnsssdr_get_alignment());
+    for (n = 0; n < num_out_vectors; n++)
+        {
+            result_aux[n] = (lv_32fc_t*)volk_gnsssdr_malloc(sizeof(lv_32fc_t) * num_points, volk_gnsssdr_get_alignment());
+        }
+
+    volk_gnsssdr_32fc_xn_resampler_32fc_xn_rvv(result_aux, local_code, rem_code_phase_chips, code_phase_step_chips, shifts_chips, code_length_chips, num_out_vectors, num_points);
+
+    memcpy((lv_32fc_t*)result, (lv_32fc_t*)result_aux[0], sizeof(lv_32fc_t) * num_points);
+
+    for (n = 0; n < num_out_vectors; n++)
+        {
+            volk_gnsssdr_free(result_aux[n]);
+        }
+    volk_gnsssdr_free(result_aux);
+}
+#endif
+
 #endif  // INCLUDED_volk_gnsssdr_32fc_resamplerpuppet_32fc_H

--- a/src/algorithms/libs/volk_gnsssdr_module/volk_gnsssdr/kernels/volk_gnsssdr/volk_gnsssdr_32fc_x2_rotator_dot_prod_32fc_xn.h
+++ b/src/algorithms/libs/volk_gnsssdr_module/volk_gnsssdr/kernels/volk_gnsssdr/volk_gnsssdr_32fc_x2_rotator_dot_prod_32fc_xn.h
@@ -797,24 +797,23 @@ static inline void volk_gnsssdr_32fc_x2_rotator_dot_prod_32fc_xn_rvv(lv_32fc_t* 
     size_t ROTATOR_RELOAD = 256;
 
     // Initialize reference pointers of compatible type that will not be stripmined
-    float* phasePtr = (float*) phase;
+    float* phasePtr = (float*)phase;
 
     // Initialize pointers of compatible type to track progress as stripmine
-    float* outPtr = (float*) result;
-    const float* comPtr = (const float*) in_common;
-    const float** inPtrBuf = (const float**) volk_gnsssdr_malloc(
-        num_a_vectors * sizeof(*in_a), volk_gnsssdr_get_alignment()
-    );
+    float* outPtr = (float*)result;
+    const float* comPtr = (const float*)in_common;
+    const float** inPtrBuf = (const float**)volk_gnsssdr_malloc(
+        num_a_vectors * sizeof(*in_a), volk_gnsssdr_get_alignment());
 
     for (int n_vec = 0; n_vec < num_a_vectors; n_vec++)
-    {
-        // Initialize `out` to zero
-        result[n_vec] = lv_cmake(0.0f, 0.0f);
+        {
+            // Initialize `out` to zero
+            result[n_vec] = lv_cmake(0.0f, 0.0f);
 
-        // Treat complex number as struct containting
-        // two 16-bit integers
-        inPtrBuf[n_vec] = (float*) in_a[n_vec];
-    }
+            // Treat complex number as struct containting
+            // two 16-bit integers
+            inPtrBuf[n_vec] = (float*)in_a[n_vec];
+        }
 
     for (int _ = 0; _ < num_points / ROTATOR_RELOAD; _++)
         {
@@ -913,7 +912,7 @@ static inline void volk_gnsssdr_32fc_x2_rotator_dot_prod_32fc_xn_rvv(lv_32fc_t* 
                     // elements left and increment the pointers
                     // by the number of elements processed
                 }
-            // Regenerate phase
+                // Regenerate phase
 #ifdef __cplusplus
             (*phase) /= std::abs((*phase));
 #else

--- a/src/algorithms/libs/volk_gnsssdr_module/volk_gnsssdr/kernels/volk_gnsssdr/volk_gnsssdr_32fc_x2_rotator_dot_prod_32fc_xn.h
+++ b/src/algorithms/libs/volk_gnsssdr_module/volk_gnsssdr/kernels/volk_gnsssdr/volk_gnsssdr_32fc_x2_rotator_dot_prod_32fc_xn.h
@@ -788,4 +788,238 @@ static inline void volk_gnsssdr_32fc_x2_rotator_dot_prod_32fc_xn_neon(lv_32fc_t*
 
 #endif /* LV_HAVE_NEON */
 
+
+#ifdef LV_HAVE_RVV
+#include <riscv_vector.h>
+
+static inline void volk_gnsssdr_32fc_x2_rotator_dot_prod_32fc_xn_rvv(lv_32fc_t* result, const lv_32fc_t* in_common, const lv_32fc_t phase_inc, lv_32fc_t* phase, const lv_32fc_t** in_a, int num_a_vectors, unsigned int num_points)
+{
+    size_t ROTATOR_RELOAD = 256;
+
+    // Initialize reference pointers of compatible type that will not be stripmined
+    float* phasePtr = (float*) phase;
+
+    // Initialize pointers of compatible type to track progress as stripmine
+    float* outPtr = (float*) result;
+    const float* comPtr = (const float*) in_common;
+    const float** inPtrBuf = (const float**) volk_gnsssdr_malloc(
+        num_a_vectors * sizeof(*in_a), volk_gnsssdr_get_alignment()
+    );
+
+    for (int n_vec = 0; n_vec < num_a_vectors; n_vec++)
+    {
+        // Initialize `out` to zero
+        result[n_vec] = lv_cmake(0.0f, 0.0f);
+
+        // Treat complex number as struct containting
+        // two 16-bit integers
+        inPtrBuf[n_vec] = (float*) in_a[n_vec];
+    }
+
+    for (int _ = 0; _ < num_points / ROTATOR_RELOAD; _++)
+        {
+            size_t n = ROTATOR_RELOAD;
+
+            for (size_t vl; n > 0; n -= vl, comPtr += vl * 2)
+                {
+                    // Record how many elements will actually be processed
+                    vl = __riscv_vsetvl_e32m4(n);
+
+                    // Splat phase
+                    vfloat32m4_t phaseRealVal = __riscv_vfmv_v_f_f32m4(phasePtr[0], vl);
+                    vfloat32m4_t phaseImagVal = __riscv_vfmv_v_f_f32m4(phasePtr[1], vl);
+
+                    // Splat phaseInc
+                    vfloat32m4_t phaseIncRealVal = __riscv_vfmv_v_f_f32m4(lv_creal(phase_inc), vl);
+                    vfloat32m4_t phaseIncImagVal = __riscv_vfmv_v_f_f32m4(lv_cimag(phase_inc), vl);
+
+                    // iter[i] = i
+                    vuint32m4_t iterVal = __riscv_vid_v_u32m4(vl);
+
+                    // phase[i] = phase[i] * ( phaseInc[i] ^ i )
+                    for (int j = 1; j < vl; j++)
+                        {
+                            vbool8_t maskVal = __riscv_vmsgtu_vx_u32m4_b8(iterVal, 0, vl);
+
+                            // Initialize as copies of phase so that can target masked
+                            // operations onto these copies instead of the original vectors
+                            vfloat32m4_t prodRealVal = phaseRealVal;
+                            vfloat32m4_t prodImagVal = phaseImagVal;
+
+                            // For more details on cross product,
+                            // check `volk_gnsssdr_8ic_x2_multiply_8ic_rvv`,
+                            // for instance
+                            prodRealVal = __riscv_vfmul_vv_f32m4_mu(maskVal, prodRealVal, phaseRealVal, phaseIncRealVal, vl);
+                            prodRealVal = __riscv_vfnmsac_vv_f32m4_mu(maskVal, prodRealVal, phaseImagVal, phaseIncImagVal, vl);
+                            prodImagVal = __riscv_vfmul_vv_f32m4_mu(maskVal, prodImagVal, phaseRealVal, phaseIncImagVal, vl);
+                            prodImagVal = __riscv_vfmacc_vv_f32m4_mu(maskVal, prodImagVal, phaseImagVal, phaseIncRealVal, vl);
+
+                            phaseRealVal = prodRealVal;
+                            phaseImagVal = prodImagVal;
+
+                            iterVal = __riscv_vsub_vx_u32m4_mu(maskVal, iterVal, iterVal, 1, vl);
+                        }
+
+                    // Load com[0..vl)
+                    vfloat32m4x2_t comVal = __riscv_vlseg2e32_v_f32m4x2(comPtr, vl);
+                    vfloat32m4_t comRealVal = __riscv_vget_v_f32m4x2_f32m4(comVal, 0);
+                    vfloat32m4_t comImagVal = __riscv_vget_v_f32m4x2_f32m4(comVal, 1);
+
+                    vfloat32m4_t comProdRealVal = __riscv_vfmul_vv_f32m4(comRealVal, phaseRealVal, vl);
+                    comProdRealVal = __riscv_vfnmsac_vv_f32m4(comProdRealVal, comImagVal, phaseImagVal, vl);
+                    vfloat32m4_t comProdImagVal = __riscv_vfmul_vv_f32m4(comRealVal, phaseImagVal, vl);
+                    comProdImagVal = __riscv_vfmacc_vv_f32m4(comProdImagVal, comImagVal, phaseRealVal, vl);
+
+                    for (int n_vec = 0; n_vec < num_a_vectors; n_vec++)
+                        {
+                            // Load in[0..vl)
+                            vfloat32m4x2_t inVal = __riscv_vlseg2e32_v_f32m4x2(inPtrBuf[n_vec], vl);
+                            vfloat32m4_t inRealVal = __riscv_vget_v_f32m4x2_f32m4(inVal, 0);
+                            vfloat32m4_t inImagVal = __riscv_vget_v_f32m4x2_f32m4(inVal, 1);
+
+                            // out[i] = in[i] * comProd[i]
+                            vfloat32m4_t outRealVal = __riscv_vfmul_vv_f32m4(inRealVal, comProdRealVal, vl);
+                            outRealVal = __riscv_vfnmsac_vv_f32m4(outRealVal, inImagVal, comProdImagVal, vl);
+                            vfloat32m4_t outImagVal = __riscv_vfmul_vv_f32m4(inRealVal, comProdImagVal, vl);
+                            outImagVal = __riscv_vfmacc_vv_f32m4(outImagVal, inImagVal, comProdRealVal, vl);
+
+                            // Load accumulator
+                            vfloat32m1_t accRealVal = __riscv_vfmv_s_f_f32m1(outPtr[2 * n_vec], 1);
+                            vfloat32m1_t accImagVal = __riscv_vfmv_s_f_f32m1(outPtr[2 * n_vec + 1], 1);
+
+                            // acc[0] = sum( acc[0], out[0..vl) )
+                            accRealVal = __riscv_vfredosum_vs_f32m4_f32m1(outRealVal, accRealVal, vl);
+                            accImagVal = __riscv_vfredosum_vs_f32m4_f32m1(outImagVal, accImagVal, vl);
+
+                            // Store acc[0]
+                            outPtr[2 * n_vec] = __riscv_vfmv_f_s_f32m1_f32(accRealVal);
+                            outPtr[2 * n_vec + 1] = __riscv_vfmv_f_s_f32m1_f32(accImagVal);
+
+                            // Increment this pointer, accounting how each complex
+                            // element is two 32-bit floats
+                            inPtrBuf[n_vec] += vl * 2;
+                        }
+
+                    // Store phase[vl - 1]
+                    phaseRealVal = __riscv_vslidedown_vx_f32m4(phaseRealVal, vl - 1, vl);
+                    phasePtr[0] = __riscv_vfmv_f_s_f32m4_f32(phaseRealVal);
+                    phaseImagVal = __riscv_vslidedown_vx_f32m4(phaseImagVal, vl - 1, vl);
+                    phasePtr[1] = __riscv_vfmv_f_s_f32m4_f32(phaseImagVal);
+
+                    // Account for multiplication after last calculation
+                    (*phase) *= phase_inc;
+
+                    // In looping, decrement the number of
+                    // elements left and increment the pointers
+                    // by the number of elements processed
+                }
+            // Regenerate phase
+#ifdef __cplusplus
+            (*phase) /= std::abs((*phase));
+#else
+            (*phase) /= hypotf(lv_creal(*phase), lv_cimag(*phase));
+#endif
+        }
+
+    size_t n = num_points % ROTATOR_RELOAD;
+
+    for (size_t vl; n > 0; n -= vl, comPtr += vl * 2)
+        {
+            // Record how many elements will actually be processed
+            vl = __riscv_vsetvl_e32m4(n);
+
+            // Splat phase
+            vfloat32m4_t phaseRealVal = __riscv_vfmv_v_f_f32m4(phasePtr[0], vl);
+            vfloat32m4_t phaseImagVal = __riscv_vfmv_v_f_f32m4(phasePtr[1], vl);
+
+            // Splat phaseInc
+            vfloat32m4_t phaseIncRealVal = __riscv_vfmv_v_f_f32m4(lv_creal(phase_inc), vl);
+            vfloat32m4_t phaseIncImagVal = __riscv_vfmv_v_f_f32m4(lv_cimag(phase_inc), vl);
+
+            // iter[i] = i
+            vuint32m4_t iterVal = __riscv_vid_v_u32m4(vl);
+
+            // phase[i] = phase[i] * ( phaseInc[i] ^ i )
+            for (int j = 1; j < vl; j++)
+                {
+                    vbool8_t maskVal = __riscv_vmsgtu_vx_u32m4_b8(iterVal, 0, vl);
+
+                    // Initialize as copies of phase so that can target masked
+                    // operations onto these copies instead of the original vectors
+                    vfloat32m4_t prodRealVal = phaseRealVal;
+                    vfloat32m4_t prodImagVal = phaseImagVal;
+
+                    // For more details on cross product,
+                    // check `volk_gnsssdr_8ic_x2_multiply_8ic_rvv`,
+                    // for instance
+                    prodRealVal = __riscv_vfmul_vv_f32m4_mu(maskVal, prodRealVal, phaseRealVal, phaseIncRealVal, vl);
+                    prodRealVal = __riscv_vfnmsac_vv_f32m4_mu(maskVal, prodRealVal, phaseImagVal, phaseIncImagVal, vl);
+                    prodImagVal = __riscv_vfmul_vv_f32m4_mu(maskVal, prodImagVal, phaseRealVal, phaseIncImagVal, vl);
+                    prodImagVal = __riscv_vfmacc_vv_f32m4_mu(maskVal, prodImagVal, phaseImagVal, phaseIncRealVal, vl);
+
+                    phaseRealVal = prodRealVal;
+                    phaseImagVal = prodImagVal;
+
+                    iterVal = __riscv_vsub_vx_u32m4_mu(maskVal, iterVal, iterVal, 1, vl);
+                }
+
+            // Load com[0..vl)
+            vfloat32m4x2_t comVal = __riscv_vlseg2e32_v_f32m4x2(comPtr, vl);
+            vfloat32m4_t comRealVal = __riscv_vget_v_f32m4x2_f32m4(comVal, 0);
+            vfloat32m4_t comImagVal = __riscv_vget_v_f32m4x2_f32m4(comVal, 1);
+
+            vfloat32m4_t comProdRealVal = __riscv_vfmul_vv_f32m4(comRealVal, phaseRealVal, vl);
+            comProdRealVal = __riscv_vfnmsac_vv_f32m4(comProdRealVal, comImagVal, phaseImagVal, vl);
+            vfloat32m4_t comProdImagVal = __riscv_vfmul_vv_f32m4(comRealVal, phaseImagVal, vl);
+            comProdImagVal = __riscv_vfmacc_vv_f32m4(comProdImagVal, comImagVal, phaseRealVal, vl);
+
+            for (int n_vec = 0; n_vec < num_a_vectors; n_vec++)
+                {
+                    // Load in[0..vl)
+                    vfloat32m4x2_t inVal = __riscv_vlseg2e32_v_f32m4x2(inPtrBuf[n_vec], vl);
+                    vfloat32m4_t inRealVal = __riscv_vget_v_f32m4x2_f32m4(inVal, 0);
+                    vfloat32m4_t inImagVal = __riscv_vget_v_f32m4x2_f32m4(inVal, 1);
+
+                    // out[i] = in[i] * comProd[i]
+                    vfloat32m4_t outRealVal = __riscv_vfmul_vv_f32m4(inRealVal, comProdRealVal, vl);
+                    outRealVal = __riscv_vfnmsac_vv_f32m4(outRealVal, inImagVal, comProdImagVal, vl);
+                    vfloat32m4_t outImagVal = __riscv_vfmul_vv_f32m4(inRealVal, comProdImagVal, vl);
+                    outImagVal = __riscv_vfmacc_vv_f32m4(outImagVal, inImagVal, comProdRealVal, vl);
+
+                    // Load accumulator
+                    vfloat32m1_t accRealVal = __riscv_vfmv_s_f_f32m1(outPtr[2 * n_vec], 1);
+                    vfloat32m1_t accImagVal = __riscv_vfmv_s_f_f32m1(outPtr[2 * n_vec + 1], 1);
+
+                    // acc[0] = sum( acc[0], out[0..vl) )
+                    accRealVal = __riscv_vfredosum_vs_f32m4_f32m1(outRealVal, accRealVal, vl);
+                    accImagVal = __riscv_vfredosum_vs_f32m4_f32m1(outImagVal, accImagVal, vl);
+
+                    // Store acc[0]
+                    outPtr[2 * n_vec] = __riscv_vfmv_f_s_f32m1_f32(accRealVal);
+                    outPtr[2 * n_vec + 1] = __riscv_vfmv_f_s_f32m1_f32(accImagVal);
+
+                    // Increment this pointer, accounting how each complex
+                    // element is two 32-bit floats
+                    inPtrBuf[n_vec] += vl * 2;
+                }
+
+            // Store phase[vl - 1]
+            phaseRealVal = __riscv_vslidedown_vx_f32m4(phaseRealVal, vl - 1, vl);
+            phasePtr[0] = __riscv_vfmv_f_s_f32m4_f32(phaseRealVal);
+            phaseImagVal = __riscv_vslidedown_vx_f32m4(phaseImagVal, vl - 1, vl);
+            phasePtr[1] = __riscv_vfmv_f_s_f32m4_f32(phaseImagVal);
+
+            // Account for multiplication after last calculation
+            (*phase) *= phase_inc;
+
+            // In looping, decrement the number of
+            // elements left and increment the pointers
+            // by the number of elements processed
+        }
+
+    // Don't leak memory!
+    volk_gnsssdr_free(inPtrBuf);
+}
+#endif /* LV_HAVE_RVV */
+
 #endif /* INCLUDED_volk_gnsssdr_32fc_x2_rotator_dot_prod_32fc_xn_H */

--- a/src/algorithms/libs/volk_gnsssdr_module/volk_gnsssdr/kernels/volk_gnsssdr/volk_gnsssdr_32fc_x2_rotator_dotprodxnpuppet_32fc.h
+++ b/src/algorithms/libs/volk_gnsssdr_module/volk_gnsssdr/kernels/volk_gnsssdr/volk_gnsssdr_32fc_x2_rotator_dotprodxnpuppet_32fc.h
@@ -236,4 +236,34 @@ static inline void volk_gnsssdr_32fc_x2_rotator_dotprodxnpuppet_32fc_neon(lv_32f
 #endif  // LV_HAVE_NEON
 
 
+#ifdef LV_HAVE_RVV
+static inline void volk_gnsssdr_32fc_x2_rotator_dotprodxnpuppet_32fc_rvv(lv_32fc_t* result, const lv_32fc_t* local_code, const lv_32fc_t* in, unsigned int num_points)
+{
+    // phases must be normalized. Phase rotator expects a complex exponential input!
+    float rem_carrier_phase_in_rad = 0.25;
+    float phase_step_rad = 0.1;
+    lv_32fc_t phase[1];
+    phase[0] = lv_cmake(cos(rem_carrier_phase_in_rad), sin(rem_carrier_phase_in_rad));
+    lv_32fc_t phase_inc[1];
+    phase_inc[0] = lv_cmake(cos(phase_step_rad), sin(phase_step_rad));
+    int n;
+    int num_a_vectors = 3;
+    lv_32fc_t** in_a = (lv_32fc_t**)volk_gnsssdr_malloc(sizeof(lv_32fc_t*) * num_a_vectors, volk_gnsssdr_get_alignment());
+    for (n = 0; n < num_a_vectors; n++)
+        {
+            in_a[n] = (lv_32fc_t*)volk_gnsssdr_malloc(sizeof(lv_32fc_t) * num_points, volk_gnsssdr_get_alignment());
+            memcpy((lv_32fc_t*)in_a[n], (lv_32fc_t*)in, sizeof(lv_32fc_t) * num_points);
+        }
+    volk_gnsssdr_32fc_x2_rotator_dot_prod_32fc_xn_rvv(result, local_code, phase_inc[0], phase, (const lv_32fc_t**)in_a, num_a_vectors, num_points);
+
+    for (n = 0; n < num_a_vectors; n++)
+        {
+            volk_gnsssdr_free(in_a[n]);
+        }
+    volk_gnsssdr_free(in_a);
+}
+
+#endif  // LV_HAVE_RVV
+
+
 #endif  // INCLUDED_volk_gnsssdr_32fc_x2_rotator_dotprodxnpuppet_32fc_H

--- a/src/algorithms/libs/volk_gnsssdr_module/volk_gnsssdr/kernels/volk_gnsssdr/volk_gnsssdr_32fc_xn_resampler_32fc_xn.h
+++ b/src/algorithms/libs/volk_gnsssdr_module/volk_gnsssdr/kernels/volk_gnsssdr/volk_gnsssdr_32fc_xn_resampler_32fc_xn.h
@@ -788,7 +788,7 @@ static inline void volk_gnsssdr_32fc_xn_resampler_32fc_xn_rvv(lv_32fc_t** result
                     vuint32m4_t iVal = __riscv_vadd_vx_u32m4(idVal, currI, vl);
                     vfloat32m4_t floatIVal = __riscv_vfcvt_f_xu_v_f32m4(iVal, vl);
 
-                    // iterIndex[i] = floatIVal[i] * code_phase_step_chips
+                    // iterIndex[i] = floatI[i] * code_phase_step_chips
                     vfloat32m4_t iterIndexVal = __riscv_vfmul_vf_f32m4(floatIVal, code_phase_step_chips, vl);
 
                     // overflowIndex[i] = (int) floor(iterIndex[i] + constIndexShift)
@@ -806,7 +806,7 @@ static inline void volk_gnsssdr_32fc_xn_resampler_32fc_xn_rvv(lv_32fc_t** result
                     vuint32m4_t finalIndexVal = __riscv_vreinterpret_v_i32m4_u32m4(indexVal);
 
                     // Convert to address offset
-                    // offset[i] = finalIndex[i] * sizeof(float)
+                    // offset[i] = finalIndex[i] * sizeof(lv_32fc_t)
                     vuint32m4_t offsetVal = __riscv_vmul_vx_u32m4(finalIndexVal, sizeof(lv_32fc_t), vl);
 
                     // This indexed load is unordered to hopefully boost run time
@@ -817,7 +817,7 @@ static inline void volk_gnsssdr_32fc_xn_resampler_32fc_xn_rvv(lv_32fc_t** result
                     __riscv_vse64_v_i64m8(outPtr, outVal, vl);
 
                     // In looping, decrement the number of
-                    // elements left and increment stripmining pointers
+                    // elements left and increment stripmining variables
                     // by the number of elements processed
                 }
         }

--- a/src/algorithms/libs/volk_gnsssdr_module/volk_gnsssdr/kernels/volk_gnsssdr/volk_gnsssdr_32fc_xn_resampler_32fc_xn.h
+++ b/src/algorithms/libs/volk_gnsssdr_module/volk_gnsssdr/kernels/volk_gnsssdr/volk_gnsssdr_32fc_xn_resampler_32fc_xn.h
@@ -755,4 +755,61 @@ static inline void volk_gnsssdr_32fc_xn_resampler_32fc_xn_neon(lv_32fc_t** resul
 #endif
 
 
+#ifdef LV_HAVE_RVV
+#include <riscv_vector.h>
+
+static inline void volk_gnsssdr_32fc_xn_resampler_32fc_xn_rvv(lv_32fc_t** result, const lv_32fc_t* local_code, float rem_code_phase_chips, float code_phase_step_chips, float* shifts_chips, unsigned int code_length_chips, int num_out_vectors, unsigned int num_points)
+{
+    // To make easier to work with in RVV, just interpret the two 32-bit components
+    // of each complex number as a single 64-bit number to move around
+
+    for (int current_correlator_tap = 0; current_correlator_tap < num_out_vectors; current_correlator_tap++) {
+        // Stores address offsets from `local_code` to load from and
+        // then store in `result[current_correlator_tap]`
+        unsigned int offsetBuffer[num_points];
+
+        for (int i = 0; i < num_points; i++) {
+            // resample code for current tap
+            int local_code_chip_index = (int)floor(code_phase_step_chips * (float)i + shifts_chips[current_correlator_tap] - rem_code_phase_chips);
+            // Take into account that in multitap correlators, the shifts can be negative!
+            if (local_code_chip_index < 0) local_code_chip_index += (int)code_length_chips * (abs(local_code_chip_index) / code_length_chips + 1);
+            local_code_chip_index = local_code_chip_index % code_length_chips;
+
+            // `local_code_chip_index` should be some positive, valid
+            // index to `local_code`
+            // Convert from index to raw address offset
+            offsetBuffer[i] = (unsigned int) (local_code_chip_index * 8);
+        }
+
+        size_t n = num_points;
+
+        // Initialize pointers to track progress as stripmine
+        long* outPtr = (long*) result[current_correlator_tap];
+        const long* inPtr = (const long*) local_code;
+        const unsigned int* offsetPtr = (const unsigned int*) offsetBuffer;
+
+        for (size_t vl; n > 0; n -= vl, outPtr += vl, offsetPtr += vl) {
+            // Record how many elements will actually be processed
+            vl = __riscv_vsetvl_e64m8(n);
+
+            // Load offset[0..vl)
+            vuint32m4_t offsetVal = __riscv_vle32_v_u32m4(offsetPtr, vl);
+
+            // This indexed load is unordered to hopefully boost run time
+            // out[i] = in[offset[i]]
+            vint64m8_t outVal = __riscv_vluxei32_v_i64m8(inPtr, offsetVal, vl);
+
+            // Store out[0..vl)
+            __riscv_vse64_v_i64m8(outPtr, outVal, vl);
+
+            // In looping, decrement the number of
+            // elements left and increment stripmining pointers
+            // by the number of elements processed
+        }
+    }
+}
+
+#endif
+
+
 #endif /* INCLUDED_volk_gnsssdr_32fc_xn_resampler_32fc_xn_H */

--- a/src/algorithms/libs/volk_gnsssdr_module/volk_gnsssdr/kernels/volk_gnsssdr/volk_gnsssdr_32fc_xn_resampler_32fc_xn.h
+++ b/src/algorithms/libs/volk_gnsssdr_module/volk_gnsssdr/kernels/volk_gnsssdr/volk_gnsssdr_32fc_xn_resampler_32fc_xn.h
@@ -763,50 +763,53 @@ static inline void volk_gnsssdr_32fc_xn_resampler_32fc_xn_rvv(lv_32fc_t** result
     // To make easier to work with in RVV, just interpret the two 32-bit components
     // of each complex number as a single 64-bit number to move around
 
-    for (int current_correlator_tap = 0; current_correlator_tap < num_out_vectors; current_correlator_tap++) {
-        // Stores address offsets from `local_code` to load from and
-        // then store in `result[current_correlator_tap]`
-        unsigned int offsetBuffer[num_points];
+    for (int current_correlator_tap = 0; current_correlator_tap < num_out_vectors; current_correlator_tap++)
+        {
+            // Stores address offsets from `local_code` to load from and
+            // then store in `result[current_correlator_tap]`
+            unsigned int offsetBuffer[num_points];
 
-        for (int i = 0; i < num_points; i++) {
-            // resample code for current tap
-            int local_code_chip_index = (int)floor(code_phase_step_chips * (float)i + shifts_chips[current_correlator_tap] - rem_code_phase_chips);
-            // Take into account that in multitap correlators, the shifts can be negative!
-            if (local_code_chip_index < 0) local_code_chip_index += (int)code_length_chips * (abs(local_code_chip_index) / code_length_chips + 1);
-            local_code_chip_index = local_code_chip_index % code_length_chips;
+            for (int i = 0; i < num_points; i++)
+                {
+                    // resample code for current tap
+                    int local_code_chip_index = (int)floor(code_phase_step_chips * (float)i + shifts_chips[current_correlator_tap] - rem_code_phase_chips);
+                    // Take into account that in multitap correlators, the shifts can be negative!
+                    if (local_code_chip_index < 0) local_code_chip_index += (int)code_length_chips * (abs(local_code_chip_index) / code_length_chips + 1);
+                    local_code_chip_index = local_code_chip_index % code_length_chips;
 
-            // `local_code_chip_index` should be some positive, valid
-            // index to `local_code`
-            // Convert from index to raw address offset
-            offsetBuffer[i] = (unsigned int) (local_code_chip_index * 8);
+                    // `local_code_chip_index` should be some positive, valid
+                    // index to `local_code`
+                    // Convert from index to raw address offset
+                    offsetBuffer[i] = (unsigned int) (local_code_chip_index * 8);
+                }
+
+            size_t n = num_points;
+
+            // Initialize pointers to track progress as stripmine
+            long* outPtr = (long*) result[current_correlator_tap];
+            const long* inPtr = (const long*) local_code;
+            const unsigned int* offsetPtr = (const unsigned int*) offsetBuffer;
+
+            for (size_t vl; n > 0; n -= vl, outPtr += vl, offsetPtr += vl)
+                {
+                    // Record how many elements will actually be processed
+                    vl = __riscv_vsetvl_e64m8(n);
+
+                    // Load offset[0..vl)
+                    vuint32m4_t offsetVal = __riscv_vle32_v_u32m4(offsetPtr, vl);
+
+                    // This indexed load is unordered to hopefully boost run time
+                    // out[i] = in[offset[i]]
+                    vint64m8_t outVal = __riscv_vluxei32_v_i64m8(inPtr, offsetVal, vl);
+
+                    // Store out[0..vl)
+                    __riscv_vse64_v_i64m8(outPtr, outVal, vl);
+
+                    // In looping, decrement the number of
+                    // elements left and increment stripmining pointers
+                    // by the number of elements processed
+                }
         }
-
-        size_t n = num_points;
-
-        // Initialize pointers to track progress as stripmine
-        long* outPtr = (long*) result[current_correlator_tap];
-        const long* inPtr = (const long*) local_code;
-        const unsigned int* offsetPtr = (const unsigned int*) offsetBuffer;
-
-        for (size_t vl; n > 0; n -= vl, outPtr += vl, offsetPtr += vl) {
-            // Record how many elements will actually be processed
-            vl = __riscv_vsetvl_e64m8(n);
-
-            // Load offset[0..vl)
-            vuint32m4_t offsetVal = __riscv_vle32_v_u32m4(offsetPtr, vl);
-
-            // This indexed load is unordered to hopefully boost run time
-            // out[i] = in[offset[i]]
-            vint64m8_t outVal = __riscv_vluxei32_v_i64m8(inPtr, offsetVal, vl);
-
-            // Store out[0..vl)
-            __riscv_vse64_v_i64m8(outPtr, outVal, vl);
-
-            // In looping, decrement the number of
-            // elements left and increment stripmining pointers
-            // by the number of elements processed
-        }
-    }
 }
 
 #endif

--- a/src/algorithms/libs/volk_gnsssdr_module/volk_gnsssdr/kernels/volk_gnsssdr/volk_gnsssdr_32fc_xn_resampler_32fc_xn.h
+++ b/src/algorithms/libs/volk_gnsssdr_module/volk_gnsssdr/kernels/volk_gnsssdr/volk_gnsssdr_32fc_xn_resampler_32fc_xn.h
@@ -763,40 +763,51 @@ static inline void volk_gnsssdr_32fc_xn_resampler_32fc_xn_rvv(lv_32fc_t** result
     // To make easier to work with in RVV, just interpret the two 32-bit components
     // of each complex number as a single 64-bit number to move around
 
+    // Initialize reference pointer, as stays same across loops
+    const long* inPtr = (const long*) local_code;
+
     for (int current_correlator_tap = 0; current_correlator_tap < num_out_vectors; current_correlator_tap++)
         {
-            // Stores address offsets from `local_code` to load from and
-            // then store in `result[current_correlator_tap]`
-            unsigned int offsetBuffer[num_points];
-
-            for (int i = 0; i < num_points; i++)
-                {
-                    // resample code for current tap
-                    int local_code_chip_index = (int)floor(code_phase_step_chips * (float)i + shifts_chips[current_correlator_tap] - rem_code_phase_chips);
-                    // Take into account that in multitap correlators, the shifts can be negative!
-                    if (local_code_chip_index < 0) local_code_chip_index += (int)code_length_chips * (abs(local_code_chip_index) / code_length_chips + 1);
-                    local_code_chip_index = local_code_chip_index % code_length_chips;
-
-                    // `local_code_chip_index` should be some positive, valid
-                    // index to `local_code`
-                    // Convert from index to raw address offset
-                    offsetBuffer[i] = (unsigned int) (local_code_chip_index * 8);
-                }
-
             size_t n = num_points;
+
+            const float constIndexShift = shifts_chips[current_correlator_tap] - rem_code_phase_chips;
 
             // Initialize pointers to track progress as stripmine
             long* outPtr = (long*) result[current_correlator_tap];
-            const long* inPtr = (const long*) local_code;
-            const unsigned int* offsetPtr = (const unsigned int*) offsetBuffer;
+            // Simulates how, compared to generic implementation, `i` continues
+            // increasing across different vector computatation batches
+            unsigned int currI = 0;
 
-            for (size_t vl; n > 0; n -= vl, outPtr += vl, offsetPtr += vl)
+            for (size_t vl; n > 0; n -= vl, outPtr += vl, currI += vl)
                 {
-                    // Record how many elements will actually be processed
+                    // Record how many data elements will actually be processed
                     vl = __riscv_vsetvl_e64m8(n);
 
-                    // Load offset[0..vl)
-                    vuint32m4_t offsetVal = __riscv_vle32_v_u32m4(offsetPtr, vl);
+                    // floatI[i] = (float) (i + currI)
+                    vuint32m4_t idVal = __riscv_vid_v_u32m4(vl);
+                    vuint32m4_t iVal = __riscv_vadd_vx_u32m4(idVal, currI, vl);
+                    vfloat32m4_t floatIVal = __riscv_vfcvt_f_xu_v_f32m4(iVal, vl);
+
+                    // iterIndex[i] = floatIVal[i] * code_phase_step_chips
+                    vfloat32m4_t iterIndexVal = __riscv_vfmul_vf_f32m4(floatIVal, code_phase_step_chips, vl);
+
+                    // overflowIndex[i] = (int) floor(iterIndex[i] + constIndexShift)
+                    vfloat32m4_t shiftedIndexVal = __riscv_vfadd_vf_f32m4(iterIndexVal, constIndexShift, vl);
+                    vint32m4_t overflowIndexVal = __riscv_vfcvt_x_f_v_i32m4_rm(shiftedIndexVal, __RISCV_FRM_RDN, vl);
+
+                    // Wrap to valid index in `local_code`, handling negative values
+                    // index[i] = ( code_length_chips + ( overflowIndex[i] % code_length_chips ) ) % code_length_chips
+                    vint32m4_t indexVal = __riscv_vrem_vx_i32m4(overflowIndexVal, code_length_chips, vl);
+                    indexVal = __riscv_vadd_vx_i32m4(indexVal, code_length_chips, vl);
+                    indexVal = __riscv_vrem_vx_i32m4(indexVal, code_length_chips, vl);
+
+                    // After above, should now be guaranteed positive and valid index
+                    // finalIndex[i] = (unsigned int) index[i];
+                    vuint32m4_t finalIndexVal = __riscv_vreinterpret_v_i32m4_u32m4(indexVal);
+
+                    // Convert to address offset
+                    // offset[i] = finalIndex[i] * sizeof(float)
+                    vuint32m4_t offsetVal = __riscv_vmul_vx_u32m4(finalIndexVal, sizeof(lv_32fc_t), vl);
 
                     // This indexed load is unordered to hopefully boost run time
                     // out[i] = in[offset[i]]

--- a/src/algorithms/libs/volk_gnsssdr_module/volk_gnsssdr/kernels/volk_gnsssdr/volk_gnsssdr_32fc_xn_resampler_32fc_xn.h
+++ b/src/algorithms/libs/volk_gnsssdr_module/volk_gnsssdr/kernels/volk_gnsssdr/volk_gnsssdr_32fc_xn_resampler_32fc_xn.h
@@ -764,7 +764,7 @@ static inline void volk_gnsssdr_32fc_xn_resampler_32fc_xn_rvv(lv_32fc_t** result
     // of each complex number as a single 64-bit number to move around
 
     // Initialize reference pointer, as stays same across loops
-    const long* inPtr = (const long*) local_code;
+    const long* inPtr = (const long*)local_code;
 
     for (int current_correlator_tap = 0; current_correlator_tap < num_out_vectors; current_correlator_tap++)
         {
@@ -773,7 +773,7 @@ static inline void volk_gnsssdr_32fc_xn_resampler_32fc_xn_rvv(lv_32fc_t** result
             const float constIndexShift = shifts_chips[current_correlator_tap] - rem_code_phase_chips;
 
             // Initialize pointers to track progress as stripmine
-            long* outPtr = (long*) result[current_correlator_tap];
+            long* outPtr = (long*)result[current_correlator_tap];
             // Simulates how, compared to generic implementation, `i` continues
             // increasing across different vector computatation batches
             unsigned int currI = 0;

--- a/src/algorithms/libs/volk_gnsssdr_module/volk_gnsssdr/kernels/volk_gnsssdr/volk_gnsssdr_64f_accumulator_64f.h
+++ b/src/algorithms/libs/volk_gnsssdr_module/volk_gnsssdr/kernels/volk_gnsssdr/volk_gnsssdr_64f_accumulator_64f.h
@@ -220,4 +220,44 @@ static inline void volk_gnsssdr_64f_accumulator_64f_a_sse3(double* result, const
 }
 #endif /* LV_HAVE_SSE3 */
 
+
+#ifdef LV_HAVE_RVV
+#include <riscv_vector.h>
+
+static inline void volk_gnsssdr_64f_accumulator_64f_rvv(double* result, const double* inputBuffer, unsigned int num_points)
+{
+    size_t n = num_points;
+
+    // Initialize pointers of correct type
+    // to keep track while stripmining
+    const double* inPtr = inputBuffer;
+
+    // acc[0] = 0
+    vfloat64m1_t accVal = __riscv_vfmv_v_f_f64m1((double) 0, 1);
+
+    for (size_t vl; n > 0; n -= vl, inPtr += vl)
+        {
+            // Record how many elements will actually be processed
+            vl = __riscv_vsetvl_e64m8(n);
+
+            // Load in[0..vl)
+            vfloat64m8_t inVal = __riscv_vle64_v_f64m8(inPtr, vl);
+
+            // Keep ordered just in case matters
+            // acc[0] = sum ( acc[0], in[0..vl) )
+            accVal = __riscv_vfredosum_vs_f64m8_f64m1(inVal, accVal, vl);
+
+            // On looping, decrement the number of
+            // elements left and increase the pointers
+            // by the number of elements processed
+        }
+
+    // For clarity, initialize pointer
+    double* resPtr = result;
+
+    // *result = acc[0]
+    __riscv_vse64_v_f64m1(resPtr, accVal, 1);
+}
+#endif /* LV_HAVE_RVV */
+
 #endif /* INCLUDED_volk_gnsssdr_64f_accumulator_64f_H */

--- a/src/algorithms/libs/volk_gnsssdr_module/volk_gnsssdr/kernels/volk_gnsssdr/volk_gnsssdr_64f_accumulator_64f.h
+++ b/src/algorithms/libs/volk_gnsssdr_module/volk_gnsssdr/kernels/volk_gnsssdr/volk_gnsssdr_64f_accumulator_64f.h
@@ -233,7 +233,7 @@ static inline void volk_gnsssdr_64f_accumulator_64f_rvv(double* result, const do
     const double* inPtr = inputBuffer;
 
     // acc[0] = 0
-    vfloat64m1_t accVal = __riscv_vfmv_v_f_f64m1((double) 0, 1);
+    vfloat64m1_t accVal = __riscv_vfmv_v_f_f64m1((double)0, 1);
 
     for (size_t vl; n > 0; n -= vl, inPtr += vl)
         {

--- a/src/algorithms/libs/volk_gnsssdr_module/volk_gnsssdr/kernels/volk_gnsssdr/volk_gnsssdr_8i_accumulator_s8i.h
+++ b/src/algorithms/libs/volk_gnsssdr_module/volk_gnsssdr/kernels/volk_gnsssdr/volk_gnsssdr_8i_accumulator_s8i.h
@@ -228,7 +228,7 @@ static inline void volk_gnsssdr_8i_accumulator_s8i_rvv(char* result, const char*
 
     // Initialize pointer of correct type
     // to keep track while stripmining
-    const signed char* inPtr = (const signed char*) inputBuffer;
+    const signed char* inPtr = (const signed char*)inputBuffer;
 
     // acc[0] = 0
     vint8m1_t accVal = __riscv_vmv_v_x_i8m1(0, 1);
@@ -251,7 +251,7 @@ static inline void volk_gnsssdr_8i_accumulator_s8i_rvv(char* result, const char*
         }
 
     // Explicitly cast to type accepted by macro
-    signed char* resPtr = (signed char*) result;
+    signed char* resPtr = (signed char*)result;
 
     // *result = acc[0]
     // NOTE: With this implementation,

--- a/src/algorithms/libs/volk_gnsssdr_module/volk_gnsssdr/kernels/volk_gnsssdr/volk_gnsssdr_8i_accumulator_s8i.h
+++ b/src/algorithms/libs/volk_gnsssdr_module/volk_gnsssdr/kernels/volk_gnsssdr/volk_gnsssdr_8i_accumulator_s8i.h
@@ -219,6 +219,48 @@ static inline void volk_gnsssdr_8i_accumulator_s8i_u_avx2(char* result, const ch
 #endif /* LV_HAVE_SSE3 */
 
 
+#ifdef LV_HAVE_RVV
+#include <riscv_vector.h>
+
+static inline void volk_gnsssdr_8i_accumulator_s8i_rvv(char* result, const char* inputBuffer, unsigned int num_points)
+{
+    size_t n = num_points;
+
+    // Initialize pointer of correct type
+    // to keep track while stripmining
+    const signed char* inPtr = (const signed char*) inputBuffer;
+
+    // acc[0] = 0
+    vint8m1_t accVal = __riscv_vmv_v_x_i8m1(0, 1);
+
+    for (size_t vl; n > 0; n -= vl, inPtr += vl)
+        {
+            // Setup state to handle max length vectors of 1-byte numbers
+            // Also collect how many elements were actually processed
+            vl = __riscv_vsetvl_e8m8(n);
+
+            // Load in[0..vl)
+            vint8m8_t inVal = __riscv_vle8_v_i8m8(inPtr, vl);
+
+            // acc[0] = sum( acc[0], in[0..vl) )
+            accVal = __riscv_vredsum_vs_i8m8_i8m1(inVal, accVal, vl);
+
+            // On looping, decrement the number of
+            // elements left and increase the pointers
+            // by the number of elements processed
+        }
+
+    // Explicitly cast to type accepted by macro
+    signed char* resPtr = (signed char*) result;
+
+    // *result = acc[0]
+    // NOTE: With this implementation,
+    // if n == 0, then *result = 0
+    __riscv_vse8_v_i8m1(resPtr, accVal, 1);
+}
+#endif /* LV_HAVE_RVV */
+
+
 #ifdef LV_HAVE_ORC
 
 extern void volk_gnsssdr_8i_accumulator_s8i_a_orc_impl(short* result, const char* inputBuffer, unsigned int num_points);

--- a/src/algorithms/libs/volk_gnsssdr_module/volk_gnsssdr/kernels/volk_gnsssdr/volk_gnsssdr_8i_x2_add_8i.h
+++ b/src/algorithms/libs/volk_gnsssdr_module/volk_gnsssdr/kernels/volk_gnsssdr/volk_gnsssdr_8i_x2_add_8i.h
@@ -205,6 +205,44 @@ static inline void volk_gnsssdr_8i_x2_add_8i_a_avx2(char* cVector, const char* a
 #endif /* LV_HAVE_SSE2 */
 
 
+#ifdef LV_HAVE_RVV
+#include <riscv_vector.h>
+
+static inline void volk_gnsssdr_8i_x2_add_8i_rvv(char* cVector, const char* aVector, const char* bVector, unsigned int num_points)
+{
+    size_t n = num_points;
+
+    // Initialize pointers to track progress as stripmine
+    // Macro expects `int8_t`, and `char`'s signedness
+    // depends on implementation
+    signed char* cPtr = (signed char*) cVector; // For consistency
+    const signed char* aPtr = (const signed char*) aVector;
+    const signed char* bPtr = (const signed char*) bVector;
+
+    for (size_t vl; n > 0; n -= vl, cPtr += vl, aPtr += vl, bPtr += vl)
+        {
+            // Setup state to handle max length vectors of 1-byte numbers
+            // Also collect how many elements were actually processed
+            vl = __riscv_vsetvl_e8m8(n);
+
+            // Load a[0..vl), b[0..vl)
+            vint8m8_t aVal = __riscv_vle8_v_i8m8(aPtr, vl);
+            vint8m8_t bVal = __riscv_vle8_v_i8m8(bPtr, vl);
+
+            // c[i] = a[i] + b[i]
+            vint8m8_t cVal = __riscv_vadd_vv_i8m8(aVal, bVal, vl);
+
+            // Store c[0..vl)
+            __riscv_vse8_v_i8m8(cPtr, cVal, vl);
+
+            // In looping, decrement the number of
+            // elements left and increment the pointers
+            // by the number of elements processed
+        }
+}
+#endif /* LV_HAVE_RVV */
+
+
 #ifdef LV_HAVE_ORC
 
 extern void volk_gnsssdr_8i_x2_add_8i_a_orc_impl(char* cVector, const char* aVector, const char* bVector, unsigned int num_points);

--- a/src/algorithms/libs/volk_gnsssdr_module/volk_gnsssdr/kernels/volk_gnsssdr/volk_gnsssdr_8i_x2_add_8i.h
+++ b/src/algorithms/libs/volk_gnsssdr_module/volk_gnsssdr/kernels/volk_gnsssdr/volk_gnsssdr_8i_x2_add_8i.h
@@ -221,8 +221,7 @@ static inline void volk_gnsssdr_8i_x2_add_8i_rvv(char* cVector, const char* aVec
 
     for (size_t vl; n > 0; n -= vl, cPtr += vl, aPtr += vl, bPtr += vl)
         {
-            // Setup state to handle max length vectors of 1-byte numbers
-            // Also collect how many elements were actually processed
+            // Record how many elements will actually be processed
             vl = __riscv_vsetvl_e8m8(n);
 
             // Load a[0..vl), b[0..vl)

--- a/src/algorithms/libs/volk_gnsssdr_module/volk_gnsssdr/kernels/volk_gnsssdr/volk_gnsssdr_8i_x2_add_8i.h
+++ b/src/algorithms/libs/volk_gnsssdr_module/volk_gnsssdr/kernels/volk_gnsssdr/volk_gnsssdr_8i_x2_add_8i.h
@@ -215,9 +215,9 @@ static inline void volk_gnsssdr_8i_x2_add_8i_rvv(char* cVector, const char* aVec
     // Initialize pointers to track progress as stripmine
     // Macro expects `int8_t`, and `char`'s signedness
     // depends on implementation
-    signed char* cPtr = (signed char*) cVector; // For consistency
-    const signed char* aPtr = (const signed char*) aVector;
-    const signed char* bPtr = (const signed char*) bVector;
+    signed char* cPtr = (signed char*)cVector;  // For consistency
+    const signed char* aPtr = (const signed char*)aVector;
+    const signed char* bPtr = (const signed char*)bVector;
 
     for (size_t vl; n > 0; n -= vl, cPtr += vl, aPtr += vl, bPtr += vl)
         {

--- a/src/algorithms/libs/volk_gnsssdr_module/volk_gnsssdr/kernels/volk_gnsssdr/volk_gnsssdr_8ic_conjugate_8ic.h
+++ b/src/algorithms/libs/volk_gnsssdr_module/volk_gnsssdr/kernels/volk_gnsssdr/volk_gnsssdr_8ic_conjugate_8ic.h
@@ -352,4 +352,47 @@ static inline void volk_gnsssdr_8ic_conjugate_8ic_neon(lv_8sc_t* cVector, const 
 }
 #endif /* LV_HAVE_NEON */
 
+
+#ifdef LV_HAVE_RVV
+#include <riscv_vector.h>
+
+static inline void volk_gnsssdr_8ic_conjugate_8ic_rvv(lv_8sc_t* cVector, const lv_8sc_t* aVector, unsigned int num_points)
+{
+    size_t n = num_points;
+
+    // Initialize pointers to track progress as stripmine
+    // Assuming that intended to use `signed char`,
+    // as `char`'s signedness is implementation-specific
+    signed char* cPtr = (signed char*) cVector;
+    const signed char* aPtr = (const signed char*) aVector;
+
+    for (size_t vl; n > 0; n -= vl, cPtr += vl * 2, aPtr += vl * 2)
+        {
+            // Record how many elements will actually be processed
+            vl = __riscv_vsetvl_e8m4(n);
+
+            // Load aReal[0..vl), aImag[0..vl)
+            vint8m4x2_t aVal = __riscv_vlseg2e8_v_i8m4x2(aPtr, vl);
+            vint8m4_t aRealVal = __riscv_vget_v_i8m4x2_i8m4(aVal, 0);
+            vint8m4_t aImagVal = __riscv_vget_v_i8m4x2_i8m4(aVal, 1);
+
+            // negImag[i] = -aImag[i]
+            vint8m4_t negImagVal = __riscv_vneg_v_i8m4(aImagVal, vl);
+
+            // Store aReal[0..vl), negImag[0..vl) into `cPtr`
+            vint8m4x2_t cVal = __riscv_vset_v_i8m4_i8m4x2(
+                __riscv_vundefined_i8m4x2(), 0, aRealVal
+            );
+            cVal = __riscv_vset_v_i8m4_i8m4x2(cVal, 1, negImagVal);
+            __riscv_vsseg2e8_v_i8m4x2(cPtr, cVal, vl);
+
+            // In looping, decrease the number of
+            // elements left and increase the pointers
+            // by the number of elements processed,
+            // taking into account how each complex number
+            // stored in `cPtr` and `aPtr` is two 1-byte chars
+        }
+}
+#endif /* LV_HAVE_RVV */
+
 #endif /* INCLUDED_volk_gnsssdr_8ic_conjugate_8ic_H */

--- a/src/algorithms/libs/volk_gnsssdr_module/volk_gnsssdr/kernels/volk_gnsssdr/volk_gnsssdr_8ic_conjugate_8ic.h
+++ b/src/algorithms/libs/volk_gnsssdr_module/volk_gnsssdr/kernels/volk_gnsssdr/volk_gnsssdr_8ic_conjugate_8ic.h
@@ -380,10 +380,7 @@ static inline void volk_gnsssdr_8ic_conjugate_8ic_rvv(lv_8sc_t* cVector, const l
             vint8m4_t negImagVal = __riscv_vneg_v_i8m4(aImagVal, vl);
 
             // Store aReal[0..vl), negImag[0..vl) into `cPtr`
-            vint8m4x2_t cVal = __riscv_vset_v_i8m4_i8m4x2(
-                __riscv_vundefined_i8m4x2(), 0, aRealVal
-            );
-            cVal = __riscv_vset_v_i8m4_i8m4x2(cVal, 1, negImagVal);
+            vint8m4x2_t cVal = __riscv_vcreate_v_i8m4x2(aRealVal, negImagVal);
             __riscv_vsseg2e8_v_i8m4x2(cPtr, cVal, vl);
 
             // In looping, decrease the number of

--- a/src/algorithms/libs/volk_gnsssdr_module/volk_gnsssdr/kernels/volk_gnsssdr/volk_gnsssdr_8ic_conjugate_8ic.h
+++ b/src/algorithms/libs/volk_gnsssdr_module/volk_gnsssdr/kernels/volk_gnsssdr/volk_gnsssdr_8ic_conjugate_8ic.h
@@ -363,8 +363,8 @@ static inline void volk_gnsssdr_8ic_conjugate_8ic_rvv(lv_8sc_t* cVector, const l
     // Initialize pointers to track progress as stripmine
     // Assuming that intended to use `signed char`,
     // as `char`'s signedness is implementation-specific
-    signed char* cPtr = (signed char*) cVector;
-    const signed char* aPtr = (const signed char*) aVector;
+    signed char* cPtr = (signed char*)cVector;
+    const signed char* aPtr = (const signed char*)aVector;
 
     for (size_t vl; n > 0; n -= vl, cPtr += vl * 2, aPtr += vl * 2)
         {

--- a/src/algorithms/libs/volk_gnsssdr_module/volk_gnsssdr/kernels/volk_gnsssdr/volk_gnsssdr_8ic_magnitude_squared_8i.h
+++ b/src/algorithms/libs/volk_gnsssdr_module/volk_gnsssdr/kernels/volk_gnsssdr/volk_gnsssdr_8ic_magnitude_squared_8i.h
@@ -185,8 +185,8 @@ static inline void volk_gnsssdr_8ic_magnitude_squared_8i_rvv(char* magnitudeVect
     // Initialize pointers to track progress as stripmine
     // Assuming that intended to use `signed char`,
     // as `char`'s signedness is implementation-specific
-    signed char* outPtr = (signed char*) magnitudeVector;
-    const signed char* inPtr = (const signed char*) complexVector;
+    signed char* outPtr = (signed char*)magnitudeVector;
+    const signed char* inPtr = (const signed char*)complexVector;
 
     for (size_t vl; n > 0; n -= vl, outPtr += vl, inPtr += vl * 2)
         {

--- a/src/algorithms/libs/volk_gnsssdr_module/volk_gnsssdr/kernels/volk_gnsssdr/volk_gnsssdr_8ic_magnitude_squared_8i.h
+++ b/src/algorithms/libs/volk_gnsssdr_module/volk_gnsssdr/kernels/volk_gnsssdr/volk_gnsssdr_8ic_magnitude_squared_8i.h
@@ -175,6 +175,49 @@ static inline void volk_gnsssdr_8ic_magnitude_squared_8i_a_sse3(char* magnitudeV
 #endif /* LV_HAVE_SSSE3 */
 
 
+#ifdef LV_HAVE_RVV
+#include <riscv_vector.h>
+
+static inline void volk_gnsssdr_8ic_magnitude_squared_8i_rvv(char* magnitudeVector, const lv_8sc_t* complexVector, unsigned int num_points)
+{
+    size_t n = num_points;
+
+    // Initialize pointers to track progress as stripmine
+    // Assuming that intended to use `signed char`,
+    // as `char`'s signedness is implementation-specific
+    signed char* outPtr = (signed char*) magnitudeVector;
+    const signed char* inPtr = (const signed char*) complexVector;
+
+    for (size_t vl; n > 0; n -= vl, outPtr += vl, inPtr += vl * 2)
+        {
+            // Record how many elements will actually be processed
+            vl = __riscv_vsetvl_e8m4(n);
+
+            // Load inReal[0..vl), inImag[0..vl)
+            vint8m4x2_t inVal = __riscv_vlseg2e8_v_i8m4x2(inPtr, vl);
+            vint8m4_t inRealVal = __riscv_vget_v_i8m4x2_i8m4(inVal, 0);
+            vint8m4_t inImagVal = __riscv_vget_v_i8m4x2_i8m4(inVal, 1);
+
+            // mag[i] = inReal[i] * inReal[i]
+            vint8m4_t magVal = __riscv_vmul_vv_i8m4(inRealVal, inRealVal, vl);
+
+            // mag[i] = (inImag[i] * inImag[i]) + mag[i]
+            magVal = __riscv_vmacc_vv_i8m4(magVal, inImagVal, inImagVal, vl);
+
+            // Store mag[0..vl)
+            __riscv_vse8_v_i8m4(outPtr, magVal, vl);
+
+            // In looping, decrease the number of
+            // elements left and increment the pointers
+            // by the number of elements processed,
+            // taking into account how each complex number
+            // stored in `inPtr` is two 1-byte `char`s
+        }
+}
+
+#endif /* LV_HAVE_RVV */
+
+
 #ifdef LV_HAVE_ORC
 
 extern void volk_gnsssdr_8ic_magnitude_squared_8i_a_orc_impl(char* magnitudeVector, const lv_8sc_t* complexVector, unsigned int num_points);

--- a/src/algorithms/libs/volk_gnsssdr_module/volk_gnsssdr/kernels/volk_gnsssdr/volk_gnsssdr_8ic_x2_dot_prod_8ic.h
+++ b/src/algorithms/libs/volk_gnsssdr_module/volk_gnsssdr/kernels/volk_gnsssdr/volk_gnsssdr_8ic_x2_dot_prod_8ic.h
@@ -483,4 +483,83 @@ static inline void volk_gnsssdr_8ic_x2_dot_prod_8ic_neon(lv_8sc_t* result, const
 }
 #endif /* LV_HAVE_NEON */
 
+
+#ifdef LV_HAVE_RVV
+#include <riscv_vector.h>
+
+static inline void volk_gnsssdr_8ic_x2_dot_prod_8ic_rvv(lv_8sc_t* result, const lv_8sc_t* in_a, const lv_8sc_t* in_b, unsigned int num_points)
+{
+    size_t n = num_points;
+
+    // Explicitly cast in order to directly fill
+    // with calculated values
+    signed char* resPtr = (signed char*) result;
+
+    // Initialize pointers to track progress as stripmine
+    // Assuming that intended to use `signed char`,
+    // as `char`'s signedness is implementation-specific
+    const signed char* aPtr = (const signed char*) in_a;
+    const signed char* bPtr = (const signed char*) in_b;
+
+    // accReal[0] = 0
+    vint8m1_t accRealVal = __riscv_vmv_s_x_i8m1(0, 1);
+    // accImag[0] = 0
+    vint8m1_t accImagVal = __riscv_vmv_s_x_i8m1(0, 1);
+
+    for (size_t vl; n > 0; n -= vl, aPtr += vl * 2, bPtr += vl * 2)
+        {
+            // Record how many elements will actually be processed
+            // Using an EMUL of 4 so that can maximize vector group
+            // length while having 6 register groups used at full
+            // capacity (with 2 vector registers being used to
+            // each store a single scalar)
+            vl = __riscv_vsetvl_e8m4(n);
+
+            // Given that complex numbers are stored as
+            // addr: aPtr    | aPtr + 1 | aPtr + 2 | aPtr + 3
+            //       real_0  | imag_0   | real_1   | imag_1
+            // Load aReal[0..vl), aImag[0..vl)
+            vint8m4x2_t aVal = __riscv_vlseg2e8_v_i8m4x2(aPtr, vl);
+            vint8m4_t aRealVal = __riscv_vget_v_i8m4x2_i8m4(aVal, 0);
+            vint8m4_t aImagVal = __riscv_vget_v_i8m4x2_i8m4(aVal, 1);
+
+            // Load bReal[0..vl), vImag[0..vl)
+            vint8m4x2_t bVal = __riscv_vlseg2e8_v_i8m4x2(bPtr, vl);
+            vint8m4_t bRealVal = __riscv_vget_v_i8m4x2_i8m4(bVal, 0);
+            vint8m4_t bImagVal = __riscv_vget_v_i8m4x2_i8m4(bVal, 1);
+
+            // outReal[i] = aReal[i] * bReal[i]
+            vint8m4_t outRealVal = __riscv_vmul_vv_i8m4(aRealVal, bRealVal, vl);
+
+            // outReal[i] = -(aImag[i] * bImag[i]) + outReal[i]
+            outRealVal = __riscv_vnmsac_vv_i8m4(outRealVal, aImagVal, bImagVal, vl);
+
+            // accReal[0] = sum( accReal[0], outReal[0..vl) )
+            accRealVal = __riscv_vredsum_vs_i8m4_i8m1(outRealVal, accRealVal, vl);
+
+            // outImag[i] = aReal[i] * bImag[i]
+            vint8m4_t outImagVal = __riscv_vmul_vv_i8m4(aRealVal, bImagVal, vl);
+
+            // outImag[i] = (aImag[i] * bReal[i]) + outImag[i]
+            outImagVal = __riscv_vmacc_vv_i8m4(outImagVal, aImagVal, bRealVal, vl);
+
+            // accImag[0] = sum( accImag[0], outImag[0..vl) )
+            accImagVal = __riscv_vredsum_vs_i8m4_i8m1(outImagVal, accImagVal, vl);
+
+            // In looping, decrement the number of
+            // elements left and increment the pointers
+            // by the number of elements processed.
+            // However, have to account for how `vl`
+            // complex numbers are being loaded, meaning
+            // that `vl * 2` `signed char`s are being
+            // loaded from both `aPtr` and `bPtr`
+        }
+
+    // Real part of resultant complex number
+    resPtr[0] = __riscv_vmv_x_s_i8m1_i8(accRealVal);
+    // Complex part of resultant complex number
+    resPtr[1] = __riscv_vmv_x_s_i8m1_i8(accImagVal);
+}
+#endif /* LV_HAVE_RVV */
+
 #endif /*INCLUDED_volk_gnsssdr_8ic_x2_dot_prod_8ic_H*/

--- a/src/algorithms/libs/volk_gnsssdr_module/volk_gnsssdr/kernels/volk_gnsssdr/volk_gnsssdr_8ic_x2_dot_prod_8ic.h
+++ b/src/algorithms/libs/volk_gnsssdr_module/volk_gnsssdr/kernels/volk_gnsssdr/volk_gnsssdr_8ic_x2_dot_prod_8ic.h
@@ -493,13 +493,13 @@ static inline void volk_gnsssdr_8ic_x2_dot_prod_8ic_rvv(lv_8sc_t* result, const 
 
     // Explicitly cast in order to directly fill
     // with calculated values
-    signed char* resPtr = (signed char*) result;
+    signed char* resPtr = (signed char*)result;
 
     // Initialize pointers to track progress as stripmine
     // Assuming that intended to use `signed char`,
     // as `char`'s signedness is implementation-specific
-    const signed char* aPtr = (const signed char*) in_a;
-    const signed char* bPtr = (const signed char*) in_b;
+    const signed char* aPtr = (const signed char*)in_a;
+    const signed char* bPtr = (const signed char*)in_b;
 
     // accReal[0] = 0
     vint8m1_t accRealVal = __riscv_vmv_s_x_i8m1(0, 1);

--- a/src/algorithms/libs/volk_gnsssdr_module/volk_gnsssdr/kernels/volk_gnsssdr/volk_gnsssdr_8ic_x2_multiply_8ic.h
+++ b/src/algorithms/libs/volk_gnsssdr_module/volk_gnsssdr/kernels/volk_gnsssdr/volk_gnsssdr_8ic_x2_multiply_8ic.h
@@ -287,6 +287,62 @@ static inline void volk_gnsssdr_8ic_x2_multiply_8ic_a_sse4_1(lv_8sc_t* cVector, 
 #endif /* LV_HAVE_SSE4_1 */
 
 
+#ifdef LV_HAVE_RVV
+#include <riscv_vector.h>
+
+static inline void volk_gnsssdr_8ic_x2_multiply_8ic_rvv(lv_8sc_t* cVector, const lv_8sc_t* aVector, const lv_8sc_t* bVector, unsigned int num_points) {
+    size_t n = num_points;
+
+    // Initialize pointers to track progress as stripmine
+    // Assuming that intended to use `signed char`
+    // as `char`'s signedness is implementation-specific
+    signed char* cPtr = (signed char*) cVector;
+    const signed char* aPtr = (const signed char*) aVector;
+    const signed char* bPtr = (const signed char*) bVector;
+
+    for (size_t vl; n > 0; n -= vl, cPtr += vl * 2, aPtr += vl * 2, bPtr += vl * 2) {
+        // Record how many elements will actually be processed
+        vl = __riscv_vsetvl_e8m4(n);
+
+        // Load aReal[0..vl), aImag[0..vl)
+        vint8m4x2_t aVal = __riscv_vlseg2e8_v_i8m4x2(aPtr, vl);
+        vint8m4_t aRealVal = __riscv_vget_v_i8m4x2_i8m4(aVal, 0);
+        vint8m4_t aImagVal = __riscv_vget_v_i8m4x2_i8m4(aVal, 1);
+
+        // Load bReal[0..vl), bImag[0..vl)
+        vint8m4x2_t bVal = __riscv_vlseg2e8_v_i8m4x2(bPtr, vl);
+        vint8m4_t bRealVal = __riscv_vget_v_i8m4x2_i8m4(bVal, 0);
+        vint8m4_t bImagVal = __riscv_vget_v_i8m4x2_i8m4(bVal, 1);
+
+        // cReal[i] = aReal[i] * bReal[i]
+        vint8m4_t cRealVal = __riscv_vmul_vv_i8m4(aRealVal, bRealVal, vl);
+
+        // cReal[i] = -(aImag[i] * bImag[i]) + cReal[i]
+        cRealVal = __riscv_vnmsac_vv_i8m4(cRealVal, aImagVal, bImagVal, vl);
+
+        // cImag[i] = aReal[i] * bImag[i]
+        vint8m4_t cImagVal = __riscv_vmul_vv_i8m4(aRealVal, bImagVal, vl);
+
+        // cImag[i] = (aImag[i] * bReal[i]) + cImag[i]
+        cImagVal = __riscv_vmacc_vv_i8m4(cImagVal, aImagVal, bRealVal, vl);
+
+        // Store cReal[0..vl), cImag[0..vl)
+        vint8m4x2_t cVal = __riscv_vset_v_i8m4_i8m4x2(
+            __riscv_vundefined_i8m4x2(), 0, cRealVal
+        );
+        cVal = __riscv_vset_v_i8m4_i8m4x2(cVal, 1, cImagVal);
+        __riscv_vsseg2e8_v_i8m4x2(cPtr, cVal, vl);
+
+        // In looping, decrement the number of
+        // elements left and increment the pointers
+        // by the number of elements processed,
+        // taking into account how the `vl` complex
+        // numbers are each stored as two 1-byte `char`s
+    }
+}
+#endif /* LV_HAVE_RVV */
+
+
 #ifdef LV_HAVE_ORC
 
 extern void volk_gnsssdr_8ic_x2_multiply_8ic_a_orc_impl(lv_8sc_t* cVector, const lv_8sc_t* aVector, const lv_8sc_t* bVector, unsigned int num_points);

--- a/src/algorithms/libs/volk_gnsssdr_module/volk_gnsssdr/kernels/volk_gnsssdr/volk_gnsssdr_8ic_x2_multiply_8ic.h
+++ b/src/algorithms/libs/volk_gnsssdr_module/volk_gnsssdr/kernels/volk_gnsssdr/volk_gnsssdr_8ic_x2_multiply_8ic.h
@@ -327,10 +327,7 @@ static inline void volk_gnsssdr_8ic_x2_multiply_8ic_rvv(lv_8sc_t* cVector, const
         cImagVal = __riscv_vmacc_vv_i8m4(cImagVal, aImagVal, bRealVal, vl);
 
         // Store cReal[0..vl), cImag[0..vl)
-        vint8m4x2_t cVal = __riscv_vset_v_i8m4_i8m4x2(
-            __riscv_vundefined_i8m4x2(), 0, cRealVal
-        );
-        cVal = __riscv_vset_v_i8m4_i8m4x2(cVal, 1, cImagVal);
+        vint8m4x2_t cVal = __riscv_vcreate_v_i8m4x2(cRealVal, cImagVal);
         __riscv_vsseg2e8_v_i8m4x2(cPtr, cVal, vl);
 
         // In looping, decrement the number of

--- a/src/algorithms/libs/volk_gnsssdr_module/volk_gnsssdr/kernels/volk_gnsssdr/volk_gnsssdr_8ic_x2_multiply_8ic.h
+++ b/src/algorithms/libs/volk_gnsssdr_module/volk_gnsssdr/kernels/volk_gnsssdr/volk_gnsssdr_8ic_x2_multiply_8ic.h
@@ -290,52 +290,54 @@ static inline void volk_gnsssdr_8ic_x2_multiply_8ic_a_sse4_1(lv_8sc_t* cVector, 
 #ifdef LV_HAVE_RVV
 #include <riscv_vector.h>
 
-static inline void volk_gnsssdr_8ic_x2_multiply_8ic_rvv(lv_8sc_t* cVector, const lv_8sc_t* aVector, const lv_8sc_t* bVector, unsigned int num_points) {
+static inline void volk_gnsssdr_8ic_x2_multiply_8ic_rvv(lv_8sc_t* cVector, const lv_8sc_t* aVector, const lv_8sc_t* bVector, unsigned int num_points)
+{
     size_t n = num_points;
 
     // Initialize pointers to track progress as stripmine
     // Assuming that intended to use `signed char`
     // as `char`'s signedness is implementation-specific
-    signed char* cPtr = (signed char*) cVector;
-    const signed char* aPtr = (const signed char*) aVector;
-    const signed char* bPtr = (const signed char*) bVector;
+    signed char* cPtr = (signed char*)cVector;
+    const signed char* aPtr = (const signed char*)aVector;
+    const signed char* bPtr = (const signed char*)bVector;
 
-    for (size_t vl; n > 0; n -= vl, cPtr += vl * 2, aPtr += vl * 2, bPtr += vl * 2) {
-        // Record how many elements will actually be processed
-        vl = __riscv_vsetvl_e8m4(n);
+    for (size_t vl; n > 0; n -= vl, cPtr += vl * 2, aPtr += vl * 2, bPtr += vl * 2)
+        {
+            // Record how many elements will actually be processed
+            vl = __riscv_vsetvl_e8m4(n);
 
-        // Load aReal[0..vl), aImag[0..vl)
-        vint8m4x2_t aVal = __riscv_vlseg2e8_v_i8m4x2(aPtr, vl);
-        vint8m4_t aRealVal = __riscv_vget_v_i8m4x2_i8m4(aVal, 0);
-        vint8m4_t aImagVal = __riscv_vget_v_i8m4x2_i8m4(aVal, 1);
+            // Load aReal[0..vl), aImag[0..vl)
+            vint8m4x2_t aVal = __riscv_vlseg2e8_v_i8m4x2(aPtr, vl);
+            vint8m4_t aRealVal = __riscv_vget_v_i8m4x2_i8m4(aVal, 0);
+            vint8m4_t aImagVal = __riscv_vget_v_i8m4x2_i8m4(aVal, 1);
 
-        // Load bReal[0..vl), bImag[0..vl)
-        vint8m4x2_t bVal = __riscv_vlseg2e8_v_i8m4x2(bPtr, vl);
-        vint8m4_t bRealVal = __riscv_vget_v_i8m4x2_i8m4(bVal, 0);
-        vint8m4_t bImagVal = __riscv_vget_v_i8m4x2_i8m4(bVal, 1);
+            // Load bReal[0..vl), bImag[0..vl)
+            vint8m4x2_t bVal = __riscv_vlseg2e8_v_i8m4x2(bPtr, vl);
+            vint8m4_t bRealVal = __riscv_vget_v_i8m4x2_i8m4(bVal, 0);
+            vint8m4_t bImagVal = __riscv_vget_v_i8m4x2_i8m4(bVal, 1);
 
-        // cReal[i] = aReal[i] * bReal[i]
-        vint8m4_t cRealVal = __riscv_vmul_vv_i8m4(aRealVal, bRealVal, vl);
+            // cReal[i] = aReal[i] * bReal[i]
+            vint8m4_t cRealVal = __riscv_vmul_vv_i8m4(aRealVal, bRealVal, vl);
 
-        // cReal[i] = -(aImag[i] * bImag[i]) + cReal[i]
-        cRealVal = __riscv_vnmsac_vv_i8m4(cRealVal, aImagVal, bImagVal, vl);
+            // cReal[i] = -(aImag[i] * bImag[i]) + cReal[i]
+            cRealVal = __riscv_vnmsac_vv_i8m4(cRealVal, aImagVal, bImagVal, vl);
 
-        // cImag[i] = aReal[i] * bImag[i]
-        vint8m4_t cImagVal = __riscv_vmul_vv_i8m4(aRealVal, bImagVal, vl);
+            // cImag[i] = aReal[i] * bImag[i]
+            vint8m4_t cImagVal = __riscv_vmul_vv_i8m4(aRealVal, bImagVal, vl);
 
-        // cImag[i] = (aImag[i] * bReal[i]) + cImag[i]
-        cImagVal = __riscv_vmacc_vv_i8m4(cImagVal, aImagVal, bRealVal, vl);
+            // cImag[i] = (aImag[i] * bReal[i]) + cImag[i]
+            cImagVal = __riscv_vmacc_vv_i8m4(cImagVal, aImagVal, bRealVal, vl);
 
-        // Store cReal[0..vl), cImag[0..vl)
-        vint8m4x2_t cVal = __riscv_vcreate_v_i8m4x2(cRealVal, cImagVal);
-        __riscv_vsseg2e8_v_i8m4x2(cPtr, cVal, vl);
+            // Store cReal[0..vl), cImag[0..vl)
+            vint8m4x2_t cVal = __riscv_vcreate_v_i8m4x2(cRealVal, cImagVal);
+            __riscv_vsseg2e8_v_i8m4x2(cPtr, cVal, vl);
 
-        // In looping, decrement the number of
-        // elements left and increment the pointers
-        // by the number of elements processed,
-        // taking into account how the `vl` complex
-        // numbers are each stored as two 1-byte `char`s
-    }
+            // In looping, decrement the number of
+            // elements left and increment the pointers
+            // by the number of elements processed,
+            // taking into account how the `vl` complex
+            // numbers are each stored as two 1-byte `char`s
+        }
 }
 #endif /* LV_HAVE_RVV */
 

--- a/src/algorithms/libs/volk_gnsssdr_module/volk_gnsssdr/kernels/volk_gnsssdr/volk_gnsssdr_8u_x2_multiply_8u.h
+++ b/src/algorithms/libs/volk_gnsssdr_module/volk_gnsssdr/kernels/volk_gnsssdr/volk_gnsssdr_8u_x2_multiply_8u.h
@@ -279,8 +279,7 @@ static inline void volk_gnsssdr_8u_x2_multiply_8u_rvv(unsigned char* cVector, co
 
     for (size_t vl; n > 0; n -= vl, cPtr += vl, aPtr += vl, bPtr += vl)
         {
-            // Initialize state to handle maximum
-            // size vectors of bytes
+            // Record how many elements will actually be processed
             vl = __riscv_vsetvl_e8m8(n);
 
             // Load a[0..vl), b[0..vl)

--- a/src/algorithms/libs/volk_gnsssdr_module/volk_gnsssdr/kernels/volk_gnsssdr/volk_gnsssdr_8u_x2_multiply_8u.h
+++ b/src/algorithms/libs/volk_gnsssdr_module/volk_gnsssdr/kernels/volk_gnsssdr/volk_gnsssdr_8u_x2_multiply_8u.h
@@ -263,6 +263,45 @@ static inline void volk_gnsssdr_8u_x2_multiply_8u_a_avx2(unsigned char* cChar, c
 #endif /* LV_HAVE_SSE3 */
 
 
+
+#ifdef LV_HAVE_RVV
+#include <riscv_vector.h>
+
+static inline void volk_gnsssdr_8u_x2_multiply_8u_rvv(unsigned char* cVector, const unsigned char* aVector, const unsigned char* bVector, unsigned int num_points)
+{
+    size_t n = num_points;
+
+    // Initialize pointers to keep track
+    // while stripmining
+    unsigned char* cPtr = cVector;
+    const unsigned char* aPtr = aVector;
+    const unsigned char* bPtr = bVector;
+
+    for (size_t vl; n > 0; n -= vl, cPtr += vl, aPtr += vl, bPtr += vl)
+        {
+            // Initialize state to handle maximum
+            // size vectors of bytes
+            vl = __riscv_vsetvl_e8m8(n);
+
+            // Load a[0..vl), b[0..vl)
+            vuint8m8_t aVal = __riscv_vle8_v_u8m8(aPtr, vl);
+            vuint8m8_t bVal = __riscv_vle8_v_u8m8(bPtr, vl);
+
+            // c[i] = lower byte of (a[i] * b[i])
+            vuint8m8_t cVal = __riscv_vmul_vv_u8m8(aVal, bVal, vl);
+
+            // Store c[0..vl)
+            __riscv_vse8_v_u8m8(cPtr, cVal, vl);
+
+            // In looping, decrease the number of
+            // elements left and increment the pointers
+            // by the number of elements processed
+        }
+}
+
+#endif /* LV_HAVE_RVV */
+
+
 #ifdef LV_HAVE_ORC
 
 extern void volk_gnsssdr_8u_x2_multiply_8u_a_orc_impl(unsigned char* cVector, const unsigned char* aVector, const unsigned char* bVector, unsigned int num_points);

--- a/src/algorithms/libs/volk_gnsssdr_module/volk_gnsssdr/kernels/volk_gnsssdr/volk_gnsssdr_8u_x2_multiply_8u.h
+++ b/src/algorithms/libs/volk_gnsssdr_module/volk_gnsssdr/kernels/volk_gnsssdr/volk_gnsssdr_8u_x2_multiply_8u.h
@@ -263,7 +263,6 @@ static inline void volk_gnsssdr_8u_x2_multiply_8u_a_avx2(unsigned char* cChar, c
 #endif /* LV_HAVE_SSE3 */
 
 
-
 #ifdef LV_HAVE_RVV
 #include <riscv_vector.h>
 

--- a/src/algorithms/libs/volk_gnsssdr_module/volk_gnsssdr/kernels/volk_gnsssdr/volk_gnsssdr_s32f_sincos_32fc.h
+++ b/src/algorithms/libs/volk_gnsssdr_module/volk_gnsssdr/kernels/volk_gnsssdr/volk_gnsssdr_s32f_sincos_32fc.h
@@ -932,4 +932,152 @@ static inline void volk_gnsssdr_s32f_sincos_32fc_neon(lv_32fc_t *out, const floa
 
 #endif /* LV_HAVE_NEON  */
 
+
+#ifdef LV_HAVE_RVV
+#include <riscv_vector.h>
+
+// Reverse-engineered from NEON implementation
+static inline void volk_gnsssdr_s32f_sincos_32fc_rvv(lv_32fc_t* out, const float phase_inc, float* phase, unsigned int num_points)
+{
+    // Copied from other implementations, specifically NEON
+    const float c_minus_cephes_DP1 = -0.78515625;
+    const float c_minus_cephes_DP2 = -2.4187564849853515625e-4;
+    const float c_minus_cephes_DP3 = -3.77489497744594108e-8;
+    const float c_sincof_p0 = -1.9515295891E-4;
+    const float c_sincof_p1 = 8.3321608736E-3;
+    const float c_sincof_p2 = -1.6666654611E-1;
+    const float c_coscof_p0 = 2.443315711809948E-005;
+    const float c_coscof_p1 = -1.388731625493765E-003;
+    const float c_coscof_p2 = 4.166664568298827E-002;
+    const float c_cephes_FOPI = 1.27323954473516;
+
+    size_t n = num_points;
+
+    // Initialize other pointers for consistency
+    float* phasePtr = phase;
+
+    // Initialize pointers to keep track as stripmine
+    float* outPtr = (float*) out;
+
+    for (size_t vl; n > 0; n -= vl, outPtr += vl * 2)
+        {
+            // Record how many elements will actually be processed
+            vl = __riscv_vsetvl_e32m4(n);
+
+            // Splat phase
+            vfloat32m4_t phaseVal = __riscv_vfmv_v_f_f32m4(*phasePtr, vl);
+
+            // Splat phaseInc
+            vfloat32m4_t phaseIncVal = __riscv_vfmv_v_f_f32m4(phase_inc, vl);
+
+            // iterFloat[i] = (float) i
+            vuint32m4_t iterVal = __riscv_vid_v_u32m4(vl);
+            vfloat32m4_t iterFloatVal = __riscv_vfcvt_f_xu_v_f32m4(iterVal, vl);
+
+            // phase[i] = +( iterFloat[i] * phaseInc[i] ) + phase[i]
+            phaseVal = __riscv_vfmacc_vv_f32m4(phaseVal, iterFloatVal, phaseIncVal, vl);
+
+            // Save initial signs
+            // signMask[i] = phase[i] < 0
+            vbool8_t signMask = __riscv_vmflt_vf_f32m4_b8(phaseVal, (float) 0, vl);
+
+            // x[i] = |phase[i]|
+            vfloat32m4_t xVal = __riscv_vfabs_v_f32m4(phaseVal, vl);
+
+            // y[i] = (4/PI) * x[i]
+            vfloat32m4_t yVal = __riscv_vfmul_vf_f32m4(xVal, c_cephes_FOPI, vl);
+
+            // Quantize (reduce) y into discrete chunks to approximate into,
+            // and use the integer version to do some neat bit masking in order
+            // to encode sin/cos signs
+            // reduced[i] = ( ((unsigned int) y[i] + 1) / 2 ) * 2 = ((unsigned int) y[i] + 1) & ~1
+            vuint32m4_t reducedVal = __riscv_vfcvt_xu_f_v_u32m4(yVal, vl);
+            reducedVal = __riscv_vadd_vx_u32m4(reducedVal, 1, vl);
+            reducedVal = __riscv_vand_vx_u32m4(reducedVal, ~1, vl);
+
+            // Save which polynomial should be used
+            // polyMask[i] = reduced[i] & 2 != 0
+            vuint32m4_t polyTempVal = __riscv_vand_vx_u32m4(reducedVal, 2, vl);
+            vbool8_t polyMask = __riscv_vmsne_vx_u32m4_b8(polyTempVal, 0, vl);
+
+            // Save sign value for sin, cos, encoded within LSB 3:1
+            // sinSignMask[i] = signMask[i] ^ ( reduced[i] & 4 != 0 )
+            vuint32m4_t sinSignTempVal = __riscv_vand_vx_u32m4(reducedVal, 4, vl);
+            vbool8_t sinSignMask = __riscv_vmsne_vx_u32m4_b8(sinSignTempVal, 0, vl);
+            sinSignMask = __riscv_vmxor_mm_b8(signMask, sinSignMask, vl);
+
+            // Encoded the opposite to sinSignMask, i.e. 0 is positive for cosSignMask
+            // cosSignMask[i] = ( reduced[i] - 2 ) & 4 != 0
+            vuint32m4_t cosSignTempVal = __riscv_vsub_vx_u32m4(reducedVal, 2, vl);
+            cosSignTempVal = __riscv_vand_vx_u32m4(cosSignTempVal, 4, vl);
+            vbool8_t cosSignMask = __riscv_vmsne_vx_u32m4_b8(cosSignTempVal, 0, vl);
+
+            // reducedY[i] = (float) reduced[i]
+            vfloat32m4_t reducedYVal = __riscv_vfcvt_f_xu_v_f32m4(reducedVal, vl);
+
+            // The magic pass: "Extended precision modular arithmetic"
+            // x[i] = ((in[i] + reducedY[i] * -DP1) + reducedY[i] * -DP2) + reducedY[i] * -DP3;
+            vfloat32m4_t xmm1Val = __riscv_vfmul_vf_f32m4(reducedYVal, c_minus_cephes_DP1, vl);
+            xVal = __riscv_vfadd_vv_f32m4(xVal, xmm1Val, vl);
+            vfloat32m4_t xmm2Val = __riscv_vfmul_vf_f32m4(reducedYVal, c_minus_cephes_DP2, vl);
+            xVal = __riscv_vfadd_vv_f32m4(xVal, xmm2Val, vl);
+            vfloat32m4_t xmm3Val = __riscv_vfmul_vf_f32m4(reducedYVal, c_minus_cephes_DP3, vl);
+            xVal = __riscv_vfadd_vv_f32m4(xVal, xmm3Val, vl);
+
+            // Calculate both polynomials; one for 0 <= x <= PI / 4,
+            //  other for PI / 4 <= x <= PI / 2
+            vfloat32m4_t xSqVal = __riscv_vfmul_vv_f32m4(xVal, xVal, vl);
+
+            vfloat32m4_t y1Val = __riscv_vfmul_vf_f32m4(xSqVal, c_coscof_p0, vl);
+            y1Val = __riscv_vfadd_vf_f32m4(y1Val, c_coscof_p1, vl);
+            y1Val = __riscv_vfmul_vv_f32m4(y1Val, xSqVal, vl);
+            y1Val = __riscv_vfadd_vf_f32m4(y1Val, c_coscof_p2, vl);
+            y1Val = __riscv_vfmul_vv_f32m4(y1Val, xSqVal, vl);
+            y1Val = __riscv_vfmul_vv_f32m4(y1Val, xSqVal, vl);
+            y1Val = __riscv_vfsub_vv_f32m4(y1Val, __riscv_vfmul_vf_f32m4(xSqVal, 0.5f, vl), vl);
+            y1Val = __riscv_vfadd_vf_f32m4(y1Val, 1, vl);
+
+            vfloat32m4_t y2Val = __riscv_vfmul_vf_f32m4(xSqVal, c_sincof_p0, vl);
+            y2Val = __riscv_vfadd_vf_f32m4(y2Val, c_sincof_p1, vl);
+            y2Val = __riscv_vfmul_vv_f32m4(y2Val, xSqVal, vl);
+            y2Val = __riscv_vfadd_vf_f32m4(y2Val, c_sincof_p2, vl);
+            y2Val = __riscv_vfmul_vv_f32m4(y2Val, xSqVal, vl);
+            y2Val = __riscv_vfmul_vv_f32m4(y2Val, xVal, vl);
+            y2Val = __riscv_vfadd_vv_f32m4(y2Val, xVal, vl);
+
+            // Output results
+            // sin[i] = polyMask ? y1[i] : y2[i]
+            // cos[i] = polyMask ? y2[i] : y1[i]
+            vfloat32m4_t sinVal = __riscv_vmerge_vvm_f32m4(y2Val, y1Val, polyMask, vl);
+            vfloat32m4_t cosVal = __riscv_vmerge_vvm_f32m4(y1Val, y2Val, polyMask, vl);
+
+            // outImag[i] = sinSignMask ? -sin[i] : sin[i]
+            // outReal[i] = cosSignMask ? cos[i] : -cos[i]
+            vfloat32m4_t outImagVal = __riscv_vmerge_vvm_f32m4(
+                sinVal, __riscv_vfneg_v_f32m4(sinVal, vl), sinSignMask, vl
+            );
+            vfloat32m4_t outRealVal = __riscv_vmerge_vvm_f32m4(
+                __riscv_vfneg_v_f32m4(cosVal, vl), cosVal, cosSignMask, vl
+            );
+
+            // Store out[0..vl)
+            vfloat32m4x2_t outVal = __riscv_vcreate_v_f32m4x2(outRealVal, outImagVal);
+            __riscv_vsseg2e32_v_f32m4x2(outPtr, outVal, vl);
+
+            // Store phase[vl - 1]
+            phaseVal = __riscv_vslidedown_vx_f32m4(phaseVal, vl - 1, vl);
+            *phasePtr = __riscv_vfmv_f_s_f32m4_f32(phaseVal);
+
+            // Account for increment after last calculation
+            *phasePtr += phase_inc;
+
+            // In looping, decrement the number of
+            // elements left and increment the pointers
+            // by the number of elements processed,
+            // taking into account how the output `vl` 
+            // complex numbers are stored as 2 `float`s
+        }
+}
+
+#endif /* LV_HAVE_RVV */
 #endif /* INCLUDED_volk_gnsssdr_s32f_sincos_32fc_H */

--- a/src/algorithms/libs/volk_gnsssdr_module/volk_gnsssdr/kernels/volk_gnsssdr/volk_gnsssdr_s32f_sincos_32fc.h
+++ b/src/algorithms/libs/volk_gnsssdr_module/volk_gnsssdr/kernels/volk_gnsssdr/volk_gnsssdr_s32f_sincos_32fc.h
@@ -937,7 +937,7 @@ static inline void volk_gnsssdr_s32f_sincos_32fc_neon(lv_32fc_t *out, const floa
 #include <riscv_vector.h>
 
 // Reverse-engineered from NEON implementation
-static inline void volk_gnsssdr_s32f_sincos_32fc_rvv(lv_32fc_t* out, const float phase_inc, float* phase, unsigned int num_points)
+static inline void volk_gnsssdr_s32f_sincos_32fc_rvv(lv_32fc_t *out, const float phase_inc, float *phase, unsigned int num_points)
 {
     // Copied from other implementations, specifically NEON
     const float c_minus_cephes_DP1 = -0.78515625;
@@ -954,10 +954,10 @@ static inline void volk_gnsssdr_s32f_sincos_32fc_rvv(lv_32fc_t* out, const float
     size_t n = num_points;
 
     // Initialize other pointers for consistency
-    float* phasePtr = phase;
+    float *phasePtr = phase;
 
     // Initialize pointers to keep track as stripmine
-    float* outPtr = (float*) out;
+    float *outPtr = (float *)out;
 
     for (size_t vl; n > 0; n -= vl, outPtr += vl * 2)
         {
@@ -979,7 +979,7 @@ static inline void volk_gnsssdr_s32f_sincos_32fc_rvv(lv_32fc_t* out, const float
 
             // Save initial signs
             // signMask[i] = phase[i] < 0
-            vbool8_t signMask = __riscv_vmflt_vf_f32m4_b8(phaseVal, (float) 0, vl);
+            vbool8_t signMask = __riscv_vmflt_vf_f32m4_b8(phaseVal, (float)0, vl);
 
             // x[i] = |phase[i]|
             vfloat32m4_t xVal = __riscv_vfabs_v_f32m4(phaseVal, vl);
@@ -1054,11 +1054,9 @@ static inline void volk_gnsssdr_s32f_sincos_32fc_rvv(lv_32fc_t* out, const float
             // outImag[i] = sinSignMask ? -sin[i] : sin[i]
             // outReal[i] = cosSignMask ? cos[i] : -cos[i]
             vfloat32m4_t outImagVal = __riscv_vmerge_vvm_f32m4(
-                sinVal, __riscv_vfneg_v_f32m4(sinVal, vl), sinSignMask, vl
-            );
+                sinVal, __riscv_vfneg_v_f32m4(sinVal, vl), sinSignMask, vl);
             vfloat32m4_t outRealVal = __riscv_vmerge_vvm_f32m4(
-                __riscv_vfneg_v_f32m4(cosVal, vl), cosVal, cosSignMask, vl
-            );
+                __riscv_vfneg_v_f32m4(cosVal, vl), cosVal, cosSignMask, vl);
 
             // Store out[0..vl)
             vfloat32m4x2_t outVal = __riscv_vcreate_v_f32m4x2(outRealVal, outImagVal);
@@ -1074,7 +1072,7 @@ static inline void volk_gnsssdr_s32f_sincos_32fc_rvv(lv_32fc_t* out, const float
             // In looping, decrement the number of
             // elements left and increment the pointers
             // by the number of elements processed,
-            // taking into account how the output `vl` 
+            // taking into account how the output `vl`
             // complex numbers are stored as 2 `float`s
         }
 }

--- a/src/algorithms/libs/volk_gnsssdr_module/volk_gnsssdr/kernels/volk_gnsssdr/volk_gnsssdr_s32f_sincospuppet_32fc.h
+++ b/src/algorithms/libs/volk_gnsssdr_module/volk_gnsssdr/kernels/volk_gnsssdr/volk_gnsssdr_s32f_sincospuppet_32fc.h
@@ -98,4 +98,14 @@ static inline void volk_gnsssdr_s32f_sincospuppet_32fc_neon(lv_32fc_t* out, cons
 }
 #endif /* LV_HAVE_NEON  */
 
+
+#ifdef LV_HAVE_RVV
+static inline void volk_gnsssdr_s32f_sincospuppet_32fc_rvv(lv_32fc_t* out, const float phase_inc, unsigned int num_points)
+{
+    float phase[1];
+    phase[0] = 3;
+    volk_gnsssdr_s32f_sincos_32fc_rvv(out, phase_inc, phase, num_points);
+}
+#endif /* LV_HAVE_RVV  */
+
 #endif /* INCLUDED_volk_gnsssdr_s32f_sincospuppet_32fc_H */


### PR DESCRIPTION
# RVV Implementations for VOLK GNSS-SDR Kernels
Contains RISC-V Vector (RVV) implementations for most kernels within `volk_gnsssdr` (as of 9/14/2025 in `src/algorithms/libs/volk_gnsssdr_module/volk_gnsssdr`). Unfortunately, code could not be tested on real RVV hardware, and so Github Actions was used to emulate it (specifically [`uraimo/run-on-arch-action`](https://github.com/uraimo/run-on-arch-action), which uses QEMU). Characterization was based upon the already provided `volk_gnsssdr_profile`, and while results varied between kernels and compiler used, overall the `rvv` implementations were often faster (though not always).

## Characterization Samples
From this [g++ compilation on riscv64 job](https://github.com/BigTurtle8/gnss-sdr/actions/runs/17707865121/job/50322374408):
```
RUN_VOLK_GNSSSDR_TESTS: volk_gnsssdr_16ic_convert_32fc(8111,100000)
generic completed in 47438.7 ms
rvv completed in 8769.42 ms
Best aligned arch: rvv
Best unaligned arch: rvv
```
One of the largest speed ups! It's possible that this is in part due to an optimization made where the RVV code simply loads elements directly unit-wise (i.e. for this kernel, every 16 bits or 2 bytes) instead of accessing each part of the complex number separately.

```
RUN_VOLK_GNSSSDR_TESTS: volk_gnsssdr_32fc_32f_rotator_dotprodxnpuppet_32fc(8111,1987)
generic completed in 2660.93 ms
generic_reload completed in 2064.49 ms
rvv completed in 12059.3 ms
Best aligned arch: generic_reload
Best unaligned arch: generic_reload
```
This was one of the worst RVV implementations in terms of speed relative to the generic implementation. Admittedly, this implementation (and the other rotator implementations) directly emulates the generic implementation, and so it is certainly possible there are more creative workarounds. For instance, each iteration has to multiply `phase` by `phaseInc`, which when vectorized -- since there is no "raise to a power" vector instruction -- means there is a manual loop using a conditional and a masking register to "emulate" raising `phaseInc` to a certain power before multiplying it with `phase`.

In any case, if anyone can think of a better solution, feel free to replace.

## Non-Implementation of Certain Kernels
This PR contains RVV implementations for most kernels except:
 - `volk_gnsssdr_32fc_32f_xn_high_dynamic_rotator_dot_prod_32f_xn.h`: There was no other architecture-specific implementation, and so didn't know if there was something inherent in the kernel that prevented vectorization.
 - "Integer max kernels" (`volk_gnsssdr_8i_max_s8i.h`, `volk_gnsssdr_8i_index_max_16u.h`, etc)

For the "integer max kernels" the reason they were left unimplemented is, given the assumed, reasonable functionality, the generic implementations seem to be incorrect. Specifically, the `8i` in the kernel names implies that the kernel operates on 8-bit signed integer elements (which is reinforced by its use in other kernels, esepcially in contrast with `8u` which operates on 8-bit unsigned integer elements). However, `volk_gnsssdr_profile` revealed that the generic implementation was getting `-1` as the maximum value in a given vector, while the RVV implementation was getting 127.

This is explained by the usage of the ambiguous `char` in the generic implementation of these "max kernels" (and, indeed, most kernels operating on 8-bit integers). Since the C specification leaves `char`'s signedness to be implementation-defined, it appears that the machines running Github Actions defined `char` as `unsigned char` for the purposes of comparison (in which case `-1`, or `0b11111111`, would be greater than `0b01111111`). As such, I **highly suspect** that the generic implementation is incorrect and should be changed. Indeed, I do change the generic implementation in my [original repo](#Original-Repository).

However, I left those specific commits out of this PR for sake of atomicity and to avoid mixing issues. Therefore, the general suite of "integer max kernels" was left out to avoid dealing with the larger problem of a potentially incorrect generic implementation.

## On Clang-Tidy
Tried to utilize `clang-tidy` (following [this GNSS-SDR guide](https://gnss-sdr.org/coding-style/#use-code-linters)), but even installing versions 18-20, after running `cmake -DCMAKE_CCX_COMPILER=/usr/bin/clang++-18 -DCMAKE_C_COMPILER=/usr/bin/clang-18 ..` (or, instead of 18, whatever version was installed), `cmake` would spit back out: `The C++ compiler is not able to compile a simple test program.`

However, was able to successfully download and run `clang-format`.

## Google Summer of Code
This contribution was made possible in large part due to participation in Google Summer of Code. Big thanks to @carlesfernandez for the mentorship and resources.

The original project scope was larger in scale (see [here](https://summerofcode.withgoogle.com/programs/2025/projects/g60T12bi)), as it was originally supposed to also implement NEON for all the kernels. Unfortunately, due to a multitude of reasons this did not pan out. Due to this narrowing in scope (as well as general inexperience with RVV), the documentation for each RVV implementation is much more verbose and detailed, for better or for worse.

## Original Repository
The original repo can be found here: [https://github.com/BigTurtle8/gnss-sdr](https://github.com/BigTurtle8/gnss-sdr)
 - `feature/impl-complex-rvv-archs`: Raw commit history, including many commits that simply re-triggered Github Actions after fixing a small typo.
 - `feature/impl-imax-rvv-archs`: Early branch which has the implemented RVV versions of the max kernels, **along with an edited generic implementation** as described in [Non-Implementation of Certain Kernels](#Non-Implementation-of-Certain-Kernels).