### PR TITLE
Make doppler max const and remove setter

### DIFF
--- a/src/algorithms/acquisition/adapters/base_pcps_acquisition.cc
+++ b/src/algorithms/acquisition/adapters/base_pcps_acquisition.cc
@@ -109,12 +109,6 @@ void BasePcpsAcquisition::set_threshold(float threshold)
 }
 
 
-void BasePcpsAcquisition::set_doppler_max(unsigned int doppler_max)
-{
-    acquisition_->set_doppler_max(doppler_max);
-}
-
-
 void BasePcpsAcquisition::set_doppler_step(unsigned int doppler_step)
 {
     acquisition_->set_doppler_step(doppler_step);

--- a/src/algorithms/acquisition/adapters/base_pcps_acquisition.h
+++ b/src/algorithms/acquisition/adapters/base_pcps_acquisition.h
@@ -99,11 +99,6 @@ public:
     void set_threshold(float threshold) override;
 
     /*!
-     * \brief Set maximum Doppler off grid search
-     */
-    void set_doppler_max(unsigned int doppler_max) override;
-
-    /*!
      * \brief Set Doppler steps for the grid search
      */
     void set_doppler_step(unsigned int doppler_step) override;

--- a/src/algorithms/acquisition/adapters/base_pcps_acquisition_fpga.cc
+++ b/src/algorithms/acquisition/adapters/base_pcps_acquisition_fpga.cc
@@ -158,15 +158,6 @@ void BasePcpsAcquisitionFpga::set_threshold(float threshold)
 }
 
 
-void BasePcpsAcquisitionFpga::set_doppler_max(unsigned int doppler_max)
-{
-    if (acquisition_fpga_)
-        {
-            acquisition_fpga_->set_doppler_max(doppler_max);
-        }
-}
-
-
 void BasePcpsAcquisitionFpga::set_doppler_step(unsigned int doppler_step)
 {
     if (acquisition_fpga_)

--- a/src/algorithms/acquisition/adapters/base_pcps_acquisition_fpga.h
+++ b/src/algorithms/acquisition/adapters/base_pcps_acquisition_fpga.h
@@ -71,7 +71,6 @@ public:
     void set_channel(unsigned int channel) override;
     void set_channel_fsm(std::weak_ptr<ChannelFsm> channel_fsm) override;
     void set_threshold(float threshold) override;
-    void set_doppler_max(unsigned int doppler_max) override;
     void set_doppler_step(unsigned int doppler_step) override;
     void set_doppler_center(int doppler_center) override;
     void set_state(int state) override;

--- a/src/algorithms/acquisition/adapters/galileo_e1_pcps_8ms_ambiguous_acquisition.cc
+++ b/src/algorithms/acquisition/adapters/galileo_e1_pcps_8ms_ambiguous_acquisition.cc
@@ -157,17 +157,6 @@ void GalileoE1Pcps8msAmbiguousAcquisition::set_threshold(float threshold)
 }
 
 
-void GalileoE1Pcps8msAmbiguousAcquisition::set_doppler_max(unsigned int doppler_max)
-{
-    doppler_max_ = doppler_max;
-
-    if (item_type_ == "gr_complex")
-        {
-            acquisition_cc_->set_doppler_max(doppler_max_);
-        }
-}
-
-
 void GalileoE1Pcps8msAmbiguousAcquisition::set_doppler_step(unsigned int doppler_step)
 {
     doppler_step_ = doppler_step;

--- a/src/algorithms/acquisition/adapters/galileo_e1_pcps_8ms_ambiguous_acquisition.h
+++ b/src/algorithms/acquisition/adapters/galileo_e1_pcps_8ms_ambiguous_acquisition.h
@@ -103,11 +103,6 @@ public:
     void set_threshold(float threshold) override;
 
     /*!
-     * \brief Set maximum Doppler off grid search
-     */
-    void set_doppler_max(unsigned int doppler_max) override;
-
-    /*!
      * \brief Set Doppler steps for the grid search
      */
     void set_doppler_step(unsigned int doppler_step) override;

--- a/src/algorithms/acquisition/adapters/galileo_e1_pcps_cccwsr_ambiguous_acquisition.cc
+++ b/src/algorithms/acquisition/adapters/galileo_e1_pcps_cccwsr_ambiguous_acquisition.cc
@@ -135,17 +135,6 @@ void GalileoE1PcpsCccwsrAmbiguousAcquisition::set_threshold(float threshold)
 }
 
 
-void GalileoE1PcpsCccwsrAmbiguousAcquisition::set_doppler_max(unsigned int doppler_max)
-{
-    doppler_max_ = doppler_max;
-
-    if (item_type_ == "gr_complex")
-        {
-            acquisition_cc_->set_doppler_max(doppler_max_);
-        }
-}
-
-
 void GalileoE1PcpsCccwsrAmbiguousAcquisition::set_doppler_step(unsigned int doppler_step)
 {
     doppler_step_ = doppler_step;

--- a/src/algorithms/acquisition/adapters/galileo_e1_pcps_cccwsr_ambiguous_acquisition.h
+++ b/src/algorithms/acquisition/adapters/galileo_e1_pcps_cccwsr_ambiguous_acquisition.h
@@ -104,11 +104,6 @@ public:
     void set_threshold(float threshold) override;
 
     /*!
-     * \brief Set maximum Doppler off grid search
-     */
-    void set_doppler_max(unsigned int doppler_max) override;
-
-    /*!
      * \brief Set Doppler steps for the grid search
      */
     void set_doppler_step(unsigned int doppler_step) override;

--- a/src/algorithms/acquisition/adapters/galileo_e1_pcps_quicksync_ambiguous_acquisition.cc
+++ b/src/algorithms/acquisition/adapters/galileo_e1_pcps_quicksync_ambiguous_acquisition.cc
@@ -190,17 +190,6 @@ void GalileoE1PcpsQuickSyncAmbiguousAcquisition::set_threshold(float threshold)
 }
 
 
-void GalileoE1PcpsQuickSyncAmbiguousAcquisition::set_doppler_max(unsigned int doppler_max)
-{
-    doppler_max_ = doppler_max;
-
-    if (item_type_ == "gr_complex")
-        {
-            acquisition_cc_->set_doppler_max(doppler_max_);
-        }
-}
-
-
 void GalileoE1PcpsQuickSyncAmbiguousAcquisition::set_doppler_step(unsigned int doppler_step)
 {
     doppler_step_ = doppler_step;

--- a/src/algorithms/acquisition/adapters/galileo_e1_pcps_quicksync_ambiguous_acquisition.h
+++ b/src/algorithms/acquisition/adapters/galileo_e1_pcps_quicksync_ambiguous_acquisition.h
@@ -104,11 +104,6 @@ public:
     void set_threshold(float threshold) override;
 
     /*!
-     * \brief Set maximum Doppler off grid search
-     */
-    void set_doppler_max(unsigned int doppler_max) override;
-
-    /*!
      * \brief Set Doppler steps for the grid search
      */
     void set_doppler_step(unsigned int doppler_step) override;

--- a/src/algorithms/acquisition/adapters/galileo_e1_pcps_tong_ambiguous_acquisition.cc
+++ b/src/algorithms/acquisition/adapters/galileo_e1_pcps_tong_ambiguous_acquisition.cc
@@ -163,17 +163,6 @@ void GalileoE1PcpsTongAmbiguousAcquisition::set_threshold(float threshold)
 }
 
 
-void GalileoE1PcpsTongAmbiguousAcquisition::set_doppler_max(unsigned int doppler_max)
-{
-    doppler_max_ = doppler_max;
-
-    if (item_type_ == "gr_complex")
-        {
-            acquisition_cc_->set_doppler_max(doppler_max_);
-        }
-}
-
-
 void GalileoE1PcpsTongAmbiguousAcquisition::set_doppler_step(unsigned int doppler_step)
 {
     doppler_step_ = doppler_step;

--- a/src/algorithms/acquisition/adapters/galileo_e1_pcps_tong_ambiguous_acquisition.h
+++ b/src/algorithms/acquisition/adapters/galileo_e1_pcps_tong_ambiguous_acquisition.h
@@ -104,11 +104,6 @@ public:
     void set_threshold(float threshold) override;
 
     /*!
-     * \brief Set maximum Doppler off grid search
-     */
-    void set_doppler_max(unsigned int doppler_max) override;
-
-    /*!
      * \brief Set Doppler steps for the grid search
      */
     void set_doppler_step(unsigned int doppler_step) override;

--- a/src/algorithms/acquisition/adapters/galileo_e5a_noncoherent_iq_acquisition_caf.cc
+++ b/src/algorithms/acquisition/adapters/galileo_e5a_noncoherent_iq_acquisition_caf.cc
@@ -170,17 +170,6 @@ void GalileoE5aNoncoherentIQAcquisitionCaf::set_threshold(float threshold)
 }
 
 
