### PR TITLE
More cleanup acquisition and tracking classes

### DIFF
--- a/src/algorithms/acquisition/adapters/base_pcps_acquisition_fpga.cc
+++ b/src/algorithms/acquisition/adapters/base_pcps_acquisition_fpga.cc
@@ -36,20 +36,13 @@ BasePcpsAcquisitionFpga::BasePcpsAcquisitionFpga(
     uint32_t acq_buff,
     unsigned int in_streams,
     unsigned int out_streams)
-    : doppler_center_(0),
-      doppler_max_(0),
-      doppler_step_(0),
-      role_(std::move(role)),
-      gnss_synchro_(nullptr),
-      channel_(0),
-      in_streams_(in_streams),
-      out_streams_(out_streams)
+    : role_(std::move(role))
 {
-    if (in_streams_ > 1)
+    if (in_streams > 1)
         {
             LOG(ERROR) << "This implementation only supports one input stream";
         }
-    if (out_streams_ > 0)
+    if (out_streams > 0)
         {
             LOG(ERROR) << "This implementation does not provide an output stream";
         }
@@ -96,8 +89,6 @@ BasePcpsAcquisitionFpga::BasePcpsAcquisitionFpga(
             acq_parameters_.doppler_max = absl::GetFlag(FLAGS_doppler_max);
         }
 #endif
-    doppler_max_ = acq_parameters_.doppler_max;
-    doppler_step_ = static_cast<unsigned int>(acq_parameters_.doppler_step);
 }
 
 
@@ -133,30 +124,27 @@ gr::basic_block_sptr BasePcpsAcquisitionFpga::get_right_block()
 
 void BasePcpsAcquisitionFpga::set_gnss_synchro(Gnss_Synchro* gnss_synchro)
 {
-    gnss_synchro_ = gnss_synchro;
     if (acquisition_fpga_)
         {
-            acquisition_fpga_->set_gnss_synchro(gnss_synchro_);
+            acquisition_fpga_->set_gnss_synchro(gnss_synchro);
         }
 }
 
 
 void BasePcpsAcquisitionFpga::set_channel(unsigned int channel)
 {
-    channel_ = channel;
     if (acquisition_fpga_)
         {
-            acquisition_fpga_->set_channel(channel_);
+            acquisition_fpga_->set_channel(channel);
         }
 }
 
 
 void BasePcpsAcquisitionFpga::set_channel_fsm(std::weak_ptr<ChannelFsm> channel_fsm)
 {
-    channel_fsm_ = std::move(channel_fsm);
     if (acquisition_fpga_)
         {
-            acquisition_fpga_->set_channel_fsm(channel_fsm_);
+            acquisition_fpga_->set_channel_fsm(channel_fsm);
         }
 }
 
@@ -172,30 +160,27 @@ void BasePcpsAcquisitionFpga::set_threshold(float threshold)
 
 void BasePcpsAcquisitionFpga::set_doppler_max(unsigned int doppler_max)
 {
-    doppler_max_ = doppler_max;
     if (acquisition_fpga_)
         {
-            acquisition_fpga_->set_doppler_max(doppler_max_);
+            acquisition_fpga_->set_doppler_max(doppler_max);
         }
 }
 
 
 void BasePcpsAcquisitionFpga::set_doppler_step(unsigned int doppler_step)
 {
-    doppler_step_ = doppler_step;
     if (acquisition_fpga_)
         {
-            acquisition_fpga_->set_doppler_step(doppler_step_);
+            acquisition_fpga_->set_doppler_step(doppler_step);
         }
 }
 
 
 void BasePcpsAcquisitionFpga::set_doppler_center(int doppler_center)
 {
-    doppler_center_ = doppler_center;
     if (acquisition_fpga_)
         {
-            acquisition_fpga_->set_doppler_center(doppler_center_);
+            acquisition_fpga_->set_doppler_center(doppler_center);
         }
 }
 

--- a/src/algorithms/acquisition/adapters/base_pcps_acquisition_fpga.h
+++ b/src/algorithms/acquisition/adapters/base_pcps_acquisition_fpga.h
@@ -28,7 +28,6 @@
 #include <cstdint>
 #include <memory>
 #include <string>
