### PR TITLE
Make doppler step const in acquisition

### DIFF
--- a/src/algorithms/acquisition/adapters/base_pcps_acquisition.cc
+++ b/src/algorithms/acquisition/adapters/base_pcps_acquisition.cc
@@ -51,10 +51,18 @@ Acq_Conf get_acq_conf(const ConfigurationInterface* configuration, const std::st
         {
             acq_parameters.doppler_max = FLAGS_doppler_max;
         }
+    if (FLAGS_doppler_step != 0)
+        {
+            acq_parameters.doppler_step = static_cast<float>(FLAGS_doppler_step);
+        }
 #else
     if (absl::GetFlag(FLAGS_doppler_max) != 0)
         {
             acq_parameters.doppler_max = absl::GetFlag(FLAGS_doppler_max);
+        }
+    if (absl::GetFlag(FLAGS_doppler_step) != 0)
+        {
+            acq_parameters.doppler_step = static_cast<float>(absl::GetFlag(FLAGS_doppler_step));
         }
 #endif
 
@@ -106,12 +114,6 @@ void BasePcpsAcquisition::stop_acquisition()
 void BasePcpsAcquisition::set_threshold(float threshold)
 {
     acquisition_->set_threshold(threshold);
-}
-
-
-void BasePcpsAcquisition::set_doppler_step(unsigned int doppler_step)
-{
-    acquisition_->set_doppler_step(doppler_step);
 }
 
 

--- a/src/algorithms/acquisition/adapters/base_pcps_acquisition.h
+++ b/src/algorithms/acquisition/adapters/base_pcps_acquisition.h
@@ -99,11 +99,6 @@ public:
     void set_threshold(float threshold) override;
 
     /*!
-     * \brief Set Doppler steps for the grid search
-     */
-    void set_doppler_step(unsigned int doppler_step) override;
-
-    /*!
      * \brief Set Doppler center for the grid search
      */
     void set_doppler_center(int doppler_center) override;

--- a/src/algorithms/acquisition/adapters/base_pcps_acquisition_fpga.cc
+++ b/src/algorithms/acquisition/adapters/base_pcps_acquisition_fpga.cc
@@ -83,10 +83,18 @@ BasePcpsAcquisitionFpga::BasePcpsAcquisitionFpga(
         {
             acq_parameters_.doppler_max = FLAGS_doppler_max;
         }
+    if (FLAGS_doppler_step != 0)
+        {
+            acq_parameters_.doppler_step = static_cast<float>(FLAGS_doppler_step);
+        }
 #else
     if (absl::GetFlag(FLAGS_doppler_max) != 0)
         {
             acq_parameters_.doppler_max = absl::GetFlag(FLAGS_doppler_max);
+        }
+    if (absl::GetFlag(FLAGS_doppler_step) != 0)
+        {
+            acq_parameters_.doppler_step = static_cast<float>(absl::GetFlag(FLAGS_doppler_step));
         }
 #endif
 }
@@ -154,15 +162,6 @@ void BasePcpsAcquisitionFpga::set_threshold(float threshold)
     if (acquisition_fpga_)
         {
             acquisition_fpga_->set_threshold(threshold);
-        }
-}
-
-
-void BasePcpsAcquisitionFpga::set_doppler_step(unsigned int doppler_step)
-{
-    if (acquisition_fpga_)
-        {
-            acquisition_fpga_->set_doppler_step(doppler_step);
         }
 }
 

--- a/src/algorithms/acquisition/adapters/base_pcps_acquisition_fpga.h
+++ b/src/algorithms/acquisition/adapters/base_pcps_acquisition_fpga.h
@@ -71,7 +71,6 @@ public:
     void set_channel(unsigned int channel) override;
     void set_channel_fsm(std::weak_ptr<ChannelFsm> channel_fsm) override;
     void set_threshold(float threshold) override;
-    void set_doppler_step(unsigned int doppler_step) override;
     void set_doppler_center(int doppler_center) override;
     void set_state(int state) override;
     void reset() override;