-void GalileoE5aNoncoherentIQAcquisitionCaf::set_doppler_max(unsigned int doppler_max)
-{
-    doppler_max_ = doppler_max;
-
-    if (item_type_ == "gr_complex")
-        {
-            acquisition_cc_->set_doppler_max(doppler_max_);
-        }
-}
-
-
 void GalileoE5aNoncoherentIQAcquisitionCaf::set_doppler_step(unsigned int doppler_step)
 {
     doppler_step_ = doppler_step;

--- a/src/algorithms/acquisition/adapters/galileo_e5a_noncoherent_iq_acquisition_caf.h
+++ b/src/algorithms/acquisition/adapters/galileo_e5a_noncoherent_iq_acquisition_caf.h
@@ -104,11 +104,6 @@ public:
     void set_threshold(float threshold) override;
 
     /*!
-     * \brief Set maximum Doppler off grid search
-     */
-    void set_doppler_max(unsigned int doppler_max) override;
-
-    /*!
      * \brief Set Doppler steps for the grid search
      */
     void set_doppler_step(unsigned int doppler_step) override;

--- a/src/algorithms/acquisition/adapters/gps_l1_ca_pcps_acquisition_fine_doppler.cc
+++ b/src/algorithms/acquisition/adapters/gps_l1_ca_pcps_acquisition_fine_doppler.cc
@@ -116,13 +116,6 @@ void GpsL1CaPcpsAcquisitionFineDoppler::set_threshold(float threshold)
 }
 
 
-void GpsL1CaPcpsAcquisitionFineDoppler::set_doppler_max(unsigned int doppler_max)
-{
-    doppler_max_ = static_cast<int>(doppler_max);
-    acquisition_cc_->set_doppler_max(doppler_max_);
-}
-
-
 void GpsL1CaPcpsAcquisitionFineDoppler::set_doppler_step(unsigned int doppler_step)
 {
     doppler_step_ = doppler_step;

--- a/src/algorithms/acquisition/adapters/gps_l1_ca_pcps_acquisition_fine_doppler.h
+++ b/src/algorithms/acquisition/adapters/gps_l1_ca_pcps_acquisition_fine_doppler.h
@@ -106,11 +106,6 @@ public:
     void set_threshold(float threshold) override;
 
     /*!
-     * \brief Set maximum Doppler off grid search
-     */
-    void set_doppler_max(unsigned int doppler_max) override;
-
-    /*!
      * \brief Set Doppler steps for the grid search
      */
     void set_doppler_step(unsigned int doppler_step) override;

--- a/src/algorithms/acquisition/adapters/gps_l1_ca_pcps_assisted_acquisition.cc
+++ b/src/algorithms/acquisition/adapters/gps_l1_ca_pcps_assisted_acquisition.cc
@@ -108,12 +108,6 @@ void GpsL1CaPcpsAssistedAcquisition::set_threshold(float threshold)
 }
 
 
-void GpsL1CaPcpsAssistedAcquisition::set_doppler_max(unsigned int doppler_max)
-{
-    acquisition_cc_->set_doppler_max(doppler_max);
-}
-
-
 void GpsL1CaPcpsAssistedAcquisition::set_doppler_step(unsigned int doppler_step)
 {
     acquisition_cc_->set_doppler_step(doppler_step);

--- a/src/algorithms/acquisition/adapters/gps_l1_ca_pcps_assisted_acquisition.h
+++ b/src/algorithms/acquisition/adapters/gps_l1_ca_pcps_assisted_acquisition.h
@@ -103,11 +103,6 @@ public:
     void set_threshold(float threshold) override;
 
     /*!
-     * \brief Set maximum Doppler off grid search
-     */
-    void set_doppler_max(unsigned int doppler_max) override;
-
-    /*!
      * \brief Set Doppler steps for the grid search
      */
     void set_doppler_step(unsigned int doppler_step) override;

--- a/src/algorithms/acquisition/adapters/gps_l1_ca_pcps_opencl_acquisition.cc
+++ b/src/algorithms/acquisition/adapters/gps_l1_ca_pcps_opencl_acquisition.cc
@@ -155,16 +155,6 @@ void GpsL1CaPcpsOpenClAcquisition::set_threshold(float threshold)
 }
 
 
-void GpsL1CaPcpsOpenClAcquisition::set_doppler_max(unsigned int doppler_max)
-{
-    doppler_max_ = doppler_max;
-    if (item_type_ == "gr_complex")
-        {
-            acquisition_cc_->set_doppler_max(doppler_max_);
-        }
-}
-
-
 void GpsL1CaPcpsOpenClAcquisition::set_doppler_step(unsigned int doppler_step)
 {
     doppler_step_ = doppler_step;

--- a/src/algorithms/acquisition/adapters/gps_l1_ca_pcps_opencl_acquisition.h
+++ b/src/algorithms/acquisition/adapters/gps_l1_ca_pcps_opencl_acquisition.h
@@ -103,11 +103,6 @@ public:
     void set_threshold(float threshold) override;
 
     /*!
-     * \brief Set maximum Doppler off grid search
-     */
-    void set_doppler_max(unsigned int doppler_max) override;
-
-    /*!
      * \brief Set Doppler steps for the grid search
      */
     void set_doppler_step(unsigned int doppler_step) override;

--- a/src/algorithms/acquisition/adapters/gps_l1_ca_pcps_quicksync_acquisition.cc
+++ b/src/algorithms/acquisition/adapters/gps_l1_ca_pcps_quicksync_acquisition.cc
@@ -187,16 +187,6 @@ void GpsL1CaPcpsQuickSyncAcquisition::set_threshold(float threshold)
 }
 
 
-void GpsL1CaPcpsQuickSyncAcquisition::set_doppler_max(unsigned int doppler_max)
-{
-    doppler_max_ = doppler_max;
-    if (item_type_ == "gr_complex")
-        {
-            acquisition_cc_->set_doppler_max(doppler_max_);
-        }
-}
-
-
 void GpsL1CaPcpsQuickSyncAcquisition::set_doppler_step(unsigned int doppler_step)
 {
     doppler_step_ = doppler_step;

--- a/src/algorithms/acquisition/adapters/gps_l1_ca_pcps_quicksync_acquisition.h
+++ b/src/algorithms/acquisition/adapters/gps_l1_ca_pcps_quicksync_acquisition.h
@@ -106,11 +106,6 @@ public:
     void set_threshold(float threshold) override;
 
     /*!
-     * \brief Set maximum Doppler off grid search
-     */
-    void set_doppler_max(unsigned int doppler_max) override;
-
-    /*!
      * \brief Set Doppler steps for the grid search
      */
     void set_doppler_step(unsigned int doppler_step) override;

--- a/src/algorithms/acquisition/adapters/gps_l1_ca_pcps_tong_acquisition.cc
+++ b/src/algorithms/acquisition/adapters/gps_l1_ca_pcps_tong_acquisition.cc
@@ -143,16 +143,6 @@ void GpsL1CaPcpsTongAcquisition::set_threshold(float threshold)
 }
 
 
-void GpsL1CaPcpsTongAcquisition::set_doppler_max(unsigned int doppler_max)
-{
-    doppler_max_ = doppler_max;
-    if (item_type_ == "gr_complex")
-        {
-            acquisition_cc_->set_doppler_max(doppler_max_);
-        }
-}
-
-
 void GpsL1CaPcpsTongAcquisition::set_doppler_step(unsigned int doppler_step)
 {
     doppler_step_ = doppler_step;

--- a/src/algorithms/acquisition/adapters/gps_l1_ca_pcps_tong_acquisition.h
+++ b/src/algorithms/acquisition/adapters/gps_l1_ca_pcps_tong_acquisition.h
@@ -104,11 +104,6 @@ public:
     void set_threshold(float threshold) override;
 
     /*!
-     * \brief Set maximum Doppler off grid search
-     */
-    void set_doppler_max(unsigned int doppler_max) override;
-
-    /*!
      * \brief Set Doppler steps for the grid search
      */
     void set_doppler_step(unsigned int doppler_step) override;

--- a/src/algorithms/acquisition/gnuradio_blocks/galileo_e5a_noncoherent_iq_acquisition_caf_cc.h
+++ b/src/algorithms/acquisition/gnuradio_blocks/galileo_e5a_noncoherent_iq_acquisition_caf_cc.h
@@ -234,7 +234,7 @@ private:
     int d_CAF_window_hz;
     int d_buffer_count;
     int d_doppler_resolution;
-    int d_doppler_max;
+    const int d_doppler_max;
     int d_doppler_step;
     int d_fft_size;
     int d_num_doppler_bins;

--- a/src/algorithms/acquisition/gnuradio_blocks/galileo_e5a_noncoherent_iq_acquisition_caf_cc.h
+++ b/src/algorithms/acquisition/gnuradio_blocks/galileo_e5a_noncoherent_iq_acquisition_caf_cc.h
@@ -146,15 +146,6 @@ public:
     }
 
     /*!
-     * \brief Set maximum Doppler grid search
-     * \param doppler_max - Maximum Doppler shift considered in the grid search [Hz].
-     */
-    inline void set_doppler_max(unsigned int doppler_max)
-    {
-        d_doppler_max = doppler_max;
-    }
-
-    /*!
      * \brief Set Doppler steps for the grid search
      * \param doppler_step - Frequency bin of the search grid [Hz].
      */