-#include <utility>
 
 /** \addtogroup Acquisition
  * Classes for GNSS signal acquisition
@@ -93,21 +92,13 @@ protected:
     static const uint32_t ACQ_BUFF_1 = 1;                     // FPGA Acquisition IP buffer containing L2 or L5/E5 frequency band samples by default.
 
     // Members subclasses must set
-    pcps_acquisition_fpga_sptr acquisition_fpga_;
     volk_gnsssdr::vector<uint32_t> d_all_fft_codes_;
     Acq_Conf_Fpga acq_parameters_;
-    int32_t doppler_center_;
-    uint32_t doppler_max_;
-    uint32_t doppler_step_;
 
 private:
     // Managed entirely by the base class
-    std::weak_ptr<ChannelFsm> channel_fsm_;
-    std::string role_;
-    Gnss_Synchro* gnss_synchro_;
-    uint32_t channel_;
-    unsigned int in_streams_;
-    unsigned int out_streams_;
+    pcps_acquisition_fpga_sptr acquisition_fpga_;
+    const std::string role_;
 };
 
 

--- a/src/algorithms/acquisition/adapters/galileo_e1_pcps_8ms_ambiguous_acquisition.cc
+++ b/src/algorithms/acquisition/adapters/galileo_e1_pcps_8ms_ambiguous_acquisition.cc
@@ -51,7 +51,8 @@ GalileoE1Pcps8msAmbiguousAcquisition::GalileoE1Pcps8msAmbiguousAcquisition(
       doppler_max_(configuration_->property(role + ".doppler_max", 5000)),
       doppler_step_(0),
       sampled_ms_(configuration_->property(role + ".coherent_integration_time_ms", 4)),
-      dump_(configuration_->property(role + ".dump", false))
+      dump_(configuration_->property(role + ".dump", false)),
+      cboc_(configuration_->property(role + ".cboc", false))
 {
     const std::string default_item_type("gr_complex");
     const std::string default_dump_filename("./acquisition.dat");
@@ -209,17 +210,13 @@ void GalileoE1Pcps8msAmbiguousAcquisition::set_local_code()
 {
     if (item_type_ == "gr_complex")
         {
-            bool cboc = configuration_->property(
-                "Acquisition" + std::to_string(channel_) + ".cboc", false);
-
             std::vector<std::complex<float>> code(code_length_);
             std::array<char, 3> Signal_{};
             Signal_[0] = gnss_synchro_->Signal[0];
             Signal_[1] = gnss_synchro_->Signal[1];
             Signal_[2] = '\0';
 
-            galileo_e1_code_gen_complex_sampled(code, Signal_,
-                cboc, gnss_synchro_->PRN, fs_in_, 0, false);
+            galileo_e1_code_gen_complex_sampled(code, Signal_, cboc_, gnss_synchro_->PRN, fs_in_, 0, false);
 
             own::span<gr_complex> code_span(code_.data(), vector_length_);
             for (unsigned int i = 0; i < sampled_ms_ / 4; i++)

--- a/src/algorithms/acquisition/adapters/galileo_e1_pcps_8ms_ambiguous_acquisition.cc
+++ b/src/algorithms/acquisition/adapters/galileo_e1_pcps_8ms_ambiguous_acquisition.cc
@@ -51,9 +51,6 @@ GalileoE1Pcps8msAmbiguousAcquisition::GalileoE1Pcps8msAmbiguousAcquisition(
       doppler_max_(configuration_->property(role + ".doppler_max", 5000)),
       doppler_step_(0),
       sampled_ms_(configuration_->property(role + ".coherent_integration_time_ms", 4)),
-      max_dwells_(configuration_->property(role + ".max_dwells", 1)),
-      in_streams_(in_streams),
-      out_streams_(out_streams),
       dump_(configuration_->property(role + ".dump", false))
 {
     const std::string default_item_type("gr_complex");
@@ -98,7 +95,8 @@ GalileoE1Pcps8msAmbiguousAcquisition::GalileoE1Pcps8msAmbiguousAcquisition(
     DLOG(INFO) << "role " << role_;
     if (item_type_ == "gr_complex")
         {
-            acquisition_cc_ = galileo_pcps_8ms_make_acquisition_cc(sampled_ms_, max_dwells_,
+            unsigned int max_dwells = configuration_->property(role + ".max_dwells", 1);
+            acquisition_cc_ = galileo_pcps_8ms_make_acquisition_cc(sampled_ms_, max_dwells,
                 doppler_max_, fs_in_, samples_per_ms, code_length_,
                 dump_, dump_filename_, enable_monitor_output);
             stream_to_vector_ = gr::blocks::stream_to_vector::make(item_size_, vector_length_);
@@ -115,11 +113,11 @@ GalileoE1Pcps8msAmbiguousAcquisition::GalileoE1Pcps8msAmbiguousAcquisition(
             LOG(WARNING) << item_type_ << " unknown acquisition item type";
         }
 
-    if (in_streams_ > 1)
+    if (in_streams > 1)
         {
             LOG(ERROR) << "This implementation only supports one input stream";
         }
-    if (out_streams_ > 0)
+    if (out_streams > 0)
         {
             LOG(ERROR) << "This implementation does not provide an output stream";
         }

--- a/src/algorithms/acquisition/adapters/galileo_e1_pcps_8ms_ambiguous_acquisition.h
+++ b/src/algorithms/acquisition/adapters/galileo_e1_pcps_8ms_ambiguous_acquisition.h
@@ -163,9 +163,6 @@ private:
     unsigned int doppler_max_;
     unsigned int doppler_step_;
     unsigned int sampled_ms_;
-    unsigned int max_dwells_;
-    unsigned int in_streams_;
-    unsigned int out_streams_;
     bool dump_;
 };
 

--- a/src/algorithms/acquisition/adapters/galileo_e1_pcps_8ms_ambiguous_acquisition.h
+++ b/src/algorithms/acquisition/adapters/galileo_e1_pcps_8ms_ambiguous_acquisition.h
@@ -164,6 +164,7 @@ private:
     unsigned int doppler_step_;
     unsigned int sampled_ms_;
     bool dump_;
+    const bool cboc_;
 };
 
 

--- a/src/algorithms/acquisition/adapters/galileo_e1_pcps_ambiguous_acquisition.cc
+++ b/src/algorithms/acquisition/adapters/galileo_e1_pcps_ambiguous_acquisition.cc
@@ -26,6 +26,7 @@ GalileoE1PcpsAmbiguousAcquisition::GalileoE1PcpsAmbiguousAcquisition(
     unsigned int in_streams,
     unsigned int out_streams)
     : BasePcpsAcquisition(configuration, role, in_streams, out_streams, GALILEO_E1_CODE_CHIP_RATE_CPS, GALILEO_E1_OPT_ACQ_FS_SPS, GALILEO_E1_B_CODE_LENGTH_CHIPS, 4),
+      configuration_(configuration),
       acquire_pilot_(configuration->property(role + ".acquire_pilot", false))
 {
 }

--- a/src/algorithms/acquisition/adapters/galileo_e1_pcps_ambiguous_acquisition.cc
+++ b/src/algorithms/acquisition/adapters/galileo_e1_pcps_ambiguous_acquisition.cc
@@ -32,6 +32,13 @@ GalileoE1PcpsAmbiguousAcquisition::GalileoE1PcpsAmbiguousAcquisition(
 }
 
 
+void GalileoE1PcpsAmbiguousAcquisition::set_gnss_synchro(Gnss_Synchro* p_gnss_synchro)
+{
+    gnss_synchro_ = p_gnss_synchro;
+    BasePcpsAcquisition::set_gnss_synchro(p_gnss_synchro);
+}
+
+
 void GalileoE1PcpsAmbiguousAcquisition::set_channel(unsigned int channel)
 {
     cboc = configuration_->property("Acquisition" + std::to_string(channel) + ".cboc", false);
@@ -49,7 +56,10 @@ void GalileoE1PcpsAmbiguousAcquisition::code_gen_complex_sampled(own::span<std::
         }
     else
         {
-            const std::array<char, 3> signal_str = {{'1', 'B', '\0'}};
-            galileo_e1_code_gen_complex_sampled(dest, signal_str, cboc, prn, sampling_freq, 0, false);
+            std::array<char, 3> Signal_{};
+            Signal_[0] = gnss_synchro_->Signal[0];
+            Signal_[1] = gnss_synchro_->Signal[1];
+            Signal_[2] = '\0';
+            galileo_e1_code_gen_complex_sampled(dest, Signal_, cboc, prn, sampling_freq, 0, false);
         }
 }

--- a/src/algorithms/acquisition/adapters/galileo_e1_pcps_ambiguous_acquisition.cc
+++ b/src/algorithms/acquisition/adapters/galileo_e1_pcps_ambiguous_acquisition.cc
@@ -17,272 +17,38 @@
 
 #include "galileo_e1_pcps_ambiguous_acquisition.h"
 #include "Galileo_E1.h"
-#include "acq_conf.h"
-#include "configuration_interface.h"
 #include "galileo_e1_signal_replica.h"
-#include "gnss_sdr_flags.h"
-#include <boost/math/distributions/exponential.hpp>
-#include <algorithm>
 
-#if USE_GLOG_AND_GFLAGS
-#include <glog/logging.h>
-#else
-#include <absl/log/log.h>
-#endif
-
-#if HAS_STD_SPAN
-#include <span>
-namespace own = std;
-#else
-#include <gsl-lite/gsl-lite.hpp>
-namespace own = gsl_lite;
-#endif
 
 GalileoE1PcpsAmbiguousAcquisition::GalileoE1PcpsAmbiguousAcquisition(
     const ConfigurationInterface* configuration,
     const std::string& role,
     unsigned int in_streams,
     unsigned int out_streams)
-    : gnss_synchro_(nullptr),
-      configuration_(configuration),
-      role_(role),
-      threshold_(0.0),
-      doppler_center_(0),
-      channel_(0),
-      in_streams_(in_streams),
-      out_streams_(out_streams),
+    : BasePcpsAcquisition(configuration, role, in_streams, out_streams, GALILEO_E1_CODE_CHIP_RATE_CPS, GALILEO_E1_OPT_ACQ_FS_SPS, GALILEO_E1_B_CODE_LENGTH_CHIPS, 4),
       acquire_pilot_(configuration->property(role + ".acquire_pilot", false))
 {
-    acq_parameters_.ms_per_code = 4;
-    acq_parameters_.SetFromConfiguration(configuration_, role_, GALILEO_E1_CODE_CHIP_RATE_CPS, GALILEO_E1_OPT_ACQ_FS_SPS);
-
-#if USE_GLOG_AND_GFLAGS
-    if (FLAGS_doppler_max != 0)
-        {
-            acq_parameters_.doppler_max = FLAGS_doppler_max;
-        }
-#else
-    if (absl::GetFlag(FLAGS_doppler_max) != 0)
-        {
-            acq_parameters_.doppler_max = absl::GetFlag(FLAGS_doppler_max);
-        }
-#endif
-    doppler_max_ = acq_parameters_.doppler_max;
-    doppler_step_ = static_cast<unsigned int>(acq_parameters_.doppler_step);
-    item_type_ = acq_parameters_.item_type;
-    item_size_ = acq_parameters_.it_size;
-    fs_in_ = acq_parameters_.fs_in;
-
-    code_length_ = static_cast<unsigned int>(std::floor(static_cast<double>(acq_parameters_.resampled_fs) / (GALILEO_E1_CODE_CHIP_RATE_CPS / GALILEO_E1_B_CODE_LENGTH_CHIPS)));
-    vector_length_ = static_cast<unsigned int>(std::floor(acq_parameters_.sampled_ms * acq_parameters_.samples_per_ms) * (acq_parameters_.bit_transition_flag ? 2.0 : 1.0));
-    code_ = volk_gnsssdr::vector<std::complex<float>>(vector_length_);
-
-    sampled_ms_ = acq_parameters_.sampled_ms;
-
-    DLOG(INFO) << "role " << role_;
-    acquisition_ = pcps_make_acquisition(acq_parameters_);
-    DLOG(INFO) << "acquisition(" << acquisition_->unique_id() << ")";
-
-    if (item_type_ == "cbyte")
-        {
-            cbyte_to_float_x2_ = make_complex_byte_to_float_x2();
-            float_to_complex_ = gr::blocks::float_to_complex::make();
-        }
-
-    if (in_streams_ > 1)
-        {
-            LOG(ERROR) << "This implementation only supports one input stream";
-        }
-    if (out_streams_ > 0)
-        {
-            LOG(ERROR) << "This implementation does not provide an output stream";
-        }
 }
 
 
-void GalileoE1PcpsAmbiguousAcquisition::stop_acquisition()
+void GalileoE1PcpsAmbiguousAcquisition::set_channel(unsigned int channel)
 {
-    acquisition_->set_active(false);
+    cboc = configuration_->property("Acquisition" + std::to_string(channel) + ".cboc", false);
+    BasePcpsAcquisition::set_channel(channel);
 }
 
 
-void GalileoE1PcpsAmbiguousAcquisition::set_threshold(float threshold)
+void GalileoE1PcpsAmbiguousAcquisition::code_gen_complex_sampled(own::span<std::complex<float>> dest, uint32_t prn, int32_t sampling_freq)
 {
-    threshold_ = threshold;
-
-    acquisition_->set_threshold(threshold_);
-}
-
-
-void GalileoE1PcpsAmbiguousAcquisition::set_doppler_max(unsigned int doppler_max)
-{
-    doppler_max_ = doppler_max;
-
-    acquisition_->set_doppler_max(doppler_max_);
-}
-
-
-void GalileoE1PcpsAmbiguousAcquisition::set_doppler_step(unsigned int doppler_step)
-{
-    doppler_step_ = doppler_step;
-
-    acquisition_->set_doppler_step(doppler_step_);
-}
-
-
-void GalileoE1PcpsAmbiguousAcquisition::set_doppler_center(int doppler_center)
-{
-    doppler_center_ = doppler_center;
-
-    acquisition_->set_doppler_center(doppler_center_);
-}
-
-
-void GalileoE1PcpsAmbiguousAcquisition::set_gnss_synchro(Gnss_Synchro* gnss_synchro)
-{
-    gnss_synchro_ = gnss_synchro;
-
-    acquisition_->set_gnss_synchro(gnss_synchro_);
-}
-
-
-signed int GalileoE1PcpsAmbiguousAcquisition::mag()
-{
-    return acquisition_->mag();
-}
-
-
-void GalileoE1PcpsAmbiguousAcquisition::init()
-{
-    acquisition_->init();
-}
-
-
-void GalileoE1PcpsAmbiguousAcquisition::set_local_code()
-{
-    bool cboc = configuration_->property(
-        "Acquisition" + std::to_string(channel_) + ".cboc", false);
-
-    volk_gnsssdr::vector<std::complex<float>> code(code_length_);
-
     if (acquire_pilot_ == true)
         {
             // set local signal generator to Galileo E1 pilot component (1C)
-            std::array<char, 3> pilot_signal = {{'1', 'C', '\0'}};
-            if (acq_parameters_.use_automatic_resampler)
-                {
-                    galileo_e1_code_gen_complex_sampled(code, pilot_signal,
-                        cboc, gnss_synchro_->PRN, acq_parameters_.resampled_fs, 0, false);
-                }
-            else
-                {
-                    galileo_e1_code_gen_complex_sampled(code, pilot_signal,
-                        cboc, gnss_synchro_->PRN, fs_in_, 0, false);
-                }
+            const std::array<char, 3> pilot_signal = {{'1', 'C', '\0'}};
+            galileo_e1_code_gen_complex_sampled(dest, pilot_signal, cboc, prn, sampling_freq, 0, false);
         }
     else
         {
-            std::array<char, 3> Signal_{};
-            Signal_[0] = gnss_synchro_->Signal[0];
-            Signal_[1] = gnss_synchro_->Signal[1];
-            Signal_[2] = '\0';
-            if (acq_parameters_.use_automatic_resampler)
-                {
-                    galileo_e1_code_gen_complex_sampled(code, Signal_,
-                        cboc, gnss_synchro_->PRN, acq_parameters_.resampled_fs, 0, false);
-                }
-            else
-                {
-                    galileo_e1_code_gen_complex_sampled(code, Signal_,
-                        cboc, gnss_synchro_->PRN, fs_in_, 0, false);
-                }
+            const std::array<char, 3> signal_str = {{'1', 'B', '\0'}};
+            galileo_e1_code_gen_complex_sampled(dest, signal_str, cboc, prn, sampling_freq, 0, false);
         }
-
-    own::span<gr_complex> code_span(code_.data(), vector_length_);
-    for (unsigned int i = 0; i < sampled_ms_ / 4; i++)
-        {
-            std::copy_n(code.data(), code_length_, code_span.subspan(i * code_length_, code_length_).data());
-        }
-
-    acquisition_->set_local_code(code_.data());
-}
-
-
-void GalileoE1PcpsAmbiguousAcquisition::reset()
-{
-    acquisition_->set_active(true);
-}
-
-
-void GalileoE1PcpsAmbiguousAcquisition::set_state(int state)
-{
-    acquisition_->set_state(state);
-}
-
-
-void GalileoE1PcpsAmbiguousAcquisition::connect(gr::top_block_sptr top_block)
-{
-    if (item_type_ == "gr_complex" || item_type_ == "cshort")
-        {
-            // nothing to connect
-        }
-    else if (item_type_ == "cbyte")
-        {
-            // Since a byte-based acq implementation is not available,
-            // we just convert cshorts to gr_complex
-            top_block->connect(cbyte_to_float_x2_, 0, float_to_complex_, 0);
-            top_block->connect(cbyte_to_float_x2_, 1, float_to_complex_, 1);
-            top_block->connect(float_to_complex_, 0, acquisition_, 0);
-        }
-    else
-        {
-            LOG(WARNING) << item_type_ << " unknown acquisition item type";
-        }
-}
-
-
-void GalileoE1PcpsAmbiguousAcquisition::disconnect(gr::top_block_sptr top_block)
-{
-    if (item_type_ == "gr_complex" || item_type_ == "cshort")
-        {
-            // nothing to disconnect
-        }
-    else if (item_type_ == "cbyte")
-        {
-            top_block->disconnect(cbyte_to_float_x2_, 0, float_to_complex_, 0);
-            top_block->disconnect(cbyte_to_float_x2_, 1, float_to_complex_, 1);
-            top_block->disconnect(float_to_complex_, 0, acquisition_, 0);
-        }
-    else
-        {
-            LOG(WARNING) << item_type_ << " unknown acquisition item type";
-        }
-}
-
-
-gr::basic_block_sptr GalileoE1PcpsAmbiguousAcquisition::get_left_block()
-{
-    if (item_type_ == "gr_complex" || item_type_ == "cshort")
-        {
-            return acquisition_;
-        }
-    if (item_type_ == "cbyte")
-        {
-            return cbyte_to_float_x2_;
-        }
-
-    LOG(WARNING) << item_type_ << " unknown acquisition item type";
-    return nullptr;
-}
-
-
-gr::basic_block_sptr GalileoE1PcpsAmbiguousAcquisition::get_right_block()
-{
-    return acquisition_;
-}
-
-
-void GalileoE1PcpsAmbiguousAcquisition::set_resampler_latency(uint32_t latency_samples)
-{
-    acquisition_->set_resampler_latency(latency_samples);
 }

--- a/src/algorithms/acquisition/adapters/galileo_e1_pcps_ambiguous_acquisition.cc
+++ b/src/algorithms/acquisition/adapters/galileo_e1_pcps_ambiguous_acquisition.cc
@@ -27,7 +27,8 @@ GalileoE1PcpsAmbiguousAcquisition::GalileoE1PcpsAmbiguousAcquisition(
     unsigned int out_streams)
     : BasePcpsAcquisition(configuration, role, in_streams, out_streams, GALILEO_E1_CODE_CHIP_RATE_CPS, GALILEO_E1_OPT_ACQ_FS_SPS, GALILEO_E1_B_CODE_LENGTH_CHIPS, 4),
       configuration_(configuration),
-      acquire_pilot_(configuration->property(role + ".acquire_pilot", false))
+      acquire_pilot_(configuration->property(role + ".acquire_pilot", false)),
+      cboc_(configuration->property(role + ".cboc", false))
 {
 }
 
@@ -39,20 +40,13 @@ void GalileoE1PcpsAmbiguousAcquisition::set_gnss_synchro(Gnss_Synchro* p_gnss_sy
 }
 
 
-void GalileoE1PcpsAmbiguousAcquisition::set_channel(unsigned int channel)
-{
-    cboc = configuration_->property("Acquisition" + std::to_string(channel) + ".cboc", false);
-    BasePcpsAcquisition::set_channel(channel);
-}
-
-
 void GalileoE1PcpsAmbiguousAcquisition::code_gen_complex_sampled(own::span<std::complex<float>> dest, uint32_t prn, int32_t sampling_freq)
 {
     if (acquire_pilot_ == true)
         {
             // set local signal generator to Galileo E1 pilot component (1C)
             const std::array<char, 3> pilot_signal = {{'1', 'C', '\0'}};
-            galileo_e1_code_gen_complex_sampled(dest, pilot_signal, cboc, prn, sampling_freq, 0, false);
+            galileo_e1_code_gen_complex_sampled(dest, pilot_signal, cboc_, prn, sampling_freq, 0, false);
         }
     else
         {
@@ -60,6 +54,6 @@ void GalileoE1PcpsAmbiguousAcquisition::code_gen_complex_sampled(own::span<std::
             Signal_[0] = gnss_synchro_->Signal[0];
             Signal_[1] = gnss_synchro_->Signal[1];
             Signal_[2] = '\0';
-            galileo_e1_code_gen_complex_sampled(dest, Signal_, cboc, prn, sampling_freq, 0, false);
+            galileo_e1_code_gen_complex_sampled(dest, Signal_, cboc_, prn, sampling_freq, 0, false);
         }
 }

--- a/src/algorithms/acquisition/adapters/galileo_e1_pcps_ambiguous_acquisition.h
+++ b/src/algorithms/acquisition/adapters/galileo_e1_pcps_ambiguous_acquisition.h
@@ -18,16 +18,7 @@
 #ifndef GNSS_SDR_GALILEO_E1_PCPS_AMBIGUOUS_ACQUISITION_H
 #define GNSS_SDR_GALILEO_E1_PCPS_AMBIGUOUS_ACQUISITION_H
 
-#include "acq_conf.h"
-#include "channel_fsm.h"
-#include "complex_byte_to_float_x2.h"
-#include "gnss_synchro.h"
-#include "pcps_acquisition.h"
-#include <gnuradio/blocks/float_to_complex.h>
-#include <volk_gnsssdr/volk_gnsssdr_alloc.h>
-#include <memory>
-#include <string>
-#include <utility>
+#include "base_pcps_acquisition.h"
 
 /** \addtogroup Acquisition
  * \{ */