--- a/src/algorithms/acquisition/adapters/galileo_e1_pcps_8ms_ambiguous_acquisition.cc
+++ b/src/algorithms/acquisition/adapters/galileo_e1_pcps_8ms_ambiguous_acquisition.cc
@@ -49,7 +49,7 @@ GalileoE1Pcps8msAmbiguousAcquisition::GalileoE1Pcps8msAmbiguousAcquisition(
       threshold_(0.0),
       channel_(0),
       doppler_max_(configuration_->property(role + ".doppler_max", 5000)),
-      doppler_step_(0),
+      doppler_step_(configuration_->property(role + ".doppler_step", 500)),
       sampled_ms_(configuration_->property(role + ".coherent_integration_time_ms", 4)),
       dump_(configuration_->property(role + ".dump", false))
 {
@@ -65,10 +65,18 @@ GalileoE1Pcps8msAmbiguousAcquisition::GalileoE1Pcps8msAmbiguousAcquisition(
         {
             doppler_max_ = FLAGS_doppler_max;
         }
+    if (FLAGS_doppler_step != 0)
+        {
+            doppler_step_ = static_cast<uint32_t>(FLAGS_doppler_step);
+        }
 #else
     if (absl::GetFlag(FLAGS_doppler_max) != 0)
         {
             doppler_max_ = absl::GetFlag(FLAGS_doppler_max);
+        }
+    if (absl::GetFlag(FLAGS_doppler_step) != 0)
+        {
+            doppler_step_ = static_cast<uint32_t>(absl::GetFlag(FLAGS_doppler_step));
         }
 #endif
 
@@ -97,7 +105,7 @@ GalileoE1Pcps8msAmbiguousAcquisition::GalileoE1Pcps8msAmbiguousAcquisition(
         {
             unsigned int max_dwells = configuration_->property(role + ".max_dwells", 1);
             acquisition_cc_ = galileo_pcps_8ms_make_acquisition_cc(sampled_ms_, max_dwells,
-                doppler_max_, fs_in_, samples_per_ms, code_length_,
+                doppler_max_, doppler_step_, fs_in_, samples_per_ms, code_length_,
                 dump_, dump_filename_, enable_monitor_output);
             stream_to_vector_ = gr::blocks::stream_to_vector::make(item_size_, vector_length_);
             DLOG(INFO) << "stream_to_vector("
@@ -153,16 +161,6 @@ void GalileoE1Pcps8msAmbiguousAcquisition::set_threshold(float threshold)
     if (item_type_ == "gr_complex")
         {
             acquisition_cc_->set_threshold(threshold_);
-        }
-}
-
-
-void GalileoE1Pcps8msAmbiguousAcquisition::set_doppler_step(unsigned int doppler_step)
-{
-    doppler_step_ = doppler_step;
-    if (item_type_ == "gr_complex")
-        {
-            acquisition_cc_->set_doppler_step(doppler_step_);
         }
 }
 

--- a/src/algorithms/acquisition/adapters/galileo_e1_pcps_8ms_ambiguous_acquisition.h
+++ b/src/algorithms/acquisition/adapters/galileo_e1_pcps_8ms_ambiguous_acquisition.h
@@ -103,11 +103,6 @@ public:
     void set_threshold(float threshold) override;
 
     /*!
-     * \brief Set Doppler steps for the grid search
-     */
-    void set_doppler_step(unsigned int doppler_step) override;
-
-    /*!
      * \brief Initializes acquisition algorithm.
      */
     void init() override;

--- a/src/algorithms/acquisition/adapters/galileo_e1_pcps_cccwsr_ambiguous_acquisition.cc
+++ b/src/algorithms/acquisition/adapters/galileo_e1_pcps_cccwsr_ambiguous_acquisition.cc
@@ -40,7 +40,7 @@ GalileoE1PcpsCccwsrAmbiguousAcquisition::GalileoE1PcpsCccwsrAmbiguousAcquisition
       threshold_(0.0),
       channel_(0),
       doppler_max_(configuration_->property(role + ".doppler_max", 5000)),
-      doppler_step_(0),
+      doppler_step_(configuration_->property(role + ".doppler_step", 500)),
       sampled_ms_(configuration_->property(role + ".coherent_integration_time_ms", 4)),
       dump_(configuration_->property(role + ".dump", false))
 {
@@ -56,10 +56,18 @@ GalileoE1PcpsCccwsrAmbiguousAcquisition::GalileoE1PcpsCccwsrAmbiguousAcquisition
         {
             doppler_max_ = FLAGS_doppler_max;
         }
+    if (FLAGS_doppler_step != 0)
+        {
+            doppler_step_ = static_cast<uint32_t>(FLAGS_doppler_step);
+        }
 #else
     if (absl::GetFlag(FLAGS_doppler_max) != 0)
         {
             doppler_max_ = absl::GetFlag(FLAGS_doppler_max);
+        }
+    if (absl::GetFlag(FLAGS_doppler_step) != 0)
+        {
+            doppler_step_ = static_cast<uint32_t>(absl::GetFlag(FLAGS_doppler_step));
         }
 #endif
 
@@ -89,7 +97,7 @@ GalileoE1PcpsCccwsrAmbiguousAcquisition::GalileoE1PcpsCccwsrAmbiguousAcquisition
         {
             unsigned int max_dwells = configuration_->property(role + ".max_dwells", 1);
             acquisition_cc_ = pcps_cccwsr_make_acquisition_cc(sampled_ms_, max_dwells,
-                doppler_max_, fs_in_, samples_per_ms, code_length_,
+                doppler_max_, doppler_step_, fs_in_, samples_per_ms, code_length_,
                 dump_, dump_filename_, enable_monitor_output);
             stream_to_vector_ = gr::blocks::stream_to_vector::make(item_size_, vector_length_);
             DLOG(INFO) << "stream_to_vector("
@@ -131,16 +139,6 @@ void GalileoE1PcpsCccwsrAmbiguousAcquisition::set_threshold(float threshold)
     if (item_type_ == "gr_complex")
         {
             acquisition_cc_->set_threshold(threshold_);
-        }
-}
-
-
-void GalileoE1PcpsCccwsrAmbiguousAcquisition::set_doppler_step(unsigned int doppler_step)
-{
-    doppler_step_ = doppler_step;
-    if (item_type_ == "gr_complex")
-        {
-            acquisition_cc_->set_doppler_step(doppler_step_);
         }
 }
 

--- a/src/algorithms/acquisition/adapters/galileo_e1_pcps_cccwsr_ambiguous_acquisition.h
+++ b/src/algorithms/acquisition/adapters/galileo_e1_pcps_cccwsr_ambiguous_acquisition.h
@@ -104,11 +104,6 @@ public:
     void set_threshold(float threshold) override;
 
     /*!
-     * \brief Set Doppler steps for the grid search
-     */
-    void set_doppler_step(unsigned int doppler_step) override;
-
-    /*!
      * \brief Initializes acquisition algorithm.
      */
     void init() override;

--- a/src/algorithms/acquisition/adapters/galileo_e1_pcps_quicksync_ambiguous_acquisition.cc
+++ b/src/algorithms/acquisition/adapters/galileo_e1_pcps_quicksync_ambiguous_acquisition.cc
@@ -49,7 +49,7 @@ GalileoE1PcpsQuickSyncAmbiguousAcquisition::GalileoE1PcpsQuickSyncAmbiguousAcqui
       threshold_(0.0),
       channel_(0),
       doppler_max_(configuration_->property(role + ".doppler_max", 5000)),
-      doppler_step_(0),
+      doppler_step_(configuration_->property(role + ".doppler_step", 500)),
       sampled_ms_(configuration_->property(role + ".coherent_integration_time_ms", 8)),
       bit_transition_flag_(configuration_->property(role + ".bit_transition_flag", false)),
       dump_(configuration_->property(role + ".dump", false))
@@ -66,10 +66,18 @@ GalileoE1PcpsQuickSyncAmbiguousAcquisition::GalileoE1PcpsQuickSyncAmbiguousAcqui
         {
             doppler_max_ = FLAGS_doppler_max;
         }
+    if (FLAGS_doppler_step != 0)
+        {
+            doppler_step_ = static_cast<uint32_t>(FLAGS_doppler_step);
+        }
 #else
     if (absl::GetFlag(FLAGS_doppler_max) != 0)
         {
             doppler_max_ = absl::GetFlag(FLAGS_doppler_max);
+        }
+    if (absl::GetFlag(FLAGS_doppler_step) != 0)
+        {
+            doppler_step_ = static_cast<uint32_t>(absl::GetFlag(FLAGS_doppler_step));
         }
 #endif
 
@@ -128,7 +136,7 @@ GalileoE1PcpsQuickSyncAmbiguousAcquisition::GalileoE1PcpsQuickSyncAmbiguousAcqui
     if (item_type_ == "gr_complex")
         {
             acquisition_cc_ = pcps_quicksync_make_acquisition_cc(folding_factor_,
-                sampled_ms_, max_dwells, doppler_max_, fs_in_,
+                sampled_ms_, max_dwells, doppler_max_, doppler_step_, fs_in_,
                 samples_per_ms, code_length_, bit_transition_flag_,
                 dump_, dump_filename_, enable_monitor_output);
             stream_to_vector_ = gr::blocks::stream_to_vector::make(item_size_,
@@ -189,15 +197,6 @@ void GalileoE1PcpsQuickSyncAmbiguousAcquisition::set_threshold(float threshold)
         }
 }
 
-
-void GalileoE1PcpsQuickSyncAmbiguousAcquisition::set_doppler_step(unsigned int doppler_step)
-{
-    doppler_step_ = doppler_step;
-    if (item_type_ == "gr_complex")
-        {
-            acquisition_cc_->set_doppler_step(doppler_step_);
-        }
-}
 
 void GalileoE1PcpsQuickSyncAmbiguousAcquisition::set_gnss_synchro(
     Gnss_Synchro* gnss_synchro)

--- a/src/algorithms/acquisition/adapters/galileo_e1_pcps_quicksync_ambiguous_acquisition.h
+++ b/src/algorithms/acquisition/adapters/galileo_e1_pcps_quicksync_ambiguous_acquisition.h
@@ -104,11 +104,6 @@ public:
     void set_threshold(float threshold) override;
 
     /*!
-     * \brief Set Doppler steps for the grid search
-     */
-    void set_doppler_step(unsigned int doppler_step) override;
-
-    /*!
      * \brief Initializes acquisition algorithm.
      */
     void init() override;

--- a/src/algorithms/acquisition/adapters/galileo_e1_pcps_tong_ambiguous_acquisition.cc
+++ b/src/algorithms/acquisition/adapters/galileo_e1_pcps_tong_ambiguous_acquisition.cc
@@ -49,7 +49,7 @@ GalileoE1PcpsTongAmbiguousAcquisition::GalileoE1PcpsTongAmbiguousAcquisition(
       threshold_(0.0),
       channel_(0),
       doppler_max_(configuration_->property(role + ".doppler_max", 5000)),
-      doppler_step_(0),
+      doppler_step_(configuration_->property(role + ".doppler_step", 500)),
       sampled_ms_(configuration_->property(role + ".coherent_integration_time_ms", 4)),
       tong_init_val_(configuration->property(role + ".tong_init_val", 1)),
       tong_max_val_(configuration->property(role + ".tong_max_val", 2)),
@@ -79,10 +79,18 @@ GalileoE1PcpsTongAmbiguousAcquisition::GalileoE1PcpsTongAmbiguousAcquisition(
         {
             doppler_max_ = FLAGS_doppler_max;
         }
+    if (FLAGS_doppler_step != 0)
+        {
+            doppler_step_ = static_cast<uint32_t>(FLAGS_doppler_step);
+        }
 #else
     if (absl::GetFlag(FLAGS_doppler_max) != 0)
         {
             doppler_max_ = absl::GetFlag(FLAGS_doppler_max);
+        }
+    if (absl::GetFlag(FLAGS_doppler_step) != 0)
+        {
+            doppler_step_ = static_cast<uint32_t>(absl::GetFlag(FLAGS_doppler_step));
         }
 #endif
 
@@ -102,7 +110,7 @@ GalileoE1PcpsTongAmbiguousAcquisition::GalileoE1PcpsTongAmbiguousAcquisition(
     if (item_type_ == "gr_complex")
         {
             acquisition_cc_ = pcps_tong_make_acquisition_cc(sampled_ms_, doppler_max_,
-                fs_in_, samples_per_ms, code_length_, tong_init_val_,
+                doppler_step_, fs_in_, samples_per_ms, code_length_, tong_init_val_,
                 tong_max_val_, tong_max_dwells_, dump_, dump_filename_, enable_monitor_output);
 
             stream_to_vector_ = gr::blocks::stream_to_vector::make(item_size_, vector_length_);
@@ -159,16 +167,6 @@ void GalileoE1PcpsTongAmbiguousAcquisition::set_threshold(float threshold)
     if (item_type_ == "gr_complex")
         {
             acquisition_cc_->set_threshold(threshold_);
-        }
-}
-
-
-void GalileoE1PcpsTongAmbiguousAcquisition::set_doppler_step(unsigned int doppler_step)
-{
-    doppler_step_ = doppler_step;
-    if (item_type_ == "gr_complex")
-        {
-            acquisition_cc_->set_doppler_step(doppler_step_);
         }
 }
 

--- a/src/algorithms/acquisition/adapters/galileo_e1_pcps_tong_ambiguous_acquisition.h
+++ b/src/algorithms/acquisition/adapters/galileo_e1_pcps_tong_ambiguous_acquisition.h
@@ -104,11 +104,6 @@ public:
     void set_threshold(float threshold) override;
 
     /*!
-     * \brief Set Doppler steps for the grid search
-     */
-    void set_doppler_step(unsigned int doppler_step) override;
-
-    /*!
      * \brief Initializes acquisition algorithm.
      */
     void init() override;

--- a/src/algorithms/acquisition/adapters/galileo_e5a_noncoherent_iq_acquisition_caf.cc
+++ b/src/algorithms/acquisition/adapters/galileo_e5a_noncoherent_iq_acquisition_caf.cc
@@ -57,7 +57,7 @@ GalileoE5aNoncoherentIQAcquisitionCaf::GalileoE5aNoncoherentIQAcquisitionCaf(
       CAF_window_hz_(configuration_->property(role + ".CAF_window_hz", 0)),
       channel_(0),
       doppler_max_(configuration_->property(role + ".doppler_max", 5000)),
-      doppler_step_(0),
+      doppler_step_(configuration_->property(role + ".doppler_step", 500)),
       sampled_ms_(configuration_->property(role + ".coherent_integration_time_ms", 1)),
       bit_transition_flag_(configuration_->property(role + ".bit_transition_flag", false)),
       dump_(configuration_->property(role + ".dump", false))
@@ -74,10 +74,18 @@ GalileoE5aNoncoherentIQAcquisitionCaf::GalileoE5aNoncoherentIQAcquisitionCaf(
         {
             doppler_max_ = FLAGS_doppler_max;
         }
+    if (FLAGS_doppler_step != 0)
+        {
+            doppler_step_ = static_cast<uint32_t>(FLAGS_doppler_step);
+        }
 #else
     if (absl::GetFlag(FLAGS_doppler_max) != 0)
         {
             doppler_max_ = absl::GetFlag(FLAGS_doppler_max);
+        }
+    if (absl::GetFlag(FLAGS_doppler_step) != 0)
+        {
+            doppler_step_ = static_cast<uint32_t>(absl::GetFlag(FLAGS_doppler_step));
         }
 #endif
 
@@ -115,7 +123,7 @@ GalileoE5aNoncoherentIQAcquisitionCaf::GalileoE5aNoncoherentIQAcquisitionCaf(
         {
             unsigned int max_dwells = configuration_->property(role + ".max_dwells", 1);
             acquisition_cc_ = galileo_e5a_noncoherentIQ_make_acquisition_caf_cc(sampled_ms_, max_dwells,
-                doppler_max_, fs_in_, code_length_, code_length_, bit_transition_flag_,
+                doppler_max_, doppler_step_, fs_in_, code_length_, code_length_, bit_transition_flag_,
                 dump_, dump_filename_, both_signal_components, CAF_window_hz_, Zero_padding, enable_monitor_output);
         }
     else
@@ -166,16 +174,6 @@ void GalileoE5aNoncoherentIQAcquisitionCaf::set_threshold(float threshold)
     if (item_type_ == "gr_complex")
         {
             acquisition_cc_->set_threshold(threshold_);
-        }
-}
-
-
-void GalileoE5aNoncoherentIQAcquisitionCaf::set_doppler_step(unsigned int doppler_step)
-{
-    doppler_step_ = doppler_step;
-    if (item_type_ == "gr_complex")
-        {
-            acquisition_cc_->set_doppler_step(doppler_step_);
         }
 }
 

--- a/src/algorithms/acquisition/adapters/galileo_e5a_noncoherent_iq_acquisition_caf.h
+++ b/src/algorithms/acquisition/adapters/galileo_e5a_noncoherent_iq_acquisition_caf.h
@@ -104,11 +104,6 @@ public:
     void set_threshold(float threshold) override;
 
     /*!
-     * \brief Set Doppler steps for the grid search
-     */
-    void set_doppler_step(unsigned int doppler_step) override;
-
-    /*!
      * \brief Initializes acquisition algorithm.
      */
     void init() override;

--- a/src/algorithms/acquisition/adapters/gps_l1_ca_pcps_acquisition_fine_doppler.cc
+++ b/src/algorithms/acquisition/adapters/gps_l1_ca_pcps_acquisition_fine_doppler.cc
@@ -42,7 +42,7 @@ GpsL1CaPcpsAcquisitionFineDoppler::GpsL1CaPcpsAcquisitionFineDoppler(
       threshold_(0.0),
       doppler_max_(configuration->property(role + ".doppler_max", 5000)),
       channel_(0),
-      doppler_step_(0),
+      doppler_step_(configuration->property(role + ".doppler_step", 500)),
       sampled_ms_(configuration->property(role + ".coherent_integration_time_ms", 1)),
       dump_(configuration->property(role + ".dump", false))
 {
@@ -63,13 +63,22 @@ GpsL1CaPcpsAcquisitionFineDoppler::GpsL1CaPcpsAcquisitionFineDoppler(
         {
             doppler_max_ = FLAGS_doppler_max;
         }
+    if (FLAGS_doppler_step != 0)
+        {
+            doppler_step_ = static_cast<uint32_t>(FLAGS_doppler_step);
+        }
 #else
     if (absl::GetFlag(FLAGS_doppler_max) != 0)
         {
             doppler_max_ = absl::GetFlag(FLAGS_doppler_max);
         }
+    if (absl::GetFlag(FLAGS_doppler_step) != 0)
+        {
+            doppler_step_ = static_cast<uint32_t>(absl::GetFlag(FLAGS_doppler_step));
+        }
 #endif
     acq_parameters.doppler_max = doppler_max_;
+    acq_parameters.doppler_step = doppler_step_;
     acq_parameters.sampled_ms = sampled_ms_;
     acq_parameters.max_dwells = configuration->property(role + ".max_dwells", 1);
     acq_parameters.blocking_on_standby = configuration->property(role + ".blocking_on_standby", false);
@@ -113,13 +122,6 @@ void GpsL1CaPcpsAcquisitionFineDoppler::set_threshold(float threshold)
 {
     threshold_ = threshold;
     acquisition_cc_->set_threshold(threshold_);
-}
-
-
-void GpsL1CaPcpsAcquisitionFineDoppler::set_doppler_step(unsigned int doppler_step)
-{
-    doppler_step_ = doppler_step;
-    acquisition_cc_->set_doppler_step(doppler_step_);
 }
 
 

--- a/src/algorithms/acquisition/adapters/gps_l1_ca_pcps_acquisition_fine_doppler.h
+++ b/src/algorithms/acquisition/adapters/gps_l1_ca_pcps_acquisition_fine_doppler.h
@@ -106,11 +106,6 @@ public:
     void set_threshold(float threshold) override;
 
     /*!
-     * \brief Set Doppler steps for the grid search
-     */
-    void set_doppler_step(unsigned int doppler_step) override;
-
-    /*!
      * \brief Initializes acquisition algorithm.
      */
     void init() override;

--- a/src/algorithms/acquisition/adapters/gps_l1_ca_pcps_assisted_acquisition.cc
+++ b/src/algorithms/acquisition/adapters/gps_l1_ca_pcps_assisted_acquisition.cc
@@ -48,16 +48,25 @@ GpsL1CaPcpsAssistedAcquisition::GpsL1CaPcpsAssistedAcquisition(
     fs_in_ = configuration->property("GNSS-SDR.internal_fs_sps", fs_in_deprecated);
 
     int doppler_max = configuration->property(role + ".doppler_max", 5000);
+    int doppler_step = configuration->property(role + ".doppler_step", 500);
 
 #if USE_GLOG_AND_GFLAGS
     if (FLAGS_doppler_max != 0)
         {
             doppler_max = FLAGS_doppler_max;
         }
+    if (FLAGS_doppler_step != 0)
+        {
+            doppler_step = static_cast<uint32_t>(FLAGS_doppler_step);
+        }
 #else
     if (absl::GetFlag(FLAGS_doppler_max) != 0)
         {
             doppler_max = absl::GetFlag(FLAGS_doppler_max);
+        }
+    if (absl::GetFlag(FLAGS_doppler_step) != 0)
+        {
+            doppler_step = static_cast<uint32_t>(absl::GetFlag(FLAGS_doppler_step));
         }
 #endif
     const int doppler_min = configuration->property(role_ + ".doppler_min", -doppler_max);
@@ -74,7 +83,7 @@ GpsL1CaPcpsAssistedAcquisition::GpsL1CaPcpsAssistedAcquisition(
             const unsigned int max_dwells = configuration->property(role + ".max_dwells", 1);
             const unsigned int sampled_ms = configuration->property(role + ".coherent_integration_time_ms", 1);
             acquisition_cc_ = pcps_make_assisted_acquisition_cc(max_dwells, sampled_ms,
-                doppler_max, doppler_min, fs_in_, vector_length_,
+                doppler_max, doppler_min, doppler_step, fs_in_, vector_length_,
                 dump_, dump_filename, enable_monitor_output);
         }
     else
@@ -105,12 +114,6 @@ void GpsL1CaPcpsAssistedAcquisition::stop_acquisition()
 void GpsL1CaPcpsAssistedAcquisition::set_threshold(float threshold)
 {
     acquisition_cc_->set_threshold(threshold);
-}
-
-
-void GpsL1CaPcpsAssistedAcquisition::set_doppler_step(unsigned int doppler_step)
-{
-    acquisition_cc_->set_doppler_step(doppler_step);
 }
 
 

--- a/src/algorithms/acquisition/adapters/gps_l1_ca_pcps_assisted_acquisition.h
+++ b/src/algorithms/acquisition/adapters/gps_l1_ca_pcps_assisted_acquisition.h
@@ -103,11 +103,6 @@ public:
     void set_threshold(float threshold) override;
 
     /*!
-     * \brief Set Doppler steps for the grid search
-     */
-    void set_doppler_step(unsigned int doppler_step) override;
-
-    /*!
      * \brief Initializes acquisition algorithm.
      */
     void init() override;

--- a/src/algorithms/acquisition/adapters/gps_l1_ca_pcps_opencl_acquisition.cc
+++ b/src/algorithms/acquisition/adapters/gps_l1_ca_pcps_opencl_acquisition.cc
@@ -47,7 +47,8 @@ GpsL1CaPcpsOpenClAcquisition::GpsL1CaPcpsOpenClAcquisition(
       role_(role),
       threshold_(0.0),
       channel_(0),
-      doppler_step_(0)
+      doppler_max_(configuration->property(role + ".doppler_max", 5000)),
+      doppler_step_(configuration->property(role + ".doppler_step", 500))
 {
     const std::string default_item_type("gr_complex");
     std::string default_dump_filename = "./data/acquisition.dat";
@@ -60,16 +61,23 @@ GpsL1CaPcpsOpenClAcquisition::GpsL1CaPcpsOpenClAcquisition(
     int64_t fs_in_deprecated = configuration->property("GNSS-SDR.internal_fs_hz", 2048000);
     fs_in_ = configuration->property("GNSS-SDR.internal_fs_sps", fs_in_deprecated);
     dump_ = configuration->property(role + ".dump", false);
-    doppler_max_ = configuration->property(role + ".doppler_max", 5000);
 #if USE_GLOG_AND_GFLAGS
     if (FLAGS_doppler_max != 0)
         {
             doppler_max_ = FLAGS_doppler_max;
         }
+    if (FLAGS_doppler_step != 0)
+        {
+            doppler_step_ = static_cast<uint32_t>(FLAGS_doppler_step);
+        }
 #else
     if (absl::GetFlag(FLAGS_doppler_max) != 0)
         {
             doppler_max_ = absl::GetFlag(FLAGS_doppler_max);
+        }
+    if (absl::GetFlag(FLAGS_doppler_step) != 0)
+        {
+            doppler_step_ = static_cast<uint32_t>(absl::GetFlag(FLAGS_doppler_step));
         }
 #endif
     sampled_ms_ = configuration->property(role + ".coherent_integration_time_ms", 1);
@@ -97,7 +105,7 @@ GpsL1CaPcpsOpenClAcquisition::GpsL1CaPcpsOpenClAcquisition(
         {
             item_size_ = sizeof(gr_complex);
             acquisition_cc_ = pcps_make_opencl_acquisition_cc(sampled_ms_, max_dwells,
-                doppler_max_, fs_in_, code_length_, code_length_,
+                doppler_max_, doppler_step_, fs_in_, code_length_, code_length_,
                 bit_transition_flag_, dump_, dump_filename_, false);
 
             stream_to_vector_ = gr::blocks::stream_to_vector::make(item_size_, vector_length_);
@@ -151,16 +159,6 @@ void GpsL1CaPcpsOpenClAcquisition::set_threshold(float threshold)
     if (item_type_ == "gr_complex")
         {
             acquisition_cc_->set_threshold(threshold_);
-        }
-}
-
-
-void GpsL1CaPcpsOpenClAcquisition::set_doppler_step(unsigned int doppler_step)
-{
-    doppler_step_ = doppler_step;
-    if (item_type_ == "gr_complex")
-        {
-            acquisition_cc_->set_doppler_step(doppler_step_);
         }
 }
 

--- a/src/algorithms/acquisition/adapters/gps_l1_ca_pcps_opencl_acquisition.h
+++ b/src/algorithms/acquisition/adapters/gps_l1_ca_pcps_opencl_acquisition.h
@@ -103,11 +103,6 @@ public:
     void set_threshold(float threshold) override;
 
     /*!
-     * \brief Set Doppler steps for the grid search
-     */
-    void set_doppler_step(unsigned int doppler_step) override;
-
-    /*!
      * \brief Initializes acquisition algorithm.
      */
     void init() override;

--- a/src/algorithms/acquisition/adapters/gps_l1_ca_pcps_quicksync_acquisition.cc
+++ b/src/algorithms/acquisition/adapters/gps_l1_ca_pcps_quicksync_acquisition.cc
@@ -50,7 +50,7 @@ GpsL1CaPcpsQuickSyncAcquisition::GpsL1CaPcpsQuickSyncAcquisition(
       threshold_(0.0),
       channel_(0),
       doppler_max_(configuration->property(role + ".doppler_max", 5000)),
-      doppler_step_(0),
+      doppler_step_(configuration_->property(role + ".doppler_step", 500)),
       sampled_ms_(configuration_->property(role + ".coherent_integration_time_ms", 4)),
       bit_transition_flag_(configuration_->property(role + ".bit_transition_flag", false)),
       dump_(configuration_->property(role + ".dump", false))
@@ -66,10 +66,18 @@ GpsL1CaPcpsQuickSyncAcquisition::GpsL1CaPcpsQuickSyncAcquisition(
         {
             doppler_max_ = FLAGS_doppler_max;
         }
+    if (FLAGS_doppler_step != 0)
+        {
+            doppler_step_ = static_cast<uint32_t>(FLAGS_doppler_step);
+        }
 #else
     if (absl::GetFlag(FLAGS_doppler_max) != 0)
         {
             doppler_max_ = absl::GetFlag(FLAGS_doppler_max);
+        }
+    if (absl::GetFlag(FLAGS_doppler_step) != 0)
+        {
+            doppler_step_ = static_cast<uint32_t>(absl::GetFlag(FLAGS_doppler_step));
         }
 #endif
 
@@ -126,7 +134,7 @@ GpsL1CaPcpsQuickSyncAcquisition::GpsL1CaPcpsQuickSyncAcquisition(
     if (item_type_ == "gr_complex")
         {
             acquisition_cc_ = pcps_quicksync_make_acquisition_cc(folding_factor_,
-                sampled_ms_, max_dwells, doppler_max_, fs_in_,
+                sampled_ms_, max_dwells, doppler_max_, doppler_step_, fs_in_,
                 samples_per_ms, code_length_, bit_transition_flag_,
                 dump_, dump_filename_, enable_monitor_output);
 
@@ -183,16 +191,6 @@ void GpsL1CaPcpsQuickSyncAcquisition::set_threshold(float threshold)
     if (item_type_ == "gr_complex")
         {
             acquisition_cc_->set_threshold(threshold_);
-        }
-}
-
-
-void GpsL1CaPcpsQuickSyncAcquisition::set_doppler_step(unsigned int doppler_step)
-{
-    doppler_step_ = doppler_step;
-    if (item_type_ == "gr_complex")
-        {
-            acquisition_cc_->set_doppler_step(doppler_step_);
         }
 }
 

--- a/src/algorithms/acquisition/adapters/gps_l1_ca_pcps_quicksync_acquisition.h
+++ b/src/algorithms/acquisition/adapters/gps_l1_ca_pcps_quicksync_acquisition.h
@@ -106,11 +106,6 @@ public:
     void set_threshold(float threshold) override;
 
     /*!
-     * \brief Set Doppler steps for the grid search
-     */
-    void set_doppler_step(unsigned int doppler_step) override;
-
-    /*!
      * \brief Initializes acquisition algorithm.
      */
     void init() override;

--- a/src/algorithms/acquisition/adapters/gps_l1_ca_pcps_tong_acquisition.cc
+++ b/src/algorithms/acquisition/adapters/gps_l1_ca_pcps_tong_acquisition.cc
@@ -48,7 +48,7 @@ GpsL1CaPcpsTongAcquisition::GpsL1CaPcpsTongAcquisition(
       item_size_(sizeof(gr_complex)),
       channel_(0),
       doppler_max_(configuration->property(role + ".doppler_max", 5000)),
-      doppler_step_(0),
+      doppler_step_(configuration_->property(role + ".doppler_step", 500)),
       sampled_ms_(configuration_->property(role + ".coherent_integration_time_ms", 1)),
       dump_(configuration_->property(role + ".dump", false))
 {
@@ -67,10 +67,18 @@ GpsL1CaPcpsTongAcquisition::GpsL1CaPcpsTongAcquisition(
         {
             doppler_max_ = FLAGS_doppler_max;
         }
+    if (FLAGS_doppler_step != 0)
+        {
+            doppler_step_ = static_cast<uint32_t>(FLAGS_doppler_step);
+        }
 #else
     if (absl::GetFlag(FLAGS_doppler_max) != 0)
         {
             doppler_max_ = absl::GetFlag(FLAGS_doppler_max);
+        }
+    if (absl::GetFlag(FLAGS_doppler_step) != 0)
+        {
+            doppler_step_ = static_cast<uint32_t>(absl::GetFlag(FLAGS_doppler_step));
         }
 #endif
     bool enable_monitor_output = configuration_->property("AcquisitionMonitor.enable_monitor", false);
@@ -87,7 +95,7 @@ GpsL1CaPcpsTongAcquisition::GpsL1CaPcpsTongAcquisition(
             const unsigned int tong_init_val = configuration->property(role + ".tong_init_val", 1);
             const unsigned int tong_max_val = configuration->property(role + ".tong_max_val", 2);
             const unsigned int tong_max_dwells = configuration->property(role + ".tong_max_dwells", tong_max_val + 1);
-            acquisition_cc_ = pcps_tong_make_acquisition_cc(sampled_ms_, doppler_max_, fs_in_,
+            acquisition_cc_ = pcps_tong_make_acquisition_cc(sampled_ms_, doppler_max_, doppler_step_, fs_in_,
                 code_length_, code_length_, tong_init_val, tong_max_val, tong_max_dwells,
                 dump_, dump_filename_, enable_monitor_output);
 
@@ -139,16 +147,6 @@ void GpsL1CaPcpsTongAcquisition::set_threshold(float threshold)
     if (item_type_ == "gr_complex")
         {
             acquisition_cc_->set_threshold(threshold);
-        }
-}
-
-
-void GpsL1CaPcpsTongAcquisition::set_doppler_step(unsigned int doppler_step)
-{
-    doppler_step_ = doppler_step;
-    if (item_type_ == "gr_complex")
-        {
-            acquisition_cc_->set_doppler_step(doppler_step_);
         }
 }
 

--- a/src/algorithms/acquisition/adapters/gps_l1_ca_pcps_tong_acquisition.h
+++ b/src/algorithms/acquisition/adapters/gps_l1_ca_pcps_tong_acquisition.h
@@ -104,11 +104,6 @@ public:
     void set_threshold(float threshold) override;
 
     /*!
-     * \brief Set Doppler steps for the grid search
-     */
-    void set_doppler_step(unsigned int doppler_step) override;
-
-    /*!
      * \brief Initializes acquisition algorithm.
      */
     void init() override;

--- a/src/algorithms/acquisition/gnuradio_blocks/galileo_e5a_noncoherent_iq_acquisition_caf_cc.cc
+++ b/src/algorithms/acquisition/gnuradio_blocks/galileo_e5a_noncoherent_iq_acquisition_caf_cc.cc
@@ -41,7 +41,9 @@
 galileo_e5a_noncoherentIQ_acquisition_caf_cc_sptr galileo_e5a_noncoherentIQ_make_acquisition_caf_cc(
     unsigned int sampled_ms,
     unsigned int max_dwells,
-    unsigned int doppler_max, int64_t fs_in,
+    unsigned int doppler_max,
+    unsigned int doppler_step,
+    int64_t fs_in,
     int samples_per_ms, int samples_per_code,
     bool bit_transition_flag,
     bool dump,
@@ -52,7 +54,7 @@ galileo_e5a_noncoherentIQ_acquisition_caf_cc_sptr galileo_e5a_noncoherentIQ_make
     bool enable_monitor_output)
 {
     return galileo_e5a_noncoherentIQ_acquisition_caf_cc_sptr(
-        new galileo_e5a_noncoherentIQ_acquisition_caf_cc(sampled_ms, max_dwells, doppler_max, fs_in, samples_per_ms,
+        new galileo_e5a_noncoherentIQ_acquisition_caf_cc(sampled_ms, max_dwells, doppler_max, doppler_step, fs_in, samples_per_ms,
             samples_per_code, bit_transition_flag, dump, dump_filename, both_signal_components_, CAF_window_hz_, Zero_padding_, enable_monitor_output));
 }
 
@@ -61,6 +63,7 @@ galileo_e5a_noncoherentIQ_acquisition_caf_cc::galileo_e5a_noncoherentIQ_acquisit
     unsigned int sampled_ms,
     unsigned int max_dwells,
     unsigned int doppler_max,
+    unsigned int doppler_step,
     int64_t fs_in,
     int samples_per_ms,
     int samples_per_code,
@@ -90,7 +93,7 @@ galileo_e5a_noncoherentIQ_acquisition_caf_cc::galileo_e5a_noncoherentIQ_acquisit
       d_buffer_count(0),
       d_doppler_resolution(0),
       d_doppler_max(static_cast<int>(doppler_max)),
-      d_doppler_step(250),
+      d_doppler_step(doppler_step),
       d_fft_size(static_cast<int>(sampled_ms) * d_samples_per_ms),
       d_num_doppler_bins(0),
       d_gr_stream_buffer(0),

--- a/src/algorithms/acquisition/gnuradio_blocks/galileo_e5a_noncoherent_iq_acquisition_caf_cc.h
+++ b/src/algorithms/acquisition/gnuradio_blocks/galileo_e5a_noncoherent_iq_acquisition_caf_cc.h
@@ -48,7 +48,9 @@ using galileo_e5a_noncoherentIQ_acquisition_caf_cc_sptr = gnss_shared_ptr<galile
 galileo_e5a_noncoherentIQ_acquisition_caf_cc_sptr galileo_e5a_noncoherentIQ_make_acquisition_caf_cc(
     unsigned int sampled_ms,
     unsigned int max_dwells,
-    unsigned int doppler_max, int64_t fs_in,
+    unsigned int doppler_max,
+    unsigned int doppler_step,
+    int64_t fs_in,
     int samples_per_ms, int samples_per_code,
     bool bit_transition_flag,
     bool dump,
@@ -146,15 +148,6 @@ public:
     }
 
     /*!
-     * \brief Set Doppler steps for the grid search
-     * \param doppler_step - Frequency bin of the search grid [Hz].
-     */
-    inline void set_doppler_step(unsigned int doppler_step)
-    {
-        d_doppler_step = doppler_step;
-    }
-
-    /*!
      * \brief Parallel Code Phase Search Acquisition signal processing.
      */
     int general_work(int noutput_items, gr_vector_int& ninput_items,
@@ -166,7 +159,9 @@ private:
     galileo_e5a_noncoherentIQ_make_acquisition_caf_cc(
         unsigned int sampled_ms,
         unsigned int max_dwells,
-        unsigned int doppler_max, int64_t fs_in,
+        unsigned int doppler_max,
+        unsigned int doppler_step,
+        int64_t fs_in,
         int samples_per_ms, int samples_per_code,
         bool bit_transition_flag,
         bool dump,
@@ -179,7 +174,9 @@ private:
     galileo_e5a_noncoherentIQ_acquisition_caf_cc(
         unsigned int sampled_ms,
         unsigned int max_dwells,
-        unsigned int doppler_max, int64_t fs_in,
+        unsigned int doppler_max,
+        unsigned int doppler_step,
+        int64_t fs_in,
         int samples_per_ms, int samples_per_code,
         bool bit_transition_flag,
         bool dump,
@@ -235,7 +232,7 @@ private:
     int d_buffer_count;
     int d_doppler_resolution;
     const int d_doppler_max;
-    int d_doppler_step;
+    const int d_doppler_step;
     int d_fft_size;
     int d_num_doppler_bins;
     unsigned int d_gr_stream_buffer;

--- a/src/algorithms/acquisition/gnuradio_blocks/galileo_pcps_8ms_acquisition_cc.cc
+++ b/src/algorithms/acquisition/gnuradio_blocks/galileo_pcps_8ms_acquisition_cc.cc
@@ -35,6 +35,7 @@ galileo_pcps_8ms_acquisition_cc_sptr galileo_pcps_8ms_make_acquisition_cc(
     uint32_t sampled_ms,
     uint32_t max_dwells,
     uint32_t doppler_max,
+    uint32_t doppler_step,
     int64_t fs_in,
     int32_t samples_per_ms,
     int32_t samples_per_code,
@@ -43,7 +44,7 @@ galileo_pcps_8ms_acquisition_cc_sptr galileo_pcps_8ms_make_acquisition_cc(
     bool enable_monitor_output)
 {
     return galileo_pcps_8ms_acquisition_cc_sptr(
-        new galileo_pcps_8ms_acquisition_cc(sampled_ms, max_dwells, doppler_max, fs_in, samples_per_ms,
+        new galileo_pcps_8ms_acquisition_cc(sampled_ms, max_dwells, doppler_max, doppler_step, fs_in, samples_per_ms,
             samples_per_code, dump, dump_filename, enable_monitor_output));
 }
 
@@ -52,6 +53,7 @@ galileo_pcps_8ms_acquisition_cc::galileo_pcps_8ms_acquisition_cc(
     uint32_t sampled_ms,
     uint32_t max_dwells,
     uint32_t doppler_max,
+    uint32_t doppler_step,
     int64_t fs_in,
     int32_t samples_per_ms,
     int32_t samples_per_code,
@@ -76,7 +78,7 @@ galileo_pcps_8ms_acquisition_cc::galileo_pcps_8ms_acquisition_cc(
       d_channel(0),
       d_doppler_resolution(0),
       d_doppler_max(doppler_max),
-      d_doppler_step(0),
+      d_doppler_step(doppler_step),
       d_sampled_ms(sampled_ms),
       d_max_dwells(max_dwells),
       d_well_count(0),

--- a/src/algorithms/acquisition/gnuradio_blocks/galileo_pcps_8ms_acquisition_cc.h
+++ b/src/algorithms/acquisition/gnuradio_blocks/galileo_pcps_8ms_acquisition_cc.h
@@ -43,6 +43,7 @@ galileo_pcps_8ms_acquisition_cc_sptr
 galileo_pcps_8ms_make_acquisition_cc(uint32_t sampled_ms,
     uint32_t max_dwells,
     uint32_t doppler_max,
+    uint32_t doppler_step,
     int64_t fs_in,
     int32_t samples_per_ms,
     int32_t samples_per_code,
@@ -136,15 +137,6 @@ public:
     }
 
     /*!
-     * \brief Set Doppler steps for the grid search
-     * \param doppler_step - Frequency bin of the search grid [Hz].
-     */
-    inline void set_doppler_step(uint32_t doppler_step)
-    {
-        d_doppler_step = doppler_step;
-    }
-
-    /*!
      * \brief Parallel Code Phase Search Acquisition signal processing.
      */
     int general_work(int noutput_items, gr_vector_int& ninput_items,
@@ -157,6 +149,7 @@ private:
         uint32_t sampled_ms,
         uint32_t max_dwells,
         uint32_t doppler_max,
+        uint32_t doppler_step,
         int64_t fs_in,
         int32_t samples_per_ms,
         int32_t samples_per_code,
@@ -168,6 +161,7 @@ private:
         uint32_t sampled_ms,
         uint32_t max_dwells,
         uint32_t doppler_max,
+        uint32_t doppler_step,
         int64_t fs_in,
         int32_t samples_per_ms,
         int32_t samples_per_code,
@@ -209,7 +203,7 @@ private:
     uint32_t d_channel;
     uint32_t d_doppler_resolution;
     const uint32_t d_doppler_max;
-    uint32_t d_doppler_step;
+    const uint32_t d_doppler_step;
     uint32_t d_sampled_ms;
     uint32_t d_max_dwells;
     uint32_t d_well_count;

--- a/src/algorithms/acquisition/gnuradio_blocks/pcps_acquisition.cc
+++ b/src/algorithms/acquisition/gnuradio_blocks/pcps_acquisition.cc
@@ -77,7 +77,7 @@ pcps_acquisition::pcps_acquisition(const Acq_Conf& conf_)
       d_num_noncoherent_integrations_counter(0U),
       d_consumed_samples(conf_.sampled_ms * conf_.samples_per_ms * (conf_.bit_transition_flag ? 2.0 : 1.0)),
       d_fft_size(conf_.sampled_ms == conf_.ms_per_code ? d_consumed_samples : d_consumed_samples * 2),
-      d_num_doppler_bins(0U),
+      d_num_doppler_bins(static_cast<uint32_t>(std::ceil(static_cast<double>(2 * d_doppler_max) / static_cast<double>(d_doppler_step)))),
       d_num_doppler_bins_step2(conf_.num_doppler_bins_step2),
       d_dump_channel(conf_.dump_channel),
       d_buffer_count(0U),
@@ -251,8 +251,6 @@ void pcps_acquisition::init()
     d_mag = 0.0;
     d_input_power = 0.0;
 
-    d_num_doppler_bins = static_cast<uint32_t>(std::ceil(static_cast<double>(2 * d_doppler_max) / static_cast<double>(d_doppler_step)));
-
     // Create the carrier Doppler wipeoff signals
     if (d_grid_doppler_wipeoffs.empty())
         {
@@ -419,7 +417,8 @@ void pcps_acquisition::dump_results(int32_t effective_fft_size, float test_stati
             Mat_VarWrite(matfp, matvar, MAT_COMPRESSION_ZLIB);  // or MAT_COMPRESSION_NONE
             Mat_VarFree(matvar);
 
-            matvar = Mat_VarCreate("doppler_step", MAT_C_INT32, MAT_T_INT32, 1, dims.data(), &d_doppler_step, 0);
+            auto doppler_step = d_doppler_step;
+            matvar = Mat_VarCreate("doppler_step", MAT_C_INT32, MAT_T_INT32, 1, dims.data(), &doppler_step, 0);
             Mat_VarWrite(matfp, matvar, MAT_COMPRESSION_ZLIB);  // or MAT_COMPRESSION_NONE
             Mat_VarFree(matvar);
 
@@ -704,7 +703,7 @@ void pcps_acquisition::acquisition_core(uint64_t samp_count)
 
     DLOG(INFO) << "Channel: " << d_channel
                << " , doing acquisition of satellite: " << d_gnss_synchro->System << " " << d_gnss_synchro->PRN
-               << " ,sample stamp: " << samp_count << ", threshold: "
+               << " , sample stamp: " << samp_count << ", threshold: "
                << d_threshold << ", doppler_max: " << d_doppler_max
                << ", doppler_step: " << d_doppler_step
                << ", use_CFAR_algorithm_flag: " << (d_use_CFAR_algorithm_flag ? "true" : "false");

--- a/src/algorithms/acquisition/gnuradio_blocks/pcps_acquisition.h
+++ b/src/algorithms/acquisition/gnuradio_blocks/pcps_acquisition.h
@@ -173,16 +173,6 @@ public:
     }
 
     /*!
-     * \brief Set Doppler steps for the grid search
-     * \param doppler_step - Frequency bin of the search grid [Hz].
-     */
-    inline void set_doppler_step(uint32_t doppler_step)
-    {
-        gr::thread::scoped_lock lock(d_setlock);  // require mutex with work function called by the scheduler
-        d_doppler_step = doppler_step;
-    }
-
-    /*!
      * \brief Set Doppler center frequency for the grid search. It will refresh the Doppler grid.
      * \param doppler_center - Frequency center of the search grid [Hz].
      */
@@ -251,11 +241,11 @@ private:
     int32_t d_doppler_bias;
     uint32_t d_channel;
     const uint32_t d_samplesPerChip;
-    uint32_t d_doppler_step;
+    const uint32_t d_doppler_step;
     uint32_t d_num_noncoherent_integrations_counter;
     const uint32_t d_consumed_samples;
     const uint32_t d_fft_size;
-    uint32_t d_num_doppler_bins;
+    const uint32_t d_num_doppler_bins;
     const uint32_t d_num_doppler_bins_step2;
     const uint32_t d_dump_channel;
     uint32_t d_buffer_count;

--- a/src/algorithms/acquisition/gnuradio_blocks/pcps_acquisition_fine_doppler_cc.cc
+++ b/src/algorithms/acquisition/gnuradio_blocks/pcps_acquisition_fine_doppler_cc.cc
@@ -60,12 +60,12 @@ pcps_acquisition_fine_doppler_cc::pcps_acquisition_fine_doppler_cc(const Acq_Con
       d_samples_per_ms(static_cast<int>(conf_.samples_per_ms)),
       d_max_dwells(conf_.max_dwells),
       d_config_doppler_max(conf_.doppler_max),
-      d_num_doppler_points(0),
+      d_doppler_step(conf_.doppler_step),
+      d_num_doppler_points(floor(std::abs(2 * d_config_doppler_max) / d_doppler_step)),
       d_well_count(0),
       d_n_samples_in_buffer(0),
       d_fft_size(d_samples_per_ms),
       d_gnuradio_forecast_samples(d_fft_size),
-      d_doppler_step(0),
       d_channel(0),
       d_dump_channel(0),
       d_active(false),
@@ -78,6 +78,8 @@ pcps_acquisition_fine_doppler_cc::pcps_acquisition_fine_doppler_cc(const Acq_Con
     d_10_ms_buffer = volk_gnsssdr::vector<gr_complex>(50 * d_samples_per_ms);
     d_fft_if = gnss_fft_fwd_make_unique(d_fft_size);
     d_ifft = gnss_fft_rev_make_unique(d_fft_size);
+    d_grid_data = volk_gnsssdr::vector<volk_gnsssdr::vector<float>>(d_num_doppler_points, volk_gnsssdr::vector<float>(d_fft_size));
+    update_carrier_wipeoff();
 
     // this implementation can only produce dumps in channel 0
     // todo: migrate config parameters to the unified acquisition config class
@@ -111,6 +113,8 @@ pcps_acquisition_fine_doppler_cc::pcps_acquisition_fine_doppler_cc(const Acq_Con
                     std::cerr << "GNSS-SDR cannot create dump file for the Acquisition block. Wrong permissions?\n";
                     d_dump = false;
                 }
+
+            grid_ = arma::fmat(d_fft_size, d_num_doppler_points, arma::fill::zeros);
         }
 }
 
@@ -128,24 +132,6 @@ unsigned int pcps_acquisition_fine_doppler_cc::nextPowerOf2(unsigned int n)
     n |= n >> 16U;
     n++;
     return n;
-}
-
-
-void pcps_acquisition_fine_doppler_cc::set_doppler_step(unsigned int doppler_step)
-{
-    d_doppler_step = doppler_step;
-    // Create the search grid array
-
-    d_num_doppler_points = floor(std::abs(2 * d_config_doppler_max) / d_doppler_step);
-
-    d_grid_data = volk_gnsssdr::vector<volk_gnsssdr::vector<float>>(d_num_doppler_points, volk_gnsssdr::vector<float>(d_fft_size));
-
-    if (d_dump)
-        {
-            grid_ = arma::fmat(d_fft_size, d_num_doppler_points, arma::fill::zeros);
-        }
-
-    update_carrier_wipeoff();
 }
 
 
@@ -648,7 +634,8 @@ void pcps_acquisition_fine_doppler_cc::dump_results(int effective_fft_size)
             Mat_VarWrite(matfp, matvar, MAT_COMPRESSION_ZLIB);  // or MAT_COMPRESSION_NONE
             Mat_VarFree(matvar);
 
-            matvar = Mat_VarCreate("doppler_step", MAT_C_INT32, MAT_T_INT32, 1, dims.data(), &d_doppler_step, 0);
+            auto doppler_step = d_doppler_step;
+            matvar = Mat_VarCreate("doppler_step", MAT_C_INT32, MAT_T_INT32, 1, dims.data(), &doppler_step, 0);
             Mat_VarWrite(matfp, matvar, MAT_COMPRESSION_ZLIB);  // or MAT_COMPRESSION_NONE
             Mat_VarFree(matvar);
 

--- a/src/algorithms/acquisition/gnuradio_blocks/pcps_acquisition_fine_doppler_cc.h
+++ b/src/algorithms/acquisition/gnuradio_blocks/pcps_acquisition_fine_doppler_cc.h
@@ -146,12 +146,6 @@ public:
     }
 
     /*!
-     * \brief Set Doppler steps for the grid search
-     * \param doppler_step - Frequency bin of the search grid [Hz].
-     */
-    void set_doppler_step(unsigned int doppler_step);
-
-    /*!
      * \brief If set to 1, ensures that acquisition starts at the
      * first available sample.
      * \param state - int=1 forces start of acquisition
@@ -206,7 +200,7 @@ private:
 
     Acq_Conf acq_parameters;
 
-    int64_t d_fs_in;
+    const int64_t d_fs_in;
     int64_t d_dump_number;
     uint64_t d_sample_counter;
 
@@ -218,12 +212,12 @@ private:
     int d_samples_per_ms;
     int d_max_dwells;
     const int d_config_doppler_max;
-    int d_num_doppler_points;
+    const unsigned int d_doppler_step;
+    const int d_num_doppler_points;
     int d_well_count;
     int d_n_samples_in_buffer;
-    int d_fft_size;
+    const int d_fft_size;
     int d_gnuradio_forecast_samples;
-    unsigned int d_doppler_step;
     unsigned int d_channel;
     unsigned int d_dump_channel;
 

--- a/src/algorithms/acquisition/gnuradio_blocks/pcps_acquisition_fpga.cc
+++ b/src/algorithms/acquisition/gnuradio_blocks/pcps_acquisition_fpga.cc
@@ -52,9 +52,9 @@ pcps_acquisition_fpga::pcps_acquisition_fpga(Acq_Conf_Fpga *conf_, uint32_t acq_
       d_state(0),
       d_doppler_index(0U),
       d_channel(0U),
-      d_doppler_step(0U),
+      d_doppler_step(d_acq_parameters->doppler_step),
       d_doppler_max(d_acq_parameters->doppler_max),
-      d_num_doppler_bins(0U),
+      d_num_doppler_bins(static_cast<uint32_t>(std::ceil(static_cast<double>(static_cast<int32_t>(d_doppler_max) - static_cast<int32_t>(-d_doppler_max)) / static_cast<double>(d_doppler_step))) + 1),
       d_total_block_exp(d_acq_parameters->total_block_exp),
       d_num_doppler_bins_step2(d_acq_parameters->num_doppler_bins_step2),
       d_max_num_acqs(d_acq_parameters->max_num_acqs),
@@ -83,8 +83,6 @@ void pcps_acquisition_fpga::init()
     d_gnss_synchro->Acq_samplestamp_samples = 0;
     d_mag = 0.0;
     d_input_power = 0.0;
-
-    d_num_doppler_bins = static_cast<uint32_t>(std::ceil(static_cast<double>(static_cast<int32_t>(d_doppler_max) - static_cast<int32_t>(-d_doppler_max)) / static_cast<double>(d_doppler_step))) + 1;
 }
 
 void pcps_acquisition_fpga::set_state(int32_t state)

--- a/src/algorithms/acquisition/gnuradio_blocks/pcps_acquisition_fpga.h
+++ b/src/algorithms/acquisition/gnuradio_blocks/pcps_acquisition_fpga.h
@@ -133,16 +133,6 @@ public:
     }
 
     /*!
-     * \brief Set Doppler steps for the grid search
-     * \param doppler_step - Frequency bin of the search grid [Hz].
-     */
-    inline void set_doppler_step(uint32_t doppler_step)
-    {
-        d_doppler_step = doppler_step;
-        d_acquisition_fpga->set_doppler_step(doppler_step);
-    }
-
-    /*!
      * \brief Set Doppler center frequency for the grid search. It will refresh the Doppler grid.
      * \param doppler_center - Frequency center of the search grid [Hz].
      */
@@ -188,9 +178,9 @@ private:
 
     uint32_t d_doppler_index;
     uint32_t d_channel;
-    uint32_t d_doppler_step;
+    const uint32_t d_doppler_step;
     const uint32_t d_doppler_max;
-    uint32_t d_num_doppler_bins;
+    const uint32_t d_num_doppler_bins;
     uint32_t d_total_block_exp;
     uint32_t d_num_doppler_bins_step2;
     uint32_t d_max_num_acqs;

--- a/src/algorithms/acquisition/gnuradio_blocks/pcps_assisted_acquisition_cc.cc
+++ b/src/algorithms/acquisition/gnuradio_blocks/pcps_assisted_acquisition_cc.cc
@@ -40,19 +40,19 @@ extern Concurrent_Map<Gps_Acq_Assist> global_gps_acq_assist_map;
 
 pcps_assisted_acquisition_cc_sptr pcps_make_assisted_acquisition_cc(
     int32_t max_dwells, uint32_t sampled_ms, int32_t doppler_max, int32_t doppler_min,
-    int64_t fs_in, int32_t samples_per_ms, bool dump,
+    int32_t doppler_step, int64_t fs_in, int32_t samples_per_ms, bool dump,
     const std::string &dump_filename, bool enable_monitor_output)
 {
     return pcps_assisted_acquisition_cc_sptr(
         new pcps_assisted_acquisition_cc(max_dwells, sampled_ms, doppler_max, doppler_min,
-            fs_in, samples_per_ms, dump, dump_filename, enable_monitor_output));
+            doppler_step, fs_in, samples_per_ms, dump, dump_filename, enable_monitor_output));
 }
 
 
 pcps_assisted_acquisition_cc::pcps_assisted_acquisition_cc(
     int32_t max_dwells, uint32_t sampled_ms, int32_t doppler_max, int32_t doppler_min,
-    int64_t fs_in, int32_t samples_per_ms, bool dump, const std::string &dump_filename,
-    bool enable_monitor_output)
+    int32_t doppler_step, int64_t fs_in, int32_t samples_per_ms, bool dump,
+    const std::string &dump_filename, bool enable_monitor_output)
     : gr::block("pcps_assisted_acquisition_cc",
           gr::io_signature::make(1, 1, sizeof(gr_complex)),
           gr::io_signature::make(0, 1, sizeof(Gnss_Synchro))),
@@ -77,7 +77,7 @@ pcps_assisted_acquisition_cc::pcps_assisted_acquisition_cc(
       d_config_doppler_max(doppler_max),
       d_config_doppler_min(doppler_min),
       d_num_doppler_points(0),
-      d_doppler_step(0),
+      d_doppler_step(doppler_step),
       d_state(0),
       d_well_count(0),
       d_active(false),
@@ -91,12 +91,6 @@ pcps_assisted_acquisition_cc::pcps_assisted_acquisition_cc(
 
     d_fft_if = gnss_fft_fwd_make_unique(d_fft_size);
     d_ifft = gnss_fft_rev_make_unique(d_fft_size);
-}
-
-
-void pcps_assisted_acquisition_cc::set_doppler_step(uint32_t doppler_step)
-{
-    d_doppler_step = doppler_step;
 }
 
 

--- a/src/algorithms/acquisition/gnuradio_blocks/pcps_assisted_acquisition_cc.h
+++ b/src/algorithms/acquisition/gnuradio_blocks/pcps_assisted_acquisition_cc.h
@@ -60,6 +60,7 @@ pcps_assisted_acquisition_cc_sptr pcps_make_assisted_acquisition_cc(
     uint32_t sampled_ms,
     int32_t doppler_max,
     int32_t doppler_min,
+    int32_t doppler_step,
     int64_t fs_in,
     int32_t samples_per_ms,
     bool dump,
@@ -152,12 +153,6 @@ public:
     }
 
     /*!
-     * \brief Set Doppler steps for the grid search
-     * \param doppler_step - Frequency bin of the search grid [Hz].
-     */
-    void set_doppler_step(uint32_t doppler_step);
-
-    /*!
      * \brief Parallel Code Phase Search Acquisition signal processing.
      */
     int general_work(int noutput_items, gr_vector_int& ninput_items,
@@ -169,13 +164,13 @@ public:
 private:
     friend pcps_assisted_acquisition_cc_sptr
     pcps_make_assisted_acquisition_cc(int32_t max_dwells, uint32_t sampled_ms,
-        int32_t doppler_max, int32_t doppler_min, int64_t fs_in,
-        int32_t samples_per_ms, bool dump,
+        int32_t doppler_max, int32_t doppler_min, int32_t doppler_step,
+        int64_t fs_in, int32_t samples_per_ms, bool dump,
         const std::string& dump_filename, bool enable_monitor_output);
 
     pcps_assisted_acquisition_cc(int32_t max_dwells, uint32_t sampled_ms,
-        int32_t doppler_max, int32_t doppler_min, int64_t fs_in,
-        int32_t samples_per_ms, bool dump,
+        int32_t doppler_max, int32_t doppler_min, int32_t doppler_step,
+        int64_t fs_in, int32_t samples_per_ms, bool dump,
         const std::string& dump_filename, bool enable_monitor_output);
 
     void calculate_magnitudes(gr_complex* fft_begin, int32_t doppler_shift,
@@ -227,7 +222,7 @@ private:
     const int32_t d_config_doppler_max;
     int32_t d_config_doppler_min;
     int32_t d_num_doppler_points;
-    int32_t d_doppler_step;
+    const int32_t d_doppler_step;
     int32_t d_state;
     int32_t d_well_count;
 

--- a/src/algorithms/acquisition/gnuradio_blocks/pcps_cccwsr_acquisition_cc.cc
+++ b/src/algorithms/acquisition/gnuradio_blocks/pcps_cccwsr_acquisition_cc.cc
@@ -42,6 +42,7 @@ pcps_cccwsr_acquisition_cc_sptr pcps_cccwsr_make_acquisition_cc(
     uint32_t sampled_ms,
     uint32_t max_dwells,
     uint32_t doppler_max,
+    uint32_t doppler_step,
     int64_t fs_in,
     int32_t samples_per_ms,
     int32_t samples_per_code,
@@ -50,7 +51,7 @@ pcps_cccwsr_acquisition_cc_sptr pcps_cccwsr_make_acquisition_cc(
     bool enable_monitor_output)
 {
     return pcps_cccwsr_acquisition_cc_sptr(
-        new pcps_cccwsr_acquisition_cc(sampled_ms, max_dwells, doppler_max, fs_in,
+        new pcps_cccwsr_acquisition_cc(sampled_ms, max_dwells, doppler_max, doppler_step, fs_in,
             samples_per_ms, samples_per_code, dump, dump_filename, enable_monitor_output));
 }
 
@@ -59,6 +60,7 @@ pcps_cccwsr_acquisition_cc::pcps_cccwsr_acquisition_cc(
     uint32_t sampled_ms,
     uint32_t max_dwells,
     uint32_t doppler_max,
+    uint32_t doppler_step,
     int64_t fs_in,
     int32_t samples_per_ms,
     int32_t samples_per_code,
@@ -82,7 +84,7 @@ pcps_cccwsr_acquisition_cc::pcps_cccwsr_acquisition_cc(
       d_samples_per_code(samples_per_code),
       d_doppler_resolution(0),
       d_doppler_max(doppler_max),
-      d_doppler_step(0),
+      d_doppler_step(doppler_step),
       d_sampled_ms(sampled_ms),
       d_max_dwells(max_dwells),
       d_well_count(0),

--- a/src/algorithms/acquisition/gnuradio_blocks/pcps_cccwsr_acquisition_cc.h
+++ b/src/algorithms/acquisition/gnuradio_blocks/pcps_cccwsr_acquisition_cc.h
@@ -48,6 +48,7 @@ pcps_cccwsr_acquisition_cc_sptr pcps_cccwsr_make_acquisition_cc(
     uint32_t sampled_ms,
     uint32_t max_dwells,
     uint32_t doppler_max,
+    uint32_t doppler_step,
     int64_t fs_in,
     int32_t samples_per_ms,
     int32_t samples_per_code,
@@ -142,15 +143,6 @@ public:
     }
 
     /*!
-     * \brief Set Doppler steps for the grid search
-     * \param doppler_step - Frequency bin of the search grid [Hz].
-     */
-    inline void set_doppler_step(uint32_t doppler_step)
-    {
-        d_doppler_step = doppler_step;
-    }
-
-    /*!
      * \brief Coherent Channel Combining With Sign Recovery Acquisition signal processing.
      */
     int general_work(int noutput_items, gr_vector_int& ninput_items,
@@ -160,12 +152,12 @@ public:
 private:
     friend pcps_cccwsr_acquisition_cc_sptr
     pcps_cccwsr_make_acquisition_cc(uint32_t sampled_ms, uint32_t max_dwells,
-        uint32_t doppler_max, int64_t fs_in,
+        uint32_t doppler_max, uint32_t doppler_step, int64_t fs_in,
         int32_t samples_per_ms, int32_t samples_per_code,
         bool dump, const std::string& dump_filename, bool enable_monitor_output);
 
     pcps_cccwsr_acquisition_cc(uint32_t sampled_ms, uint32_t max_dwells,
-        uint32_t doppler_max, int64_t fs_in,
+        uint32_t doppler_max, uint32_t doppler_step, int64_t fs_in,
         int32_t samples_per_ms, int32_t samples_per_code,
         bool dump, const std::string& dump_filename, bool enable_monitor_output);
 
@@ -206,7 +198,7 @@ private:
     int32_t d_samples_per_code;
     uint32_t d_doppler_resolution;
     const uint32_t d_doppler_max;
-    uint32_t d_doppler_step;
+    const uint32_t d_doppler_step;
     uint32_t d_sampled_ms;
     uint32_t d_max_dwells;
     uint32_t d_well_count;

--- a/src/algorithms/acquisition/gnuradio_blocks/pcps_opencl_acquisition_cc.cc
+++ b/src/algorithms/acquisition/gnuradio_blocks/pcps_opencl_acquisition_cc.cc
@@ -58,7 +58,7 @@
 
 pcps_opencl_acquisition_cc_sptr pcps_make_opencl_acquisition_cc(
     uint32_t sampled_ms, uint32_t max_dwells,
-    uint32_t doppler_max, int64_t fs_in,
+    uint32_t doppler_max, uint32_t doppler_step, int64_t fs_in,
     int samples_per_ms, int samples_per_code,
     bool bit_transition_flag,
     bool dump,
@@ -66,7 +66,7 @@ pcps_opencl_acquisition_cc_sptr pcps_make_opencl_acquisition_cc(
     bool enable_monitor_output)
 {
     return pcps_opencl_acquisition_cc_sptr(
-        new pcps_opencl_acquisition_cc(sampled_ms, max_dwells, doppler_max, fs_in, samples_per_ms,
+        new pcps_opencl_acquisition_cc(sampled_ms, max_dwells, doppler_max, doppler_step, fs_in, samples_per_ms,
             samples_per_code, bit_transition_flag, dump, dump_filename, enable_monitor_output));
 }
 
@@ -75,6 +75,7 @@ pcps_opencl_acquisition_cc::pcps_opencl_acquisition_cc(
     uint32_t sampled_ms,
     uint32_t max_dwells,
     uint32_t doppler_max,
+    uint32_t doppler_step,
     int64_t fs_in,
     int samples_per_ms,
     int samples_per_code,
@@ -95,6 +96,7 @@ pcps_opencl_acquisition_cc::pcps_opencl_acquisition_cc(
       d_samples_per_code(samples_per_code),
       d_state(0),
       d_doppler_max(doppler_max),
+      d_doppler_step(doppler_step),
       d_sampled_ms(sampled_ms),
       d_max_dwells(max_dwells),
       d_well_count(0),

--- a/src/algorithms/acquisition/gnuradio_blocks/pcps_opencl_acquisition_cc.h
+++ b/src/algorithms/acquisition/gnuradio_blocks/pcps_opencl_acquisition_cc.h
@@ -66,6 +66,7 @@ pcps_opencl_acquisition_cc_sptr pcps_make_opencl_acquisition_cc(
     uint32_t sampled_ms,
     uint32_t max_dwells,
     uint32_t doppler_max,
+    uint32_t doppler_step,
     int64_t fs_in,
     int samples_per_ms,
     int samples_per_code,
@@ -161,15 +162,6 @@ public:
         d_threshold = threshold;
     }
 
-    /*!
-     * \brief Set Doppler steps for the grid search
-     * \param doppler_step - Frequency bin of the search grid [Hz].
-     */
-    inline void set_doppler_step(uint32_t doppler_step)
-    {
-        d_doppler_step = doppler_step;
-    }
-
     inline bool opencl_ready() const
     {
         bool ready = false;
@@ -194,7 +186,7 @@ public:
 private:
     friend pcps_opencl_acquisition_cc_sptr
     pcps_make_opencl_acquisition_cc(uint32_t sampled_ms, uint32_t max_dwells,
-        uint32_t doppler_max, int64_t fs_in,
+        uint32_t doppler_max, uint32_t doppler_step, int64_t fs_in,
         int samples_per_ms, int samples_per_code,
         bool bit_transition_flag,
         bool dump,
@@ -202,7 +194,7 @@ private:
         bool enable_monitor_output);
 
     pcps_opencl_acquisition_cc(uint32_t sampled_ms, uint32_t max_dwells,
-        uint32_t doppler_max, int64_t fs_in,
+        uint32_t doppler_max, uint32_t doppler_step, int64_t fs_in,
         int samples_per_ms, int samples_per_code,
         bool bit_transition_flag,
         bool dump,
@@ -265,7 +257,7 @@ private:
 
     uint32_t d_doppler_resolution;
     const uint32_t d_doppler_max;
-    uint32_t d_doppler_step;
+    const uint32_t d_doppler_step;
     uint32_t d_sampled_ms;
     uint32_t d_max_dwells;
     uint32_t d_well_count;

--- a/src/algorithms/acquisition/gnuradio_blocks/pcps_quicksync_acquisition_cc.cc
+++ b/src/algorithms/acquisition/gnuradio_blocks/pcps_quicksync_acquisition_cc.cc
@@ -36,6 +36,7 @@ pcps_quicksync_acquisition_cc_sptr pcps_quicksync_make_acquisition_cc(
     uint32_t sampled_ms,
     uint32_t max_dwells,
     uint32_t doppler_max,
+    uint32_t doppler_step,
     int64_t fs_in,
     int32_t samples_per_ms,
     int32_t samples_per_code,
@@ -48,7 +49,7 @@ pcps_quicksync_acquisition_cc_sptr pcps_quicksync_make_acquisition_cc(
         new pcps_quicksync_acquisition_cc(
             folding_factor,
             sampled_ms, max_dwells, doppler_max,
-            fs_in, samples_per_ms,
+            doppler_step, fs_in, samples_per_ms,
             samples_per_code,
             bit_transition_flag,
             dump, dump_filename,
@@ -59,7 +60,7 @@ pcps_quicksync_acquisition_cc_sptr pcps_quicksync_make_acquisition_cc(
 pcps_quicksync_acquisition_cc::pcps_quicksync_acquisition_cc(
     uint32_t folding_factor,
     uint32_t sampled_ms, uint32_t max_dwells,
-    uint32_t doppler_max, int64_t fs_in,
+    uint32_t doppler_max, uint32_t doppler_step, int64_t fs_in,
     int32_t samples_per_ms, int32_t samples_per_code,
     bool bit_transition_flag,
     bool dump,
@@ -85,7 +86,7 @@ pcps_quicksync_acquisition_cc::pcps_quicksync_acquisition_cc(
       d_folding_factor(folding_factor),
       d_doppler_resolution(0),
       d_doppler_max(doppler_max),
-      d_doppler_step(0),
+      d_doppler_step(doppler_step),
       d_sampled_ms(sampled_ms),
       d_max_dwells(max_dwells),
       d_well_count(0),
@@ -174,11 +175,6 @@ void pcps_quicksync_acquisition_cc::init()
     d_gnss_synchro->Acq_doppler_step = 0U;
     d_mag = 0.0;
     d_input_power = 0.0;
-
-    if (d_doppler_step == 0)
-        {
-            d_doppler_step = 250;
-        }
 
     // Count the number of bins
     d_num_doppler_bins = 0;

--- a/src/algorithms/acquisition/gnuradio_blocks/pcps_quicksync_acquisition_cc.h
+++ b/src/algorithms/acquisition/gnuradio_blocks/pcps_quicksync_acquisition_cc.h
@@ -66,6 +66,7 @@ pcps_quicksync_acquisition_cc_sptr pcps_quicksync_make_acquisition_cc(
     uint32_t sampled_ms,
     uint32_t max_dwells,
     uint32_t doppler_max,
+    uint32_t doppler_step,
     int64_t fs_in,
     int32_t samples_per_ms,
     int32_t samples_per_code,
@@ -163,15 +164,6 @@ public:
     }
 
     /*!
-     * \brief Set Doppler steps for the grid search
-     * \param doppler_step - Frequency bin of the search grid [Hz].
-     */
-    inline void set_doppler_step(uint32_t doppler_step)
-    {
-        d_doppler_step = doppler_step;
-    }
-
-    /*!
      * \brief Parallel Code Phase Search Acquisition signal processing.
      */
     int general_work(int noutput_items, gr_vector_int& ninput_items,
@@ -182,7 +174,7 @@ private:
     friend pcps_quicksync_acquisition_cc_sptr
     pcps_quicksync_make_acquisition_cc(uint32_t folding_factor,
         uint32_t sampled_ms, uint32_t max_dwells,
-        uint32_t doppler_max, int64_t fs_in,
+        uint32_t doppler_max, uint32_t doppler_step, int64_t fs_in,
         int32_t samples_per_ms, int32_t samples_per_code,
         bool bit_transition_flag,
         bool dump,
@@ -191,7 +183,7 @@ private:
 
     pcps_quicksync_acquisition_cc(uint32_t folding_factor,
         uint32_t sampled_ms, uint32_t max_dwells,
-        uint32_t doppler_max, int64_t fs_in,
+        uint32_t doppler_max, uint32_t doppler_step, int64_t fs_in,
         int32_t samples_per_ms, int32_t samples_per_code,
         bool bit_transition_flag,
         bool dump,
@@ -239,7 +231,7 @@ private:
     uint32_t d_folding_factor;  // also referred in the paper as 'p'
     uint32_t d_doppler_resolution;
     const uint32_t d_doppler_max;
-    uint32_t d_doppler_step;
+    const uint32_t d_doppler_step;
     uint32_t d_sampled_ms;
     uint32_t d_max_dwells;
     uint32_t d_well_count;

--- a/src/algorithms/acquisition/gnuradio_blocks/pcps_tong_acquisition_cc.cc
+++ b/src/algorithms/acquisition/gnuradio_blocks/pcps_tong_acquisition_cc.cc
@@ -54,6 +54,7 @@
 pcps_tong_acquisition_cc_sptr pcps_tong_make_acquisition_cc(
     uint32_t sampled_ms,
     uint32_t doppler_max,
+    uint32_t doppler_step,
     int64_t fs_in,
     int32_t samples_per_ms,
     int32_t samples_per_code,
@@ -65,7 +66,7 @@ pcps_tong_acquisition_cc_sptr pcps_tong_make_acquisition_cc(
     bool enable_monitor_output)
 {
     return pcps_tong_acquisition_cc_sptr(
-        new pcps_tong_acquisition_cc(sampled_ms, doppler_max, fs_in, samples_per_ms, samples_per_code,
+        new pcps_tong_acquisition_cc(sampled_ms, doppler_max, doppler_step, fs_in, samples_per_ms, samples_per_code,
             tong_init_val, tong_max_val, tong_max_dwells, dump, dump_filename, enable_monitor_output));
 }
 
@@ -73,6 +74,7 @@ pcps_tong_acquisition_cc_sptr pcps_tong_make_acquisition_cc(
 pcps_tong_acquisition_cc::pcps_tong_acquisition_cc(
     uint32_t sampled_ms,
     uint32_t doppler_max,
+    uint32_t doppler_step,
     int64_t fs_in,
     int32_t samples_per_ms,
     int32_t samples_per_code,
@@ -100,7 +102,7 @@ pcps_tong_acquisition_cc::pcps_tong_acquisition_cc(
       d_channel(0),
       d_doppler_resolution(0),
       d_doppler_max(doppler_max),
-      d_doppler_step(0),
+      d_doppler_step(doppler_step),
       d_sampled_ms(sampled_ms),
       d_dwell_count(0),
       d_tong_init_val(tong_init_val),

--- a/src/algorithms/acquisition/gnuradio_blocks/pcps_tong_acquisition_cc.h
+++ b/src/algorithms/acquisition/gnuradio_blocks/pcps_tong_acquisition_cc.h
@@ -61,6 +61,7 @@ using pcps_tong_acquisition_cc_sptr = gnss_shared_ptr<pcps_tong_acquisition_cc>;
 pcps_tong_acquisition_cc_sptr pcps_tong_make_acquisition_cc(
     uint32_t sampled_ms,
     uint32_t doppler_max,
+    uint32_t doppler_step,
     int64_t fs_in,
     int32_t samples_per_ms,
     int32_t samples_per_code,
@@ -157,15 +158,6 @@ public:
     }
 
     /*!
-     * \brief Set Doppler steps for the grid search
-     * \param doppler_step - Frequency bin of the search grid [Hz].
-     */
-    inline void set_doppler_step(uint32_t doppler_step)
-    {
-        d_doppler_step = doppler_step;
-    }
-
-    /*!
      * \brief Parallel Code Phase Search Acquisition signal processing.
      */
     int general_work(int noutput_items, gr_vector_int& ninput_items,
@@ -175,13 +167,13 @@ public:
 private:
     friend pcps_tong_acquisition_cc_sptr
     pcps_tong_make_acquisition_cc(uint32_t sampled_ms, uint32_t doppler_max,
-        int64_t fs_in, int32_t samples_per_ms,
+        uint32_t doppler_step, int64_t fs_in, int32_t samples_per_ms,
         int32_t samples_per_code, uint32_t tong_init_val,
         uint32_t tong_max_val, uint32_t tong_max_dwells,
         bool dump, const std::string& dump_filename, bool enable_monitor_output);
 
     pcps_tong_acquisition_cc(uint32_t sampled_ms, uint32_t doppler_max,
-        int64_t fs_in, int32_t samples_per_ms,
+        uint32_t doppler_step, int64_t fs_in, int32_t samples_per_ms,
         int32_t samples_per_code, uint32_t tong_init_val,
         uint32_t tong_max_val, uint32_t tong_max_dwells,
         bool dump, const std::string& dump_filename, bool enable_monitor_output);
@@ -219,7 +211,7 @@ private:
     uint32_t d_channel;
     uint32_t d_doppler_resolution;
     const uint32_t d_doppler_max;
-    uint32_t d_doppler_step;
+    const uint32_t d_doppler_step;
     uint32_t d_sampled_ms;
     uint32_t d_dwell_count;
     uint32_t d_tong_init_val;

--- a/src/algorithms/acquisition/libs/acq_conf.h
+++ b/src/algorithms/acquisition/libs/acq_conf.h
@@ -46,7 +46,7 @@ public:
 
     size_t it_size{sizeof(gr_complex)};
 
-    float doppler_step{250.0};
+    float doppler_step{500.0};
     float samples_per_ms{0.0};
     float doppler_step2{125.0};
     float pfa{0.0};

--- a/src/algorithms/acquisition/libs/acq_conf_fpga.cc
+++ b/src/algorithms/acquisition/libs/acq_conf_fpga.cc
@@ -35,6 +35,9 @@ void Acq_Conf_Fpga::SetFromConfiguration(const ConfigurationInterface *configura
     // max doppler
     doppler_max = configuration->property(role + ".doppler_max", doppler_max);
 
+    // max doppler
+    doppler_step = configuration->property(role + ".doppler_step", 500);
+
     // code chips per second
     code_rate_cps = code_chips_per_sec;
 

--- a/src/algorithms/acquisition/libs/fpga_acquisition.cc
+++ b/src/algorithms/acquisition/libs/fpga_acquisition.cc
@@ -64,7 +64,6 @@ Fpga_Acquisition::Fpga_Acquisition(std::string device_name,
                               d_downsampling_filter_delay(0),
                               d_select_queue(select_queue),
                               d_doppler_max(doppler_max),
-                              d_doppler_step(0),
                               d_PRN(0),
                               d_IP_core_version(0)
 {

--- a/src/algorithms/acquisition/libs/fpga_acquisition.h
+++ b/src/algorithms/acquisition/libs/fpga_acquisition.h
@@ -89,15 +89,6 @@ public:
         uint32_t *total_blk_exp);
 
     /*!
-     * \brief Set Doppler steps for the grid search
-     * \param doppler_step - Frequency bin of the search grid [Hz].
-     */
-    void set_doppler_step(uint32_t doppler_step)
-    {
-        d_doppler_step = doppler_step;
-    }
-
-    /*!
      * \brief Reset the FPGA PL.
      */
     void reset_acquisition();
@@ -212,7 +203,6 @@ private:
     uint32_t d_downsampling_filter_delay;  // Impulse response delay of the downsampling filter
     uint32_t d_select_queue;               // queue selection
     const uint32_t d_doppler_max;          // max doppler
-    uint32_t d_doppler_step;               // doppler step
     uint32_t d_PRN;                        // PRN
     uint32_t d_IP_core_version;            // FPGA acquisition IP core version
 };

--- a/src/algorithms/channel/adapters/channel.cc
+++ b/src/algorithms/channel/adapters/channel.cc
@@ -74,28 +74,7 @@ Channel::Channel(const ConfigurationInterface* configuration,
                 }
         }
 
-    // IMPORTANT: Do not change the order between set_doppler_step and set_threshold
-
-    uint32_t doppler_step = configuration->property("Acquisition_" + signal_str + std::to_string(channel_) + ".doppler_step", 0);
-    if (doppler_step == 0)
-        {
-            doppler_step = configuration->property("Acquisition_" + signal_str + ".doppler_step", 500);
-        }
-#if USE_GLOG_AND_GFLAGS
-    if (FLAGS_doppler_step != 0)
-        {
-            doppler_step = static_cast<uint32_t>(FLAGS_doppler_step);
-        }
-#else
-    if (absl::GetFlag(FLAGS_doppler_step) != 0)
-        {
-            doppler_step = static_cast<uint32_t>(absl::GetFlag(FLAGS_doppler_step));
-        }
-#endif
-    DLOG(INFO) << "Channel " << channel_ << " Doppler_step = " << doppler_step;
-
-    acq_->set_doppler_step(doppler_step);
-
+    // IMPORTANT: set_threshold needs to be called after construction where doppler step is set (is it really though?)
     float threshold = configuration->property("Acquisition_" + signal_str + std::to_string(channel_) + ".threshold", static_cast<float>(0.0));
     if (threshold == 0.0)
         {

--- a/src/algorithms/channel/adapters/channel.cc
+++ b/src/algorithms/channel/adapters/channel.cc
@@ -74,7 +74,7 @@ Channel::Channel(const ConfigurationInterface* configuration,
                 }
         }
 
-    // IMPORTANT: set_threshold needs to be called after construction where doppler step is set (is it really though?)
+    // IMPORTANT: For future reference set_threshold needs to be called after doppler step is set (currently done at acquisition construction)
     float threshold = configuration->property("Acquisition_" + signal_str + std::to_string(channel_) + ".threshold", static_cast<float>(0.0));
     if (threshold == 0.0)
         {

--- a/src/core/interfaces/acquisition_interface.h
+++ b/src/core/interfaces/acquisition_interface.h
@@ -54,11 +54,7 @@ public:
     virtual void set_channel(unsigned int channel_id) = 0;
     virtual void set_channel_fsm(std::weak_ptr<ChannelFsm> channel_fsm) = 0;
     virtual void set_threshold(float threshold) = 0;
-    virtual void set_doppler_step(unsigned int doppler_step) = 0;
-    virtual void set_doppler_center(int doppler_center __attribute__((unused)))
-    {
-        return;
-    }
+    virtual void set_doppler_center(int /*doppler_center*/) {}
     virtual void init() = 0;
     virtual void set_local_code() = 0;
     virtual void set_state(int state) = 0;

--- a/tests/unit-tests/signal-processing-blocks/acquisition/acq_performance_test.cc
+++ b/tests/unit-tests/signal-processing-blocks/acquisition/acq_performance_test.cc
@@ -854,7 +854,6 @@ int AcquisitionPerformanceTest::run_receiver()
 
     acquisition->set_gnss_synchro(&gnss_synchro);
     acquisition->set_channel(0);
-    acquisition->set_doppler_step(config->property("Acquisition.doppler_step", 500));
     acquisition->set_threshold(config->property("Acquisition.threshold", 0.0));
     acquisition->init();
     acquisition->set_local_code();

--- a/tests/unit-tests/signal-processing-blocks/acquisition/beidou_b1i_pcps_acquisition_test.cc
+++ b/tests/unit-tests/signal-processing-blocks/acquisition/beidou_b1i_pcps_acquisition_test.cc
@@ -323,10 +323,6 @@ TEST_F(BeidouB1iPcpsAcquisitionTest, ValidationOfResults)
     }) << "Failure setting threshold.";
 
     ASSERT_NO_THROW({
-        acquisition->set_doppler_step(doppler_step);
-    }) << "Failure setting doppler_step.";
-
-    ASSERT_NO_THROW({
         acquisition->connect(top_block);
     }) << "Failure connecting acquisition to the top_block.";
 

--- a/tests/unit-tests/signal-processing-blocks/acquisition/beidou_b3i_pcps_acquisition_test.cc
+++ b/tests/unit-tests/signal-processing-blocks/acquisition/beidou_b3i_pcps_acquisition_test.cc
@@ -321,10 +321,6 @@ TEST_F(BeidouB3iPcpsAcquisitionTest, ValidationOfResults)
     }) << "Failure setting threshold.";
 
     ASSERT_NO_THROW({
-        acquisition->set_doppler_step(doppler_step);
-    }) << "Failure setting doppler_step.";
-
-    ASSERT_NO_THROW({
         acquisition->connect(top_block);
     }) << "Failure connecting acquisition to the top_block.";
 

--- a/tests/unit-tests/signal-processing-blocks/acquisition/galileo_e1_pcps_8ms_ambiguous_acquisition_gsoc2013_test.cc
+++ b/tests/unit-tests/signal-processing-blocks/acquisition/galileo_e1_pcps_8ms_ambiguous_acquisition_gsoc2013_test.cc
@@ -457,10 +457,6 @@ TEST_F(GalileoE1Pcps8msAmbiguousAcquisitionGSoC2013Test, ConnectAndRun)
     }) << "Failure setting gnss_synchro.";
 
     ASSERT_NO_THROW({
-        acquisition->set_doppler_step(config->property("Acquisition_1B.doppler_step", 500));
-    }) << "Failure setting doppler_step.";
-
-    ASSERT_NO_THROW({
         acquisition->set_threshold(config->property("Acquisition_1B.threshold", 0.0));
     }) << "Failure setting threshold.";
 
@@ -501,10 +497,6 @@ TEST_F(GalileoE1Pcps8msAmbiguousAcquisitionGSoC2013Test, ValidationOfResults)
     ASSERT_NO_THROW({
         acquisition->set_gnss_synchro(&gnss_synchro);
     }) << "Failure setting gnss_synchro.";
-
-    ASSERT_NO_THROW({
-        acquisition->set_doppler_step(config->property("Acquisition_1B.doppler_step", 500));
-    }) << "Failure setting doppler_step.";
 
     ASSERT_NO_THROW({
         acquisition->set_threshold(config->property("Acquisition_1B.threshold", 0.0));
@@ -584,10 +576,6 @@ TEST_F(GalileoE1Pcps8msAmbiguousAcquisitionGSoC2013Test, ValidationOfResultsProb
     ASSERT_NO_THROW({
         acquisition->set_gnss_synchro(&gnss_synchro);
     }) << "Failure setting gnss_synchro.";
-
-    ASSERT_NO_THROW({
-        acquisition->set_doppler_step(config->property("Acquisition_1B.doppler_step", 500));
-    }) << "Failure setting doppler_step.";
 
     ASSERT_NO_THROW({
         acquisition->set_threshold(config->property("Acquisition_1B.threshold", 0.0));

--- a/tests/unit-tests/signal-processing-blocks/acquisition/galileo_e1_pcps_ambiguous_acquisition_gsoc2013_test.cc
+++ b/tests/unit-tests/signal-processing-blocks/acquisition/galileo_e1_pcps_ambiguous_acquisition_gsoc2013_test.cc
@@ -485,10 +485,6 @@ TEST_F(GalileoE1PcpsAmbiguousAcquisitionGSoC2013Test, ValidationOfResults)
     }) << "Failure setting gnss_synchro.";
 
     ASSERT_NO_THROW({
-        acquisition->set_doppler_step(config->property("Acquisition_1B.doppler_step", 500));
-    }) << "Failure setting doppler_step.";
-
-    ASSERT_NO_THROW({
         acquisition->connect(top_block);
     }) << "Failure connecting acquisition to the top_block.";
 
@@ -559,10 +555,6 @@ TEST_F(GalileoE1PcpsAmbiguousAcquisitionGSoC2013Test, ValidationOfResultsProbabi
     ASSERT_NO_THROW({
         acquisition->set_gnss_synchro(&gnss_synchro);
     }) << "Failure setting gnss_synchro.";
-
-    ASSERT_NO_THROW({
-        acquisition->set_doppler_step(config->property("Acquisition_1B.doppler_step", 500));
-    }) << "Failure setting doppler_step.";
 
     ASSERT_NO_THROW({
         acquisition->connect(top_block);

--- a/tests/unit-tests/signal-processing-blocks/acquisition/galileo_e1_pcps_ambiguous_acquisition_gsoc_test.cc
+++ b/tests/unit-tests/signal-processing-blocks/acquisition/galileo_e1_pcps_ambiguous_acquisition_gsoc_test.cc
@@ -276,10 +276,6 @@ TEST_F(GalileoE1PcpsAmbiguousAcquisitionGSoCTest, ValidationOfResults)
     }) << "Failure setting threshold.";
 
     ASSERT_NO_THROW({
-        acquisition->set_doppler_step(config->property("Acquisition_1B.doppler_step", 250));
-    }) << "Failure setting doppler_step.";
-
-    ASSERT_NO_THROW({
         acquisition->connect(top_block);
     }) << "Failure connecting acquisition to the top_block.";
 

--- a/tests/unit-tests/signal-processing-blocks/acquisition/galileo_e1_pcps_ambiguous_acquisition_test.cc
+++ b/tests/unit-tests/signal-processing-blocks/acquisition/galileo_e1_pcps_ambiguous_acquisition_test.cc
@@ -337,10 +337,6 @@ TEST_F(GalileoE1PcpsAmbiguousAcquisitionTest, ValidationOfResults)
     }) << "Failure setting threshold.";
 
     ASSERT_NO_THROW({
-        acquisition->set_doppler_step(config->property("Acquisition_1B.doppler_step", doppler_step));
-    }) << "Failure setting doppler_step.";
-
-    ASSERT_NO_THROW({
         acquisition->connect(top_block);
     }) << "Failure connecting acquisition to the top_block.";
 

--- a/tests/unit-tests/signal-processing-blocks/acquisition/galileo_e1_pcps_ambiguous_acquisition_test_fpga.cc
+++ b/tests/unit-tests/signal-processing-blocks/acquisition/galileo_e1_pcps_ambiguous_acquisition_test_fpga.cc
@@ -335,7 +335,6 @@ bool GalileoE1PcpsAmbiguousAcquisitionTestFpga::acquire_signal()
     acquisition->set_gnss_synchro(&tmp_gnss_synchro);
     acquisition->set_channel_fsm(channel_fsm_);
     acquisition->set_channel(1);
-    acquisition->set_doppler_step(doppler_step);
     acquisition->set_doppler_center(0);
     acquisition->set_threshold(0.001);
 

--- a/tests/unit-tests/signal-processing-blocks/acquisition/galileo_e1_pcps_cccwsr_ambiguous_acquisition_gsoc2013_test.cc
+++ b/tests/unit-tests/signal-processing-blocks/acquisition/galileo_e1_pcps_cccwsr_ambiguous_acquisition_gsoc2013_test.cc
@@ -488,10 +488,6 @@ TEST_F(GalileoE1PcpsCccwsrAmbiguousAcquisitionTest, ValidationOfResults)
     }) << "Failure setting gnss_synchro.";
 
     ASSERT_NO_THROW({
-        acquisition->set_doppler_step(config->property("Acquisition_1B.doppler_step", 500));
-    }) << "Failure setting doppler_step.";
-
-    ASSERT_NO_THROW({
         acquisition->set_threshold(config->property("Acquisition_1B.threshold", 0.00001));
     }) << "Failure setting threshold.";
 
@@ -574,10 +570,6 @@ TEST_F(GalileoE1PcpsCccwsrAmbiguousAcquisitionTest, ValidationOfResultsProbabili
     ASSERT_NO_THROW({
         acquisition->set_gnss_synchro(&gnss_synchro);
     }) << "Failure setting gnss_synchro.";
-
-    ASSERT_NO_THROW({
-        acquisition->set_doppler_step(config->property("Acquisition_1B.doppler_step", 500));
-    }) << "Failure setting doppler_step.";
 
     ASSERT_NO_THROW({
         acquisition->set_threshold(config->property("Acquisition_1B.threshold", 0.00215));

--- a/tests/unit-tests/signal-processing-blocks/acquisition/galileo_e1_pcps_quicksync_ambiguous_acquisition_gsoc2014_test.cc
+++ b/tests/unit-tests/signal-processing-blocks/acquisition/galileo_e1_pcps_quicksync_ambiguous_acquisition_gsoc2014_test.cc
@@ -479,7 +479,7 @@ void GalileoE1PcpsQuickSyncAmbiguousAcquisitionGSoC2014Test::config_3()
     config->set_property("Acquisition_1B.bit_transition_flag", "false");
     config->set_property("Acquisition_1B.threshold", "0.2");
     config->set_property("Acquisition_1B.doppler_max", "10000");
-    config->set_property("Acquisition_1B.doppler_step", "125");
+    config->set_property("Acquisition_1B.doppler_step", "50");
     config->set_property("Acquisition_1B.folding_factor", "4");
     config->set_property("Acquisition_1B.dump", "false");
 }
@@ -639,10 +639,6 @@ TEST_F(GalileoE1PcpsQuickSyncAmbiguousAcquisitionGSoC2014Test, ValidationOfResul
     }) << "Failure setting gnss_synchro.";
 
     ASSERT_NO_THROW({
-        acquisition->set_doppler_step(config->property("Acquisition_1B.doppler_step", 125));
-    }) << "Failure setting doppler_step.";
-
-    ASSERT_NO_THROW({
         acquisition->set_threshold(1);
     }) << "Failure setting threshold.";
 
@@ -725,10 +721,6 @@ TEST_F(GalileoE1PcpsQuickSyncAmbiguousAcquisitionGSoC2014Test, ValidationOfResul
     }) << "Failure setting gnss_synchro.";
 
     ASSERT_NO_THROW({
-        acquisition->set_doppler_step(50);
-    }) << "Failure setting doppler_step.";
-
-    ASSERT_NO_THROW({
         acquisition->set_threshold(5);
     }) << "Failure setting threshold.";
 
@@ -806,10 +798,6 @@ TEST_F(GalileoE1PcpsQuickSyncAmbiguousAcquisitionGSoC2014Test, ValidationOfResul
     ASSERT_NO_THROW({
         acquisition->set_gnss_synchro(&gnss_synchro);
     }) << "Failure setting gnss_synchro.";
-
-    ASSERT_NO_THROW({
-        acquisition->set_doppler_step(config->property("Acquisition_1B.doppler_step", 500));
-    }) << "Failure setting doppler_step.";
 
     ASSERT_NO_THROW({
         acquisition->set_threshold(config->property("Acquisition_1B.threshold", 0.0));

--- a/tests/unit-tests/signal-processing-blocks/acquisition/galileo_e1_pcps_tong_ambiguous_acquisition_gsoc2013_test.cc
+++ b/tests/unit-tests/signal-processing-blocks/acquisition/galileo_e1_pcps_tong_ambiguous_acquisition_gsoc2013_test.cc
@@ -258,7 +258,7 @@ void GalileoE1PcpsTongAmbiguousAcquisitionGSoC2013Test::config_1()
     config->set_property("Acquisition_1B.tong_max_val", "8");
     config->set_property("Acquisition_1B.threshold", "0.3");
     config->set_property("Acquisition_1B.doppler_max", "10000");
-    config->set_property("Acquisition_1B.doppler_step", "250");
+    config->set_property("Acquisition_1B.doppler_step", "100");
     config->set_property("Acquisition_1B.dump", "false");
 }
 
@@ -486,10 +486,6 @@ TEST_F(GalileoE1PcpsTongAmbiguousAcquisitionGSoC2013Test, ValidationOfResults)
     }) << "Failure setting gnss_synchro.";
 
     ASSERT_NO_THROW({
-        acquisition->set_doppler_step(100);
-    }) << "Failure setting doppler_step.";
-
-    ASSERT_NO_THROW({
         acquisition->set_threshold(0.01);
     }) << "Failure setting threshold.";
 
@@ -568,10 +564,6 @@ TEST_F(GalileoE1PcpsTongAmbiguousAcquisitionGSoC2013Test, ValidationOfResultsPro
     ASSERT_NO_THROW({
         acquisition->set_gnss_synchro(&gnss_synchro);
     }) << "Failure setting gnss_synchro.";
-
-    ASSERT_NO_THROW({
-        acquisition->set_doppler_step(config->property("Acquisition_1B.doppler_step", 500));
-    }) << "Failure setting doppler_step.";
 
     ASSERT_NO_THROW({
         acquisition->set_threshold(config->property("Acquisition_1B.threshold", 0.00028));

--- a/tests/unit-tests/signal-processing-blocks/acquisition/galileo_e5a_pcps_acquisition_gsoc2014_gensource_test.cc
+++ b/tests/unit-tests/signal-processing-blocks/acquisition/galileo_e5a_pcps_acquisition_gsoc2014_gensource_test.cc
@@ -586,10 +586,6 @@ TEST_F(GalileoE5aPcpsAcquisitionGSoC2014GensourceTest, ValidationOfSIM)
     }) << "Failure setting gnss_synchro.";
 
     ASSERT_NO_THROW({
-        acquisition->set_doppler_step(config->property("Acquisition_5X.doppler_step", 100));
-    }) << "Failure setting doppler_step.";
-
-    ASSERT_NO_THROW({
         acquisition->set_threshold(config->property("Acquisition_5X.threshold", 0.0001));
     }) << "Failure setting threshold.";
 

--- a/tests/unit-tests/signal-processing-blocks/acquisition/galileo_e5b_pcps_acquisition_test.cc
+++ b/tests/unit-tests/signal-processing-blocks/acquisition/galileo_e5b_pcps_acquisition_test.cc
@@ -378,10 +378,6 @@ TEST_F(GalileoE5bPcpsAcquisitionTest, ValidationOfResults)
     }) << "Failure setting threshold.";
 
     ASSERT_NO_THROW({
-        acquisition->set_doppler_step(100);
-    }) << "Failure setting doppler_step.";
-
-    ASSERT_NO_THROW({
         acquisition->connect(top_block);
     }) << "Failure connecting acquisition to the top_block.";
 

--- a/tests/unit-tests/signal-processing-blocks/acquisition/galileo_e6_pcps_acquisition_test.cc
+++ b/tests/unit-tests/signal-processing-blocks/acquisition/galileo_e6_pcps_acquisition_test.cc
@@ -373,10 +373,6 @@ TEST_F(GalileoE6PcpsAcquisitionTest, ValidationOfResults)
     }) << "Failure setting gnss_synchro.";
 
     ASSERT_NO_THROW({
-        acquisition->set_doppler_step(100);
-    }) << "Failure setting doppler_step.";
-
-    ASSERT_NO_THROW({
         acquisition->connect(top_block);
     }) << "Failure connecting acquisition to the top_block.";
 

--- a/tests/unit-tests/signal-processing-blocks/acquisition/glonass_l1_ca_pcps_acquisition_gsoc2017_test.cc
+++ b/tests/unit-tests/signal-processing-blocks/acquisition/glonass_l1_ca_pcps_acquisition_gsoc2017_test.cc
@@ -492,10 +492,6 @@ TEST_F(GlonassL1CaPcpsAcquisitionGSoC2017Test, ValidationOfResults)
     }) << "Failure setting gnss_synchro.";
 
     ASSERT_NO_THROW({
-        acquisition->set_doppler_step(500);
-    }) << "Failure setting doppler_step.";
-
-    ASSERT_NO_THROW({
         acquisition->connect(top_block);
         top_block->msg_connect(acquisition->get_right_block(), pmt::mp("events"), msg_rx, pmt::mp("events"));
     }) << "Failure connecting acquisition to the top_block.";
@@ -568,10 +564,6 @@ TEST_F(GlonassL1CaPcpsAcquisitionGSoC2017Test, ValidationOfResultsProbabilities)
     ASSERT_NO_THROW({
         acquisition->set_gnss_synchro(&gnss_synchro);
     }) << "Failure setting gnss_synchro.";
-
-    ASSERT_NO_THROW({
-        acquisition->set_doppler_step(config->property("Acquisition.doppler_step", 500));
-    }) << "Failure setting doppler_step.";
 
     ASSERT_NO_THROW({
         acquisition->connect(top_block);

--- a/tests/unit-tests/signal-processing-blocks/acquisition/glonass_l1_ca_pcps_acquisition_test.cc
+++ b/tests/unit-tests/signal-processing-blocks/acquisition/glonass_l1_ca_pcps_acquisition_test.cc
@@ -239,10 +239,6 @@ TEST_F(GlonassL1CaPcpsAcquisitionTest, ValidationOfResults)
     }) << "Failure setting threshold.";
 
     ASSERT_NO_THROW({
-        acquisition->set_doppler_step(500);
-    }) << "Failure setting doppler_step.";
-
-    ASSERT_NO_THROW({
         acquisition->connect(top_block);
     }) << "Failure connecting acquisition to the top_block.";
 

--- a/tests/unit-tests/signal-processing-blocks/acquisition/glonass_l2_ca_pcps_acquisition_test.cc
+++ b/tests/unit-tests/signal-processing-blocks/acquisition/glonass_l2_ca_pcps_acquisition_test.cc
@@ -490,10 +490,6 @@ TEST_F(GlonassL2CaPcpsAcquisitionTest, ValidationOfResults)
     }) << "Failure setting gnss_synchro.";
 
     ASSERT_NO_THROW({
-        acquisition->set_doppler_step(500);
-    }) << "Failure setting doppler_step.";
-
-    ASSERT_NO_THROW({
         acquisition->set_threshold(0.0005);
     }) << "Failure setting threshold.";
 
@@ -570,10 +566,6 @@ TEST_F(GlonassL2CaPcpsAcquisitionTest, ValidationOfResultsProbabilities)
     ASSERT_NO_THROW({
         acquisition->set_gnss_synchro(&gnss_synchro);
     }) << "Failure setting gnss_synchro.";
-
-    ASSERT_NO_THROW({
-        acquisition->set_doppler_step(config->property("Acquisition_2G.doppler_step", 500));
-    }) << "Failure setting doppler_step.";
 
     ASSERT_NO_THROW({
         acquisition->set_threshold(config->property("Acquisition_2G.threshold", 0.0));

--- a/tests/unit-tests/signal-processing-blocks/acquisition/gps_l1_ca_pcps_acquisition_gsoc2013_test.cc
+++ b/tests/unit-tests/signal-processing-blocks/acquisition/gps_l1_ca_pcps_acquisition_gsoc2013_test.cc
@@ -484,10 +484,6 @@ TEST_F(GpsL1CaPcpsAcquisitionGSoC2013Test, ValidationOfResults)
     }) << "Failure setting gnss_synchro.";
 
     ASSERT_NO_THROW({
-        acquisition->set_doppler_step(500);
-    }) << "Failure setting doppler_step.";
-
-    ASSERT_NO_THROW({
         acquisition->connect(top_block);
         top_block->msg_connect(acquisition->get_right_block(), pmt::mp("events"), msg_rx, pmt::mp("events"));
     }) << "Failure connecting acquisition to the top_block.";
@@ -560,10 +556,6 @@ TEST_F(GpsL1CaPcpsAcquisitionGSoC2013Test, ValidationOfResultsProbabilities)
     ASSERT_NO_THROW({
         acquisition->set_gnss_synchro(&gnss_synchro);
     }) << "Failure setting gnss_synchro.";
-
-    ASSERT_NO_THROW({
-        acquisition->set_doppler_step(config->property("Acquisition_1C.doppler_step", 500));
-    }) << "Failure setting doppler_step.";
 
     ASSERT_NO_THROW({
         acquisition->connect(top_block);

--- a/tests/unit-tests/signal-processing-blocks/acquisition/gps_l1_ca_pcps_acquisition_test.cc
+++ b/tests/unit-tests/signal-processing-blocks/acquisition/gps_l1_ca_pcps_acquisition_test.cc
@@ -334,10 +334,6 @@ TEST_F(GpsL1CaPcpsAcquisitionTest /*unused*/, ValidationOfResults /*unused*/)
     }) << "Failure setting threshold.";
 
     ASSERT_NO_THROW({
-        acquisition->set_doppler_step(doppler_step);
-    }) << "Failure setting doppler_step.";
-
-    ASSERT_NO_THROW({
         acquisition->connect(top_block);
     }) << "Failure connecting acquisition to the top_block.";
 

--- a/tests/unit-tests/signal-processing-blocks/acquisition/gps_l1_ca_pcps_acquisition_test_fpga.cc
+++ b/tests/unit-tests/signal-processing-blocks/acquisition/gps_l1_ca_pcps_acquisition_test_fpga.cc
@@ -334,7 +334,6 @@ bool GpsL1CaPcpsAcquisitionTestFpga::acquire_signal()
     acquisition->set_gnss_synchro(&tmp_gnss_synchro);
     acquisition->set_channel_fsm(channel_fsm_);
     acquisition->set_channel(1);
-    acquisition->set_doppler_step(doppler_step);
     acquisition->set_doppler_center(0);
     acquisition->set_threshold(0.001);
 

--- a/tests/unit-tests/signal-processing-blocks/acquisition/gps_l1_ca_pcps_opencl_acquisition_gsoc2013_test.cc
+++ b/tests/unit-tests/signal-processing-blocks/acquisition/gps_l1_ca_pcps_opencl_acquisition_gsoc2013_test.cc
@@ -483,10 +483,6 @@ TEST_F(GpsL1CaPcpsOpenClAcquisitionGSoC2013Test, ValidationOfResults)
     }) << "Failure setting gnss_synchro.";
 
     ASSERT_NO_THROW({
-        acquisition->set_doppler_step(config->property("Acquisition_1C.doppler_step", 500));
-    }) << "Failure setting doppler_step.";
-
-    ASSERT_NO_THROW({
         acquisition->set_threshold(config->property("Acquisition_1C.threshold", 0.0));
     }) << "Failure setting threshold.";
 
@@ -565,10 +561,6 @@ TEST_F(GpsL1CaPcpsOpenClAcquisitionGSoC2013Test, ValidationOfResultsProbabilitie
     ASSERT_NO_THROW({
         acquisition->set_gnss_synchro(&gnss_synchro);
     }) << "Failure setting gnss_synchro.";
-
-    ASSERT_NO_THROW({
-        acquisition->set_doppler_step(config->property("Acquisition_1C.doppler_step", 500));
-    }) << "Failure setting doppler_step.";
 
     ASSERT_NO_THROW({
         acquisition->set_threshold(config->property("Acquisition_1C.threshold", 0.0));

--- a/tests/unit-tests/signal-processing-blocks/acquisition/gps_l1_ca_pcps_quicksync_acquisition_gsoc2014_test.cc
+++ b/tests/unit-tests/signal-processing-blocks/acquisition/gps_l1_ca_pcps_quicksync_acquisition_gsoc2014_test.cc
@@ -611,10 +611,6 @@ TEST_F(GpsL1CaPcpsQuickSyncAcquisitionGSoC2014Test, ValidationOfResults)
     }) << "Failure setting gnss_synchro.";
 
     ASSERT_NO_THROW({
-        acquisition->set_doppler_step(250);
-    }) << "Failure setting doppler_step.";
-
-    ASSERT_NO_THROW({
         acquisition->set_threshold(100);
     }) << "Failure setting threshold.";
 
@@ -698,10 +694,6 @@ TEST_F(GpsL1CaPcpsQuickSyncAcquisitionGSoC2014Test, ValidationOfResultsWithNoise
     ASSERT_NO_THROW({
         acquisition->set_gnss_synchro(&gnss_synchro);
     }) << "Failure setting gnss_synchro.";
-
-    ASSERT_NO_THROW({
-        acquisition->set_doppler_step(250);
-    }) << "Failure setting doppler_step.";
 
     ASSERT_NO_THROW({
         acquisition->set_threshold(100);

--- a/tests/unit-tests/signal-processing-blocks/acquisition/gps_l1_ca_pcps_tong_acquisition_gsoc2013_test.cc
+++ b/tests/unit-tests/signal-processing-blocks/acquisition/gps_l1_ca_pcps_tong_acquisition_gsoc2013_test.cc
@@ -480,10 +480,6 @@ TEST_F(GpsL1CaPcpsTongAcquisitionGSoC2013Test, ValidationOfResults)
     }) << "Failure setting gnss_synchro.";
 
     ASSERT_NO_THROW({
-        acquisition->set_doppler_step(config->property("Acquisition_1C.doppler_step", 500));
-    }) << "Failure setting doppler_step.";
-
-    ASSERT_NO_THROW({
         acquisition->set_threshold(config->property("Acquisition_1C.threshold", 0.0));
     }) << "Failure setting threshold.";
 
@@ -561,10 +557,6 @@ TEST_F(GpsL1CaPcpsTongAcquisitionGSoC2013Test, ValidationOfResultsProbabilities)
     ASSERT_NO_THROW({
         acquisition->set_gnss_synchro(&gnss_synchro);
     }) << "Failure setting gnss_synchro.";
-
-    ASSERT_NO_THROW({
-        acquisition->set_doppler_step(config->property("Acquisition_1C.doppler_step", 500));
-    }) << "Failure setting doppler_step.";
 
     ASSERT_NO_THROW({
         acquisition->set_threshold(config->property("Acquisition_1C.threshold", 0.0));

--- a/tests/unit-tests/signal-processing-blocks/acquisition/gps_l2_m_pcps_acquisition_test.cc
+++ b/tests/unit-tests/signal-processing-blocks/acquisition/gps_l2_m_pcps_acquisition_test.cc
@@ -333,10 +333,6 @@ TEST_F(GpsL2MPcpsAcquisitionTest, ValidationOfResults)
     }) << "Failure setting threshold.";
 
     ASSERT_NO_THROW({
-        acquisition->set_doppler_step(doppler_step);
-    }) << "Failure setting doppler_step.";
-
-    ASSERT_NO_THROW({
         acquisition->connect(top_block);
     }) << "Failure connecting acquisition to the top_block.";
 

--- a/tests/unit-tests/signal-processing-blocks/observables/hybrid_observables_test.cc
+++ b/tests/unit-tests/signal-processing-blocks/observables/hybrid_observables_test.cc
@@ -543,10 +543,8 @@ bool HybridObservablesTest::acquire_signal()
     acquisition->set_gnss_synchro(&tmp_gnss_synchro);
     acquisition->set_channel(0);
 #if USE_GLOG_AND_GFLAGS
-    acquisition->set_doppler_step(config->property("Acquisition.doppler_step", FLAGS_external_signal_acquisition_doppler_step_hz));
     acquisition->set_threshold(config->property("Acquisition.threshold", FLAGS_external_signal_acquisition_threshold));
 #else
-    acquisition->set_doppler_step(config->property("Acquisition.doppler_step", absl::GetFlag(FLAGS_external_signal_acquisition_doppler_step_hz)));
     acquisition->set_threshold(config->property("Acquisition.threshold", absl::GetFlag(FLAGS_external_signal_acquisition_threshold)));
 #endif
     acquisition->init();

--- a/tests/unit-tests/signal-processing-blocks/observables/hybrid_observables_test_fpga.cc
+++ b/tests/unit-tests/signal-processing-blocks/observables/hybrid_observables_test_fpga.cc
@@ -700,11 +700,9 @@ bool HybridObservablesTestFpga::acquire_signal()
     acquisition->set_channel_fsm(channel_fsm_);
     acquisition->set_channel(0);
 #if USE_GLOG_AND_GFLAGS
-    acquisition->set_doppler_step(config->property("Acquisition.doppler_step", FLAGS_external_signal_acquisition_doppler_step_hz));
     acquisition->set_doppler_center(0);
     acquisition->set_threshold(config->property("Acquisition.threshold", FLAGS_external_signal_acquisition_threshold));
 #else
-    acquisition->set_doppler_step(config->property("Acquisition.doppler_step", absl::GetFlag(FLAGS_external_signal_acquisition_doppler_step_hz)));
     acquisition->set_doppler_center(0);
     acquisition->set_threshold(config->property("Acquisition.threshold", absl::GetFlag(FLAGS_external_signal_acquisition_threshold)));
 #endif

--- a/tests/unit-tests/signal-processing-blocks/tracking/tracking_pull-in_test.cc
+++ b/tests/unit-tests/signal-processing-blocks/tracking/tracking_pull-in_test.cc
@@ -536,10 +536,8 @@ bool TrackingPullInTest::acquire_signal(int SV_ID)
     acquisition->set_gnss_synchro(&tmp_gnss_synchro);
     acquisition->set_channel(0);
 #if USE_GLOG_AND_GFLAGS
-    acquisition->set_doppler_step(config->property("Acquisition.doppler_step", FLAGS_external_signal_acquisition_doppler_step_hz));
     acquisition->set_threshold(config->property("Acquisition.threshold", FLAGS_external_signal_acquisition_threshold));
 #else
-    acquisition->set_doppler_step(config->property("Acquisition.doppler_step", absl::GetFlag(FLAGS_external_signal_acquisition_doppler_step_hz)));
     acquisition->set_threshold(config->property("Acquisition.threshold", absl::GetFlag(FLAGS_external_signal_acquisition_threshold)));
 #endif
     acquisition->init();

--- a/tests/unit-tests/signal-processing-blocks/tracking/tracking_pull-in_test_fpga.cc
+++ b/tests/unit-tests/signal-processing-blocks/tracking/tracking_pull-in_test_fpga.cc
@@ -696,11 +696,9 @@ bool TrackingPullInTestFpga::acquire_signal(int SV_ID)
     acquisition->set_channel_fsm(channel_fsm_);
     acquisition->set_channel(0);
 #if USE_GLOG_AND_GFLAGS
-    acquisition->set_doppler_step(config->property("Acquisition.doppler_step", FLAGS_external_signal_acquisition_doppler_step_hz));
     acquisition->set_doppler_center(0);
     acquisition->set_threshold(config->property("Acquisition.threshold", FLAGS_external_signal_acquisition_threshold));
 #else
-    acquisition->set_doppler_step(config->property("Acquisition.doppler_step", absl::GetFlag(FLAGS_external_signal_acquisition_doppler_step_hz)));
     acquisition->set_doppler_center(0);
     acquisition->set_threshold(config->property("Acquisition.threshold", absl::GetFlag(FLAGS_external_signal_acquisition_threshold)));
 #endif

--- a/utils/front-end-cal/main.cc
+++ b/utils/front-end-cal/main.cc
@@ -480,7 +480,6 @@ int main(int argc, char** argv)
             acquisition->set_channel(1);
             acquisition->set_gnss_synchro(&gnss_synchro);
             acquisition->set_threshold(configuration->property("Acquisition.threshold", 2.0));
-            acquisition->set_doppler_step(configuration->property("Acquisition.doppler_step", 250));
 
             gr::block_sptr source;
             source = gr::blocks::file_source::make(sizeof(gr_complex), "tmp_capture.dat");


### PR DESCRIPTION
Same idea, making `doppler_step` member `const` to simplify logic.

The function `set_doppler_step` was called in the `Channel` class constructor, where it read the configuration and the flags to set the value. It used to read the config with the channel number like this: `"Acquisition_" + signal_str + std::to_string(channel_) + ".doppler_step"`, but I removed that since @carlesfernandez mentioned in another PR that this was the old way of doing it.

I moved the config and flag reading to each acquisition class constructor, note that in a future PR I want to remove all this duplicated code to a base class, but to simplify this PR, I kept that separated.

Note I changed the default value in [acq_conf.h](https://github.com/gnss-sdr/gnss-sdr/compare/next...MathieuFavreau:gnss-sdr:refactor/const-doppler-step?expand=1#diff-6f8c179d36d1a28ab2cb2f30d8ea8070254319d49ae178a8abb4e2179bcb024b) to `500` instead of `250` for `doppler_step`, because anyway it was being overridden when set in the `Channel` constructor to `500` as the default value. Also the website documentation is citing 500Hz as the default value.

Note that making `doppler_step` const also allowed to move the initialization of other variables in the constructor, since they no longer have the potential to change.