--- a/src/algorithms/acquisition/gnuradio_blocks/galileo_pcps_8ms_acquisition_cc.h
+++ b/src/algorithms/acquisition/gnuradio_blocks/galileo_pcps_8ms_acquisition_cc.h
@@ -208,7 +208,7 @@ private:
     int32_t d_samples_per_code;
     uint32_t d_channel;
     uint32_t d_doppler_resolution;
-    uint32_t d_doppler_max;
+    const uint32_t d_doppler_max;
     uint32_t d_doppler_step;
     uint32_t d_sampled_ms;
     uint32_t d_max_dwells;

--- a/src/algorithms/acquisition/gnuradio_blocks/galileo_pcps_8ms_acquisition_cc.h
+++ b/src/algorithms/acquisition/gnuradio_blocks/galileo_pcps_8ms_acquisition_cc.h
@@ -136,15 +136,6 @@ public:
     }
 
     /*!
-     * \brief Set maximum Doppler grid search
-     * \param doppler_max - Maximum Doppler shift considered in the grid search [Hz].
-     */
-    inline void set_doppler_max(uint32_t doppler_max)
-    {
-        d_doppler_max = doppler_max;
-    }
-
-    /*!
      * \brief Set Doppler steps for the grid search
      * \param doppler_step - Frequency bin of the search grid [Hz].
      */

--- a/src/algorithms/acquisition/gnuradio_blocks/pcps_acquisition.cc
+++ b/src/algorithms/acquisition/gnuradio_blocks/pcps_acquisition.cc
@@ -414,7 +414,8 @@ void pcps_acquisition::dump_results(int32_t effective_fft_size, float test_stati
 
             dims[0] = static_cast<size_t>(1);
             dims[1] = static_cast<size_t>(1);
-            matvar = Mat_VarCreate("doppler_max", MAT_C_INT32, MAT_T_INT32, 1, dims.data(), &d_doppler_max, 0);
+            auto doppler_max = d_doppler_max;
+            matvar = Mat_VarCreate("doppler_max", MAT_C_INT32, MAT_T_INT32, 1, dims.data(), &doppler_max, 0);
             Mat_VarWrite(matfp, matvar, MAT_COMPRESSION_ZLIB);  // or MAT_COMPRESSION_NONE
             Mat_VarFree(matvar);
 

--- a/src/algorithms/acquisition/gnuradio_blocks/pcps_acquisition.h
+++ b/src/algorithms/acquisition/gnuradio_blocks/pcps_acquisition.h
@@ -173,16 +173,6 @@ public:
     }
 
     /*!
-     * \brief Set maximum Doppler grid search
-     * \param doppler_max - Maximum Doppler shift considered in the grid search [Hz].
-     */
-    inline void set_doppler_max(uint32_t doppler_max)
-    {
-        gr::thread::scoped_lock lock(d_setlock);  // require mutex with work function called by the scheduler
-        d_doppler_max = doppler_max;
-    }
-
-    /*!
      * \brief Set Doppler steps for the grid search
      * \param doppler_step - Frequency bin of the search grid [Hz].
      */
@@ -253,7 +243,7 @@ private:
     float d_mag;
     float d_input_power;
     float d_doppler_center_step_two;
-    float d_doppler_max;
+    const float d_doppler_max;
 
     int32_t d_state;
     int32_t d_positive_acq;

--- a/src/algorithms/acquisition/gnuradio_blocks/pcps_acquisition_fine_doppler_cc.cc
+++ b/src/algorithms/acquisition/gnuradio_blocks/pcps_acquisition_fine_doppler_cc.cc
@@ -643,7 +643,8 @@ void pcps_acquisition_fine_doppler_cc::dump_results(int effective_fft_size)
 
             dims[0] = static_cast<size_t>(1);
             dims[1] = static_cast<size_t>(1);
-            matvar = Mat_VarCreate("doppler_max", MAT_C_INT32, MAT_T_INT32, 1, dims.data(), &d_config_doppler_max, 0);
+            auto doppler_max = d_config_doppler_max;
+            matvar = Mat_VarCreate("doppler_max", MAT_C_INT32, MAT_T_INT32, 1, dims.data(), &doppler_max, 0);
             Mat_VarWrite(matfp, matvar, MAT_COMPRESSION_ZLIB);  // or MAT_COMPRESSION_NONE
             Mat_VarFree(matvar);
 

--- a/src/algorithms/acquisition/gnuradio_blocks/pcps_acquisition_fine_doppler_cc.h
+++ b/src/algorithms/acquisition/gnuradio_blocks/pcps_acquisition_fine_doppler_cc.h
@@ -146,15 +146,6 @@ public:
     }
 
     /*!
-     * \brief Set maximum Doppler grid search
-     * \param doppler_max - Maximum Doppler shift considered in the grid search [Hz].
-     */
-    inline void set_doppler_max(unsigned int doppler_max)
-    {
-        d_config_doppler_max = doppler_max;
-    }
-
-    /*!
      * \brief Set Doppler steps for the grid search
      * \param doppler_step - Frequency bin of the search grid [Hz].
      */

--- a/src/algorithms/acquisition/gnuradio_blocks/pcps_acquisition_fine_doppler_cc.h
+++ b/src/algorithms/acquisition/gnuradio_blocks/pcps_acquisition_fine_doppler_cc.h
@@ -217,7 +217,7 @@ private:
     int d_state;
     int d_samples_per_ms;
     int d_max_dwells;
-    int d_config_doppler_max;
+    const int d_config_doppler_max;
     int d_num_doppler_points;
     int d_well_count;
     int d_n_samples_in_buffer;

--- a/src/algorithms/acquisition/gnuradio_blocks/pcps_acquisition_fpga.cc
+++ b/src/algorithms/acquisition/gnuradio_blocks/pcps_acquisition_fpga.cc
@@ -62,7 +62,7 @@ pcps_acquisition_fpga::pcps_acquisition_fpga(Acq_Conf_Fpga *conf_, uint32_t acq_
       d_make_2_steps(d_acq_parameters->make_2_steps)
 {
     d_acquisition_fpga = std::make_unique<Fpga_Acquisition>(d_acq_parameters->device_name, acq_buff_num,
-        downsampling_filter_specs, max_FFT_size);
+        d_doppler_max, downsampling_filter_specs, max_FFT_size);
 }
 
 void pcps_acquisition_fpga::set_local_code()
@@ -72,7 +72,7 @@ void pcps_acquisition_fpga::set_local_code()
 
 void pcps_acquisition_fpga::init()
 {
-    d_acquisition_fpga->init(d_acq_parameters->code_length, d_doppler_max, d_acq_parameters->fft_size,
+    d_acquisition_fpga->init(d_acq_parameters->code_length, d_acq_parameters->fft_size,
         d_acq_parameters->resampled_fs, d_acq_parameters->downsampling_filter_num, d_acq_parameters->excludelimit, d_acq_parameters->all_fft_codes);
     d_gnss_synchro->Flag_valid_acquisition = false;
     d_gnss_synchro->Flag_valid_symbol_output = false;

--- a/src/algorithms/acquisition/gnuradio_blocks/pcps_acquisition_fpga.h
+++ b/src/algorithms/acquisition/gnuradio_blocks/pcps_acquisition_fpga.h
@@ -133,16 +133,6 @@ public:
     }
 
     /*!
-     * \brief Set maximum Doppler grid search
-     * \param doppler_max - Maximum Doppler shift considered in the grid search [Hz].
-     */
-    inline void set_doppler_max(uint32_t doppler_max)
-    {
-        d_doppler_max = doppler_max;
-        d_acquisition_fpga->set_doppler_max(doppler_max);
-    }
-
-    /*!
      * \brief Set Doppler steps for the grid search
      * \param doppler_step - Frequency bin of the search grid [Hz].
      */

--- a/src/algorithms/acquisition/gnuradio_blocks/pcps_acquisition_fpga.h
+++ b/src/algorithms/acquisition/gnuradio_blocks/pcps_acquisition_fpga.h
@@ -189,7 +189,7 @@ private:
     uint32_t d_doppler_index;
     uint32_t d_channel;
     uint32_t d_doppler_step;
-    uint32_t d_doppler_max;
+    const uint32_t d_doppler_max;
     uint32_t d_num_doppler_bins;
     uint32_t d_total_block_exp;
     uint32_t d_num_doppler_bins_step2;

--- a/src/algorithms/acquisition/gnuradio_blocks/pcps_assisted_acquisition_cc.h
+++ b/src/algorithms/acquisition/gnuradio_blocks/pcps_assisted_acquisition_cc.h
@@ -224,7 +224,7 @@ private:
     int32_t d_gnuradio_forecast_samples;
     int32_t d_doppler_max;
     int32_t d_doppler_min;
-    int32_t d_config_doppler_max;
+    const int32_t d_config_doppler_max;
     int32_t d_config_doppler_min;
     int32_t d_num_doppler_points;
     int32_t d_doppler_step;

--- a/src/algorithms/acquisition/gnuradio_blocks/pcps_assisted_acquisition_cc.h
+++ b/src/algorithms/acquisition/gnuradio_blocks/pcps_assisted_acquisition_cc.h
@@ -152,15 +152,6 @@ public:
     }
 
     /*!
-     * \brief Set maximum Doppler grid search
-     * \param doppler_max - Maximum Doppler shift considered in the grid search [Hz].
-     */
-    inline void set_doppler_max(uint32_t doppler_max)
-    {
-        d_doppler_max = doppler_max;
-    }
-
-    /*!
      * \brief Set Doppler steps for the grid search
      * \param doppler_step - Frequency bin of the search grid [Hz].
      */