@@ -35,13 +26,11 @@
  * \{ */
 
 
-class ConfigurationInterface;
-
 /*!
  * \brief This class adapts a PCPS acquisition block to an
  *  AcquisitionInterface for Galileo E1 Signals
  */
-class GalileoE1PcpsAmbiguousAcquisition : public AcquisitionInterface
+class GalileoE1PcpsAmbiguousAcquisition : public BasePcpsAcquisition
 {
 public:
     GalileoE1PcpsAmbiguousAcquisition(
@@ -52,11 +41,6 @@ public:
 
     ~GalileoE1PcpsAmbiguousAcquisition() = default;
 
-    inline std::string role() override
-    {
-        return role_;
-    }
-
     /*!
      * \brief Returns "Galileo_E1_PCPS_Ambiguous_Acquisition"
      */
@@ -65,121 +49,18 @@ public:
         return "Galileo_E1_PCPS_Ambiguous_Acquisition";
     }
 
-    size_t item_size() override
-    {
-        return item_size_;
-    }
-
-    void connect(gr::top_block_sptr top_block) override;
-    void disconnect(gr::top_block_sptr top_block) override;
-    gr::basic_block_sptr get_left_block() override;
-    gr::basic_block_sptr get_right_block() override;
-
-    /*!
-     * \brief Set acquisition/tracking common Gnss_Synchro object pointer
-     * to efficiently exchange synchronization data between acquisition and
-     *  tracking blocks
-     */
-    void set_gnss_synchro(Gnss_Synchro* p_gnss_synchro) override;
-
     /*!
      * \brief Set acquisition channel unique ID
      */
-    inline void set_channel(unsigned int channel) override
-    {
-        channel_ = channel;
-        acquisition_->set_channel(channel_);
-    }
-
-    /*!
-     * \brief Set channel fsm associated to this acquisition instance
-     */
-    inline void set_channel_fsm(std::weak_ptr<ChannelFsm> channel_fsm) override
-    {
-        channel_fsm_ = std::move(channel_fsm);
-        acquisition_->set_channel_fsm(channel_fsm_);
-    }
-
-    /*!
-     * \brief Set statistics threshold of PCPS algorithm
-     */
-    void set_threshold(float threshold) override;
-
-    /*!
-     * \brief Set maximum Doppler off grid search
-     */
-    void set_doppler_max(unsigned int doppler_max) override;
-
-    /*!
-     * \brief Set Doppler steps for the grid search
-     */
-    void set_doppler_step(unsigned int doppler_step) override;
-
-    /*!
-     * \brief Set Doppler center for the grid search
-     */
-    void set_doppler_center(int doppler_center) override;
-
-    /*!
-     * \brief Initializes acquisition algorithm.
-     */
-    void init() override;
-
-    /*!
-     * \brief Sets local code for Galileo E1 PCPS acquisition algorithm.
-     */
-    void set_local_code() override;
-
-    /*!
-     * \brief Returns the maximum peak of grid search
-     */
-    signed int mag() override;
-
-    /*!
-     * \brief Restart acquisition algorithm
-     */
-    void reset() override;
-
-    /*!
-     * \brief If state = 1, it forces the block to start acquiring from the first sample
-     */
-    void set_state(int state) override;
-
-    /*!
-     * \brief Stop running acquisition
-     */
-    void stop_acquisition() override;
-
-    /*!
-     * \brief Sets the resampler latency to account it in the acquisition code delay estimation
-     */
-    void set_resampler_latency(uint32_t latency_samples) override;
+    void set_channel(unsigned int channel) override;
 
 private:
-    pcps_acquisition_sptr acquisition_;
-    volk_gnsssdr::vector<std::complex<float>> code_;
-    std::weak_ptr<ChannelFsm> channel_fsm_;
-    gr::blocks::float_to_complex::sptr float_to_complex_;
-    complex_byte_to_float_x2_sptr cbyte_to_float_x2_;
-    Gnss_Synchro* gnss_synchro_;
+    void code_gen_complex_sampled(own::span<std::complex<float>> dest, uint32_t prn, int32_t sampling_freq) override;
+
     const ConfigurationInterface* configuration_;
-    Acq_Conf acq_parameters_;
-    std::string item_type_;
-    std::string dump_filename_;
-    std::string role_;
-    int64_t fs_in_;
-    size_t item_size_;
-    float threshold_;
-    int doppler_center_;
-    unsigned int vector_length_;
-    unsigned int code_length_;
-    unsigned int channel_;
-    unsigned int doppler_max_;
-    unsigned int doppler_step_;
-    unsigned int sampled_ms_;
-    unsigned int in_streams_;
-    unsigned int out_streams_;
-    bool acquire_pilot_;
+    const bool acquire_pilot_;
+
+    bool cboc{false};
 };
 
 

--- a/src/algorithms/acquisition/adapters/galileo_e1_pcps_ambiguous_acquisition.h
+++ b/src/algorithms/acquisition/adapters/galileo_e1_pcps_ambiguous_acquisition.h
@@ -52,6 +52,11 @@ public:
     /*!
      * \brief Set acquisition channel unique ID
      */
+    void set_gnss_synchro(Gnss_Synchro* p_gnss_synchro) override;
+
+    /*!
+     * \brief Set acquisition channel unique ID
+     */
     void set_channel(unsigned int channel) override;
 
 private:
@@ -61,6 +66,7 @@ private:
     const bool acquire_pilot_;
 
     bool cboc{false};
+    Gnss_Synchro* gnss_synchro_;
 };
 
 