--- a/src/algorithms/acquisition/gnuradio_blocks/pcps_cccwsr_acquisition_cc.h
+++ b/src/algorithms/acquisition/gnuradio_blocks/pcps_cccwsr_acquisition_cc.h
@@ -142,15 +142,6 @@ public:
     }
 
     /*!
-     * \brief Set maximum Doppler grid search
-     * \param doppler_max - Maximum Doppler shift considered in the grid search [Hz].
-     */
-    inline void set_doppler_max(uint32_t doppler_max)
-    {
-        d_doppler_max = doppler_max;
-    }
-
-    /*!
      * \brief Set Doppler steps for the grid search
      * \param doppler_step - Frequency bin of the search grid [Hz].
      */

--- a/src/algorithms/acquisition/gnuradio_blocks/pcps_cccwsr_acquisition_cc.h
+++ b/src/algorithms/acquisition/gnuradio_blocks/pcps_cccwsr_acquisition_cc.h
@@ -205,7 +205,7 @@ private:
     int32_t d_samples_per_ms;
     int32_t d_samples_per_code;
     uint32_t d_doppler_resolution;
-    uint32_t d_doppler_max;
+    const uint32_t d_doppler_max;
     uint32_t d_doppler_step;
     uint32_t d_sampled_ms;
     uint32_t d_max_dwells;

--- a/src/algorithms/acquisition/gnuradio_blocks/pcps_opencl_acquisition_cc.h
+++ b/src/algorithms/acquisition/gnuradio_blocks/pcps_opencl_acquisition_cc.h
@@ -162,15 +162,6 @@ public:
     }
 
     /*!
-     * \brief Set maximum Doppler grid search
-     * \param doppler_max - Maximum Doppler shift considered in the grid search [Hz].
-     */
-    inline void set_doppler_max(uint32_t doppler_max)
-    {
-        d_doppler_max = doppler_max;
-    }
-
-    /*!
      * \brief Set Doppler steps for the grid search
      * \param doppler_step - Frequency bin of the search grid [Hz].
      */

--- a/src/algorithms/acquisition/gnuradio_blocks/pcps_opencl_acquisition_cc.h
+++ b/src/algorithms/acquisition/gnuradio_blocks/pcps_opencl_acquisition_cc.h
@@ -264,7 +264,7 @@ private:
     int d_opencl;
 
     uint32_t d_doppler_resolution;
-    uint32_t d_doppler_max;
+    const uint32_t d_doppler_max;
     uint32_t d_doppler_step;
     uint32_t d_sampled_ms;
     uint32_t d_max_dwells;

--- a/src/algorithms/acquisition/gnuradio_blocks/pcps_quicksync_acquisition_cc.h
+++ b/src/algorithms/acquisition/gnuradio_blocks/pcps_quicksync_acquisition_cc.h
@@ -238,7 +238,7 @@ private:
     uint32_t d_channel;
     uint32_t d_folding_factor;  // also referred in the paper as 'p'
     uint32_t d_doppler_resolution;
-    uint32_t d_doppler_max;
+    const uint32_t d_doppler_max;
     uint32_t d_doppler_step;
     uint32_t d_sampled_ms;
     uint32_t d_max_dwells;

--- a/src/algorithms/acquisition/gnuradio_blocks/pcps_quicksync_acquisition_cc.h
+++ b/src/algorithms/acquisition/gnuradio_blocks/pcps_quicksync_acquisition_cc.h
@@ -163,15 +163,6 @@ public:
     }
 
     /*!
-     * \brief Set maximum Doppler grid search
-     * \param doppler_max - Maximum Doppler shift considered in the grid search [Hz].
-     */
-    inline void set_doppler_max(uint32_t doppler_max)
-    {
-        d_doppler_max = doppler_max;
-    }
-
-    /*!
      * \brief Set Doppler steps for the grid search
      * \param doppler_step - Frequency bin of the search grid [Hz].
      */

--- a/src/algorithms/acquisition/gnuradio_blocks/pcps_tong_acquisition_cc.h
+++ b/src/algorithms/acquisition/gnuradio_blocks/pcps_tong_acquisition_cc.h
@@ -218,7 +218,7 @@ private:
     int32_t d_samples_per_code;
     uint32_t d_channel;
     uint32_t d_doppler_resolution;
-    uint32_t d_doppler_max;
+    const uint32_t d_doppler_max;
     uint32_t d_doppler_step;
     uint32_t d_sampled_ms;
     uint32_t d_dwell_count;

--- a/src/algorithms/acquisition/gnuradio_blocks/pcps_tong_acquisition_cc.h
+++ b/src/algorithms/acquisition/gnuradio_blocks/pcps_tong_acquisition_cc.h
@@ -157,15 +157,6 @@ public:
     }
 
     /*!
-     * \brief Set maximum Doppler grid search
-     * \param doppler_max - Maximum Doppler shift considered in the grid search [Hz].
-     */
-    inline void set_doppler_max(uint32_t doppler_max)
-    {
-        d_doppler_max = doppler_max;
-    }
-
-    /*!
      * \brief Set Doppler steps for the grid search
      * \param doppler_step - Frequency bin of the search grid [Hz].
      */

--- a/src/algorithms/acquisition/libs/fpga_acquisition.cc
+++ b/src/algorithms/acquisition/libs/fpga_acquisition.cc
@@ -49,6 +49,7 @@
 
 Fpga_Acquisition::Fpga_Acquisition(std::string device_name,
     uint32_t select_queue,
+    uint32_t doppler_max,
     std::vector<std::pair<uint32_t, uint32_t>> &downsampling_filter_specs,
     uint32_t &max_FFT_size) : d_device_name(std::move(device_name)),
                               d_resampled_fs(0),
@@ -62,7 +63,7 @@ Fpga_Acquisition::Fpga_Acquisition(std::string device_name,
                               d_downsampling_factor(1),
                               d_downsampling_filter_delay(0),
                               d_select_queue(select_queue),
-                              d_doppler_max(0),
+                              d_doppler_max(doppler_max),
                               d_doppler_step(0),
                               d_PRN(0),
                               d_IP_core_version(0)
@@ -76,7 +77,7 @@ Fpga_Acquisition::Fpga_Acquisition(std::string device_name,
 }
 
 
-void Fpga_Acquisition::init(uint32_t nsamples, uint32_t doppler_max, uint32_t fft_size,
+void Fpga_Acquisition::init(uint32_t nsamples uint32_t fft_size,
     int64_t resampled_fs, uint32_t downsampling_filter_num, uint32_t excludelimit, uint32_t *all_fft_codes)
 {
     d_resampled_fs = resampled_fs;
@@ -90,7 +91,6 @@ void Fpga_Acquisition::init(uint32_t nsamples, uint32_t doppler_max, uint32_t ff
             d_downsampling_factor = d_downsampling_filter_specs[d_filter_num - 1].first;
             d_downsampling_filter_delay = d_downsampling_filter_specs[d_filter_num - 1].second;
         }
-    d_doppler_max = doppler_max;
 }
 
 

--- a/src/algorithms/acquisition/libs/fpga_acquisition.h
+++ b/src/algorithms/acquisition/libs/fpga_acquisition.h
@@ -88,15 +88,6 @@ public:
         uint32_t *total_blk_exp);
 
     /*!
-     * \brief Set maximum Doppler grid search
-     * \param doppler_max - Maximum Doppler shift considered in the grid search [Hz].
-     */
-    void set_doppler_max(uint32_t doppler_max)
-    {
-        d_doppler_max = doppler_max;
-    }
-
-    /*!
      * \brief Set Doppler steps for the grid search
      * \param doppler_step - Frequency bin of the search grid [Hz].
      */

--- a/src/algorithms/acquisition/libs/fpga_acquisition.h
+++ b/src/algorithms/acquisition/libs/fpga_acquisition.h
@@ -45,6 +45,7 @@ public:
     Fpga_Acquisition(
         std::string device_name,
         uint32_t select_queue,
+        uint32_t doppler_max,
         std::vector<std::pair<uint32_t, uint32_t>> &downsampling_filter_specs,
         uint32_t &max_FFT_size);
 
@@ -57,7 +58,7 @@ public:
      * \brief Initialize acquisition parameters
      */
     // void init(uint32_t samples_per_code, uint32_t code_length, int64_t resampled_fs, uint32_t *all_fft_codes);
-    void init(uint32_t nsamples, uint32_t doppler_max, uint32_t d_fft_size,
+    void init(uint32_t nsamples, uint32_t d_fft_size,
         int64_t resampled_fs, uint32_t downsampling_filter_num, uint32_t excludelimit, uint32_t *all_fft_codes);
 
     /*!
@@ -210,7 +211,7 @@ private:
     uint32_t d_downsampling_factor;        // downsampling_factor
     uint32_t d_downsampling_filter_delay;  // Impulse response delay of the downsampling filter
     uint32_t d_select_queue;               // queue selection
-    uint32_t d_doppler_max;                // max doppler
+    const uint32_t d_doppler_max;          // max doppler
     uint32_t d_doppler_step;               // doppler step
     uint32_t d_PRN;                        // PRN
     uint32_t d_IP_core_version;            // FPGA acquisition IP core version

--- a/src/core/interfaces/acquisition_interface.h
+++ b/src/core/interfaces/acquisition_interface.h
@@ -54,7 +54,6 @@ public:
     virtual void set_channel(unsigned int channel_id) = 0;
     virtual void set_channel_fsm(std::weak_ptr<ChannelFsm> channel_fsm) = 0;
     virtual void set_threshold(float threshold) = 0;
-    virtual void set_doppler_max(unsigned int doppler_max) = 0;
     virtual void set_doppler_step(unsigned int doppler_step) = 0;
     virtual void set_doppler_center(int doppler_center __attribute__((unused)))
     {

--- a/tests/unit-tests/signal-processing-blocks/acquisition/acq_performance_test.cc
+++ b/tests/unit-tests/signal-processing-blocks/acquisition/acq_performance_test.cc
@@ -854,7 +854,6 @@ int AcquisitionPerformanceTest::run_receiver()
 
     acquisition->set_gnss_synchro(&gnss_synchro);
     acquisition->set_channel(0);
-    acquisition->set_doppler_max(config->property("Acquisition.doppler_max", 10000));
     acquisition->set_doppler_step(config->property("Acquisition.doppler_step", 500));
     acquisition->set_threshold(config->property("Acquisition.threshold", 0.0));
     acquisition->init();

--- a/tests/unit-tests/signal-processing-blocks/acquisition/beidou_b1i_pcps_acquisition_test.cc
+++ b/tests/unit-tests/signal-processing-blocks/acquisition/beidou_b1i_pcps_acquisition_test.cc
@@ -323,10 +323,6 @@ TEST_F(BeidouB1iPcpsAcquisitionTest, ValidationOfResults)
     }) << "Failure setting threshold.";
 
     ASSERT_NO_THROW({
-        acquisition->set_doppler_max(doppler_max);
-    }) << "Failure setting doppler_max.";
-
-    ASSERT_NO_THROW({
         acquisition->set_doppler_step(doppler_step);
     }) << "Failure setting doppler_step.";
 

--- a/tests/unit-tests/signal-processing-blocks/acquisition/beidou_b3i_pcps_acquisition_test.cc
+++ b/tests/unit-tests/signal-processing-blocks/acquisition/beidou_b3i_pcps_acquisition_test.cc
@@ -321,10 +321,6 @@ TEST_F(BeidouB3iPcpsAcquisitionTest, ValidationOfResults)
     }) << "Failure setting threshold.";
 
     ASSERT_NO_THROW({
-        acquisition->set_doppler_max(doppler_max);
-    }) << "Failure setting doppler_max.";
-
-    ASSERT_NO_THROW({
         acquisition->set_doppler_step(doppler_step);
     }) << "Failure setting doppler_step.";
 

--- a/tests/unit-tests/signal-processing-blocks/acquisition/galileo_e1_pcps_8ms_ambiguous_acquisition_gsoc2013_test.cc
+++ b/tests/unit-tests/signal-processing-blocks/acquisition/galileo_e1_pcps_8ms_ambiguous_acquisition_gsoc2013_test.cc
@@ -457,10 +457,6 @@ TEST_F(GalileoE1Pcps8msAmbiguousAcquisitionGSoC2013Test, ConnectAndRun)
     }) << "Failure setting gnss_synchro.";
 
     ASSERT_NO_THROW({
-        acquisition->set_doppler_max(config->property("Acquisition_1B.doppler_max", 10000));
-    }) << "Failure setting doppler_max.";
-
-    ASSERT_NO_THROW({
         acquisition->set_doppler_step(config->property("Acquisition_1B.doppler_step", 500));
     }) << "Failure setting doppler_step.";
 
@@ -505,10 +501,6 @@ TEST_F(GalileoE1Pcps8msAmbiguousAcquisitionGSoC2013Test, ValidationOfResults)
     ASSERT_NO_THROW({
         acquisition->set_gnss_synchro(&gnss_synchro);
     }) << "Failure setting gnss_synchro.";
-
-    ASSERT_NO_THROW({
-        acquisition->set_doppler_max(config->property("Acquisition_1B.doppler_max", 10000));
-    }) << "Failure setting doppler_max.";
 
     ASSERT_NO_THROW({
         acquisition->set_doppler_step(config->property("Acquisition_1B.doppler_step", 500));
@@ -592,10 +584,6 @@ TEST_F(GalileoE1Pcps8msAmbiguousAcquisitionGSoC2013Test, ValidationOfResultsProb
     ASSERT_NO_THROW({
         acquisition->set_gnss_synchro(&gnss_synchro);
     }) << "Failure setting gnss_synchro.";
-
-    ASSERT_NO_THROW({
-        acquisition->set_doppler_max(config->property("Acquisition_1B.doppler_max", 10000));
-    }) << "Failure setting doppler_max.";
 
     ASSERT_NO_THROW({
         acquisition->set_doppler_step(config->property("Acquisition_1B.doppler_step", 500));

--- a/tests/unit-tests/signal-processing-blocks/acquisition/galileo_e1_pcps_ambiguous_acquisition_gsoc2013_test.cc
+++ b/tests/unit-tests/signal-processing-blocks/acquisition/galileo_e1_pcps_ambiguous_acquisition_gsoc2013_test.cc
@@ -485,10 +485,6 @@ TEST_F(GalileoE1PcpsAmbiguousAcquisitionGSoC2013Test, ValidationOfResults)
     }) << "Failure setting gnss_synchro.";
 
     ASSERT_NO_THROW({
-        acquisition->set_doppler_max(config->property("Acquisition_1B.doppler_max", 10000));
-    }) << "Failure setting doppler_max.";
-
-    ASSERT_NO_THROW({
         acquisition->set_doppler_step(config->property("Acquisition_1B.doppler_step", 500));
     }) << "Failure setting doppler_step.";
 
@@ -563,10 +559,6 @@ TEST_F(GalileoE1PcpsAmbiguousAcquisitionGSoC2013Test, ValidationOfResultsProbabi
     ASSERT_NO_THROW({
         acquisition->set_gnss_synchro(&gnss_synchro);
     }) << "Failure setting gnss_synchro.";
-
-    ASSERT_NO_THROW({
-        acquisition->set_doppler_max(config->property("Acquisition_1B.doppler_max", 10000));
-    }) << "Failure setting doppler_max.";
 
     ASSERT_NO_THROW({
         acquisition->set_doppler_step(config->property("Acquisition_1B.doppler_step", 500));

--- a/tests/unit-tests/signal-processing-blocks/acquisition/galileo_e1_pcps_ambiguous_acquisition_gsoc_test.cc
+++ b/tests/unit-tests/signal-processing-blocks/acquisition/galileo_e1_pcps_ambiguous_acquisition_gsoc_test.cc
@@ -174,7 +174,7 @@ void GalileoE1PcpsAmbiguousAcquisitionGSoCTest::init()
     // config->set_property("Acquisition_1B.threshold", "2.5");
     config->set_property("Acquisition_1B.pfa", "0.001");
     config->set_property("Acquisition_1B.doppler_max", "10000");
-    config->set_property("Acquisition_1B.doppler_step", "125");
+    config->set_property("Acquisition_1B.doppler_step", "250");
     config->set_property("Acquisition_1B.repeat_satellite", "false");
     config->set_property("Acquisition_1B.cboc", "true");
 }
@@ -274,10 +274,6 @@ TEST_F(GalileoE1PcpsAmbiguousAcquisitionGSoCTest, ValidationOfResults)
     ASSERT_NO_THROW({
         acquisition->set_threshold(config->property("Acquisition_1B.threshold", 0.00001));
     }) << "Failure setting threshold.";
-
-    ASSERT_NO_THROW({
-        acquisition->set_doppler_max(config->property("Acquisition_1B.doppler_max", 10000));
-    }) << "Failure setting doppler_max.";
 
     ASSERT_NO_THROW({
         acquisition->set_doppler_step(config->property("Acquisition_1B.doppler_step", 250));

--- a/tests/unit-tests/signal-processing-blocks/acquisition/galileo_e1_pcps_ambiguous_acquisition_test.cc
+++ b/tests/unit-tests/signal-processing-blocks/acquisition/galileo_e1_pcps_ambiguous_acquisition_test.cc
@@ -337,10 +337,6 @@ TEST_F(GalileoE1PcpsAmbiguousAcquisitionTest, ValidationOfResults)
     }) << "Failure setting threshold.";
 
     ASSERT_NO_THROW({
-        acquisition->set_doppler_max(config->property("Acquisition_1B.doppler_max", doppler_max));
-    }) << "Failure setting doppler_max.";
-
-    ASSERT_NO_THROW({
         acquisition->set_doppler_step(config->property("Acquisition_1B.doppler_step", doppler_step));
     }) << "Failure setting doppler_step.";
 

--- a/tests/unit-tests/signal-processing-blocks/acquisition/galileo_e1_pcps_ambiguous_acquisition_test_fpga.cc
+++ b/tests/unit-tests/signal-processing-blocks/acquisition/galileo_e1_pcps_ambiguous_acquisition_test_fpga.cc
@@ -335,7 +335,6 @@ bool GalileoE1PcpsAmbiguousAcquisitionTestFpga::acquire_signal()
     acquisition->set_gnss_synchro(&tmp_gnss_synchro);
     acquisition->set_channel_fsm(channel_fsm_);
     acquisition->set_channel(1);
-    acquisition->set_doppler_max(doppler_max);
     acquisition->set_doppler_step(doppler_step);
     acquisition->set_doppler_center(0);
     acquisition->set_threshold(0.001);

--- a/tests/unit-tests/signal-processing-blocks/acquisition/galileo_e1_pcps_cccwsr_ambiguous_acquisition_gsoc2013_test.cc
+++ b/tests/unit-tests/signal-processing-blocks/acquisition/galileo_e1_pcps_cccwsr_ambiguous_acquisition_gsoc2013_test.cc
@@ -488,10 +488,6 @@ TEST_F(GalileoE1PcpsCccwsrAmbiguousAcquisitionTest, ValidationOfResults)
     }) << "Failure setting gnss_synchro.";
 
     ASSERT_NO_THROW({
-        acquisition->set_doppler_max(config->property("Acquisition_1B.doppler_max", 10000));
-    }) << "Failure setting doppler_max.";
-
-    ASSERT_NO_THROW({
         acquisition->set_doppler_step(config->property("Acquisition_1B.doppler_step", 500));
     }) << "Failure setting doppler_step.";
 
@@ -578,10 +574,6 @@ TEST_F(GalileoE1PcpsCccwsrAmbiguousAcquisitionTest, ValidationOfResultsProbabili
     ASSERT_NO_THROW({
         acquisition->set_gnss_synchro(&gnss_synchro);
     }) << "Failure setting gnss_synchro.";
-
-    ASSERT_NO_THROW({
-        acquisition->set_doppler_max(config->property("Acquisition_1B.doppler_max", 10000));
-    }) << "Failure setting doppler_max.";
 
     ASSERT_NO_THROW({
         acquisition->set_doppler_step(config->property("Acquisition_1B.doppler_step", 500));

--- a/tests/unit-tests/signal-processing-blocks/acquisition/galileo_e1_pcps_quicksync_ambiguous_acquisition_gsoc2014_test.cc
+++ b/tests/unit-tests/signal-processing-blocks/acquisition/galileo_e1_pcps_quicksync_ambiguous_acquisition_gsoc2014_test.cc
@@ -639,10 +639,6 @@ TEST_F(GalileoE1PcpsQuickSyncAmbiguousAcquisitionGSoC2014Test, ValidationOfResul
     }) << "Failure setting gnss_synchro.";
 
     ASSERT_NO_THROW({
-        acquisition->set_doppler_max(config->property("Acquisition_1B.doppler_max", 10000));
-    }) << "Failure setting doppler_max.";
-
-    ASSERT_NO_THROW({
         acquisition->set_doppler_step(config->property("Acquisition_1B.doppler_step", 125));
     }) << "Failure setting doppler_step.";
 
@@ -729,10 +725,6 @@ TEST_F(GalileoE1PcpsQuickSyncAmbiguousAcquisitionGSoC2014Test, ValidationOfResul
     }) << "Failure setting gnss_synchro.";
 
     ASSERT_NO_THROW({
-        acquisition->set_doppler_max(config->property("Acquisition_1B.doppler_max", 10000));
-    }) << "Failure setting doppler_max.";
-
-    ASSERT_NO_THROW({
         acquisition->set_doppler_step(50);
     }) << "Failure setting doppler_step.";
 
@@ -814,10 +806,6 @@ TEST_F(GalileoE1PcpsQuickSyncAmbiguousAcquisitionGSoC2014Test, ValidationOfResul
     ASSERT_NO_THROW({
         acquisition->set_gnss_synchro(&gnss_synchro);
     }) << "Failure setting gnss_synchro.";
-
-    ASSERT_NO_THROW({
-        acquisition->set_doppler_max(config->property("Acquisition_1B.doppler_max", 10000));
-    }) << "Failure setting doppler_max.";
 
     ASSERT_NO_THROW({
         acquisition->set_doppler_step(config->property("Acquisition_1B.doppler_step", 500));

--- a/tests/unit-tests/signal-processing-blocks/acquisition/galileo_e1_pcps_tong_ambiguous_acquisition_gsoc2013_test.cc
+++ b/tests/unit-tests/signal-processing-blocks/acquisition/galileo_e1_pcps_tong_ambiguous_acquisition_gsoc2013_test.cc
@@ -486,10 +486,6 @@ TEST_F(GalileoE1PcpsTongAmbiguousAcquisitionGSoC2013Test, ValidationOfResults)
     }) << "Failure setting gnss_synchro.";
 
     ASSERT_NO_THROW({
-        acquisition->set_doppler_max(5000);
-    }) << "Failure setting doppler_max.";
-
-    ASSERT_NO_THROW({
         acquisition->set_doppler_step(100);
     }) << "Failure setting doppler_step.";
 
@@ -572,10 +568,6 @@ TEST_F(GalileoE1PcpsTongAmbiguousAcquisitionGSoC2013Test, ValidationOfResultsPro
     ASSERT_NO_THROW({
         acquisition->set_gnss_synchro(&gnss_synchro);
     }) << "Failure setting gnss_synchro.";
-
-    ASSERT_NO_THROW({
-        acquisition->set_doppler_max(config->property("Acquisition_1B.doppler_max", 10000));
-    }) << "Failure setting doppler_max.";
 
     ASSERT_NO_THROW({
         acquisition->set_doppler_step(config->property("Acquisition_1B.doppler_step", 500));

--- a/tests/unit-tests/signal-processing-blocks/acquisition/galileo_e5a_pcps_acquisition_gsoc2014_gensource_test.cc
+++ b/tests/unit-tests/signal-processing-blocks/acquisition/galileo_e5a_pcps_acquisition_gsoc2014_gensource_test.cc
@@ -586,10 +586,6 @@ TEST_F(GalileoE5aPcpsAcquisitionGSoC2014GensourceTest, ValidationOfSIM)
     }) << "Failure setting gnss_synchro.";
 
     ASSERT_NO_THROW({
-        acquisition->set_doppler_max(config->property("Acquisition_5X.doppler_max", 5000));
-    }) << "Failure setting doppler_max.";
-
-    ASSERT_NO_THROW({
         acquisition->set_doppler_step(config->property("Acquisition_5X.doppler_step", 100));
     }) << "Failure setting doppler_step.";
 

--- a/tests/unit-tests/signal-processing-blocks/acquisition/galileo_e5b_pcps_acquisition_test.cc
+++ b/tests/unit-tests/signal-processing-blocks/acquisition/galileo_e5b_pcps_acquisition_test.cc
@@ -378,10 +378,6 @@ TEST_F(GalileoE5bPcpsAcquisitionTest, ValidationOfResults)
     }) << "Failure setting threshold.";
 
     ASSERT_NO_THROW({
-        acquisition->set_doppler_max(5000);
-    }) << "Failure setting doppler_max.";
-
-    ASSERT_NO_THROW({
         acquisition->set_doppler_step(100);
     }) << "Failure setting doppler_step.";
 

--- a/tests/unit-tests/signal-processing-blocks/acquisition/galileo_e6_pcps_acquisition_test.cc
+++ b/tests/unit-tests/signal-processing-blocks/acquisition/galileo_e6_pcps_acquisition_test.cc
@@ -373,10 +373,6 @@ TEST_F(GalileoE6PcpsAcquisitionTest, ValidationOfResults)
     }) << "Failure setting gnss_synchro.";
 
     ASSERT_NO_THROW({
-        acquisition->set_doppler_max(5000);
-    }) << "Failure setting doppler_max.";
-
-    ASSERT_NO_THROW({
         acquisition->set_doppler_step(100);
     }) << "Failure setting doppler_step.";
 

--- a/tests/unit-tests/signal-processing-blocks/acquisition/glonass_l1_ca_pcps_acquisition_gsoc2017_test.cc
+++ b/tests/unit-tests/signal-processing-blocks/acquisition/glonass_l1_ca_pcps_acquisition_gsoc2017_test.cc
@@ -492,10 +492,6 @@ TEST_F(GlonassL1CaPcpsAcquisitionGSoC2017Test, ValidationOfResults)
     }) << "Failure setting gnss_synchro.";
 
     ASSERT_NO_THROW({
-        acquisition->set_doppler_max(10000);
-    }) << "Failure setting doppler_max.";
-
-    ASSERT_NO_THROW({
         acquisition->set_doppler_step(500);
     }) << "Failure setting doppler_step.";
 
@@ -572,10 +568,6 @@ TEST_F(GlonassL1CaPcpsAcquisitionGSoC2017Test, ValidationOfResultsProbabilities)
     ASSERT_NO_THROW({
         acquisition->set_gnss_synchro(&gnss_synchro);
     }) << "Failure setting gnss_synchro.";
-
-    ASSERT_NO_THROW({
-        acquisition->set_doppler_max(config->property("Acquisition.doppler_max", 10000));
-    }) << "Failure setting doppler_max.";
 
     ASSERT_NO_THROW({
         acquisition->set_doppler_step(config->property("Acquisition.doppler_step", 500));

--- a/tests/unit-tests/signal-processing-blocks/acquisition/glonass_l1_ca_pcps_acquisition_test.cc
+++ b/tests/unit-tests/signal-processing-blocks/acquisition/glonass_l1_ca_pcps_acquisition_test.cc
@@ -239,10 +239,6 @@ TEST_F(GlonassL1CaPcpsAcquisitionTest, ValidationOfResults)
     }) << "Failure setting threshold.";
 
     ASSERT_NO_THROW({
-        acquisition->set_doppler_max(10000);
-    }) << "Failure setting doppler_max.";
-
-    ASSERT_NO_THROW({
         acquisition->set_doppler_step(500);
     }) << "Failure setting doppler_step.";
 

--- a/tests/unit-tests/signal-processing-blocks/acquisition/glonass_l2_ca_pcps_acquisition_test.cc
+++ b/tests/unit-tests/signal-processing-blocks/acquisition/glonass_l2_ca_pcps_acquisition_test.cc
@@ -490,10 +490,6 @@ TEST_F(GlonassL2CaPcpsAcquisitionTest, ValidationOfResults)
     }) << "Failure setting gnss_synchro.";
 
     ASSERT_NO_THROW({
-        acquisition->set_doppler_max(10000);
-    }) << "Failure setting doppler_max.";
-
-    ASSERT_NO_THROW({
         acquisition->set_doppler_step(500);
     }) << "Failure setting doppler_step.";
 
@@ -574,10 +570,6 @@ TEST_F(GlonassL2CaPcpsAcquisitionTest, ValidationOfResultsProbabilities)
     ASSERT_NO_THROW({
         acquisition->set_gnss_synchro(&gnss_synchro);
     }) << "Failure setting gnss_synchro.";
-
-    ASSERT_NO_THROW({
-        acquisition->set_doppler_max(config->property("Acquisition_2G.doppler_max", 10000));
-    }) << "Failure setting doppler_max.";
 
     ASSERT_NO_THROW({
         acquisition->set_doppler_step(config->property("Acquisition_2G.doppler_step", 500));

--- a/tests/unit-tests/signal-processing-blocks/acquisition/gps_l1_ca_pcps_acquisition_gsoc2013_test.cc
+++ b/tests/unit-tests/signal-processing-blocks/acquisition/gps_l1_ca_pcps_acquisition_gsoc2013_test.cc
@@ -484,10 +484,6 @@ TEST_F(GpsL1CaPcpsAcquisitionGSoC2013Test, ValidationOfResults)
     }) << "Failure setting gnss_synchro.";
 
     ASSERT_NO_THROW({
-        acquisition->set_doppler_max(10000);
-    }) << "Failure setting doppler_max.";
-
-    ASSERT_NO_THROW({
         acquisition->set_doppler_step(500);
     }) << "Failure setting doppler_step.";
 
@@ -564,10 +560,6 @@ TEST_F(GpsL1CaPcpsAcquisitionGSoC2013Test, ValidationOfResultsProbabilities)
     ASSERT_NO_THROW({
         acquisition->set_gnss_synchro(&gnss_synchro);
     }) << "Failure setting gnss_synchro.";
-
-    ASSERT_NO_THROW({
-        acquisition->set_doppler_max(config->property("Acquisition_1C.doppler_max", 10000));
-    }) << "Failure setting doppler_max.";
 
     ASSERT_NO_THROW({
         acquisition->set_doppler_step(config->property("Acquisition_1C.doppler_step", 500));

--- a/tests/unit-tests/signal-processing-blocks/acquisition/gps_l1_ca_pcps_acquisition_test.cc
+++ b/tests/unit-tests/signal-processing-blocks/acquisition/gps_l1_ca_pcps_acquisition_test.cc
@@ -334,10 +334,6 @@ TEST_F(GpsL1CaPcpsAcquisitionTest /*unused*/, ValidationOfResults /*unused*/)
     }) << "Failure setting threshold.";
 
     ASSERT_NO_THROW({
-        acquisition->set_doppler_max(doppler_max);
-    }) << "Failure setting doppler_max.";
-
-    ASSERT_NO_THROW({
         acquisition->set_doppler_step(doppler_step);
     }) << "Failure setting doppler_step.";
 