--- a/src/algorithms/acquisition/adapters/galileo_e1_pcps_ambiguous_acquisition.h
+++ b/src/algorithms/acquisition/adapters/galileo_e1_pcps_ambiguous_acquisition.h
@@ -54,18 +54,12 @@ public:
      */
     void set_gnss_synchro(Gnss_Synchro* p_gnss_synchro) override;
 
-    /*!
-     * \brief Set acquisition channel unique ID
-     */
-    void set_channel(unsigned int channel) override;
-
 private:
     void code_gen_complex_sampled(own::span<std::complex<float>> dest, uint32_t prn, int32_t sampling_freq) override;
 
     const ConfigurationInterface* configuration_;
     const bool acquire_pilot_;
-
-    bool cboc{false};
+    const bool cboc_;
     Gnss_Synchro* gnss_synchro_;
 };
 

--- a/src/algorithms/acquisition/adapters/galileo_e1_pcps_ambiguous_acquisition_fpga.cc
+++ b/src/algorithms/acquisition/adapters/galileo_e1_pcps_ambiguous_acquisition_fpga.cc
@@ -48,9 +48,9 @@ GalileoE1PcpsAmbiguousAcquisitionFpga::GalileoE1PcpsAmbiguousAcquisitionFpga(
           DEFAULT_FPGA_BLK_EXP,
           ACQ_BUFF_0,
           in_streams,
-          out_streams)
+          out_streams),
+      acquire_pilot_(configuration->property(role + ".acquire_pilot", false))
 {
-    acquire_pilot_ = configuration->property(role + ".acquire_pilot", false);
     generate_galileo_e1_prn_codes();
     DLOG(INFO) << "Initialized FPGA acquisition adapter for role " << role;
 }