--- a/tests/unit-tests/signal-processing-blocks/acquisition/gps_l1_ca_pcps_acquisition_test_fpga.cc
+++ b/tests/unit-tests/signal-processing-blocks/acquisition/gps_l1_ca_pcps_acquisition_test_fpga.cc
@@ -334,7 +334,6 @@ bool GpsL1CaPcpsAcquisitionTestFpga::acquire_signal()
     acquisition->set_gnss_synchro(&tmp_gnss_synchro);
     acquisition->set_channel_fsm(channel_fsm_);
     acquisition->set_channel(1);
-    acquisition->set_doppler_max(doppler_max);
     acquisition->set_doppler_step(doppler_step);
     acquisition->set_doppler_center(0);
     acquisition->set_threshold(0.001);

--- a/tests/unit-tests/signal-processing-blocks/acquisition/gps_l1_ca_pcps_opencl_acquisition_gsoc2013_test.cc
+++ b/tests/unit-tests/signal-processing-blocks/acquisition/gps_l1_ca_pcps_opencl_acquisition_gsoc2013_test.cc
@@ -483,10 +483,6 @@ TEST_F(GpsL1CaPcpsOpenClAcquisitionGSoC2013Test, ValidationOfResults)
     }) << "Failure setting gnss_synchro.";
 
     ASSERT_NO_THROW({
-        acquisition->set_doppler_max(config->property("Acquisition_1C.doppler_max", 10000));
-    }) << "Failure setting doppler_max.";
-
-    ASSERT_NO_THROW({
         acquisition->set_doppler_step(config->property("Acquisition_1C.doppler_step", 500));
     }) << "Failure setting doppler_step.";
 