--- a/src/algorithms/acquisition/adapters/galileo_e1_pcps_ambiguous_acquisition_fpga.h
+++ b/src/algorithms/acquisition/adapters/galileo_e1_pcps_ambiguous_acquisition_fpga.h
@@ -26,8 +26,6 @@
  * \{ */
 
 
-class ConfigurationInterface;
-
 /*!
  * \brief This class adapts a PCPS acquisition block off-loaded on an FPGA
  * to an AcquisitionInterface for Galileo E1 Signals
@@ -55,7 +53,7 @@ public:
 private:
     static const uint32_t DEFAULT_FPGA_BLK_EXP = 13;  // default block exponent
     void generate_galileo_e1_prn_codes();
-    bool acquire_pilot_;
+    const bool acquire_pilot_;
 };
 
 

--- a/src/algorithms/acquisition/adapters/galileo_e1_pcps_cccwsr_ambiguous_acquisition.cc
+++ b/src/algorithms/acquisition/adapters/galileo_e1_pcps_cccwsr_ambiguous_acquisition.cc
@@ -42,9 +42,6 @@ GalileoE1PcpsCccwsrAmbiguousAcquisition::GalileoE1PcpsCccwsrAmbiguousAcquisition
       doppler_max_(configuration_->property(role + ".doppler_max", 5000)),
       doppler_step_(0),
       sampled_ms_(configuration_->property(role + ".coherent_integration_time_ms", 4)),
-      max_dwells_(configuration_->property(role + ".max_dwells", 1)),
-      in_streams_(in_streams),
-      out_streams_(out_streams),
       dump_(configuration_->property(role + ".dump", false))
 {
     const std::string default_item_type("gr_complex");
@@ -90,7 +87,8 @@ GalileoE1PcpsCccwsrAmbiguousAcquisition::GalileoE1PcpsCccwsrAmbiguousAcquisition
     DLOG(INFO) << "role " << role_;
     if (item_type_ == "gr_complex")
         {
-            acquisition_cc_ = pcps_cccwsr_make_acquisition_cc(sampled_ms_, max_dwells_,
+            unsigned int max_dwells = configuration_->property(role + ".max_dwells", 1);
+            acquisition_cc_ = pcps_cccwsr_make_acquisition_cc(sampled_ms_, max_dwells,
                 doppler_max_, fs_in_, samples_per_ms, code_length_,
                 dump_, dump_filename_, enable_monitor_output);
             stream_to_vector_ = gr::blocks::stream_to_vector::make(item_size_, vector_length_);
@@ -106,11 +104,11 @@ GalileoE1PcpsCccwsrAmbiguousAcquisition::GalileoE1PcpsCccwsrAmbiguousAcquisition
             LOG(WARNING) << item_type_ << " unknown acquisition item type";
         }
 
-    if (in_streams_ > 1)
+    if (in_streams > 1)
         {
             LOG(ERROR) << "This implementation only supports one input stream";
         }
-    if (out_streams_ > 0)
+    if (out_streams > 0)
         {
             LOG(ERROR) << "This implementation does not provide an output stream";
         }

--- a/src/algorithms/acquisition/adapters/galileo_e1_pcps_cccwsr_ambiguous_acquisition.cc
+++ b/src/algorithms/acquisition/adapters/galileo_e1_pcps_cccwsr_ambiguous_acquisition.cc
@@ -42,7 +42,8 @@ GalileoE1PcpsCccwsrAmbiguousAcquisition::GalileoE1PcpsCccwsrAmbiguousAcquisition
       doppler_max_(configuration_->property(role + ".doppler_max", 5000)),
       doppler_step_(0),
       sampled_ms_(configuration_->property(role + ".coherent_integration_time_ms", 4)),
-      dump_(configuration_->property(role + ".dump", false))
+      dump_(configuration_->property(role + ".dump", false)),
+      cboc_(configuration_->property(role + ".cboc", false))
 {
     const std::string default_item_type("gr_complex");
     const std::string default_dump_filename("./acquisition.dat");
@@ -187,18 +188,11 @@ void GalileoE1PcpsCccwsrAmbiguousAcquisition::set_local_code()
 {
     if (item_type_ == "gr_complex")
         {
-            bool cboc = configuration_->property(
-                "Acquisition" + std::to_string(channel_) + ".cboc", false);
-
             std::array<char, 3> signal = {{'1', 'B', '\0'}};
-
-            galileo_e1_code_gen_complex_sampled(code_data_, signal,
-                cboc, gnss_synchro_->PRN, fs_in_, 0, false);
+            galileo_e1_code_gen_complex_sampled(code_data_, signal, cboc_, gnss_synchro_->PRN, fs_in_, 0, false);
 
             std::array<char, 3> signal_C = {{'1', 'C', '\0'}};
-
-            galileo_e1_code_gen_complex_sampled(code_pilot_, signal_C,
-                cboc, gnss_synchro_->PRN, fs_in_, 0, false);
+            galileo_e1_code_gen_complex_sampled(code_pilot_, signal_C, cboc_, gnss_synchro_->PRN, fs_in_, 0, false);
 
             acquisition_cc_->set_local_code(code_data_.data(), code_pilot_.data());
         }

--- a/src/algorithms/acquisition/adapters/galileo_e1_pcps_cccwsr_ambiguous_acquisition.h
+++ b/src/algorithms/acquisition/adapters/galileo_e1_pcps_cccwsr_ambiguous_acquisition.h
@@ -165,6 +165,7 @@ private:
     unsigned int doppler_step_;
     unsigned int sampled_ms_;
     bool dump_;
+    const bool cboc_;
 };
 
 

--- a/src/algorithms/acquisition/adapters/galileo_e1_pcps_cccwsr_ambiguous_acquisition.h
+++ b/src/algorithms/acquisition/adapters/galileo_e1_pcps_cccwsr_ambiguous_acquisition.h
@@ -164,9 +164,6 @@ private:
     unsigned int doppler_max_;
     unsigned int doppler_step_;
     unsigned int sampled_ms_;
-    unsigned int max_dwells_;
-    unsigned int in_streams_;
-    unsigned int out_streams_;
     bool dump_;
 };
 

--- a/src/algorithms/acquisition/adapters/galileo_e1_pcps_quicksync_ambiguous_acquisition.cc
+++ b/src/algorithms/acquisition/adapters/galileo_e1_pcps_quicksync_ambiguous_acquisition.cc
@@ -52,7 +52,8 @@ GalileoE1PcpsQuickSyncAmbiguousAcquisition::GalileoE1PcpsQuickSyncAmbiguousAcqui
       doppler_step_(0),
       sampled_ms_(configuration_->property(role + ".coherent_integration_time_ms", 8)),
       bit_transition_flag_(configuration_->property(role + ".bit_transition_flag", false)),
-      dump_(configuration_->property(role + ".dump", false))
+      dump_(configuration_->property(role + ".dump", false)),
+      cboc_(configuration_->property(role + ".cboc", false))
 {
     const std::string default_item_type("gr_complex");
     const std::string default_dump_filename("./acquisition.dat");
@@ -242,17 +243,13 @@ void GalileoE1PcpsQuickSyncAmbiguousAcquisition::set_local_code()
 {
     if (item_type_ == "gr_complex")
         {
-            bool cboc = configuration_->property(
-                "Acquisition" + std::to_string(channel_) + ".cboc", false);
-
             std::vector<std::complex<float>> code(code_length_);
             std::array<char, 3> Signal_{};
             Signal_[0] = gnss_synchro_->Signal[0];
             Signal_[1] = gnss_synchro_->Signal[1];
             Signal_[2] = '\0';
 
-            galileo_e1_code_gen_complex_sampled(code, Signal_,
-                cboc, gnss_synchro_->PRN, fs_in_, 0, false);
+            galileo_e1_code_gen_complex_sampled(code, Signal_, cboc_, gnss_synchro_->PRN, fs_in_, 0, false);
 
             own::span<gr_complex> code_span(code_.data(), vector_length_);
             for (unsigned int i = 0; i < (sampled_ms_ / (folding_factor_ * 4)); i++)

--- a/src/algorithms/acquisition/adapters/galileo_e1_pcps_quicksync_ambiguous_acquisition.cc
+++ b/src/algorithms/acquisition/adapters/galileo_e1_pcps_quicksync_ambiguous_acquisition.cc
@@ -51,8 +51,6 @@ GalileoE1PcpsQuickSyncAmbiguousAcquisition::GalileoE1PcpsQuickSyncAmbiguousAcqui
       doppler_max_(configuration_->property(role + ".doppler_max", 5000)),
       doppler_step_(0),
       sampled_ms_(configuration_->property(role + ".coherent_integration_time_ms", 8)),
-      in_streams_(in_streams),
-      out_streams_(out_streams),
       bit_transition_flag_(configuration_->property(role + ".bit_transition_flag", false)),
       dump_(configuration_->property(role + ".dump", false))
 {
@@ -112,15 +110,12 @@ GalileoE1PcpsQuickSyncAmbiguousAcquisition::GalileoE1PcpsQuickSyncAmbiguousAcqui
     // vector_length_ = (sampled_ms_/folding_factor_) * code_length_;
     vector_length_ = sampled_ms_ * samples_per_ms;
 
+    unsigned int max_dwells = 2;
+
     if (!bit_transition_flag_)
         {
-            max_dwells_ = configuration_->property(role + ".max_dwells", 1);
+            max_dwells = configuration_->property(role + ".max_dwells", 1);
         }
-    else
-        {
-            max_dwells_ = 2;
-        }
-
 
     bool enable_monitor_output = configuration_->property("AcquisitionMonitor.enable_monitor", false);
 
@@ -133,7 +128,7 @@ GalileoE1PcpsQuickSyncAmbiguousAcquisition::GalileoE1PcpsQuickSyncAmbiguousAcqui
     if (item_type_ == "gr_complex")
         {
             acquisition_cc_ = pcps_quicksync_make_acquisition_cc(folding_factor_,
-                sampled_ms_, max_dwells_, doppler_max_, fs_in_,
+                sampled_ms_, max_dwells, doppler_max_, fs_in_,
                 samples_per_ms, code_length_, bit_transition_flag_,
                 dump_, dump_filename_, enable_monitor_output);
             stream_to_vector_ = gr::blocks::stream_to_vector::make(item_size_,
@@ -150,11 +145,11 @@ GalileoE1PcpsQuickSyncAmbiguousAcquisition::GalileoE1PcpsQuickSyncAmbiguousAcqui
             LOG(WARNING) << item_type_ << " unknown acquisition item type";
         }
 
-    if (in_streams_ > 1)
+    if (in_streams > 1)
         {
             LOG(ERROR) << "This implementation only supports one input stream";
         }
-    if (out_streams_ > 0)
+    if (out_streams > 0)
         {
             LOG(ERROR) << "This implementation does not provide an output stream";
         }

--- a/src/algorithms/acquisition/adapters/galileo_e1_pcps_quicksync_ambiguous_acquisition.h
+++ b/src/algorithms/acquisition/adapters/galileo_e1_pcps_quicksync_ambiguous_acquisition.h
@@ -166,10 +166,7 @@ private:
     unsigned int doppler_max_;
     unsigned int doppler_step_;
     unsigned int sampled_ms_;
-    unsigned int max_dwells_;
     unsigned int folding_factor_;
-    unsigned int in_streams_;
-    unsigned int out_streams_;
     bool bit_transition_flag_;
     bool dump_;
 };

--- a/src/algorithms/acquisition/adapters/galileo_e1_pcps_quicksync_ambiguous_acquisition.h
+++ b/src/algorithms/acquisition/adapters/galileo_e1_pcps_quicksync_ambiguous_acquisition.h
@@ -169,6 +169,7 @@ private:
     unsigned int folding_factor_;
     bool bit_transition_flag_;
     bool dump_;
+    const bool cboc_;
 };
 
 

--- a/src/algorithms/acquisition/adapters/galileo_e1_pcps_tong_ambiguous_acquisition.cc
+++ b/src/algorithms/acquisition/adapters/galileo_e1_pcps_tong_ambiguous_acquisition.cc
@@ -54,8 +54,6 @@ GalileoE1PcpsTongAmbiguousAcquisition::GalileoE1PcpsTongAmbiguousAcquisition(
       tong_init_val_(configuration->property(role + ".tong_init_val", 1)),
       tong_max_val_(configuration->property(role + ".tong_max_val", 2)),
       tong_max_dwells_(configuration->property(role + ".tong_max_dwells", tong_max_val_ + 1)),
-      in_streams_(in_streams),
-      out_streams_(out_streams),
       dump_(configuration_->property(role + ".dump", false))
 {
     const std::string default_item_type("gr_complex");
@@ -120,11 +118,11 @@ GalileoE1PcpsTongAmbiguousAcquisition::GalileoE1PcpsTongAmbiguousAcquisition(
             LOG(WARNING) << item_type_ << " unknown acquisition item type";
         }
 
-    if (in_streams_ > 1)
+    if (in_streams > 1)
         {
             LOG(ERROR) << "This implementation only supports one input stream";
         }
-    if (out_streams_ > 0)
+    if (out_streams > 0)
         {
             LOG(ERROR) << "This implementation does not provide an output stream";
         }

--- a/src/algorithms/acquisition/adapters/galileo_e1_pcps_tong_ambiguous_acquisition.cc
+++ b/src/algorithms/acquisition/adapters/galileo_e1_pcps_tong_ambiguous_acquisition.cc
@@ -54,7 +54,8 @@ GalileoE1PcpsTongAmbiguousAcquisition::GalileoE1PcpsTongAmbiguousAcquisition(
       tong_init_val_(configuration->property(role + ".tong_init_val", 1)),
       tong_max_val_(configuration->property(role + ".tong_max_val", 2)),
       tong_max_dwells_(configuration->property(role + ".tong_max_dwells", tong_max_val_ + 1)),
-      dump_(configuration_->property(role + ".dump", false))
+      dump_(configuration_->property(role + ".dump", false)),
+      cboc_(configuration_->property(role + ".cboc", false))
 {
     const std::string default_item_type("gr_complex");
     const std::string default_dump_filename("./acquisition.dat");
@@ -215,16 +216,12 @@ void GalileoE1PcpsTongAmbiguousAcquisition::set_local_code()
 {
     if (item_type_ == "gr_complex")
         {
-            bool cboc = configuration_->property(
-                "Acquisition" + std::to_string(channel_) + ".cboc", false);
-
             std::vector<std::complex<float>> code(code_length_);
             std::array<char, 3> Signal_{};
             Signal_[0] = gnss_synchro_->Signal[0];
             Signal_[1] = gnss_synchro_->Signal[1];
             Signal_[2] = '\0';
-            galileo_e1_code_gen_complex_sampled(code, Signal_,
-                cboc, gnss_synchro_->PRN, fs_in_, 0, false);
+            galileo_e1_code_gen_complex_sampled(code, Signal_, cboc_, gnss_synchro_->PRN, fs_in_, 0, false);
 
             own::span<gr_complex> code_span(code_.data(), vector_length_);
             for (unsigned int i = 0; i < sampled_ms_ / 4; i++)

--- a/src/algorithms/acquisition/adapters/galileo_e1_pcps_tong_ambiguous_acquisition.h
+++ b/src/algorithms/acquisition/adapters/galileo_e1_pcps_tong_ambiguous_acquisition.h
@@ -169,6 +169,7 @@ private:
     unsigned int tong_max_val_;
     unsigned int tong_max_dwells_;
     bool dump_;
+    const bool cboc_;
 };
 
 

--- a/src/algorithms/acquisition/adapters/galileo_e1_pcps_tong_ambiguous_acquisition.h
+++ b/src/algorithms/acquisition/adapters/galileo_e1_pcps_tong_ambiguous_acquisition.h
@@ -168,8 +168,6 @@ private:
     unsigned int tong_init_val_;
     unsigned int tong_max_val_;
     unsigned int tong_max_dwells_;
-    unsigned int in_streams_;
-    unsigned int out_streams_;
     bool dump_;
 };
 

--- a/src/algorithms/acquisition/adapters/galileo_e5a_noncoherent_iq_acquisition_caf.cc
+++ b/src/algorithms/acquisition/adapters/galileo_e5a_noncoherent_iq_acquisition_caf.cc
@@ -59,9 +59,6 @@ GalileoE5aNoncoherentIQAcquisitionCaf::GalileoE5aNoncoherentIQAcquisitionCaf(
       doppler_max_(configuration_->property(role + ".doppler_max", 5000)),
       doppler_step_(0),
       sampled_ms_(configuration_->property(role + ".coherent_integration_time_ms", 1)),
-      max_dwells_(configuration_->property(role + ".max_dwells", 1)),
-      in_streams_(in_streams),
-      out_streams_(out_streams),
       bit_transition_flag_(configuration_->property(role + ".bit_transition_flag", false)),
       dump_(configuration_->property(role + ".dump", false))
 {
@@ -116,7 +113,8 @@ GalileoE5aNoncoherentIQAcquisitionCaf::GalileoE5aNoncoherentIQAcquisitionCaf(
         }
     if (item_type_ == "gr_complex")
         {
-            acquisition_cc_ = galileo_e5a_noncoherentIQ_make_acquisition_caf_cc(sampled_ms_, max_dwells_,
+            unsigned int max_dwells = configuration_->property(role + ".max_dwells", 1);
+            acquisition_cc_ = galileo_e5a_noncoherentIQ_make_acquisition_caf_cc(sampled_ms_, max_dwells,
                 doppler_max_, fs_in_, code_length_, code_length_, bit_transition_flag_,
                 dump_, dump_filename_, both_signal_components, CAF_window_hz_, Zero_padding, enable_monitor_output);
         }
@@ -127,11 +125,11 @@ GalileoE5aNoncoherentIQAcquisitionCaf::GalileoE5aNoncoherentIQAcquisitionCaf(
             LOG(WARNING) << item_type_ << " unknown acquisition item type";
         }
 
-    if (in_streams_ > 1)
+    if (in_streams > 1)
         {
             LOG(ERROR) << "This implementation only supports one input stream";
         }
-    if (out_streams_ > 0)
+    if (out_streams > 0)
         {
             LOG(ERROR) << "This implementation does not provide an output stream";
         }

--- a/src/algorithms/acquisition/adapters/galileo_e5a_noncoherent_iq_acquisition_caf.h
+++ b/src/algorithms/acquisition/adapters/galileo_e5a_noncoherent_iq_acquisition_caf.h
@@ -170,9 +170,6 @@ private:
     unsigned int doppler_max_;
     unsigned int doppler_step_;
     unsigned int sampled_ms_;
-    unsigned int max_dwells_;
-    unsigned int in_streams_;
-    unsigned int out_streams_;
     bool bit_transition_flag_;
     bool both_signal_components;
     bool dump_;

--- a/src/algorithms/acquisition/adapters/galileo_e5a_pcps_acquisition_fpga.h
+++ b/src/algorithms/acquisition/adapters/galileo_e5a_pcps_acquisition_fpga.h
@@ -26,9 +26,6 @@
  * \{ */
 
 
-class ConfigurationInterface;
-
-
 /*!
  * \brief This class adapts a PCPS acquisition block off-loaded on an FPGA
  * to an AcquisitionInterface for Galileo E5a signals

--- a/src/algorithms/acquisition/adapters/galileo_e5b_pcps_acquisition_fpga.cc
+++ b/src/algorithms/acquisition/adapters/galileo_e5b_pcps_acquisition_fpga.cc
@@ -46,10 +46,10 @@ GalileoE5bPcpsAcquisitionFpga::GalileoE5bPcpsAcquisitionFpga(
           DEFAULT_FPGA_BLK_EXP,
           ACQ_BUFF_1,
           in_streams,
-          out_streams)
+          out_streams),
+      acq_pilot_(configuration->property(role + ".acquire_pilot", false)),
+      acq_iq_(configuration->property(role + ".acquire_iq", false))
 {
-    acq_pilot_ = configuration->property(role + ".acquire_pilot", false);
-    acq_iq_ = configuration->property(role + ".acquire_iq", false);
     generate_galileo_e5b_prn_codes();
     DLOG(INFO) << "Initialized FPGA acquisition adapter for role " << role;
 }

--- a/src/algorithms/acquisition/adapters/galileo_e5b_pcps_acquisition_fpga.h
+++ b/src/algorithms/acquisition/adapters/galileo_e5b_pcps_acquisition_fpga.h
@@ -27,8 +27,6 @@
  * \{ */
 
 
-class ConfigurationInterface;
-
 /*!
  * \brief This class adapts a PCPS acquisition block off-loaded on an FPGA
  * to an AcquisitionInterface for Galileo E5b signals
@@ -56,7 +54,7 @@ private:
     static const uint32_t DEFAULT_FPGA_BLK_EXP = 13;  // default block exponent
     void generate_galileo_e5b_prn_codes();
     bool acq_pilot_;
-    bool acq_iq_;
+    const bool acq_iq_;
 };
 
 

--- a/src/algorithms/acquisition/adapters/glonass_l2_ca_pcps_acquisition.h
+++ b/src/algorithms/acquisition/adapters/glonass_l2_ca_pcps_acquisition.h
@@ -19,17 +19,7 @@
 #ifndef GNSS_SDR_GLONASS_L2_CA_PCPS_ACQUISITION_H
 #define GNSS_SDR_GLONASS_L2_CA_PCPS_ACQUISITION_H
 
-#include "acq_conf.h"
 #include "base_pcps_acquisition.h"
-#include "channel_fsm.h"
-#include "complex_byte_to_float_x2.h"
-#include "gnss_synchro.h"
-#include "pcps_acquisition.h"
-#include <gnuradio/blocks/float_to_complex.h>
-#include <volk_gnsssdr/volk_gnsssdr_alloc.h>
-#include <memory>
-#include <string>
-#include <utility>
 
 /** \addtogroup Acquisition
  * \{ */

--- a/src/algorithms/acquisition/adapters/gps_l1_ca_pcps_acquisition_fine_doppler.cc
+++ b/src/algorithms/acquisition/adapters/gps_l1_ca_pcps_acquisition_fine_doppler.cc
@@ -41,12 +41,9 @@ GpsL1CaPcpsAcquisitionFineDoppler::GpsL1CaPcpsAcquisitionFineDoppler(
       item_size_(sizeof(gr_complex)),
       threshold_(0.0),
       doppler_max_(configuration->property(role + ".doppler_max", 5000)),
-      max_dwells_(configuration->property(role + ".max_dwells", 1)),
       channel_(0),
       doppler_step_(0),
       sampled_ms_(configuration->property(role + ".coherent_integration_time_ms", 1)),
-      in_streams_(in_streams),
-      out_streams_(out_streams),
       dump_(configuration->property(role + ".dump", false))
 {
     const std::string default_item_type("gr_complex");
@@ -74,7 +71,7 @@ GpsL1CaPcpsAcquisitionFineDoppler::GpsL1CaPcpsAcquisitionFineDoppler(
 #endif
     acq_parameters.doppler_max = doppler_max_;
     acq_parameters.sampled_ms = sampled_ms_;
-    acq_parameters.max_dwells = max_dwells_;
+    acq_parameters.max_dwells = configuration->property(role + ".max_dwells", 1);
     acq_parameters.blocking_on_standby = configuration->property(role + ".blocking_on_standby", false);
 
     // -- Find number of samples per spreading code -------------------------
@@ -94,11 +91,11 @@ GpsL1CaPcpsAcquisitionFineDoppler::GpsL1CaPcpsAcquisitionFineDoppler(
             LOG(WARNING) << item_type_ << " unknown acquisition item type";
         }
 
-    if (in_streams_ > 1)
+    if (in_streams > 1)
         {
             LOG(ERROR) << "This implementation only supports one input stream";
         }
-    if (out_streams_ > 0)
+    if (out_streams > 0)
         {
             LOG(ERROR) << "This implementation does not provide an output stream";
         }

--- a/src/algorithms/acquisition/adapters/gps_l1_ca_pcps_acquisition_fine_doppler.h
+++ b/src/algorithms/acquisition/adapters/gps_l1_ca_pcps_acquisition_fine_doppler.h
@@ -156,13 +156,10 @@ private:
     size_t item_size_;
     float threshold_;
     int doppler_max_;
-    int max_dwells_;
     unsigned int vector_length_;
     unsigned int channel_;
     unsigned int doppler_step_;
     unsigned int sampled_ms_;
-    unsigned int in_streams_;
-    unsigned int out_streams_;
     bool dump_;
 };
 

--- a/src/algorithms/acquisition/adapters/gps_l1_ca_pcps_assisted_acquisition.cc
+++ b/src/algorithms/acquisition/adapters/gps_l1_ca_pcps_assisted_acquisition.cc
@@ -38,27 +38,21 @@ GpsL1CaPcpsAssistedAcquisition::GpsL1CaPcpsAssistedAcquisition(
     : role_(role),
       gnss_synchro_(nullptr),
       item_size_(sizeof(gr_complex)),
-      threshold_(0.0),
-      doppler_max_(configuration->property(role + ".doppler_max", 5000)),
-      max_dwells_(configuration->property(role + ".max_dwells", 1)),
-      channel_(0),
-      doppler_step_(0),
-      sampled_ms_(configuration->property(role + ".coherent_integration_time_ms", 1)),
-      in_streams_(in_streams),
-      out_streams_(out_streams),
       dump_(configuration->property(role + ".dump", false))
 {
     const std::string default_item_type("gr_complex");
-    std::string default_dump_filename = "./data/acquisition.dat";
-    dump_filename_ = configuration->property(role_ + ".dump_filename", std::move(default_dump_filename));
-    item_type_ = configuration->property(role_ + ".item_type", default_item_type);
-    int64_t fs_in_deprecated = configuration->property("GNSS-SDR.internal_fs_hz", 2048000);
+    const std::string default_dump_filename = "./data/acquisition.dat";
+    const std::string dump_filename = configuration->property(role_ + ".dump_filename", default_dump_filename);
+    const std::string item_type = configuration->property(role_ + ".item_type", default_item_type);
+    const int64_t fs_in_deprecated = configuration->property("GNSS-SDR.internal_fs_hz", 2048000);
     fs_in_ = configuration->property("GNSS-SDR.internal_fs_sps", fs_in_deprecated);
+
+    int doppler_max = configuration->property(role + ".doppler_max", 5000);
 
 #if USE_GLOG_AND_GFLAGS
     if (FLAGS_doppler_max != 0)
         {
-            doppler_max_ = FLAGS_doppler_max;
+            doppler_max = FLAGS_doppler_max;
         }
 #else
     if (absl::GetFlag(FLAGS_doppler_max) != 0)
@@ -66,8 +60,7 @@ GpsL1CaPcpsAssistedAcquisition::GpsL1CaPcpsAssistedAcquisition(
             doppler_max_ = absl::GetFlag(FLAGS_doppler_max);
         }
 #endif
-    doppler_min_ = configuration->property(role_ + ".doppler_min", -doppler_max_);
-
+    const int doppler_min = configuration->property(role_ + ".doppler_min", -doppler_max);
     bool enable_monitor_output = configuration->property("AcquisitionMonitor.enable_monitor", false);
 
     // --- Find number of samples per spreading code -------------------------
@@ -76,24 +69,26 @@ GpsL1CaPcpsAssistedAcquisition::GpsL1CaPcpsAssistedAcquisition(
     code_ = std::vector<std::complex<float>>(vector_length_);
 
     DLOG(INFO) << "role " << role_;
-    if (item_type_ == "gr_complex")
+    if (item_type == "gr_complex")
         {
-            acquisition_cc_ = pcps_make_assisted_acquisition_cc(max_dwells_, sampled_ms_,
-                doppler_max_, doppler_min_, fs_in_, vector_length_,
-                dump_, dump_filename_, enable_monitor_output);
+            const unsigned int max_dwells = configuration->property(role + ".max_dwells", 1);
+            const unsigned int sampled_ms = configuration->property(role + ".coherent_integration_time_ms", 1);
+            acquisition_cc_ = pcps_make_assisted_acquisition_cc(max_dwells, sampled_ms,
+                doppler_max, doppler_min, fs_in_, vector_length_,
+                dump_, dump_filename, enable_monitor_output);
         }
     else
         {
             item_size_ = 0;
             acquisition_cc_ = nullptr;
-            LOG(WARNING) << item_type_ << " unknown acquisition item type";
+            LOG(WARNING) << item_type << " unknown acquisition item type";
         }
 
-    if (in_streams_ > 1)
+    if (in_streams > 1)
         {
             LOG(ERROR) << "This implementation only supports one input stream";
         }
-    if (out_streams_ > 0)
+    if (out_streams > 0)
         {
             LOG(ERROR) << "This implementation does not provide an output stream";
         }
@@ -109,22 +104,19 @@ void GpsL1CaPcpsAssistedAcquisition::stop_acquisition()
 
 void GpsL1CaPcpsAssistedAcquisition::set_threshold(float threshold)
 {
-    threshold_ = threshold;
-    acquisition_cc_->set_threshold(threshold_);
+    acquisition_cc_->set_threshold(threshold);
 }
 
 
 void GpsL1CaPcpsAssistedAcquisition::set_doppler_max(unsigned int doppler_max)
 {
-    doppler_max_ = static_cast<int>(doppler_max);
-    acquisition_cc_->set_doppler_max(doppler_max_);
+    acquisition_cc_->set_doppler_max(doppler_max);
 }
 
 
 void GpsL1CaPcpsAssistedAcquisition::set_doppler_step(unsigned int doppler_step)
 {
-    doppler_step_ = doppler_step;
-    acquisition_cc_->set_doppler_step(doppler_step_);
+    acquisition_cc_->set_doppler_step(doppler_step);
 }
 
 
@@ -160,21 +152,13 @@ void GpsL1CaPcpsAssistedAcquisition::reset()
 }
 
 
-void GpsL1CaPcpsAssistedAcquisition::connect(gr::top_block_sptr top_block)
+void GpsL1CaPcpsAssistedAcquisition::connect(gr::top_block_sptr /*top_block*/)
 {
-    if (top_block)
-        { /* top_block is not null */
-        };
-    // nothing to disconnect, now the tracking uses gr_sync_decimator
 }
 
 
-void GpsL1CaPcpsAssistedAcquisition::disconnect(gr::top_block_sptr top_block)
+void GpsL1CaPcpsAssistedAcquisition::disconnect(gr::top_block_sptr /*top_block*/)
 {
-    if (top_block)
-        { /* top_block is not null */
-        };
-    // nothing to disconnect, now the tracking uses gr_sync_decimator
 }
 
 

--- a/src/algorithms/acquisition/adapters/gps_l1_ca_pcps_assisted_acquisition.cc
+++ b/src/algorithms/acquisition/adapters/gps_l1_ca_pcps_assisted_acquisition.cc
@@ -57,7 +57,7 @@ GpsL1CaPcpsAssistedAcquisition::GpsL1CaPcpsAssistedAcquisition(
 #else
     if (absl::GetFlag(FLAGS_doppler_max) != 0)
         {
-            doppler_max_ = absl::GetFlag(FLAGS_doppler_max);
+            doppler_max = absl::GetFlag(FLAGS_doppler_max);
         }
 #endif
     const int doppler_min = configuration->property(role_ + ".doppler_min", -doppler_max);

--- a/src/algorithms/acquisition/adapters/gps_l1_ca_pcps_assisted_acquisition.h
+++ b/src/algorithms/acquisition/adapters/gps_l1_ca_pcps_assisted_acquisition.h
@@ -86,8 +86,7 @@ public:
      */
     inline void set_channel(unsigned int channel) override
     {
-        channel_ = channel;
-        acquisition_cc_->set_channel(channel_);
+        acquisition_cc_->set_channel(channel);
     }
 
     /*!
@@ -95,8 +94,7 @@ public:
      */
     inline void set_channel_fsm(std::weak_ptr<ChannelFsm> channel_fsm) override
     {
-        channel_fsm_ = std::move(channel_fsm);
-        acquisition_cc_->set_channel_fsm(channel_fsm_);
+        acquisition_cc_->set_channel_fsm(std::move(channel_fsm));
     }
 
     /*!
@@ -141,11 +139,8 @@ public:
 
 private:
     pcps_assisted_acquisition_cc_sptr acquisition_cc_;
-    std::weak_ptr<ChannelFsm> channel_fsm_;
     std::vector<std::complex<float>> code_;
 
-    std::string item_type_;
-    std::string dump_filename_;
     std::string role_;
 
     Gnss_Synchro* gnss_synchro_;
@@ -153,16 +148,7 @@ private:
     size_t item_size_;
     int64_t fs_in_;
 
-    float threshold_;
-    int doppler_max_;
-    int doppler_min_;
-    int max_dwells_;
     unsigned int vector_length_;
-    unsigned int channel_;
-    unsigned int doppler_step_;
-    unsigned int sampled_ms_;
-    unsigned int in_streams_;
-    unsigned int out_streams_;
 
     bool dump_;
 };

--- a/src/algorithms/acquisition/adapters/gps_l1_ca_pcps_opencl_acquisition.cc
+++ b/src/algorithms/acquisition/adapters/gps_l1_ca_pcps_opencl_acquisition.cc
@@ -47,9 +47,7 @@ GpsL1CaPcpsOpenClAcquisition::GpsL1CaPcpsOpenClAcquisition(
       role_(role),
       threshold_(0.0),
       channel_(0),
-      doppler_step_(0),
-      in_streams_(in_streams),
-      out_streams_(out_streams)
+      doppler_step_(0)
 {
     const std::string default_item_type("gr_complex");
     std::string default_dump_filename = "./data/acquisition.dat";
@@ -78,13 +76,11 @@ GpsL1CaPcpsOpenClAcquisition::GpsL1CaPcpsOpenClAcquisition(
 
     bit_transition_flag_ = configuration->property("Acquisition.bit_transition_flag", false);
 
+    unsigned int max_dwells = 2;
+
     if (!bit_transition_flag_)
         {
-            max_dwells_ = configuration->property(role + ".max_dwells", 1);
-        }
-    else
-        {
-            max_dwells_ = 2;
+            max_dwells = configuration->property(role + ".max_dwells", 1);
         }
 
     dump_filename_ = configuration->property(role + ".dump_filename",
@@ -100,7 +96,7 @@ GpsL1CaPcpsOpenClAcquisition::GpsL1CaPcpsOpenClAcquisition(
     if (item_type_ == "gr_complex")
         {
             item_size_ = sizeof(gr_complex);
-            acquisition_cc_ = pcps_make_opencl_acquisition_cc(sampled_ms_, max_dwells_,
+            acquisition_cc_ = pcps_make_opencl_acquisition_cc(sampled_ms_, max_dwells,
                 doppler_max_, fs_in_, code_length_, code_length_,
                 bit_transition_flag_, dump_, dump_filename_, false);
 
@@ -115,11 +111,11 @@ GpsL1CaPcpsOpenClAcquisition::GpsL1CaPcpsOpenClAcquisition(
             LOG(WARNING) << item_type_ << " unknown acquisition item type";
         }
 
-    if (in_streams_ > 1)
+    if (in_streams > 1)
         {
             LOG(ERROR) << "This implementation only supports one input stream";
         }
-    if (out_streams_ > 0)
+    if (out_streams > 0)
         {
             LOG(ERROR) << "This implementation does not provide an output stream";
         }

--- a/src/algorithms/acquisition/adapters/gps_l1_ca_pcps_opencl_acquisition.h
+++ b/src/algorithms/acquisition/adapters/gps_l1_ca_pcps_opencl_acquisition.h
@@ -170,9 +170,6 @@ private:
     unsigned int doppler_max_;
     unsigned int doppler_step_;
     unsigned int sampled_ms_;
-    unsigned int max_dwells_;
-    unsigned int in_streams_;
-    unsigned int out_streams_;
     bool bit_transition_flag_;
     bool dump_;
 };

--- a/src/algorithms/acquisition/adapters/gps_l1_ca_pcps_quicksync_acquisition.cc
+++ b/src/algorithms/acquisition/adapters/gps_l1_ca_pcps_quicksync_acquisition.cc
@@ -52,8 +52,6 @@ GpsL1CaPcpsQuickSyncAcquisition::GpsL1CaPcpsQuickSyncAcquisition(
       doppler_max_(configuration->property(role + ".doppler_max", 5000)),
       doppler_step_(0),
       sampled_ms_(configuration_->property(role + ".coherent_integration_time_ms", 4)),
-      in_streams_(in_streams),
-      out_streams_(out_streams),
       bit_transition_flag_(configuration_->property(role + ".bit_transition_flag", false)),
       dump_(configuration_->property(role + ".dump", false))
 {
@@ -102,13 +100,11 @@ GpsL1CaPcpsQuickSyncAcquisition::GpsL1CaPcpsQuickSyncAcquisition(
 
     vector_length_ = code_length_ * sampled_ms_;
 
+    unsigned int max_dwells = 2;
+
     if (!bit_transition_flag_)
         {
-            max_dwells_ = configuration_->property(role_ + ".max_dwells", 1);
-        }
-    else
-        {
-            max_dwells_ = 2;
+            max_dwells = configuration->property(role + ".max_dwells", 1);
         }
 
     dump_filename_ = configuration_->property(role_ + ".dump_filename", std::move(default_dump_filename));
@@ -130,7 +126,7 @@ GpsL1CaPcpsQuickSyncAcquisition::GpsL1CaPcpsQuickSyncAcquisition(
     if (item_type_ == "gr_complex")
         {
             acquisition_cc_ = pcps_quicksync_make_acquisition_cc(folding_factor_,
-                sampled_ms_, max_dwells_, doppler_max_, fs_in_,
+                sampled_ms_, max_dwells, doppler_max_, fs_in_,
                 samples_per_ms, code_length_, bit_transition_flag_,
                 dump_, dump_filename_, enable_monitor_output);
 
@@ -147,11 +143,11 @@ GpsL1CaPcpsQuickSyncAcquisition::GpsL1CaPcpsQuickSyncAcquisition(
             LOG(WARNING) << item_type_ << " unknown acquisition item type";
         }
 
-    if (in_streams_ > 1)
+    if (in_streams > 1)
         {
             LOG(ERROR) << "This implementation only supports one input stream";
         }
-    if (out_streams_ > 0)
+    if (out_streams > 0)
         {
             LOG(ERROR) << "This implementation does not provide an output stream";
         }

--- a/src/algorithms/acquisition/adapters/gps_l1_ca_pcps_quicksync_acquisition.h
+++ b/src/algorithms/acquisition/adapters/gps_l1_ca_pcps_quicksync_acquisition.h
@@ -171,10 +171,7 @@ private:
     unsigned int doppler_max_;
     unsigned int doppler_step_;
     unsigned int sampled_ms_;
-    unsigned int max_dwells_;
     unsigned int folding_factor_;
-    unsigned int in_streams_;
-    unsigned int out_streams_;
     bool bit_transition_flag_;
     bool dump_;
 };

--- a/src/algorithms/acquisition/adapters/gps_l1_ca_pcps_tong_acquisition.cc
+++ b/src/algorithms/acquisition/adapters/gps_l1_ca_pcps_tong_acquisition.cc
@@ -46,16 +46,10 @@ GpsL1CaPcpsTongAcquisition::GpsL1CaPcpsTongAcquisition(
       gnss_synchro_(nullptr),
       role_(role),
       item_size_(sizeof(gr_complex)),
-      threshold_(0.0),
       channel_(0),
       doppler_max_(configuration->property(role + ".doppler_max", 5000)),
       doppler_step_(0),
       sampled_ms_(configuration_->property(role + ".coherent_integration_time_ms", 1)),
-      tong_init_val_(configuration->property(role + ".tong_init_val", 1)),
-      tong_max_val_(configuration->property(role + ".tong_max_val", 2)),
-      tong_max_dwells_(configuration->property(role + ".tong_max_dwells", tong_max_val_ + 1)),
-      in_streams_(in_streams),
-      out_streams_(out_streams),
       dump_(configuration_->property(role + ".dump", false))
 {
     const std::string default_item_type("gr_complex");
@@ -90,8 +84,11 @@ GpsL1CaPcpsTongAcquisition::GpsL1CaPcpsTongAcquisition(
 
     if (item_type_ == "gr_complex")
         {
+            const unsigned int tong_init_val = configuration->property(role + ".tong_init_val", 1);
+            const unsigned int tong_max_val = configuration->property(role + ".tong_max_val", 2);
+            const unsigned int tong_max_dwells = configuration->property(role + ".tong_max_dwells", tong_max_val + 1);
             acquisition_cc_ = pcps_tong_make_acquisition_cc(sampled_ms_, doppler_max_, fs_in_,
-                code_length_, code_length_, tong_init_val_, tong_max_val_, tong_max_dwells_,
+                code_length_, code_length_, tong_init_val, tong_max_val, tong_max_dwells,
                 dump_, dump_filename_, enable_monitor_output);
 
             stream_to_vector_ = gr::blocks::stream_to_vector::make(item_size_, vector_length_);
@@ -106,11 +103,11 @@ GpsL1CaPcpsTongAcquisition::GpsL1CaPcpsTongAcquisition(
             LOG(WARNING) << item_type_ << " unknown acquisition item type";
         }
 
-    if (in_streams_ > 1)
+    if (in_streams > 1)
         {
             LOG(ERROR) << "This implementation only supports one input stream";
         }
-    if (out_streams_ > 0)
+    if (out_streams > 0)
         {
             LOG(ERROR) << "This implementation does not provide an output stream";
         }
@@ -132,20 +129,16 @@ void GpsL1CaPcpsTongAcquisition::set_threshold(float threshold)
         {
             pfa = configuration_->property(role_ + ".pfa", static_cast<float>(0.0));
         }
-    if (pfa == 0.0)
+    if (pfa != 0.0)
         {
-            threshold_ = threshold;
-        }
-    else
-        {
-            threshold_ = calculate_threshold(pfa);
+            threshold = calculate_threshold(pfa);
         }
 
-    DLOG(INFO) << "Channel " << channel_ << "  Threshold = " << threshold_;
+    DLOG(INFO) << "Channel " << channel_ << "  Threshold = " << threshold;
 
     if (item_type_ == "gr_complex")
         {
-            acquisition_cc_->set_threshold(threshold_);
+            acquisition_cc_->set_threshold(threshold);
         }
 }
 

--- a/src/algorithms/acquisition/adapters/gps_l1_ca_pcps_tong_acquisition.h
+++ b/src/algorithms/acquisition/adapters/gps_l1_ca_pcps_tong_acquisition.h
@@ -159,18 +159,12 @@ private:
     std::string role_;
     int64_t fs_in_;
     size_t item_size_;
-    float threshold_;
     unsigned int vector_length_;
     unsigned int code_length_;
     unsigned int channel_;
     unsigned int doppler_max_;
     unsigned int doppler_step_;
     unsigned int sampled_ms_;
-    unsigned int tong_init_val_;
-    unsigned int tong_max_val_;
-    unsigned int tong_max_dwells_;
-    unsigned int in_streams_;
-    unsigned int out_streams_;
     bool dump_;
 };
 

--- a/src/algorithms/tracking/adapters/base_dll_pll_tracking.cc
+++ b/src/algorithms/tracking/adapters/base_dll_pll_tracking.cc
@@ -29,19 +29,15 @@ BaseDllPllTracking::BaseDllPllTracking(
     unsigned int in_streams,
     unsigned int out_streams)
     : role_(std::move(role)),
-      item_size_(sizeof(gr_complex)),
-      channel_(0),
-      in_streams_(in_streams),
-      out_streams_(out_streams)
+      item_size_(sizeof(gr_complex))
 {
-    trk_params_ = Dll_Pll_Conf();
     trk_params_.SetFromConfiguration(configuration, role_);
 
-    if (in_streams_ > 1)
+    if (in_streams > 1)
         {
             LOG(ERROR) << "Only one input stream is supported.";
         }
-    if (out_streams_ > 1)
+    if (out_streams > 1)
         {
             LOG(ERROR) << "Only one output stream is supported.";
         }
@@ -80,7 +76,6 @@ gr::basic_block_sptr BaseDllPllTracking::get_right_block()
 
 void BaseDllPllTracking::set_channel(unsigned int channel)
 {
-    channel_ = channel;
     tracking_sptr_->set_channel(channel);
 }
 

--- a/src/algorithms/tracking/adapters/base_dll_pll_tracking.h
+++ b/src/algorithms/tracking/adapters/base_dll_pll_tracking.h
@@ -117,11 +117,8 @@ protected:
 private:
     // Managed by the base class
     Dll_Pll_Conf trk_params_;
-    std::string role_;
+    const std::string role_;
     size_t item_size_;
-    unsigned int channel_;
-    unsigned int in_streams_;
-    unsigned int out_streams_;
 };
 
 /** \} */

--- a/src/algorithms/tracking/adapters/base_dll_pll_tracking_fpga.cc
+++ b/src/algorithms/tracking/adapters/base_dll_pll_tracking_fpga.cc
@@ -32,17 +32,14 @@ BaseDllPllTrackingFpga::BaseDllPllTrackingFpga(
     unsigned int out_streams)
     : role_(role),
       channel_(0),
-      num_prev_assigned_ch_(0),
-      in_streams_(in_streams),
-      out_streams_(out_streams)
+      num_prev_assigned_ch_(0)
 {
-    trk_params_ = Dll_Pll_Conf_Fpga();
     trk_params_.SetFromConfiguration(configuration, role_);
-    if (in_streams_ > 1)
+    if (in_streams > 1)
         {
             LOG(ERROR) << "This implementation only supports one input stream";
         }
-    if (out_streams_ > 1)
+    if (out_streams > 1)
         {
             LOG(ERROR) << "This implementation only supports one output stream";
         }
@@ -95,7 +92,7 @@ void BaseDllPllTrackingFpga::set_channel(unsigned int channel)
     channel_ = channel;
     std::string device_io_name;
 
-    if (find_uio_dev_file_name(device_io_name, device_name_, channel_ - num_prev_assigned_ch_) < 0)
+    if (find_uio_dev_file_name(device_io_name, device_name_, channel - num_prev_assigned_ch_) < 0)
         {
             if (!find_alternative_device(device_io_name))
                 {

--- a/src/algorithms/tracking/adapters/base_dll_pll_tracking_fpga.h
+++ b/src/algorithms/tracking/adapters/base_dll_pll_tracking_fpga.h
@@ -125,11 +125,9 @@ protected:
 
 private:
     Dll_Pll_Conf_Fpga trk_params_;
-    std::string role_;
+    const std::string role_;
     uint32_t channel_;
     uint32_t num_prev_assigned_ch_;
-    uint32_t in_streams_;
-    uint32_t out_streams_;
 };
 
 /** \} */


### PR DESCRIPTION
Let's keep going with cleaning up acquisition and tracking classes, @carlesfernandez great to see you clean it up as well!

I have a question regarding code like this:
```
if (item_type_ == "gr_complex")
    {
        ...
    }
else
    {
        item_size_ = 0;
        acquisition_cc_ = nullptr;
        LOG(WARNING) << item_type_ << " unknown acquisition item type";
    }
```

What are we expecting when `item_type_ != "gr_complex"`?
To me this is just an invalid configuration and we should throw an error to the user, not ignore it, but interested to see other opinions.