@@ -569,10 +565,6 @@ TEST_F(GpsL1CaPcpsOpenClAcquisitionGSoC2013Test, ValidationOfResultsProbabilitie
     ASSERT_NO_THROW({
         acquisition->set_gnss_synchro(&gnss_synchro);
     }) << "Failure setting gnss_synchro.";
-
-    ASSERT_NO_THROW({
-        acquisition->set_doppler_max(config->property("Acquisition_1C.doppler_max", 10000));
-    }) << "Failure setting doppler_max.";
 
     ASSERT_NO_THROW({
         acquisition->set_doppler_step(config->property("Acquisition_1C.doppler_step", 500));

--- a/tests/unit-tests/signal-processing-blocks/acquisition/gps_l1_ca_pcps_quicksync_acquisition_gsoc2014_test.cc
+++ b/tests/unit-tests/signal-processing-blocks/acquisition/gps_l1_ca_pcps_quicksync_acquisition_gsoc2014_test.cc
@@ -611,10 +611,6 @@ TEST_F(GpsL1CaPcpsQuickSyncAcquisitionGSoC2014Test, ValidationOfResults)
     }) << "Failure setting gnss_synchro.";
 
     ASSERT_NO_THROW({
-        acquisition->set_doppler_max(10000);
-    }) << "Failure setting doppler_max.";
-
-    ASSERT_NO_THROW({
         acquisition->set_doppler_step(250);
     }) << "Failure setting doppler_step.";
 
@@ -702,10 +698,6 @@ TEST_F(GpsL1CaPcpsQuickSyncAcquisitionGSoC2014Test, ValidationOfResultsWithNoise
     ASSERT_NO_THROW({
         acquisition->set_gnss_synchro(&gnss_synchro);
     }) << "Failure setting gnss_synchro.";
-
-    ASSERT_NO_THROW({
-        acquisition->set_doppler_max(10000);
-    }) << "Failure setting doppler_max.";
 
     ASSERT_NO_THROW({
         acquisition->set_doppler_step(250);

--- a/tests/unit-tests/signal-processing-blocks/acquisition/gps_l1_ca_pcps_tong_acquisition_gsoc2013_test.cc
+++ b/tests/unit-tests/signal-processing-blocks/acquisition/gps_l1_ca_pcps_tong_acquisition_gsoc2013_test.cc
@@ -480,10 +480,6 @@ TEST_F(GpsL1CaPcpsTongAcquisitionGSoC2013Test, ValidationOfResults)
     }) << "Failure setting gnss_synchro.";
 
     ASSERT_NO_THROW({
-        acquisition->set_doppler_max(config->property("Acquisition_1C.doppler_max", 10000));
-    }) << "Failure setting doppler_max.";
-
-    ASSERT_NO_THROW({
         acquisition->set_doppler_step(config->property("Acquisition_1C.doppler_step", 500));
     }) << "Failure setting doppler_step.";
 
@@ -565,10 +561,6 @@ TEST_F(GpsL1CaPcpsTongAcquisitionGSoC2013Test, ValidationOfResultsProbabilities)
     ASSERT_NO_THROW({
         acquisition->set_gnss_synchro(&gnss_synchro);
     }) << "Failure setting gnss_synchro.";
-
-    ASSERT_NO_THROW({
-        acquisition->set_doppler_max(config->property("Acquisition_1C.doppler_max", 10000));
-    }) << "Failure setting doppler_max.";
 
     ASSERT_NO_THROW({
         acquisition->set_doppler_step(config->property("Acquisition_1C.doppler_step", 500));

--- a/tests/unit-tests/signal-processing-blocks/acquisition/gps_l2_m_pcps_acquisition_test.cc
+++ b/tests/unit-tests/signal-processing-blocks/acquisition/gps_l2_m_pcps_acquisition_test.cc
@@ -333,10 +333,6 @@ TEST_F(GpsL2MPcpsAcquisitionTest, ValidationOfResults)
     }) << "Failure setting threshold.";
 
     ASSERT_NO_THROW({
-        acquisition->set_doppler_max(doppler_max);
-    }) << "Failure setting doppler_max.";
-
-    ASSERT_NO_THROW({
         acquisition->set_doppler_step(doppler_step);
     }) << "Failure setting doppler_step.";
 

--- a/tests/unit-tests/signal-processing-blocks/observables/hybrid_observables_test.cc
+++ b/tests/unit-tests/signal-processing-blocks/observables/hybrid_observables_test.cc
@@ -543,11 +543,9 @@ bool HybridObservablesTest::acquire_signal()
     acquisition->set_gnss_synchro(&tmp_gnss_synchro);
     acquisition->set_channel(0);
 #if USE_GLOG_AND_GFLAGS
-    acquisition->set_doppler_max(config->property("Acquisition.doppler_max", FLAGS_external_signal_acquisition_doppler_max_hz));
     acquisition->set_doppler_step(config->property("Acquisition.doppler_step", FLAGS_external_signal_acquisition_doppler_step_hz));
     acquisition->set_threshold(config->property("Acquisition.threshold", FLAGS_external_signal_acquisition_threshold));
 #else
-    acquisition->set_doppler_max(config->property("Acquisition.doppler_max", absl::GetFlag(FLAGS_external_signal_acquisition_doppler_max_hz)));
     acquisition->set_doppler_step(config->property("Acquisition.doppler_step", absl::GetFlag(FLAGS_external_signal_acquisition_doppler_step_hz)));
     acquisition->set_threshold(config->property("Acquisition.threshold", absl::GetFlag(FLAGS_external_signal_acquisition_threshold)));
 #endif

--- a/tests/unit-tests/signal-processing-blocks/observables/hybrid_observables_test_fpga.cc
+++ b/tests/unit-tests/signal-processing-blocks/observables/hybrid_observables_test_fpga.cc
@@ -700,12 +700,10 @@ bool HybridObservablesTestFpga::acquire_signal()
     acquisition->set_channel_fsm(channel_fsm_);
     acquisition->set_channel(0);
 #if USE_GLOG_AND_GFLAGS
-    acquisition->set_doppler_max(config->property("Acquisition.doppler_max", FLAGS_external_signal_acquisition_doppler_max_hz));
     acquisition->set_doppler_step(config->property("Acquisition.doppler_step", FLAGS_external_signal_acquisition_doppler_step_hz));
     acquisition->set_doppler_center(0);
     acquisition->set_threshold(config->property("Acquisition.threshold", FLAGS_external_signal_acquisition_threshold));
 #else
-    acquisition->set_doppler_max(config->property("Acquisition.doppler_max", absl::GetFlag(FLAGS_external_signal_acquisition_doppler_max_hz)));
     acquisition->set_doppler_step(config->property("Acquisition.doppler_step", absl::GetFlag(FLAGS_external_signal_acquisition_doppler_step_hz)));
     acquisition->set_doppler_center(0);
     acquisition->set_threshold(config->property("Acquisition.threshold", absl::GetFlag(FLAGS_external_signal_acquisition_threshold)));

--- a/tests/unit-tests/signal-processing-blocks/tracking/tracking_pull-in_test.cc
+++ b/tests/unit-tests/signal-processing-blocks/tracking/tracking_pull-in_test.cc
@@ -536,11 +536,9 @@ bool TrackingPullInTest::acquire_signal(int SV_ID)
     acquisition->set_gnss_synchro(&tmp_gnss_synchro);
     acquisition->set_channel(0);
 #if USE_GLOG_AND_GFLAGS
-    acquisition->set_doppler_max(config->property("Acquisition.doppler_max", FLAGS_external_signal_acquisition_doppler_max_hz));
     acquisition->set_doppler_step(config->property("Acquisition.doppler_step", FLAGS_external_signal_acquisition_doppler_step_hz));
     acquisition->set_threshold(config->property("Acquisition.threshold", FLAGS_external_signal_acquisition_threshold));
 #else
-    acquisition->set_doppler_max(config->property("Acquisition.doppler_max", absl::GetFlag(FLAGS_external_signal_acquisition_doppler_max_hz)));
     acquisition->set_doppler_step(config->property("Acquisition.doppler_step", absl::GetFlag(FLAGS_external_signal_acquisition_doppler_step_hz)));
     acquisition->set_threshold(config->property("Acquisition.threshold", absl::GetFlag(FLAGS_external_signal_acquisition_threshold)));
 #endif

--- a/tests/unit-tests/signal-processing-blocks/tracking/tracking_pull-in_test_fpga.cc
+++ b/tests/unit-tests/signal-processing-blocks/tracking/tracking_pull-in_test_fpga.cc
@@ -696,12 +696,10 @@ bool TrackingPullInTestFpga::acquire_signal(int SV_ID)
     acquisition->set_channel_fsm(channel_fsm_);
     acquisition->set_channel(0);
 #if USE_GLOG_AND_GFLAGS
-    acquisition->set_doppler_max(config->property("Acquisition.doppler_max", FLAGS_external_signal_acquisition_doppler_max_hz));
     acquisition->set_doppler_step(config->property("Acquisition.doppler_step", FLAGS_external_signal_acquisition_doppler_step_hz));
     acquisition->set_doppler_center(0);
     acquisition->set_threshold(config->property("Acquisition.threshold", FLAGS_external_signal_acquisition_threshold));
 #else
-    acquisition->set_doppler_max(config->property("Acquisition.doppler_max", absl::GetFlag(FLAGS_external_signal_acquisition_doppler_max_hz)));
     acquisition->set_doppler_step(config->property("Acquisition.doppler_step", absl::GetFlag(FLAGS_external_signal_acquisition_doppler_step_hz)));
     acquisition->set_doppler_center(0);
     acquisition->set_threshold(config->property("Acquisition.threshold", absl::GetFlag(FLAGS_external_signal_acquisition_threshold)));

--- a/utils/front-end-cal/main.cc
+++ b/utils/front-end-cal/main.cc
@@ -473,13 +473,13 @@ int main(int argc, char** argv)
 
             int64_t fs_in_ = configuration->property("GNSS-SDR.internal_fs_sps", 2048000);
             configuration->set_property("Acquisition.max_dwells", "10");
+            configuration->set_property("Acquisition.doppler_max", "10000");
 
             auto acquisition = std::make_shared<GpsL1CaPcpsAcquisitionFineDoppler>(configuration.get(), "Acquisition", 1, 1);
 
             acquisition->set_channel(1);
             acquisition->set_gnss_synchro(&gnss_synchro);
             acquisition->set_threshold(configuration->property("Acquisition.threshold", 2.0));
-            acquisition->set_doppler_max(configuration->property("Acquisition.doppler_max", 10000));
             acquisition->set_doppler_step(configuration->property("Acquisition.doppler_step", 250));
 
             gr::block_sptr source;


### PR DESCRIPTION
In my opinion it is easier to understand code and less error prone when the state is set at object construction in const member variables, if they aren't going to change during the object lifetime.

This is especially true for multi-threaded code, since we can assume const member variables won't have race conditions (if we make the sane assumption that no-one is using const cast).