### PR TITLE
Add other acquisition base class temporarily to remove duplicated code

### DIFF
--- a/src/algorithms/acquisition/adapters/CMakeLists.txt
+++ b/src/algorithms/acquisition/adapters/CMakeLists.txt
@@ -7,6 +7,7 @@
 
 set(ACQ_ADAPTER_SOURCES
     base_pcps_acquisition.cc
+    base_pcps_acquisition_custom.cc
     gps_l1_ca_pcps_acquisition.cc
     gps_l1_ca_pcps_assisted_acquisition.cc
     gps_l1_ca_pcps_acquisition_fine_doppler.cc
@@ -31,6 +32,7 @@ set(ACQ_ADAPTER_SOURCES
 
 set(ACQ_ADAPTER_HEADERS
     base_pcps_acquisition.h
+    base_pcps_acquisition_custom.h
     gps_l1_ca_pcps_acquisition.h
     gps_l1_ca_pcps_assisted_acquisition.h
     gps_l1_ca_pcps_acquisition_fine_doppler.h

--- a/src/algorithms/acquisition/adapters/base_pcps_acquisition.cc
+++ b/src/algorithms/acquisition/adapters/base_pcps_acquisition.cc
@@ -41,6 +41,7 @@ Acq_Conf get_acq_conf(const ConfigurationInterface* configuration, const std::st
 {
     Acq_Conf acq_parameters;
     acq_parameters.ms_per_code = ms_per_code;
+    acq_parameters.sampled_ms = ms_per_code;  // Set as default value
     acq_parameters.SetFromConfiguration(configuration, role, chip_rate, opt_freq);
 
 #if USE_GLOG_AND_GFLAGS

--- a/src/algorithms/acquisition/adapters/base_pcps_acquisition.cc
+++ b/src/algorithms/acquisition/adapters/base_pcps_acquisition.cc
@@ -1,11 +1,8 @@
 /*!
- * \file gps_l1_ca_pcps_acquisition.cc
- * \brief Adapts a PCPS acquisition block to an AcquisitionInterface for
- *  GPS L1 C/A signals
+ * \file base_ca_pcps_acquisition.h
+ * \brief Adapts a PCPS acquisition block to an AcquisitionInterface
  * \authors <ul>
- *          <li> Javier Arribas, 2011. jarribas(at)cttc.es
- *          <li> Luis Esteve, 2012. luis(at)epsilon-formacion.com
- *          <li> Marc Molina, 2013. marc.molina.pena(at)gmail.com
+ *          <li> Mathieu Favreau, 2025. favreau.mathieu(at)hotmail.com
  *          </ul>
  *
  * -----------------------------------------------------------------------------
@@ -13,7 +10,7 @@
  * GNSS-SDR is a Global Navigation Satellite System software-defined receiver.
  * This file is part of GNSS-SDR.
  *
- * Copyright (C) 2010-2020  (see AUTHORS file for a list of contributors)
+ * Copyright (C) 2010-2025  (see AUTHORS file for a list of contributors)
  * SPDX-License-Identifier: GPL-3.0-or-later
  *
  * -----------------------------------------------------------------------------

--- a/src/algorithms/acquisition/adapters/base_pcps_acquisition_custom.cc
+++ b/src/algorithms/acquisition/adapters/base_pcps_acquisition_custom.cc
@@ -30,75 +30,61 @@
 
 namespace
 {
-const std::string default_item_type("gr_complex");
 const std::string default_dump_filename("./acquisition.dat");
 
-unsigned int get_doppler_max(const ConfigurationInterface* configuration, const std::string& role)
+Acq_Conf get_acq_conf(const ConfigurationInterface* configuration, const std::string& role, double chip_rate, double opt_freq, uint32_t ms_per_code)
 {
-    unsigned int doppler_max = configuration->property(role + ".doppler_max", 5000);
+    Acq_Conf acq_parameters;
+    acq_parameters.ms_per_code = ms_per_code;
+    acq_parameters.sampled_ms = ms_per_code;               // Set as default value
+    acq_parameters.dump_filename = default_dump_filename;  // Set as default value
+    acq_parameters.SetFromConfiguration(configuration, role, chip_rate, opt_freq);
 
 #if USE_GLOG_AND_GFLAGS
     if (FLAGS_doppler_max != 0)
         {
-            doppler_max = FLAGS_doppler_max;
+            acq_parameters.doppler_max = FLAGS_doppler_max;
+        }
+    if (FLAGS_doppler_step != 0)
+        {
+            acq_parameters.doppler_step = static_cast<float>(FLAGS_doppler_step);
         }
 #else
     if (absl::GetFlag(FLAGS_doppler_max) != 0)
         {
-            doppler_max = absl::GetFlag(FLAGS_doppler_max);
+            acq_parameters.doppler_max = absl::GetFlag(FLAGS_doppler_max);
         }
-#endif
-
-    return doppler_max;
-}
-
-unsigned int get_doppler_step(const ConfigurationInterface* configuration, const std::string& role)
-{
-    unsigned int doppler_step = configuration->property(role + ".doppler_step", 500);
-
-#if USE_GLOG_AND_GFLAGS
-    if (FLAGS_doppler_step != 0)
-        {
-            doppler_step = static_cast<uint32_t>(FLAGS_doppler_step);
-        }
-#else
     if (absl::GetFlag(FLAGS_doppler_step) != 0)
         {
-            doppler_step = static_cast<uint32_t>(absl::GetFlag(FLAGS_doppler_step));
+            acq_parameters.doppler_step = static_cast<float>(absl::GetFlag(FLAGS_doppler_step));
         }
 #endif
 
-    return doppler_step;
+    return acq_parameters;
 }
-
 }  // namespace
+
 
 BasePcpsAcquisitionCustom::BasePcpsAcquisitionCustom(
     const ConfigurationInterface* configuration,
     const std::string& role,
     unsigned int in_streams,
     unsigned int out_streams,
-    unsigned int sampled_ms,
     double chip_rate,
     double code_length_chips,
     unsigned int ms_per_code,
     bool use_stream_to_vector,
     bool compute_threshold_from_pfa)
-    : fs_in_(configuration->property("GNSS-SDR.internal_fs_sps", configuration->property("GNSS-SDR.internal_fs_hz", static_cast<int64_t>(4000000)))),
-      doppler_max_(get_doppler_max(configuration, role)),
-      doppler_step_(get_doppler_step(configuration, role)),
-      sampled_ms_(sampled_ms),
+    : acq_parameters_(get_acq_conf(configuration, role, chip_rate, 0, ms_per_code)),
       ms_per_code_(ms_per_code),
-      code_length_(static_cast<unsigned int>(round(fs_in_ / (chip_rate / code_length_chips)))),
-      vector_length_(code_length_ * static_cast<int>(sampled_ms_ / ms_per_code)),
+      code_length_(static_cast<unsigned int>(round(acq_parameters_.fs_in / (chip_rate / code_length_chips)))),
+      vector_length_(code_length_ * static_cast<int>(acq_parameters_.sampled_ms / ms_per_code)),
       gnss_synchro_(nullptr),
       channel_(0),
       code_(vector_length_),
-      item_type_(configuration->property(role + ".item_type", default_item_type)),
       role_(role),
-      is_type_gr_complex_(item_type_ == "gr_complex"),
+      is_type_gr_complex_(acq_parameters_.item_type == "gr_complex"),
       item_size_(is_type_gr_complex_ ? sizeof(gr_complex) : 0),
-      pfa_(configuration->property(role + ".pfa", 0.0F)),
       use_stream_to_vector_(use_stream_to_vector),
       compute_threshold_from_pfa_(compute_threshold_from_pfa)
 {
@@ -114,7 +100,7 @@ BasePcpsAcquisitionCustom::BasePcpsAcquisitionCustom(
         }
     else
         {
-            LOG(WARNING) << item_type_ << " unknown acquisition item type";
+            LOG(WARNING) << acq_parameters_.item_type << " unknown acquisition item type";
         }
 
     if (in_streams > 1)
@@ -243,9 +229,9 @@ void BasePcpsAcquisitionCustom::set_threshold(float threshold)
 {
     if (is_type_gr_complex_)
         {
-            if (compute_threshold_from_pfa_ && pfa_ != 0)
+            if (compute_threshold_from_pfa_ && acq_parameters_.pfa != 0)
                 {
-                    threshold = calculate_threshold(pfa_);
+                    threshold = calculate_threshold(acq_parameters_.pfa);
                     DLOG(INFO) << "Channel " << channel_ << " Threshold = " << threshold;
                 }
 
@@ -259,9 +245,9 @@ void BasePcpsAcquisitionCustom::set_local_code()
     if (is_type_gr_complex())
         {
             std::vector<std::complex<float>> code(code_length_);
-            code_gen_complex_sampled(code, gnss_synchro_->PRN, fs_in_);
+            code_gen_complex_sampled(code, gnss_synchro_->PRN, acq_parameters_.fs_in);
 
-            const auto num_codes = sampled_ms_ / ms_per_code_;
+            const auto num_codes = acq_parameters_.sampled_ms / ms_per_code_;
 
             own::span<gr_complex> code_span(code_.data(), vector_length_);
             for (unsigned int i = 0; i < num_codes; i++)
@@ -278,7 +264,7 @@ float BasePcpsAcquisitionCustom::calculate_threshold(float pfa) const
 {
     // Calculate the threshold
     unsigned int frequency_bins = 0;
-    for (int doppler = static_cast<int>(-doppler_max_); doppler <= static_cast<int>(doppler_max_); doppler += static_cast<int>(doppler_step_))
+    for (int doppler = -acq_parameters_.doppler_max; doppler <= acq_parameters_.doppler_max; doppler += static_cast<int>(acq_parameters_.doppler_step))
         {
             frequency_bins++;
         }

--- a/src/algorithms/acquisition/adapters/base_pcps_acquisition_custom.cc
+++ b/src/algorithms/acquisition/adapters/base_pcps_acquisition_custom.cc
@@ -76,9 +76,9 @@ BasePcpsAcquisitionCustom::BasePcpsAcquisitionCustom(
     bool use_stream_to_vector,
     bool compute_threshold_from_pfa)
     : acq_parameters_(get_acq_conf(configuration, role, chip_rate, 0, ms_per_code)),
-      ms_per_code_(ms_per_code),
+      num_codes_(acq_parameters_.sampled_ms / ms_per_code),
       code_length_(static_cast<unsigned int>(round(acq_parameters_.fs_in / (chip_rate / code_length_chips)))),
-      vector_length_(code_length_ * static_cast<int>(acq_parameters_.sampled_ms / ms_per_code)),
+      vector_length_(code_length_ * num_codes_),
       gnss_synchro_(nullptr),
       channel_(0),
       code_(vector_length_),
@@ -247,10 +247,8 @@ void BasePcpsAcquisitionCustom::set_local_code()
             std::vector<std::complex<float>> code(code_length_);
             code_gen_complex_sampled(code, gnss_synchro_->PRN, acq_parameters_.fs_in);
 
-            const auto num_codes = acq_parameters_.sampled_ms / ms_per_code_;
-
             own::span<gr_complex> code_span(code_.data(), vector_length_);
-            for (unsigned int i = 0; i < num_codes; i++)
+            for (unsigned int i = 0; i < num_codes_; i++)
                 {
                     std::copy_n(code.data(), code_length_, code_span.subspan(i * code_length_, code_length_).data());
                 }

--- a/src/algorithms/acquisition/adapters/base_pcps_acquisition_custom.cc
+++ b/src/algorithms/acquisition/adapters/base_pcps_acquisition_custom.cc
@@ -1,0 +1,296 @@
+/*!
+ * \file base_ca_pcps_acquisition_custom.h
+ * \brief Adapts a PCPS acquisition block to an AcquisitionInterface
+ * \authors <ul>
+ *          <li> Mathieu Favreau, 2025. favreau.mathieu(at)hotmail.com
+ *          </ul>
+ *
+ * -----------------------------------------------------------------------------
+ *
+ * GNSS-SDR is a Global Navigation Satellite System software-defined receiver.
+ * This file is part of GNSS-SDR.
+ *
+ * Copyright (C) 2010-2025  (see AUTHORS file for a list of contributors)
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ *
+ * -----------------------------------------------------------------------------
+ */
+
+#include "base_pcps_acquisition_custom.h"
+#include "configuration_interface.h"
+#include "gnss_sdr_flags.h"
+#include <boost/math/distributions/exponential.hpp>
+
+#if USE_GLOG_AND_GFLAGS
+#include <glog/logging.h>
+#else
+#include <absl/log/log.h>
+#endif
+
+
+namespace
+{
+const std::string default_item_type("gr_complex");
+const std::string default_dump_filename("./acquisition.dat");
+
+unsigned int get_doppler_max(const ConfigurationInterface* configuration, const std::string& role)
+{
+    unsigned int doppler_max = configuration->property(role + ".doppler_max", 5000);
+
+#if USE_GLOG_AND_GFLAGS
+    if (FLAGS_doppler_max != 0)
+        {
+            doppler_max = FLAGS_doppler_max;
+        }
+#else
+    if (absl::GetFlag(FLAGS_doppler_max) != 0)
+        {
+            doppler_max = absl::GetFlag(FLAGS_doppler_max);
+        }
+#endif
+
+    return doppler_max;
+}
+
+unsigned int get_doppler_step(const ConfigurationInterface* configuration, const std::string& role)
+{
+    unsigned int doppler_step = configuration->property(role + ".doppler_step", 500);
+
+#if USE_GLOG_AND_GFLAGS
+    if (FLAGS_doppler_step != 0)
+        {
+            doppler_step = static_cast<uint32_t>(FLAGS_doppler_step);
+        }
+#else
+    if (absl::GetFlag(FLAGS_doppler_step) != 0)
+        {
+            doppler_step = static_cast<uint32_t>(absl::GetFlag(FLAGS_doppler_step));
+        }
+#endif
+
+    return doppler_step;
+}
+
+}  // namespace
+
+BasePcpsAcquisitionCustom::BasePcpsAcquisitionCustom(
+    const ConfigurationInterface* configuration,
+    const std::string& role,
+    unsigned int in_streams,
+    unsigned int out_streams,
+    unsigned int sampled_ms,
+    double chip_rate,
+    double code_length_chips,
+    unsigned int ms_per_code,
+    bool use_stream_to_vector,
+    bool compute_threshold_from_pfa)
+    : fs_in_(configuration->property("GNSS-SDR.internal_fs_sps", configuration->property("GNSS-SDR.internal_fs_hz", 4000000L))),
+      doppler_max_(get_doppler_max(configuration, role)),
+      doppler_step_(get_doppler_step(configuration, role)),
+      sampled_ms_(sampled_ms),
+      ms_per_code_(ms_per_code),
+      code_length_(static_cast<unsigned int>(round(fs_in_ / (chip_rate / code_length_chips)))),
+      vector_length_(code_length_ * static_cast<int>(sampled_ms_ / ms_per_code)),
+      gnss_synchro_(nullptr),
+      channel_(0),
+      code_(vector_length_),
+      item_type_(configuration->property(role + ".item_type", default_item_type)),
+      role_(role),
+      is_type_gr_complex_(item_type_ == "gr_complex"),
+      item_size_(is_type_gr_complex_ ? sizeof(gr_complex) : 0),
+      pfa_(configuration->property(role + ".pfa", 0.0F)),
+      use_stream_to_vector_(use_stream_to_vector),
+      compute_threshold_from_pfa_(compute_threshold_from_pfa)
+{
+    DLOG(INFO) << "role " << role_;
+
+    if (is_type_gr_complex_)
+        {
+            if (use_stream_to_vector_)
+                {
+                    stream_to_vector_ = gr::blocks::stream_to_vector::make(item_size_, vector_length_);
+                    DLOG(INFO) << "stream_to_vector(" << stream_to_vector_->unique_id() << ")";
+                }
+        }
+    else
+        {
+            LOG(WARNING) << item_type_ << " unknown acquisition item type";
+        }
+
+    if (in_streams > 1)
+        {
+            LOG(ERROR) << "This implementation only supports one input stream";
+        }
+    if (out_streams > 0)
+        {
+            LOG(ERROR) << "This implementation does not provide an output stream";
+        }
+}
+
+
+void BasePcpsAcquisitionCustom::connect(gr::top_block_sptr top_block)
+{
+    if (is_type_gr_complex_ && use_stream_to_vector_)
+        {
+            top_block->connect(stream_to_vector_, 0, acquisition_cc_, 0);
+        }
+}
+
+
+void BasePcpsAcquisitionCustom::disconnect(gr::top_block_sptr top_block)
+{
+    if (is_type_gr_complex_ && use_stream_to_vector_)
+        {
+            top_block->disconnect(stream_to_vector_, 0, acquisition_cc_, 0);
+        }
+}
+
+
+gr::basic_block_sptr BasePcpsAcquisitionCustom::get_left_block()
+{
+    if (use_stream_to_vector_)
+        {
+            return stream_to_vector_;
+        }
+    return acquisition_cc_;
+}
+
+
+gr::basic_block_sptr BasePcpsAcquisitionCustom::get_right_block()
+{
+    return acquisition_cc_;
+}
+
+
+void BasePcpsAcquisitionCustom::set_gnss_synchro(Gnss_Synchro* gnss_synchro)
+{
+    gnss_synchro_ = gnss_synchro;
+
+    if (is_type_gr_complex_)
+        {
+            acquisition_cc_->set_gnss_synchro(gnss_synchro);
+        }
+}
+
+void BasePcpsAcquisitionCustom::set_channel(unsigned int channel)
+{
+    channel_ = channel;
+
+    if (is_type_gr_complex_)
+        {
+            acquisition_cc_->set_channel(channel);
+        }
+}
+
+
+void BasePcpsAcquisitionCustom::set_channel_fsm(std::weak_ptr<ChannelFsm> channel_fsm)
+{
+    if (is_type_gr_complex_)
+        {
+            acquisition_cc_->set_channel_fsm(channel_fsm);
+        }
+}
+
+
+void BasePcpsAcquisitionCustom::init()
+{
+    if (is_type_gr_complex_)
+        {
+            acquisition_cc_->init();
+        }
+}
+
+
+signed int BasePcpsAcquisitionCustom::mag()
+{
+    if (is_type_gr_complex_)
+        {
+            return acquisition_cc_->mag();
+        }
+    return 0;
+}
+
+
+void BasePcpsAcquisitionCustom::reset()
+{
+    if (is_type_gr_complex_)
+        {
+            acquisition_cc_->set_active(true);
+        }
+}
+
+
+void BasePcpsAcquisitionCustom::stop_acquisition()
+{
+    if (is_type_gr_complex_)
+        {
+            acquisition_cc_->set_state(0);
+            acquisition_cc_->set_active(false);
+        }
+}
+
+
+void BasePcpsAcquisitionCustom::set_state(int state)
+{
+    if (is_type_gr_complex_)
+        {
+            acquisition_cc_->set_state(state);
+        }
+}
+
+
+void BasePcpsAcquisitionCustom::set_threshold(float threshold)
+{
+    if (is_type_gr_complex_)
+        {
+            if (compute_threshold_from_pfa_ && pfa_ != 0)
+                {
+                    threshold = calculate_threshold(pfa_);
+                    DLOG(INFO) << "Channel " << channel_ << " Threshold = " << threshold;
+                }
+
+            acquisition_cc_->set_threshold(threshold);
+        }
+}
+
+
+void BasePcpsAcquisitionCustom::set_local_code()
+{
+    if (is_type_gr_complex())
+        {
+            std::vector<std::complex<float>> code(code_length_);
+            code_gen_complex_sampled(code, gnss_synchro_->PRN, fs_in_);
+
+            const auto num_codes = sampled_ms_ / ms_per_code_;
+
+            own::span<gr_complex> code_span(code_.data(), vector_length_);
+            for (unsigned int i = 0; i < num_codes; i++)
+                {
+                    std::copy_n(code.data(), code_length_, code_span.subspan(i * code_length_, code_length_).data());
+                }
+
+            acquisition_cc_->set_local_code(code_.data());
+        }
+}
+
+
+float BasePcpsAcquisitionCustom::calculate_threshold(float pfa) const
+{
+    // Calculate the threshold
+    unsigned int frequency_bins = 0;
+    for (int doppler = static_cast<int>(-doppler_max_); doppler <= static_cast<int>(doppler_max_); doppler += static_cast<int>(doppler_step_))
+        {
+            frequency_bins++;
+        }
+
+    DLOG(INFO) << "Channel " << channel_ << "  Pfa = " << pfa;
+
+    const auto ncells = vector_length_ * frequency_bins;
+    const auto exponent = 1 / static_cast<double>(ncells);
+    const auto val = pow(1.0 - pfa, exponent);
+    const auto lambda = static_cast<double>(vector_length_);
+    boost::math::exponential_distribution<double> mydist(lambda);
+    const auto threshold = static_cast<float>(quantile(mydist, val));
+
+    return threshold;
+}

--- a/src/algorithms/acquisition/adapters/base_pcps_acquisition_custom.cc
+++ b/src/algorithms/acquisition/adapters/base_pcps_acquisition_custom.cc
@@ -84,7 +84,7 @@ BasePcpsAcquisitionCustom::BasePcpsAcquisitionCustom(
     unsigned int ms_per_code,
     bool use_stream_to_vector,
     bool compute_threshold_from_pfa)
-    : fs_in_(configuration->property("GNSS-SDR.internal_fs_sps", configuration->property("GNSS-SDR.internal_fs_hz", 4000000L))),
+    : fs_in_(configuration->property("GNSS-SDR.internal_fs_sps", configuration->property("GNSS-SDR.internal_fs_hz", static_cast<int64_t>(4000000)))),
       doppler_max_(get_doppler_max(configuration, role)),
       doppler_step_(get_doppler_step(configuration, role)),
       sampled_ms_(sampled_ms),

--- a/src/algorithms/acquisition/adapters/base_pcps_acquisition_custom.h
+++ b/src/algorithms/acquisition/adapters/base_pcps_acquisition_custom.h
@@ -122,7 +122,7 @@ protected:
     bool is_type_gr_complex() const { return is_type_gr_complex_; }
 
     const Acq_Conf acq_parameters_;
-    const unsigned int ms_per_code_;
+    const unsigned int num_codes_;
     const unsigned int code_length_;
     const unsigned int vector_length_;
     acquisition_impl_interface_sptr acquisition_cc_;

--- a/src/algorithms/acquisition/adapters/base_pcps_acquisition_custom.h
+++ b/src/algorithms/acquisition/adapters/base_pcps_acquisition_custom.h
@@ -46,7 +46,6 @@ public:
         const std::string& role,
         unsigned int in_streams,
         unsigned int out_streams,
-        unsigned int sampled_ms,
         double chip_rate,
         double code_length_chips,
         unsigned int ms_per_code,
@@ -122,10 +121,7 @@ public:
 protected:
     bool is_type_gr_complex() const { return is_type_gr_complex_; }
 
-    const int64_t fs_in_;
-    const unsigned int doppler_max_;
-    const unsigned int doppler_step_;
-    const unsigned int sampled_ms_;
+    const Acq_Conf acq_parameters_;
     const unsigned int ms_per_code_;
     const unsigned int code_length_;
     const unsigned int vector_length_;
@@ -143,11 +139,9 @@ private:
 
     volk_gnsssdr::vector<std::complex<float>> code_;
     gr::blocks::stream_to_vector::sptr stream_to_vector_;
-    const std::string item_type_;
     const std::string role_;
     const bool is_type_gr_complex_;
     const size_t item_size_;
-    const float pfa_;
     const bool use_stream_to_vector_;
     const bool compute_threshold_from_pfa_;
 };

--- a/src/algorithms/acquisition/adapters/base_pcps_acquisition_custom.h
+++ b/src/algorithms/acquisition/adapters/base_pcps_acquisition_custom.h
@@ -1,5 +1,5 @@
 /*!
- * \file base_ca_pcps_acquisition.h
+ * \file base_ca_pcps_acquisition_custom.h
  * \brief Adapts a PCPS acquisition block to an AcquisitionInterface
  * \authors <ul>
  *          <li> Mathieu Favreau, 2025. favreau.mathieu(at)hotmail.com
@@ -16,15 +16,14 @@
  * -----------------------------------------------------------------------------
  */
 
-#ifndef GNSS_SDR_BASE_PCPS_ACQUISITION_H
-#define GNSS_SDR_BASE_PCPS_ACQUISITION_H
+#ifndef GNSS_SDR_BASE_PCPS_ACQUISITION_CUSTOM_H
+#define GNSS_SDR_BASE_PCPS_ACQUISITION_CUSTOM_H
 
-#include "acq_conf.h"
+#include "acquisition_impl_interface.h"
 #include "channel_fsm.h"
-#include "complex_byte_to_float_x2.h"
 #include "gnss_synchro.h"
 #include "pcps_acquisition.h"
-#include <gnuradio/blocks/float_to_complex.h>
+#include <gnuradio/blocks/stream_to_vector.h>
 #include <volk_gnsssdr/volk_gnsssdr_alloc.h>
 
 /** \addtogroup Acquisition
@@ -40,30 +39,25 @@ class ConfigurationInterface;
 /*!
  * \brief This class adapts a PCPS acquisition block to an AcquisitionInterface
  */
-class BasePcpsAcquisition : public AcquisitionInterface
+class BasePcpsAcquisitionCustom : public AcquisitionInterface
 {
 public:
-    BasePcpsAcquisition(
-        const ConfigurationInterface* configuration,
+    BasePcpsAcquisitionCustom(const ConfigurationInterface* configuration,
         const std::string& role,
         unsigned int in_streams,
         unsigned int out_streams,
+        unsigned int sampled_ms,
         double chip_rate,
-        double opt_freq,
         double code_length_chips,
-        uint32_t ms_per_code);
+        unsigned int ms_per_code,
+        bool use_stream_to_vector,
+        bool compute_threshold_from_pfa);
 
-    ~BasePcpsAcquisition() = default;
+    ~BasePcpsAcquisitionCustom() = default;
 
-    inline std::string role() override
-    {
-        return role_;
-    }
+    inline std::string role() override { return role_; }
 
-    inline size_t item_size() override
-    {
-        return acq_parameters_.it_size;
-    }
+    inline size_t item_size() override { return item_size_; }
 
     void connect(gr::top_block_sptr top_block) override;
     void disconnect(gr::top_block_sptr top_block) override;
@@ -80,28 +74,12 @@ public:
     /*!
      * \brief Set acquisition channel unique ID
      */
-    inline void set_channel(unsigned int channel) override
-    {
-        acquisition_->set_channel(channel);
-    }
+    void set_channel(unsigned int channel) override;
 
     /*!
      * \brief Set channel fsm associated to this acquisition instance
      */
-    inline void set_channel_fsm(std::weak_ptr<ChannelFsm> channel_fsm) override
-    {
-        acquisition_->set_channel_fsm(std::move(channel_fsm));
-    }
-
-    /*!
-     * \brief Set statistics threshold of PCPS algorithm
-     */
-    void set_threshold(float threshold) override;
-
-    /*!
-     * \brief Set Doppler center for the grid search
-     */
-    void set_doppler_center(int doppler_center) override;
+    void set_channel_fsm(std::weak_ptr<ChannelFsm> channel_fsm) override;
 
     /*!
      * \brief Initializes acquisition algorithm.
@@ -119,40 +97,59 @@ public:
     void reset() override;
 
     /*!
-     * \brief If state = 1, it forces the block to start acquiring from the first sample
-     */
-    void set_state(int state) override;
-
-    /*!
      * \brief Stop running acquisition
      */
     void stop_acquisition() override;
 
     /*!
-     * \brief Sets the resampler latency to account it in the acquisition code delay estimation
+     * \brief If state = 1, it forces the block to start acquiring from the first sample
      */
-    void set_resampler_latency(uint32_t latency_samples) override;
+    void set_state(int state) override;
+
+    /*!
+     * \brief Set statistics threshold of PCPS algorithm
+     */
+    void set_threshold(float threshold) override;
+
+    void set_resampler_latency(uint32_t /*latency_samples*/) override {};
 
     /*!
      * \brief Sets local code
      */
     void set_local_code() override;
 
+
+protected:
+    bool is_type_gr_complex() const { return is_type_gr_complex_; }
+
+    const int64_t fs_in_;
+    const unsigned int doppler_max_;
+    const unsigned int doppler_step_;
+    const unsigned int sampled_ms_;
+    const unsigned int ms_per_code_;
+    const unsigned int code_length_;
+    const unsigned int vector_length_;
+    acquisition_impl_interface_sptr acquisition_cc_;
+    Gnss_Synchro* gnss_synchro_;
+    unsigned int channel_;
+
 private:
+    float calculate_threshold(float pfa) const;
+
     /*!
      * \brief Generate code
      */
     virtual void code_gen_complex_sampled(own::span<std::complex<float>> dest, uint32_t prn, int32_t sampling_freq) = 0;
 
-    const Acq_Conf acq_parameters_;
-    gr::blocks::float_to_complex::sptr float_to_complex_;
-    complex_byte_to_float_x2_sptr cbyte_to_float_x2_;
-    Gnss_Synchro* gnss_synchro_;
-    const std::string role_;
-    const unsigned int vector_length_;
-    const unsigned int code_length_;
     volk_gnsssdr::vector<std::complex<float>> code_;
-    pcps_acquisition_sptr acquisition_;
+    gr::blocks::stream_to_vector::sptr stream_to_vector_;
+    const std::string item_type_;
+    const std::string role_;
+    const bool is_type_gr_complex_;
+    const size_t item_size_;
+    const float pfa_;
+    const bool use_stream_to_vector_;
+    const bool compute_threshold_from_pfa_;
 };
 
 

--- a/src/algorithms/acquisition/adapters/beidou_b1i_pcps_acquisition.h
+++ b/src/algorithms/acquisition/adapters/beidou_b1i_pcps_acquisition.h
@@ -27,9 +27,6 @@
 /** \addtogroup Acq_adapters
  * \{ */
 
-
-class ConfigurationInterface;
-
 /*!
  * \brief This class adapts a PCPS acquisition block to an AcquisitionInterface
  *  for GPS L1 C/A signals

--- a/src/algorithms/acquisition/adapters/beidou_b3i_pcps_acquisition.h
+++ b/src/algorithms/acquisition/adapters/beidou_b3i_pcps_acquisition.h
@@ -25,9 +25,6 @@
 /** \addtogroup Acq_adapters
  * \{ */
 
-
-class ConfigurationInterface;
-
 /*!
  * \brief This class adapts a PCPS acquisition block to an AcquisitionInterface
  *  for BeiDou B3I signals

--- a/src/algorithms/acquisition/adapters/galileo_e1_pcps_8ms_ambiguous_acquisition.cc
+++ b/src/algorithms/acquisition/adapters/galileo_e1_pcps_8ms_ambiguous_acquisition.cc
@@ -17,11 +17,9 @@
 
 #include "galileo_e1_pcps_8ms_ambiguous_acquisition.h"
 #include "Galileo_E1.h"
-#include "configuration_interface.h"
 #include "galileo_e1_signal_replica.h"
-#include "gnss_sdr_flags.h"
+#include "galileo_pcps_8ms_acquisition_cc.h"
 #include <boost/math/distributions/exponential.hpp>
-#include <algorithm>
 
 #if USE_GLOG_AND_GFLAGS
 #include <glog/logging.h>
@@ -29,248 +27,67 @@
 #include <absl/log/log.h>
 #endif
 
-#if HAS_STD_SPAN
-#include <span>
-namespace own = std;
-#else
-#include <gsl-lite/gsl-lite.hpp>
-namespace own = gsl_lite;
-#endif
+namespace
+{
+unsigned int get_sampled_ms(const ConfigurationInterface* configuration, const std::string& role)
+{
+    unsigned int sampled_ms = configuration->property(role + ".coherent_integration_time_ms", GALILEO_E1_CODE_PERIOD_MS);
+
+    if (sampled_ms % GALILEO_E1_CODE_PERIOD_MS != 0)
+        {
+            sampled_ms = static_cast<int>(sampled_ms / GALILEO_E1_CODE_PERIOD_MS) * GALILEO_E1_CODE_PERIOD_MS;
+            LOG(WARNING) << "coherent_integration_time should be multiple of "
+                         << "Galileo code length (" << GALILEO_E1_CODE_PERIOD_MS << " ms). coherent_integration_time = "
+                         << sampled_ms << " ms will be used.";
+        }
+
+    return sampled_ms;
+}
+}  // namespace
+
 
 GalileoE1Pcps8msAmbiguousAcquisition::GalileoE1Pcps8msAmbiguousAcquisition(
     const ConfigurationInterface* configuration,
     const std::string& role,
     unsigned int in_streams,
     unsigned int out_streams)
-    : configuration_(configuration),
-      gnss_synchro_(nullptr),
-      role_(role),
-      item_size_(sizeof(gr_complex)),
-      threshold_(0.0),
-      channel_(0),
-      doppler_max_(configuration_->property(role + ".doppler_max", 5000)),
-      doppler_step_(configuration_->property(role + ".doppler_step", 500)),
-      sampled_ms_(configuration_->property(role + ".coherent_integration_time_ms", 4)),
-      dump_(configuration_->property(role + ".dump", false)),
-      cboc_(configuration_->property(role + ".cboc", false))
+    : BasePcpsAcquisitionCustom(
+          configuration,
+          role,
+          in_streams,
+          out_streams,
+          get_sampled_ms(configuration, role),
+          GALILEO_E1_CODE_CHIP_RATE_CPS,
+          GALILEO_E1_B_CODE_LENGTH_CHIPS,
+          GALILEO_E1_CODE_PERIOD_MS,
+          true,
+          true),
+      cboc_(configuration->property(role + ".cboc", false))
 {
-    const std::string default_item_type("gr_complex");
-    const std::string default_dump_filename("./acquisition.dat");
-    item_type_ = configuration_->property(role_ + ".item_type", default_item_type);
-    int64_t fs_in_deprecated = configuration_->property("GNSS-SDR.internal_fs_hz", 4000000);
-    fs_in_ = configuration_->property("GNSS-SDR.internal_fs_sps", fs_in_deprecated);
-    dump_filename_ = configuration_->property(role_ + ".dump_filename", default_dump_filename);
-
-#if USE_GLOG_AND_GFLAGS
-    if (FLAGS_doppler_max != 0)
+    if (is_type_gr_complex())
         {
-            doppler_max_ = FLAGS_doppler_max;
-        }
-    if (FLAGS_doppler_step != 0)
-        {
-            doppler_step_ = static_cast<uint32_t>(FLAGS_doppler_step);
-        }
-#else
-    if (absl::GetFlag(FLAGS_doppler_max) != 0)
-        {
-            doppler_max_ = absl::GetFlag(FLAGS_doppler_max);
-        }
-    if (absl::GetFlag(FLAGS_doppler_step) != 0)
-        {
-            doppler_step_ = static_cast<uint32_t>(absl::GetFlag(FLAGS_doppler_step));
-        }
-#endif
+            const auto samples_per_ms = static_cast<int>(code_length_) / GALILEO_E1_CODE_PERIOD_MS;
+            const std::string default_dump_filename("./acquisition.dat");
+            const auto dump_filename = configuration->property(role + ".dump_filename", default_dump_filename);
+            const auto enable_monitor_output = configuration->property("AcquisitionMonitor.enable_monitor", false);
+            const auto dump = configuration->property(role + ".dump", false);
+            const auto max_dwells = configuration->property(role + ".max_dwells", 1U);
 
-    if (sampled_ms_ % 4 != 0)
-        {
-            sampled_ms_ = static_cast<int>(sampled_ms_ / 4) * 4;
-            LOG(WARNING) << "coherent_integration_time should be multiple of "
-                         << "Galileo code length (4 ms). coherent_integration_time = "
-                         << sampled_ms_ << " ms will be used.";
-        }
-
-    // -- Find number of samples per spreading code (4 ms)  -----------------
-    code_length_ = static_cast<unsigned int>(round(
-        fs_in_ / (GALILEO_E1_CODE_CHIP_RATE_CPS / GALILEO_E1_B_CODE_LENGTH_CHIPS)));
-
-    vector_length_ = code_length_ * static_cast<int>(sampled_ms_ / 4);
-
-    auto samples_per_ms = static_cast<int>(code_length_) / 4;
-
-    code_ = std::vector<std::complex<float>>(vector_length_);
-
-    bool enable_monitor_output = configuration->property("AcquisitionMonitor.enable_monitor", false);
-
-    DLOG(INFO) << "role " << role_;
-    if (item_type_ == "gr_complex")
-        {
-            unsigned int max_dwells = configuration_->property(role + ".max_dwells", 1);
             acquisition_cc_ = galileo_pcps_8ms_make_acquisition_cc(sampled_ms_, max_dwells,
                 doppler_max_, doppler_step_, fs_in_, samples_per_ms, code_length_,
-                dump_, dump_filename_, enable_monitor_output);
-            stream_to_vector_ = gr::blocks::stream_to_vector::make(item_size_, vector_length_);
-            DLOG(INFO) << "stream_to_vector("
-                       << stream_to_vector_->unique_id() << ")";
-            DLOG(INFO) << "acquisition(" << acquisition_cc_->unique_id()
-                       << ")";
-        }
-    else
-        {
-            item_size_ = 0;
-            acquisition_cc_ = nullptr;
-            stream_to_vector_ = nullptr;
-            LOG(WARNING) << item_type_ << " unknown acquisition item type";
-        }
+                dump, dump_filename, enable_monitor_output);
 
-    if (in_streams > 1)
-        {
-            LOG(ERROR) << "This implementation only supports one input stream";
-        }
-    if (out_streams > 0)
-        {
-            LOG(ERROR) << "This implementation does not provide an output stream";
+            DLOG(INFO) << "acquisition(" << acquisition_cc_->unique_id() << ")";
         }
 }
 
 
-void GalileoE1Pcps8msAmbiguousAcquisition::stop_acquisition()
+void GalileoE1Pcps8msAmbiguousAcquisition::code_gen_complex_sampled(own::span<std::complex<float>> dest, uint32_t prn, int32_t sampling_freq)
 {
-    acquisition_cc_->set_active(false);
-}
+    std::array<char, 3> Signal_{};
+    Signal_[0] = gnss_synchro_->Signal[0];
+    Signal_[1] = gnss_synchro_->Signal[1];
+    Signal_[2] = '\0';
 
-
-void GalileoE1Pcps8msAmbiguousAcquisition::set_threshold(float threshold)
-{
-    float pfa = configuration_->property(role_ + std::to_string(channel_) + ".pfa", static_cast<float>(0.0));
-
-    if (pfa == 0.0)
-        {
-            pfa = configuration_->property(role_ + ".pfa", static_cast<float>(0.0));
-        }
-
-    if (pfa == 0.0)
-        {
-            threshold_ = threshold;
-        }
-    else
-        {
-            threshold_ = calculate_threshold(pfa);
-        }
-
-    DLOG(INFO) << "Channel " << channel_ << " Threshold = " << threshold_;
-
-    if (item_type_ == "gr_complex")
-        {
-            acquisition_cc_->set_threshold(threshold_);
-        }
-}
-
-
-void GalileoE1Pcps8msAmbiguousAcquisition::set_gnss_synchro(
-    Gnss_Synchro* gnss_synchro)
-{
-    gnss_synchro_ = gnss_synchro;
-    if (item_type_ == "gr_complex")
-        {
-            acquisition_cc_->set_gnss_synchro(gnss_synchro_);
-        }
-}
-
-
-signed int GalileoE1Pcps8msAmbiguousAcquisition::mag()
-{
-    if (item_type_ == "gr_complex")
-        {
-            return acquisition_cc_->mag();
-        }
-    return 0;
-}
-
-
-void GalileoE1Pcps8msAmbiguousAcquisition::init()
-{
-    acquisition_cc_->init();
-}
-
-
-void GalileoE1Pcps8msAmbiguousAcquisition::set_local_code()
-{
-    if (item_type_ == "gr_complex")
-        {
-            std::vector<std::complex<float>> code(code_length_);
-            std::array<char, 3> Signal_{};
-            Signal_[0] = gnss_synchro_->Signal[0];
-            Signal_[1] = gnss_synchro_->Signal[1];
-            Signal_[2] = '\0';
-
-            galileo_e1_code_gen_complex_sampled(code, Signal_, cboc_, gnss_synchro_->PRN, fs_in_, 0, false);
-
-            own::span<gr_complex> code_span(code_.data(), vector_length_);
-            for (unsigned int i = 0; i < sampled_ms_ / 4; i++)
-                {
-                    std::copy_n(code.data(), code_length_, code_span.subspan(i * code_length_, code_length_).data());
-                }
-
-            acquisition_cc_->set_local_code(code_.data());
-        }
-}
-
-
-void GalileoE1Pcps8msAmbiguousAcquisition::reset()
-{
-    if (item_type_ == "gr_complex")
-        {
-            acquisition_cc_->set_active(true);
-        }
-}
-
-
-float GalileoE1Pcps8msAmbiguousAcquisition::calculate_threshold(float pfa) const
-{
-    unsigned int frequency_bins = 0;
-    for (int doppler = static_cast<int>(-doppler_max_); doppler <= static_cast<int>(doppler_max_); doppler += static_cast<int>(doppler_step_))
-        {
-            frequency_bins++;
-        }
-
-    DLOG(INFO) << "Channel " << channel_ << "  Pfa = " << pfa;
-
-    unsigned int ncells = vector_length_ * frequency_bins;
-    double exponent = 1 / static_cast<double>(ncells);
-    double val = pow(1.0 - pfa, exponent);
-    auto lambda = static_cast<double>(vector_length_);
-    boost::math::exponential_distribution<double> mydist(lambda);
-    auto threshold = static_cast<float>(quantile(mydist, val));
-
-    return threshold;
-}
-
-
-void GalileoE1Pcps8msAmbiguousAcquisition::connect(gr::top_block_sptr top_block)
-{
-    if (item_type_ == "gr_complex")
-        {
-            top_block->connect(stream_to_vector_, 0, acquisition_cc_, 0);
-        }
-}
-
-
-void GalileoE1Pcps8msAmbiguousAcquisition::disconnect(gr::top_block_sptr top_block)
-{
-    if (item_type_ == "gr_complex")
-        {
-            top_block->disconnect(stream_to_vector_, 0, acquisition_cc_, 0);
-        }
-}
-
-
-gr::basic_block_sptr GalileoE1Pcps8msAmbiguousAcquisition::get_left_block()
-{
-    return stream_to_vector_;
-}
-
-
-gr::basic_block_sptr GalileoE1Pcps8msAmbiguousAcquisition::get_right_block()
-{
-    return acquisition_cc_;
+    galileo_e1_code_gen_complex_sampled(dest, Signal_, cboc_, prn, sampling_freq, 0, false);
 }

--- a/src/algorithms/acquisition/adapters/galileo_e1_pcps_8ms_ambiguous_acquisition.cc
+++ b/src/algorithms/acquisition/adapters/galileo_e1_pcps_8ms_ambiguous_acquisition.cc
@@ -27,24 +27,6 @@
 #include <absl/log/log.h>
 #endif
 
-namespace
-{
-unsigned int get_sampled_ms(const ConfigurationInterface* configuration, const std::string& role)
-{
-    unsigned int sampled_ms = configuration->property(role + ".coherent_integration_time_ms", GALILEO_E1_CODE_PERIOD_MS);
-
-    if (sampled_ms % GALILEO_E1_CODE_PERIOD_MS != 0)
-        {
-            sampled_ms = static_cast<int>(sampled_ms / GALILEO_E1_CODE_PERIOD_MS) * GALILEO_E1_CODE_PERIOD_MS;
-            LOG(WARNING) << "coherent_integration_time should be multiple of "
-                         << "Galileo code length (" << GALILEO_E1_CODE_PERIOD_MS << " ms). coherent_integration_time = "
-                         << sampled_ms << " ms will be used.";
-        }
-
-    return sampled_ms;
-}
-}  // namespace
-
 
 GalileoE1Pcps8msAmbiguousAcquisition::GalileoE1Pcps8msAmbiguousAcquisition(
     const ConfigurationInterface* configuration,
@@ -56,7 +38,6 @@ GalileoE1Pcps8msAmbiguousAcquisition::GalileoE1Pcps8msAmbiguousAcquisition(
           role,
           in_streams,
           out_streams,
-          get_sampled_ms(configuration, role),
           GALILEO_E1_CODE_CHIP_RATE_CPS,
           GALILEO_E1_B_CODE_LENGTH_CHIPS,
           GALILEO_E1_CODE_PERIOD_MS,
@@ -67,15 +48,10 @@ GalileoE1Pcps8msAmbiguousAcquisition::GalileoE1Pcps8msAmbiguousAcquisition(
     if (is_type_gr_complex())
         {
             const auto samples_per_ms = static_cast<int>(code_length_) / GALILEO_E1_CODE_PERIOD_MS;
-            const std::string default_dump_filename("./acquisition.dat");
-            const auto dump_filename = configuration->property(role + ".dump_filename", default_dump_filename);
-            const auto enable_monitor_output = configuration->property("AcquisitionMonitor.enable_monitor", false);
-            const auto dump = configuration->property(role + ".dump", false);
-            const auto max_dwells = configuration->property(role + ".max_dwells", 1U);
 
-            acquisition_cc_ = galileo_pcps_8ms_make_acquisition_cc(sampled_ms_, max_dwells,
-                doppler_max_, doppler_step_, fs_in_, samples_per_ms, code_length_,
-                dump, dump_filename, enable_monitor_output);
+            acquisition_cc_ = galileo_pcps_8ms_make_acquisition_cc(acq_parameters_.sampled_ms, acq_parameters_.max_dwells,
+                acq_parameters_.doppler_max, acq_parameters_.doppler_step, acq_parameters_.fs_in, samples_per_ms, code_length_,
+                acq_parameters_.dump, acq_parameters_.dump_filename, acq_parameters_.enable_monitor_output);
 
             DLOG(INFO) << "acquisition(" << acquisition_cc_->unique_id() << ")";
         }

--- a/src/algorithms/acquisition/adapters/galileo_e1_pcps_8ms_ambiguous_acquisition.h
+++ b/src/algorithms/acquisition/adapters/galileo_e1_pcps_8ms_ambiguous_acquisition.h
@@ -18,28 +18,18 @@
 #ifndef GNSS_SDR_GALILEO_E1_PCPS_8MS_AMBIGUOUS_ACQUISITION_H
 #define GNSS_SDR_GALILEO_E1_PCPS_8MS_AMBIGUOUS_ACQUISITION_H
 
-#include "acquisition_interface.h"
-#include "galileo_pcps_8ms_acquisition_cc.h"
-#include "gnss_synchro.h"
-#include <gnuradio/blocks/stream_to_vector.h>
-#include <memory>
-#include <string>
-#include <utility>
-#include <vector>
+#include "base_pcps_acquisition_custom.h"
 
 /** \addtogroup Acquisition
  * \{ */
 /** \addtogroup Acq_adapters
  * \{ */
 
-
-class ConfigurationInterface;
-
 /*!
  * \brief Adapts a PCPS 8ms acquisition block to an
  * AcquisitionInterface for Galileo E1 Signals
  */
-class GalileoE1Pcps8msAmbiguousAcquisition : public AcquisitionInterface
+class GalileoE1Pcps8msAmbiguousAcquisition : public BasePcpsAcquisitionCustom
 {
 public:
     GalileoE1Pcps8msAmbiguousAcquisition(const ConfigurationInterface* configuration,
@@ -49,11 +39,6 @@ public:
 
     ~GalileoE1Pcps8msAmbiguousAcquisition() = default;
 
-    inline std::string role() override
-    {
-        return role_;
-    }
-
     /*!
      * \brief Returns "Galileo_E1_PCPS_8ms_Ambiguous_Acquisition"
      */
@@ -62,98 +47,9 @@ public:
         return "Galileo_E1_PCPS_8ms_Ambiguous_Acquisition";
     }
 
-    inline size_t item_size() override
-    {
-        return item_size_;
-    }
-
-    void connect(gr::top_block_sptr top_block) override;
-    void disconnect(gr::top_block_sptr top_block) override;
-    gr::basic_block_sptr get_left_block() override;
-    gr::basic_block_sptr get_right_block() override;
-
-    /*!
-     * \brief Set acquisition/tracking common Gnss_Synchro object pointer
-     * to efficiently exchange synchronization data between acquisition and
-     *  tracking blocks
-     */
-    void set_gnss_synchro(Gnss_Synchro* p_gnss_synchro) override;
-
-    /*!
-     * \brief Set acquisition channel unique ID
-     */
-    inline void set_channel(unsigned int channel) override
-    {
-        channel_ = channel;
-        acquisition_cc_->set_channel(channel_);
-    }
-
-    /*!
-     * \brief Set channel fsm associated to this acquisition instance
-     */
-    inline void set_channel_fsm(std::weak_ptr<ChannelFsm> channel_fsm) override
-    {
-        channel_fsm_ = std::move(channel_fsm);
-        acquisition_cc_->set_channel_fsm(channel_fsm_);
-    }
-
-    /*!
-     * \brief Set statistics threshold of PCPS algorithm
-     */
-    void set_threshold(float threshold) override;
-
-    /*!
-     * \brief Initializes acquisition algorithm.
-     */
-    void init() override;
-
-    /*!
-     * \brief Sets local code for Galileo E1 PCPS acquisition algorithm.
-     */
-    void set_local_code() override;
-
-    /*!
-     * \brief Returns the maximum peak of grid search
-     */
-    signed int mag() override;
-
-    /*!
-     * \brief Restart acquisition algorithm
-     */
-    void reset() override;
-
-    /*!
-     * \brief Stop running acquisition
-     */
-    void stop_acquisition() override;
-
-    void set_state(int state __attribute__((unused))) override {};
-
-    void set_resampler_latency(uint32_t latency_samples __attribute__((unused))) override {};
-
-
 private:
-    float calculate_threshold(float pfa) const;
+    void code_gen_complex_sampled(own::span<std::complex<float>> dest, uint32_t prn, int32_t sampling_freq) override;
 
-    const ConfigurationInterface* configuration_;
-    galileo_pcps_8ms_acquisition_cc_sptr acquisition_cc_;
-    gr::blocks::stream_to_vector::sptr stream_to_vector_;
-    std::weak_ptr<ChannelFsm> channel_fsm_;
-    std::vector<std::complex<float>> code_;
-    Gnss_Synchro* gnss_synchro_;
-    std::string item_type_;
-    std::string dump_filename_;
-    std::string role_;
-    int64_t fs_in_;
-    size_t item_size_;
-    float threshold_;
-    unsigned int vector_length_;
-    unsigned int code_length_;
-    unsigned int channel_;
-    unsigned int doppler_max_;
-    unsigned int doppler_step_;
-    unsigned int sampled_ms_;
-    bool dump_;
     const bool cboc_;
 };
 

--- a/src/algorithms/acquisition/adapters/galileo_e1_pcps_quicksync_ambiguous_acquisition.cc
+++ b/src/algorithms/acquisition/adapters/galileo_e1_pcps_quicksync_ambiguous_acquisition.cc
@@ -119,6 +119,9 @@ GalileoE1PcpsQuickSyncAmbiguousAcquisition::GalileoE1PcpsQuickSyncAmbiguousAcqui
     // vector_length_ = (sampled_ms_/folding_factor_) * code_length_;
     vector_length_ = sampled_ms_ * samples_per_ms;
 
+    // 8/2 * code_length_
+    // 8 * code_length_ / 4
+
     unsigned int max_dwells = 2;
 
     if (!bit_transition_flag_)

--- a/src/algorithms/acquisition/adapters/galileo_e1_pcps_tong_ambiguous_acquisition.cc
+++ b/src/algorithms/acquisition/adapters/galileo_e1_pcps_tong_ambiguous_acquisition.cc
@@ -27,24 +27,6 @@
 #include <absl/log/log.h>
 #endif
 
-namespace
-{
-unsigned int get_sampled_ms(const ConfigurationInterface* configuration, const std::string& role)
-{
-    unsigned int sampled_ms = configuration->property(role + ".coherent_integration_time_ms", GALILEO_E1_CODE_PERIOD_MS);
-
-    if (sampled_ms % GALILEO_E1_CODE_PERIOD_MS != 0)
-        {
-            sampled_ms = static_cast<int>(sampled_ms / GALILEO_E1_CODE_PERIOD_MS) * GALILEO_E1_CODE_PERIOD_MS;
-            LOG(WARNING) << "coherent_integration_time should be multiple of "
-                         << "Galileo code length (" << GALILEO_E1_CODE_PERIOD_MS << " ms). coherent_integration_time = "
-                         << sampled_ms << " ms will be used.";
-        }
-
-    return sampled_ms;
-}
-}  // namespace
-
 
 GalileoE1PcpsTongAmbiguousAcquisition::GalileoE1PcpsTongAmbiguousAcquisition(
     const ConfigurationInterface* configuration,
@@ -56,7 +38,6 @@ GalileoE1PcpsTongAmbiguousAcquisition::GalileoE1PcpsTongAmbiguousAcquisition(
           role,
           in_streams,
           out_streams,
-          get_sampled_ms(configuration, role),
           GALILEO_E1_CODE_CHIP_RATE_CPS,
           GALILEO_E1_B_CODE_LENGTH_CHIPS,
           GALILEO_E1_CODE_PERIOD_MS,
@@ -67,17 +48,13 @@ GalileoE1PcpsTongAmbiguousAcquisition::GalileoE1PcpsTongAmbiguousAcquisition(
     if (is_type_gr_complex())
         {
             const auto samples_per_ms = static_cast<int>(code_length_) / GALILEO_E1_CODE_PERIOD_MS;
-            const std::string default_dump_filename("./acquisition.dat");
-            const auto dump_filename = configuration->property(role + ".dump_filename", default_dump_filename);
-            const auto enable_monitor_output = configuration->property("AcquisitionMonitor.enable_monitor", false);
-            const auto dump = configuration->property(role + ".dump", false);
             const auto tong_init_val = configuration->property(role + ".tong_init_val", 1U);
             const auto tong_max_val = configuration->property(role + ".tong_max_val", 2U);
             const auto tong_max_dwells = configuration->property(role + ".tong_max_dwells", tong_max_val + 1U);
 
-            acquisition_cc_ = pcps_tong_make_acquisition_cc(sampled_ms_, doppler_max_,
-                doppler_step_, fs_in_, samples_per_ms, code_length_, tong_init_val,
-                tong_max_val, tong_max_dwells, dump, dump_filename, enable_monitor_output);
+            acquisition_cc_ = pcps_tong_make_acquisition_cc(acq_parameters_.sampled_ms, acq_parameters_.doppler_max,
+                acq_parameters_.doppler_step, acq_parameters_.fs_in, samples_per_ms, code_length_, tong_init_val,
+                tong_max_val, tong_max_dwells, acq_parameters_.dump, acq_parameters_.dump_filename, acq_parameters_.enable_monitor_output);
 
             DLOG(INFO) << "acquisition(" << acquisition_cc_->unique_id() << ")";
         }

--- a/src/algorithms/acquisition/adapters/galileo_e1_pcps_tong_ambiguous_acquisition.cc
+++ b/src/algorithms/acquisition/adapters/galileo_e1_pcps_tong_ambiguous_acquisition.cc
@@ -17,11 +17,9 @@
 
 #include "galileo_e1_pcps_tong_ambiguous_acquisition.h"
 #include "Galileo_E1.h"
-#include "configuration_interface.h"
 #include "galileo_e1_signal_replica.h"
-#include "gnss_sdr_flags.h"
+#include "pcps_tong_acquisition_cc.h"
 #include <boost/math/distributions/exponential.hpp>
-#include <algorithm>
 
 #if USE_GLOG_AND_GFLAGS
 #include <glog/logging.h>
@@ -29,259 +27,69 @@
 #include <absl/log/log.h>
 #endif
 
-#if HAS_STD_SPAN
-#include <span>
-namespace own = std;
-#else
-#include <gsl-lite/gsl-lite.hpp>
-namespace own = gsl_lite;
-#endif
+namespace
+{
+unsigned int get_sampled_ms(const ConfigurationInterface* configuration, const std::string& role)
+{
+    unsigned int sampled_ms = configuration->property(role + ".coherent_integration_time_ms", GALILEO_E1_CODE_PERIOD_MS);
+
+    if (sampled_ms % GALILEO_E1_CODE_PERIOD_MS != 0)
+        {
+            sampled_ms = static_cast<int>(sampled_ms / GALILEO_E1_CODE_PERIOD_MS) * GALILEO_E1_CODE_PERIOD_MS;
+            LOG(WARNING) << "coherent_integration_time should be multiple of "
+                         << "Galileo code length (" << GALILEO_E1_CODE_PERIOD_MS << " ms). coherent_integration_time = "
+                         << sampled_ms << " ms will be used.";
+        }
+
+    return sampled_ms;
+}
+}  // namespace
+
 
 GalileoE1PcpsTongAmbiguousAcquisition::GalileoE1PcpsTongAmbiguousAcquisition(
     const ConfigurationInterface* configuration,
     const std::string& role,
     unsigned int in_streams,
     unsigned int out_streams)
-    : configuration_(configuration),
-      gnss_synchro_(nullptr),
-      role_(role),
-      item_size_(sizeof(gr_complex)),
-      threshold_(0.0),
-      channel_(0),
-      doppler_max_(configuration_->property(role + ".doppler_max", 5000)),
-      doppler_step_(configuration_->property(role + ".doppler_step", 500)),
-      sampled_ms_(configuration_->property(role + ".coherent_integration_time_ms", 4)),
-      tong_init_val_(configuration->property(role + ".tong_init_val", 1)),
-      tong_max_val_(configuration->property(role + ".tong_max_val", 2)),
-      tong_max_dwells_(configuration->property(role + ".tong_max_dwells", tong_max_val_ + 1)),
-      dump_(configuration_->property(role + ".dump", false)),
-      cboc_(configuration_->property(role + ".cboc", false))
+    : BasePcpsAcquisitionCustom(
+          configuration,
+          role,
+          in_streams,
+          out_streams,
+          get_sampled_ms(configuration, role),
+          GALILEO_E1_CODE_CHIP_RATE_CPS,
+          GALILEO_E1_B_CODE_LENGTH_CHIPS,
+          GALILEO_E1_CODE_PERIOD_MS,
+          true,
+          true),
+      cboc_(configuration->property(role + ".cboc", false))
 {
-    const std::string default_item_type("gr_complex");
-    const std::string default_dump_filename("./acquisition.dat");
-
-    DLOG(INFO) << "role " << role_;
-
-    item_type_ = configuration_->property(role_ + ".item_type", default_item_type);
-    int64_t fs_in_deprecated = configuration_->property("GNSS-SDR.internal_fs_hz", 4000000);
-    fs_in_ = configuration_->property("GNSS-SDR.internal_fs_sps", fs_in_deprecated);
-    dump_filename_ = configuration_->property(role_ + ".dump_filename", default_dump_filename);
-
-    if (sampled_ms_ % 4 != 0)
+    if (is_type_gr_complex())
         {
-            sampled_ms_ = static_cast<int>(sampled_ms_ / 4) * 4;
-            LOG(WARNING) << "coherent_integration_time should be multiple of "
-                         << "Galileo code length (4 ms). coherent_integration_time = "
-                         << sampled_ms_ << " ms will be used.";
-        }
+            const auto samples_per_ms = static_cast<int>(code_length_) / GALILEO_E1_CODE_PERIOD_MS;
+            const std::string default_dump_filename("./acquisition.dat");
+            const auto dump_filename = configuration->property(role + ".dump_filename", default_dump_filename);
+            const auto enable_monitor_output = configuration->property("AcquisitionMonitor.enable_monitor", false);
+            const auto dump = configuration->property(role + ".dump", false);
+            const auto tong_init_val = configuration->property(role + ".tong_init_val", 1U);
+            const auto tong_max_val = configuration->property(role + ".tong_max_val", 2U);
+            const auto tong_max_dwells = configuration->property(role + ".tong_max_dwells", tong_max_val + 1U);
 
-#if USE_GLOG_AND_GFLAGS
-    if (FLAGS_doppler_max != 0)
-        {
-            doppler_max_ = FLAGS_doppler_max;
-        }
-    if (FLAGS_doppler_step != 0)
-        {
-            doppler_step_ = static_cast<uint32_t>(FLAGS_doppler_step);
-        }
-#else
-    if (absl::GetFlag(FLAGS_doppler_max) != 0)
-        {
-            doppler_max_ = absl::GetFlag(FLAGS_doppler_max);
-        }
-    if (absl::GetFlag(FLAGS_doppler_step) != 0)
-        {
-            doppler_step_ = static_cast<uint32_t>(absl::GetFlag(FLAGS_doppler_step));
-        }
-#endif
-
-    bool enable_monitor_output = configuration_->property("AcquisitionMonitor.enable_monitor", false);
-
-    // -- Find number of samples per spreading code (4 ms)  -----------------
-
-    code_length_ = static_cast<unsigned int>(round(
-        fs_in_ / (GALILEO_E1_CODE_CHIP_RATE_CPS / GALILEO_E1_B_CODE_LENGTH_CHIPS)));
-
-    vector_length_ = code_length_ * static_cast<int>(sampled_ms_ / 4);
-
-    auto samples_per_ms = static_cast<int>(code_length_) / 4;
-
-    code_ = std::vector<std::complex<float>>(vector_length_);
-
-    if (item_type_ == "gr_complex")
-        {
             acquisition_cc_ = pcps_tong_make_acquisition_cc(sampled_ms_, doppler_max_,
-                doppler_step_, fs_in_, samples_per_ms, code_length_, tong_init_val_,
-                tong_max_val_, tong_max_dwells_, dump_, dump_filename_, enable_monitor_output);
+                doppler_step_, fs_in_, samples_per_ms, code_length_, tong_init_val,
+                tong_max_val, tong_max_dwells, dump, dump_filename, enable_monitor_output);
 
-            stream_to_vector_ = gr::blocks::stream_to_vector::make(item_size_, vector_length_);
-            DLOG(INFO) << "stream_to_vector("
-                       << stream_to_vector_->unique_id() << ")";
-            DLOG(INFO) << "acquisition(" << acquisition_cc_->unique_id()
-                       << ")";
-        }
-    else
-        {
-            item_size_ = 0;
-            acquisition_cc_ = nullptr;
-            LOG(WARNING) << item_type_ << " unknown acquisition item type";
-        }
-
-    if (in_streams > 1)
-        {
-            LOG(ERROR) << "This implementation only supports one input stream";
-        }
-    if (out_streams > 0)
-        {
-            LOG(ERROR) << "This implementation does not provide an output stream";
+            DLOG(INFO) << "acquisition(" << acquisition_cc_->unique_id() << ")";
         }
 }
 
 
-void GalileoE1PcpsTongAmbiguousAcquisition::stop_acquisition()
+void GalileoE1PcpsTongAmbiguousAcquisition::code_gen_complex_sampled(own::span<std::complex<float>> dest, uint32_t prn, int32_t sampling_freq)
 {
-    acquisition_cc_->set_state(0);
-    acquisition_cc_->set_active(false);
-}
+    std::array<char, 3> Signal_{};
+    Signal_[0] = gnss_synchro_->Signal[0];
+    Signal_[1] = gnss_synchro_->Signal[1];
+    Signal_[2] = '\0';
 
-
-void GalileoE1PcpsTongAmbiguousAcquisition::set_threshold(float threshold)
-{
-    float pfa = configuration_->property(role_ + std::to_string(channel_) + ".pfa", static_cast<float>(0.0));
-
-    if (pfa == 0.0)
-        {
-            pfa = configuration_->property(role_ + ".pfa", static_cast<float>(0.0));
-        }
-
-    if (pfa == 0.0)
-        {
-            threshold_ = threshold;
-        }
-    else
-        {
-            threshold_ = calculate_threshold(pfa);
-        }
-
-    DLOG(INFO) << "Channel " << channel_ << " Threshold = " << threshold_;
-
-    if (item_type_ == "gr_complex")
-        {
-            acquisition_cc_->set_threshold(threshold_);
-        }
-}
-
-
-void GalileoE1PcpsTongAmbiguousAcquisition::set_gnss_synchro(
-    Gnss_Synchro* gnss_synchro)
-{
-    gnss_synchro_ = gnss_synchro;
-    if (item_type_ == "gr_complex")
-        {
-            acquisition_cc_->set_gnss_synchro(gnss_synchro_);
-        }
-}
-
-
-signed int GalileoE1PcpsTongAmbiguousAcquisition::mag()
-{
-    if (item_type_ == "gr_complex")
-        {
-            return acquisition_cc_->mag();
-        }
-    return 0;
-}
-
-
-void GalileoE1PcpsTongAmbiguousAcquisition::init()
-{
-    acquisition_cc_->init();
-}
-
-
-void GalileoE1PcpsTongAmbiguousAcquisition::set_local_code()
-{
-    if (item_type_ == "gr_complex")
-        {
-            std::vector<std::complex<float>> code(code_length_);
-            std::array<char, 3> Signal_{};
-            Signal_[0] = gnss_synchro_->Signal[0];
-            Signal_[1] = gnss_synchro_->Signal[1];
-            Signal_[2] = '\0';
-            galileo_e1_code_gen_complex_sampled(code, Signal_, cboc_, gnss_synchro_->PRN, fs_in_, 0, false);
-
-            own::span<gr_complex> code_span(code_.data(), vector_length_);
-            for (unsigned int i = 0; i < sampled_ms_ / 4; i++)
-                {
-                    std::copy_n(code.data(), code_length_, code_span.subspan(i * code_length_, code_length_).data());
-                }
-
-            acquisition_cc_->set_local_code(code_.data());
-        }
-}
-
-
-void GalileoE1PcpsTongAmbiguousAcquisition::reset()
-{
-    if (item_type_ == "gr_complex")
-        {
-            acquisition_cc_->set_active(true);
-        }
-}
-
-
-void GalileoE1PcpsTongAmbiguousAcquisition::set_state(int state)
-{
-    acquisition_cc_->set_state(state);
-}
-
-
-float GalileoE1PcpsTongAmbiguousAcquisition::calculate_threshold(float pfa) const
-{
-    unsigned int frequency_bins = 0;
-    for (int doppler = static_cast<int>(-doppler_max_); doppler <= static_cast<int>(doppler_max_); doppler += static_cast<int>(doppler_step_))
-        {
-            frequency_bins++;
-        }
-
-    DLOG(INFO) << "Channel " << channel_ << "  Pfa = " << pfa;
-
-    unsigned int ncells = vector_length_ * frequency_bins;
-    double exponent = 1 / static_cast<double>(ncells);
-    double val = pow(1.0 - pfa, exponent);
-    auto lambda = static_cast<double>(vector_length_);
-    boost::math::exponential_distribution<double> mydist(lambda);
-    auto threshold = static_cast<float>(quantile(mydist, val));
-
-    return threshold;
-}
-
-
-void GalileoE1PcpsTongAmbiguousAcquisition::connect(gr::top_block_sptr top_block)
-{
-    if (item_type_ == "gr_complex")
-        {
-            top_block->connect(stream_to_vector_, 0, acquisition_cc_, 0);
-        }
-}
-
-
-void GalileoE1PcpsTongAmbiguousAcquisition::disconnect(gr::top_block_sptr top_block)
-{
-    if (item_type_ == "gr_complex")
-        {
-            top_block->disconnect(stream_to_vector_, 0, acquisition_cc_, 0);
-        }
-}
-
-
-gr::basic_block_sptr GalileoE1PcpsTongAmbiguousAcquisition::get_left_block()
-{
-    return stream_to_vector_;
-}
-
-
-gr::basic_block_sptr GalileoE1PcpsTongAmbiguousAcquisition::get_right_block()
-{
-    return acquisition_cc_;
+    galileo_e1_code_gen_complex_sampled(dest, Signal_, cboc_, prn, sampling_freq, 0, false);
 }

--- a/src/algorithms/acquisition/adapters/galileo_e1_pcps_tong_ambiguous_acquisition.h
+++ b/src/algorithms/acquisition/adapters/galileo_e1_pcps_tong_ambiguous_acquisition.h
@@ -18,28 +18,18 @@
 #ifndef GNSS_SDR_GALILEO_E1_PCPS_TONG_AMBIGUOUS_ACQUISITION_H
 #define GNSS_SDR_GALILEO_E1_PCPS_TONG_AMBIGUOUS_ACQUISITION_H
 
-#include "channel_fsm.h"
-#include "gnss_synchro.h"
-#include "pcps_tong_acquisition_cc.h"
-#include <gnuradio/blocks/stream_to_vector.h>
-#include <memory>
-#include <string>
-#include <utility>
-#include <vector>
+#include "base_pcps_acquisition_custom.h"
 
 /** \addtogroup Acquisition
  * \{ */
 /** \addtogroup Acq_adapters
  * \{ */
 
-
-class ConfigurationInterface;
-
 /*!
  * \brief Adapts a PCPS Tong acquisition block to an AcquisitionInterface
  *  for Galileo E1 Signals
  */
-class GalileoE1PcpsTongAmbiguousAcquisition : public AcquisitionInterface
+class GalileoE1PcpsTongAmbiguousAcquisition : public BasePcpsAcquisitionCustom
 {
 public:
     GalileoE1PcpsTongAmbiguousAcquisition(
@@ -50,11 +40,6 @@ public:
 
     ~GalileoE1PcpsTongAmbiguousAcquisition() = default;
 
-    inline std::string role() override
-    {
-        return role_;
-    }
-
     /*!
      * \brief Returns "Galileo_E1_PCPS_Tong_Ambiguous_Acquisition"
      */
@@ -63,102 +48,9 @@ public:
         return "Galileo_E1_PCPS_Tong_Ambiguous_Acquisition";
     }
 
-    inline size_t item_size() override
-    {
-        return item_size_;
-    }
-
-    void connect(gr::top_block_sptr top_block) override;
-    void disconnect(gr::top_block_sptr top_block) override;
-    gr::basic_block_sptr get_left_block() override;
-    gr::basic_block_sptr get_right_block() override;
-
-    /*!
-     * \brief Set acquisition/tracking common Gnss_Synchro object pointer
-     * to efficiently exchange synchronization data between acquisition and
-     *  tracking blocks
-     */
-    void set_gnss_synchro(Gnss_Synchro* p_gnss_synchro) override;
-
-    /*!
-     * \brief Set acquisition channel unique ID
-     */
-    inline void set_channel(unsigned int channel) override
-    {
-        channel_ = channel;
-        acquisition_cc_->set_channel(channel_);
-    }
-
-    /*!
-     * \brief Set channel fsm associated to this acquisition instance
-     */
-    inline void set_channel_fsm(std::weak_ptr<ChannelFsm> channel_fsm) override
-    {
-        channel_fsm_ = std::move(channel_fsm);
-        acquisition_cc_->set_channel_fsm(channel_fsm_);
-    }
-
-    /*!
-     * \brief Set statistics threshold of TONG algorithm
-     */
-    void set_threshold(float threshold) override;
-
-    /*!
-     * \brief Initializes acquisition algorithm.
-     */
-    void init() override;
-
-    /*!
-     * \brief Sets local code for Galileo E1 TONG acquisition algorithm.
-     */
-    void set_local_code() override;
-
-    /*!
-     * \brief Returns the maximum peak of grid search
-     */
-    signed int mag() override;
-
-    /*!
-     * \brief Restart acquisition algorithm
-     */
-    void reset() override;
-
-    /*!
-     * \brief If state = 1, it forces the block to start acquiring from the first sample
-     */
-    void set_state(int state) override;
-
-    /*!
-     * \brief Stop running acquisition
-     */
-    void stop_acquisition() override;
-
-    void set_resampler_latency(uint32_t latency_samples __attribute__((unused))) override {};
-
 private:
-    float calculate_threshold(float pfa) const;
-    const ConfigurationInterface* configuration_;
-    pcps_tong_acquisition_cc_sptr acquisition_cc_;
-    gr::blocks::stream_to_vector::sptr stream_to_vector_;
-    std::weak_ptr<ChannelFsm> channel_fsm_;
-    std::vector<std::complex<float>> code_;
-    Gnss_Synchro* gnss_synchro_;
-    std::string item_type_;
-    std::string dump_filename_;
-    std::string role_;
-    int64_t fs_in_;
-    size_t item_size_;
-    float threshold_;
-    unsigned int vector_length_;
-    unsigned int code_length_;
-    unsigned int channel_;
-    unsigned int doppler_max_;
-    unsigned int doppler_step_;
-    unsigned int sampled_ms_;
-    unsigned int tong_init_val_;
-    unsigned int tong_max_val_;
-    unsigned int tong_max_dwells_;
-    bool dump_;
+    void code_gen_complex_sampled(own::span<std::complex<float>> dest, uint32_t prn, int32_t sampling_freq) override;
+
     const bool cboc_;
 };
 

--- a/src/algorithms/acquisition/adapters/galileo_e5b_pcps_acquisition.h
+++ b/src/algorithms/acquisition/adapters/galileo_e5b_pcps_acquisition.h
@@ -27,9 +27,6 @@
 /** \addtogroup Acq_adapters
  * \{ */
 
-
-class ConfigurationInterface;
-
 class GalileoE5bPcpsAcquisition : public BasePcpsAcquisition
 {
 public:

--- a/src/algorithms/acquisition/adapters/glonass_l1_ca_pcps_acquisition.h
+++ b/src/algorithms/acquisition/adapters/glonass_l1_ca_pcps_acquisition.h
@@ -27,9 +27,6 @@
 /** \addtogroup Acq_adapters
  * \{ */
 
-
-class ConfigurationInterface;
-
 /*!
  * \brief This class adapts a PCPS acquisition block to an AcquisitionInterface
  *  for GPS L1 C/A signals

--- a/src/algorithms/acquisition/adapters/glonass_l2_ca_pcps_acquisition.h
+++ b/src/algorithms/acquisition/adapters/glonass_l2_ca_pcps_acquisition.h
@@ -26,9 +26,6 @@
 /** \addtogroup Acq_adapters
  * \{ */
 
-
-class ConfigurationInterface;
-
 /*!
  * \brief This class adapts a PCPS acquisition block to an AcquisitionInterface
  *  for GLONASS L2 C/A signals

--- a/src/algorithms/acquisition/adapters/gps_l1_ca_pcps_acquisition.h
+++ b/src/algorithms/acquisition/adapters/gps_l1_ca_pcps_acquisition.h
@@ -31,9 +31,6 @@
  * Wrap GNU Radio acquisition blocks with an AcquisitionInterface
  * \{ */
 
-
-class ConfigurationInterface;
-
 /*!
  * \brief This class adapts a PCPS acquisition block to an AcquisitionInterface
  *  for GPS L1 C/A signals

--- a/src/algorithms/acquisition/adapters/gps_l1_ca_pcps_acquisition_fine_doppler.cc
+++ b/src/algorithms/acquisition/adapters/gps_l1_ca_pcps_acquisition_fine_doppler.cc
@@ -21,9 +21,8 @@
 #include "gps_l1_ca_pcps_acquisition_fine_doppler.h"
 #include "GPS_L1_CA.h"
 #include "acq_conf.h"
-#include "configuration_interface.h"
-#include "gnss_sdr_flags.h"
 #include "gps_sdr_signal_replica.h"
+#include "pcps_acquisition_fine_doppler_cc.h"
 
 #if USE_GLOG_AND_GFLAGS
 #include <glog/logging.h>
@@ -36,158 +35,42 @@ GpsL1CaPcpsAcquisitionFineDoppler::GpsL1CaPcpsAcquisitionFineDoppler(
     const std::string& role,
     unsigned int in_streams,
     unsigned int out_streams)
-    : role_(role),
-      gnss_synchro_(nullptr),
-      item_size_(sizeof(gr_complex)),
-      threshold_(0.0),
-      doppler_max_(configuration->property(role + ".doppler_max", 5000)),
-      channel_(0),
-      doppler_step_(configuration->property(role + ".doppler_step", 500)),
-      sampled_ms_(configuration->property(role + ".coherent_integration_time_ms", 1)),
-      dump_(configuration->property(role + ".dump", false))
+    : BasePcpsAcquisitionCustom(
+          configuration,
+          role,
+          in_streams,
+          out_streams,
+          configuration->property(role + ".coherent_integration_time_ms", GPS_L1_CA_CODE_PERIOD_MS),
+          GPS_L1_CA_CODE_RATE_CPS,
+          GPS_L1_CA_CODE_LENGTH_CHIPS,
+          GPS_L1_CA_CODE_PERIOD_MS,
+          false,
+          false)
 {
-    const std::string default_item_type("gr_complex");
-    std::string default_dump_filename = "./acquisition.mat";
-    Acq_Conf acq_parameters = Acq_Conf();
+    if (is_type_gr_complex())
+        {
+            const std::string default_dump_filename = "./acquisition.mat";
 
-    item_type_ = configuration->property(role_ + ".item_type", default_item_type);
-    int64_t fs_in_deprecated = configuration->property("GNSS-SDR.internal_fs_hz", 2048000);
-    fs_in_ = configuration->property("GNSS-SDR.internal_fs_sps", fs_in_deprecated);
-    acq_parameters.fs_in = fs_in_;
-    acq_parameters.samples_per_chip = static_cast<unsigned int>(ceil(GPS_L1_CA_CHIP_PERIOD_S * static_cast<float>(acq_parameters.fs_in)));
-    acq_parameters.dump = dump_;
-    dump_filename_ = configuration->property(role_ + ".dump_filename", std::move(default_dump_filename));
-    acq_parameters.dump_filename = dump_filename_;
-#if USE_GLOG_AND_GFLAGS
-    if (FLAGS_doppler_max != 0)
-        {
-            doppler_max_ = FLAGS_doppler_max;
-        }
-    if (FLAGS_doppler_step != 0)
-        {
-            doppler_step_ = static_cast<uint32_t>(FLAGS_doppler_step);
-        }
-#else
-    if (absl::GetFlag(FLAGS_doppler_max) != 0)
-        {
-            doppler_max_ = absl::GetFlag(FLAGS_doppler_max);
-        }
-    if (absl::GetFlag(FLAGS_doppler_step) != 0)
-        {
-            doppler_step_ = static_cast<uint32_t>(absl::GetFlag(FLAGS_doppler_step));
-        }
-#endif
-    acq_parameters.doppler_max = doppler_max_;
-    acq_parameters.doppler_step = doppler_step_;
-    acq_parameters.sampled_ms = sampled_ms_;
-    acq_parameters.max_dwells = configuration->property(role + ".max_dwells", 1);
-    acq_parameters.blocking_on_standby = configuration->property(role + ".blocking_on_standby", false);
+            Acq_Conf acq_parameters = Acq_Conf();
+            acq_parameters.fs_in = fs_in_;
+            acq_parameters.samples_per_chip = static_cast<unsigned int>(ceil(GPS_L1_CA_CHIP_PERIOD_S * static_cast<float>(fs_in_)));
+            acq_parameters.dump = configuration->property(role + ".dump", false);
+            acq_parameters.dump_filename = configuration->property(role + ".dump_filename", default_dump_filename);
+            acq_parameters.doppler_max = doppler_max_;
+            acq_parameters.doppler_step = doppler_step_;
+            acq_parameters.sampled_ms = sampled_ms_;
+            acq_parameters.max_dwells = configuration->property(role + ".max_dwells", 1);
+            acq_parameters.blocking_on_standby = configuration->property(role + ".blocking_on_standby", false);
+            acq_parameters.samples_per_ms = static_cast<float>(vector_length_);
 
-    // -- Find number of samples per spreading code -------------------------
-    vector_length_ = static_cast<unsigned int>(round(fs_in_ / (GPS_L1_CA_CODE_RATE_CPS / GPS_L1_CA_CODE_LENGTH_CHIPS)));
-    acq_parameters.samples_per_ms = static_cast<float>(vector_length_);
-    code_ = std::vector<std::complex<float>>(vector_length_);
-
-    DLOG(INFO) << "role " << role_;
-    if (item_type_ == "gr_complex")
-        {
             acquisition_cc_ = pcps_make_acquisition_fine_doppler_cc(acq_parameters);
-        }
-    else
-        {
-            item_size_ = 0;
-            acquisition_cc_ = nullptr;
-            LOG(WARNING) << item_type_ << " unknown acquisition item type";
-        }
 
-    if (in_streams > 1)
-        {
-            LOG(ERROR) << "This implementation only supports one input stream";
-        }
-    if (out_streams > 0)
-        {
-            LOG(ERROR) << "This implementation does not provide an output stream";
+            DLOG(INFO) << "acquisition(" << acquisition_cc_->unique_id() << ")";
         }
 }
 
 
-void GpsL1CaPcpsAcquisitionFineDoppler::stop_acquisition()
+void GpsL1CaPcpsAcquisitionFineDoppler::code_gen_complex_sampled(own::span<std::complex<float>> dest, uint32_t prn, int32_t sampling_freq)
 {
-    acquisition_cc_->set_state(0);
-    acquisition_cc_->set_active(false);
-}
-
-
-void GpsL1CaPcpsAcquisitionFineDoppler::set_threshold(float threshold)
-{
-    threshold_ = threshold;
-    acquisition_cc_->set_threshold(threshold_);
-}
-
-
-void GpsL1CaPcpsAcquisitionFineDoppler::set_gnss_synchro(Gnss_Synchro* gnss_synchro)
-{
-    gnss_synchro_ = gnss_synchro;
-    acquisition_cc_->set_gnss_synchro(gnss_synchro_);
-}
-
-
-signed int GpsL1CaPcpsAcquisitionFineDoppler::mag()
-{
-    return static_cast<signed int>(acquisition_cc_->mag());
-}
-
-
-void GpsL1CaPcpsAcquisitionFineDoppler::init()
-{
-    acquisition_cc_->init();
-}
-
-
-void GpsL1CaPcpsAcquisitionFineDoppler::set_local_code()
-{
-    gps_l1_ca_code_gen_complex_sampled(code_, gnss_synchro_->PRN, fs_in_, 0);
-    acquisition_cc_->set_local_code(code_.data());
-}
-
-
-void GpsL1CaPcpsAcquisitionFineDoppler::reset()
-{
-    acquisition_cc_->set_active(true);
-}
-
-
-void GpsL1CaPcpsAcquisitionFineDoppler::set_state(int state)
-{
-    acquisition_cc_->set_state(state);
-}
-
-
-void GpsL1CaPcpsAcquisitionFineDoppler::connect(gnss_shared_ptr<gr::top_block> top_block)
-{
-    if (top_block)
-        { /* top_block is not null */
-        };
-    // nothing to disconnect, now the tracking uses gr_sync_decimator
-}
-
-
-void GpsL1CaPcpsAcquisitionFineDoppler::disconnect(gnss_shared_ptr<gr::top_block> top_block)
-{
-    if (top_block)
-        { /* top_block is not null */
-        };
-    // nothing to disconnect, now the tracking uses gr_sync_decimator
-}
-
-
-gnss_shared_ptr<gr::basic_block> GpsL1CaPcpsAcquisitionFineDoppler::get_left_block()
-{
-    return acquisition_cc_;
-}
-
-
-gnss_shared_ptr<gr::basic_block> GpsL1CaPcpsAcquisitionFineDoppler::get_right_block()
-{
-    return acquisition_cc_;
+    gps_l1_ca_code_gen_complex_sampled(dest, prn, sampling_freq, 0);
 }

--- a/src/algorithms/acquisition/adapters/gps_l1_ca_pcps_acquisition_fine_doppler.cc
+++ b/src/algorithms/acquisition/adapters/gps_l1_ca_pcps_acquisition_fine_doppler.cc
@@ -40,7 +40,6 @@ GpsL1CaPcpsAcquisitionFineDoppler::GpsL1CaPcpsAcquisitionFineDoppler(
           role,
           in_streams,
           out_streams,
-          configuration->property(role + ".coherent_integration_time_ms", GPS_L1_CA_CODE_PERIOD_MS),
           GPS_L1_CA_CODE_RATE_CPS,
           GPS_L1_CA_CODE_LENGTH_CHIPS,
           GPS_L1_CA_CODE_PERIOD_MS,
@@ -49,18 +48,7 @@ GpsL1CaPcpsAcquisitionFineDoppler::GpsL1CaPcpsAcquisitionFineDoppler(
 {
     if (is_type_gr_complex())
         {
-            const std::string default_dump_filename = "./acquisition.mat";
-
-            Acq_Conf acq_parameters = Acq_Conf();
-            acq_parameters.fs_in = fs_in_;
-            acq_parameters.samples_per_chip = static_cast<unsigned int>(ceil(GPS_L1_CA_CHIP_PERIOD_S * static_cast<float>(fs_in_)));
-            acq_parameters.dump = configuration->property(role + ".dump", false);
-            acq_parameters.dump_filename = configuration->property(role + ".dump_filename", default_dump_filename);
-            acq_parameters.doppler_max = doppler_max_;
-            acq_parameters.doppler_step = doppler_step_;
-            acq_parameters.sampled_ms = sampled_ms_;
-            acq_parameters.max_dwells = configuration->property(role + ".max_dwells", 1);
-            acq_parameters.blocking_on_standby = configuration->property(role + ".blocking_on_standby", false);
+            Acq_Conf acq_parameters = acq_parameters_;
             acq_parameters.samples_per_ms = static_cast<float>(vector_length_);
 
             acquisition_cc_ = pcps_make_acquisition_fine_doppler_cc(acq_parameters);

--- a/src/algorithms/acquisition/adapters/gps_l1_ca_pcps_acquisition_fine_doppler.h
+++ b/src/algorithms/acquisition/adapters/gps_l1_ca_pcps_acquisition_fine_doppler.h
@@ -20,13 +20,7 @@
 #ifndef GNSS_SDR_GPS_L1_CA_PCPS_ACQUISITION_FINE_DOPPLER_H
 #define GNSS_SDR_GPS_L1_CA_PCPS_ACQUISITION_FINE_DOPPLER_H
 
-#include "channel_fsm.h"
-#include "gnss_synchro.h"
-#include "pcps_acquisition_fine_doppler_cc.h"
-#include <memory>
-#include <string>
-#include <utility>
-#include <vector>
+#include "base_pcps_acquisition_custom.h"
 
 /** \addtogroup Acquisition
  * \{ */
@@ -34,15 +28,11 @@
  * \{ */
 
 
-using pcps_acquisition_fine_doppler_cc_sptr = gnss_shared_ptr<pcps_acquisition_fine_doppler_cc>;
-
-class ConfigurationInterface;
-
 /*!
  * \brief This class Adapts a PCPS acquisition block with fine Doppler estimation to an AcquisitionInterface for
  *  GPS L1 C/A signals
  */
-class GpsL1CaPcpsAcquisitionFineDoppler : public AcquisitionInterface
+class GpsL1CaPcpsAcquisitionFineDoppler : public BasePcpsAcquisitionCustom
 {
 public:
     GpsL1CaPcpsAcquisitionFineDoppler(const ConfigurationInterface* configuration,
@@ -52,11 +42,6 @@ public:
 
     ~GpsL1CaPcpsAcquisitionFineDoppler() = default;
 
-    inline std::string role() override
-    {
-        return role_;
-    }
-
     /*!
      * \brief Returns "GPS_L1_CA_PCPS_Acquisition_Fine_Doppler"
      */
@@ -65,92 +50,8 @@ public:
         return "GPS_L1_CA_PCPS_Acquisition_Fine_Doppler";
     }
 
-    inline size_t item_size() override
-    {
-        return item_size_;
-    }
-
-    void connect(gnss_shared_ptr<gr::top_block> top_block) override;
-    void disconnect(gnss_shared_ptr<gr::top_block> top_block) override;
-    gnss_shared_ptr<gr::basic_block> get_left_block() override;
-    gnss_shared_ptr<gr::basic_block> get_right_block() override;
-
-    /*!
-     * \brief Set acquisition/tracking common Gnss_Synchro object pointer
-     * to efficiently exchange synchronization data between acquisition and
-     *  tracking blocks
-     */
-    void set_gnss_synchro(Gnss_Synchro* p_gnss_synchro) override;
-
-    /*!
-     * \brief Set acquisition channel unique ID
-     */
-    inline void set_channel(unsigned int channel) override
-    {
-        channel_ = channel;
-        acquisition_cc_->set_channel(channel_);
-    }
-
-    /*!
-     * \brief Set channel fsm associated to this acquisition instance
-     */
-    inline void set_channel_fsm(std::weak_ptr<ChannelFsm> channel_fsm) override
-    {
-        channel_fsm_ = std::move(channel_fsm);
-        acquisition_cc_->set_channel_fsm(channel_fsm_);
-    }
-
-    /*!
-     * \brief Set statistics threshold of PCPS algorithm
-     */
-    void set_threshold(float threshold) override;
-
-    /*!
-     * \brief Initializes acquisition algorithm.
-     */
-    void init() override;
-
-    void set_local_code() override;
-
-    /*!
-     * \brief Returns the maximum peak of grid search
-     */
-    signed int mag() override;
-
-    /*!
-     * \brief Restart acquisition algorithm
-     */
-    void reset() override;
-
-    /*!
-     * \brief If state = 1, it forces the block to start acquiring from the first sample
-     */
-    void set_state(int state) override;
-
-    /*!
-     * \brief Stop running acquisition
-     */
-    void stop_acquisition() override;
-
-    void set_resampler_latency(uint32_t latency_samples __attribute__((unused))) override {};
-
 private:
-    pcps_acquisition_fine_doppler_cc_sptr acquisition_cc_;
-    std::weak_ptr<ChannelFsm> channel_fsm_;
-    std::vector<std::complex<float>> code_;
-    std::string item_type_;
-    std::string dump_filename_;
-    std::string role_;
-    Gnss_Synchro* gnss_synchro_;
-    int64_t fs_in_;
-    size_t item_size_;
-    float threshold_;
-    int doppler_max_;
-    unsigned int vector_length_;
-    unsigned int channel_;
-    unsigned int doppler_step_;
-    unsigned int sampled_ms_;
-    bool dump_;
+    void code_gen_complex_sampled(own::span<std::complex<float>> dest, uint32_t prn, int32_t sampling_freq) override;
 };
 
 

--- a/src/algorithms/acquisition/adapters/gps_l1_ca_pcps_acquisition_fpga.h
+++ b/src/algorithms/acquisition/adapters/gps_l1_ca_pcps_acquisition_fpga.h
@@ -28,9 +28,6 @@
 /** \addtogroup Acq_adapters
  * \{ */
 
-
-class ConfigurationInterface;
-
 /*!
  * \brief This class adapts a PCPS acquisition block off-loaded on an FPGA
  * to an AcquisitionInterface for GPS L1 C/A signals

--- a/src/algorithms/acquisition/adapters/gps_l1_ca_pcps_assisted_acquisition.cc
+++ b/src/algorithms/acquisition/adapters/gps_l1_ca_pcps_assisted_acquisition.cc
@@ -20,9 +20,8 @@
 
 #include "gps_l1_ca_pcps_assisted_acquisition.h"
 #include "GPS_L1_CA.h"
-#include "configuration_interface.h"
-#include "gnss_sdr_flags.h"
 #include "gps_sdr_signal_replica.h"
+#include "pcps_assisted_acquisition_cc.h"
 
 #if USE_GLOG_AND_GFLAGS
 #include <glog/logging.h>
@@ -35,137 +34,38 @@ GpsL1CaPcpsAssistedAcquisition::GpsL1CaPcpsAssistedAcquisition(
     const std::string& role,
     unsigned int in_streams,
     unsigned int out_streams)
-    : role_(role),
-      gnss_synchro_(nullptr),
-      item_size_(sizeof(gr_complex)),
-      dump_(configuration->property(role + ".dump", false))
+    : BasePcpsAcquisitionCustom(
+          configuration,
+          role,
+          in_streams,
+          out_streams,
+          configuration->property(role + ".coherent_integration_time_ms", GPS_L1_CA_CODE_PERIOD_MS),
+          GPS_L1_CA_CODE_RATE_CPS,
+          GPS_L1_CA_CODE_LENGTH_CHIPS,
+          GPS_L1_CA_CODE_PERIOD_MS,
+          false,
+          false)
 {
-    const std::string default_item_type("gr_complex");
-    const std::string default_dump_filename = "./data/acquisition.dat";
-    const std::string dump_filename = configuration->property(role_ + ".dump_filename", default_dump_filename);
-    const std::string item_type = configuration->property(role_ + ".item_type", default_item_type);
-    const int64_t fs_in_deprecated = configuration->property("GNSS-SDR.internal_fs_hz", 2048000);
-    fs_in_ = configuration->property("GNSS-SDR.internal_fs_sps", fs_in_deprecated);
-
-    int doppler_max = configuration->property(role + ".doppler_max", 5000);
-    int doppler_step = configuration->property(role + ".doppler_step", 500);
-
-#if USE_GLOG_AND_GFLAGS
-    if (FLAGS_doppler_max != 0)
+    if (is_type_gr_complex())
         {
-            doppler_max = FLAGS_doppler_max;
-        }
-    if (FLAGS_doppler_step != 0)
-        {
-            doppler_step = static_cast<uint32_t>(FLAGS_doppler_step);
-        }
-#else
-    if (absl::GetFlag(FLAGS_doppler_max) != 0)
-        {
-            doppler_max = absl::GetFlag(FLAGS_doppler_max);
-        }
-    if (absl::GetFlag(FLAGS_doppler_step) != 0)
-        {
-            doppler_step = static_cast<uint32_t>(absl::GetFlag(FLAGS_doppler_step));
-        }
-#endif
-    const int doppler_min = configuration->property(role_ + ".doppler_min", -doppler_max);
-    bool enable_monitor_output = configuration->property("AcquisitionMonitor.enable_monitor", false);
-
-    // --- Find number of samples per spreading code -------------------------
-    vector_length_ = static_cast<unsigned int>(round(fs_in_ / (GPS_L1_CA_CODE_RATE_CPS / GPS_L1_CA_CODE_LENGTH_CHIPS)));
-
-    code_ = std::vector<std::complex<float>>(vector_length_);
-
-    DLOG(INFO) << "role " << role_;
-    if (item_type == "gr_complex")
-        {
+            const std::string default_dump_filename("./acquisition.dat");
+            const auto dump_filename = configuration->property(role + ".dump_filename", default_dump_filename);
+            const auto enable_monitor_output = configuration->property("AcquisitionMonitor.enable_monitor", false);
+            const auto dump = configuration->property(role + ".dump", false);
             const unsigned int max_dwells = configuration->property(role + ".max_dwells", 1);
             const unsigned int sampled_ms = configuration->property(role + ".coherent_integration_time_ms", 1);
+            const auto doppler_min = configuration->property(role + ".doppler_min", -static_cast<int32_t>(doppler_max_));
+
             acquisition_cc_ = pcps_make_assisted_acquisition_cc(max_dwells, sampled_ms,
-                doppler_max, doppler_min, doppler_step, fs_in_, vector_length_,
-                dump_, dump_filename, enable_monitor_output);
-        }
-    else
-        {
-            item_size_ = 0;
-            acquisition_cc_ = nullptr;
-            LOG(WARNING) << item_type << " unknown acquisition item type";
-        }
+                doppler_max_, doppler_min, doppler_step_, fs_in_, vector_length_,
+                dump, dump_filename, enable_monitor_output);
 
-    if (in_streams > 1)
-        {
-            LOG(ERROR) << "This implementation only supports one input stream";
-        }
-    if (out_streams > 0)
-        {
-            LOG(ERROR) << "This implementation does not provide an output stream";
+            DLOG(INFO) << "acquisition(" << acquisition_cc_->unique_id() << ")";
         }
 }
 
 
-void GpsL1CaPcpsAssistedAcquisition::stop_acquisition()
+void GpsL1CaPcpsAssistedAcquisition::code_gen_complex_sampled(own::span<std::complex<float>> dest, uint32_t prn, int32_t sampling_freq)
 {
-    acquisition_cc_->set_active(false);
-    acquisition_cc_->set_state(0);
-}
-
-
-void GpsL1CaPcpsAssistedAcquisition::set_threshold(float threshold)
-{
-    acquisition_cc_->set_threshold(threshold);
-}
-
-
-void GpsL1CaPcpsAssistedAcquisition::set_gnss_synchro(Gnss_Synchro* gnss_synchro)
-{
-    gnss_synchro_ = gnss_synchro;
-    acquisition_cc_->set_gnss_synchro(gnss_synchro_);
-}
-
-
-signed int GpsL1CaPcpsAssistedAcquisition::mag()
-{
-    return acquisition_cc_->mag();
-}
-
-
-void GpsL1CaPcpsAssistedAcquisition::init()
-{
-    acquisition_cc_->init();
-}
-
-
-void GpsL1CaPcpsAssistedAcquisition::set_local_code()
-{
-    gps_l1_ca_code_gen_complex_sampled(code_, gnss_synchro_->PRN, fs_in_, 0);
-    acquisition_cc_->set_local_code(code_.data());
-}
-
-
-void GpsL1CaPcpsAssistedAcquisition::reset()
-{
-    acquisition_cc_->set_active(true);
-}
-
-
-void GpsL1CaPcpsAssistedAcquisition::connect(gr::top_block_sptr /*top_block*/)
-{
-}
-
-
-void GpsL1CaPcpsAssistedAcquisition::disconnect(gr::top_block_sptr /*top_block*/)
-{
-}
-
-
-gr::basic_block_sptr GpsL1CaPcpsAssistedAcquisition::get_left_block()
-{
-    return acquisition_cc_;
-}
-
-
-gr::basic_block_sptr GpsL1CaPcpsAssistedAcquisition::get_right_block()
-{
-    return acquisition_cc_;
+    gps_l1_ca_code_gen_complex_sampled(dest, prn, sampling_freq, 0);
 }

--- a/src/algorithms/acquisition/adapters/gps_l1_ca_pcps_assisted_acquisition.cc
+++ b/src/algorithms/acquisition/adapters/gps_l1_ca_pcps_assisted_acquisition.cc
@@ -39,7 +39,6 @@ GpsL1CaPcpsAssistedAcquisition::GpsL1CaPcpsAssistedAcquisition(
           role,
           in_streams,
           out_streams,
-          configuration->property(role + ".coherent_integration_time_ms", GPS_L1_CA_CODE_PERIOD_MS),
           GPS_L1_CA_CODE_RATE_CPS,
           GPS_L1_CA_CODE_LENGTH_CHIPS,
           GPS_L1_CA_CODE_PERIOD_MS,
@@ -48,17 +47,11 @@ GpsL1CaPcpsAssistedAcquisition::GpsL1CaPcpsAssistedAcquisition(
 {
     if (is_type_gr_complex())
         {
-            const std::string default_dump_filename("./acquisition.dat");
-            const auto dump_filename = configuration->property(role + ".dump_filename", default_dump_filename);
-            const auto enable_monitor_output = configuration->property("AcquisitionMonitor.enable_monitor", false);
-            const auto dump = configuration->property(role + ".dump", false);
-            const unsigned int max_dwells = configuration->property(role + ".max_dwells", 1);
-            const unsigned int sampled_ms = configuration->property(role + ".coherent_integration_time_ms", 1);
-            const auto doppler_min = configuration->property(role + ".doppler_min", -static_cast<int32_t>(doppler_max_));
+            const auto doppler_min = configuration->property(role + ".doppler_min", -acq_parameters_.doppler_max);
 
-            acquisition_cc_ = pcps_make_assisted_acquisition_cc(max_dwells, sampled_ms,
-                doppler_max_, doppler_min, doppler_step_, fs_in_, vector_length_,
-                dump, dump_filename, enable_monitor_output);
+            acquisition_cc_ = pcps_make_assisted_acquisition_cc(acq_parameters_.max_dwells, acq_parameters_.sampled_ms,
+                acq_parameters_.doppler_max, doppler_min, acq_parameters_.doppler_step, acq_parameters_.fs_in, vector_length_,
+                acq_parameters_.dump, acq_parameters_.dump_filename, acq_parameters_.enable_monitor_output);
 
             DLOG(INFO) << "acquisition(" << acquisition_cc_->unique_id() << ")";
         }

--- a/src/algorithms/acquisition/adapters/gps_l1_ca_pcps_assisted_acquisition.h
+++ b/src/algorithms/acquisition/adapters/gps_l1_ca_pcps_assisted_acquisition.h
@@ -20,13 +20,7 @@
 #ifndef GNSS_SDR_GPS_L1_CA_PCPS_ASSISTED_ACQUISITION_H
 #define GNSS_SDR_GPS_L1_CA_PCPS_ASSISTED_ACQUISITION_H
 
-#include "channel_fsm.h"
-#include "gnss_synchro.h"
-#include "pcps_assisted_acquisition_cc.h"
-#include <memory>
-#include <string>
-#include <utility>
-#include <vector>
+#include "base_pcps_acquisition_custom.h"
 
 /** \addtogroup Acquisition
  * \{ */
@@ -34,13 +28,11 @@
  * \{ */
 
 
-class ConfigurationInterface;
-
 /*!
  * \brief This class adapts a PCPS acquisition block to an AcquisitionInterface
  *  for GPS L1 C/A signals
  */
-class GpsL1CaPcpsAssistedAcquisition : public AcquisitionInterface
+class GpsL1CaPcpsAssistedAcquisition : public BasePcpsAcquisitionCustom
 {
 public:
     GpsL1CaPcpsAssistedAcquisition(
@@ -51,11 +43,6 @@ public:
 
     ~GpsL1CaPcpsAssistedAcquisition() = default;
 
-    inline std::string role() override
-    {
-        return role_;
-    }
-
     /*!
      * \brief Returns "GPS_L1_CA_PCPS_Assisted_Acquisition"
      */
@@ -64,83 +51,8 @@ public:
         return "GPS_L1_CA_PCPS_Assisted_Acquisition";
     }
 
-    inline size_t item_size() override
-    {
-        return item_size_;
-    }
-
-    void connect(gr::top_block_sptr top_block) override;
-    void disconnect(gr::top_block_sptr top_block) override;
-    gr::basic_block_sptr get_left_block() override;
-    gr::basic_block_sptr get_right_block() override;
-
-    /*!
-     * \brief Set acquisition/tracking common Gnss_Synchro object pointer
-     * to efficiently exchange synchronization data between acquisition and
-     *  tracking blocks
-     */
-    void set_gnss_synchro(Gnss_Synchro* p_gnss_synchro) override;
-
-    /*!
-     * \brief Set acquisition channel unique ID
-     */
-    inline void set_channel(unsigned int channel) override
-    {
-        acquisition_cc_->set_channel(channel);
-    }
-
-    /*!
-     * \brief Set channel fsm associated to this acquisition instance
-     */
-    inline void set_channel_fsm(std::weak_ptr<ChannelFsm> channel_fsm) override
-    {
-        acquisition_cc_->set_channel_fsm(std::move(channel_fsm));
-    }
-
-    /*!
-     * \brief Set statistics threshold of PCPS algorithm
-     */
-    void set_threshold(float threshold) override;
-
-    /*!
-     * \brief Initializes acquisition algorithm.
-     */
-    void init() override;
-
-    void set_local_code() override;
-
-    /*!
-     * \brief Returns the maximum peak of grid search
-     */
-    signed int mag() override;
-
-    /*!
-     * \brief Restart acquisition algorithm
-     */
-    void reset() override;
-    void set_state(int state __attribute__((unused))) override {};
-
-    /*!
-     * \brief Stop running acquisition
-     */
-    void stop_acquisition() override;
-
-    void set_resampler_latency(uint32_t latency_samples __attribute__((unused))) override {};
-
 private:
-    pcps_assisted_acquisition_cc_sptr acquisition_cc_;
-    std::vector<std::complex<float>> code_;
-
-    std::string role_;
-
-    Gnss_Synchro* gnss_synchro_;
-
-    size_t item_size_;
-    int64_t fs_in_;
-
-    unsigned int vector_length_;
-
-    bool dump_;
+    void code_gen_complex_sampled(own::span<std::complex<float>> dest, uint32_t prn, int32_t sampling_freq) override;
 };
 
 

--- a/src/algorithms/acquisition/adapters/gps_l1_ca_pcps_opencl_acquisition.cc
+++ b/src/algorithms/acquisition/adapters/gps_l1_ca_pcps_opencl_acquisition.cc
@@ -41,7 +41,6 @@ GpsL1CaPcpsOpenClAcquisition::GpsL1CaPcpsOpenClAcquisition(
           role,
           in_streams,
           out_streams,
-          configuration->property(role + ".coherent_integration_time_ms", GPS_L1_CA_CODE_PERIOD_MS),
           GPS_L1_CA_CODE_RATE_CPS,
           GPS_L1_CA_CODE_LENGTH_CHIPS,
           GPS_L1_CA_CODE_PERIOD_MS,
@@ -51,22 +50,11 @@ GpsL1CaPcpsOpenClAcquisition::GpsL1CaPcpsOpenClAcquisition(
 {
     if (is_type_gr_complex())
         {
-            const auto bit_transition_flag = configuration->property(role + ".bit_transition_flag", false);
+            const unsigned int max_dwells = acq_parameters_.bit_transition_flag ? 2 : acq_parameters_.max_dwells;
 
-            unsigned int max_dwells = 2;
-
-            if (!bit_transition_flag)
-                {
-                    max_dwells = configuration->property(role + ".max_dwells", 1);
-                }
-
-            const std::string default_dump_filename = "./acquisition.dat";
-            const auto dump_filename = configuration->property(role + ".dump_filename", default_dump_filename);
-            const auto dump = configuration->property(role + ".dump", false);
-
-            auto acquisition_cc = pcps_make_opencl_acquisition_cc(sampled_ms_, max_dwells,
-                doppler_max_, doppler_step_, fs_in_, code_length_, code_length_,
-                bit_transition_flag, dump, dump_filename, false);
+            auto acquisition_cc = pcps_make_opencl_acquisition_cc(acq_parameters_.sampled_ms, max_dwells,
+                acq_parameters_.doppler_max, acq_parameters_.doppler_step, acq_parameters_.fs_in, code_length_, code_length_,
+                acq_parameters_.bit_transition_flag, acq_parameters_.dump, acq_parameters_.dump_filename, false);
 
             opencl_ready_ = acquisition_cc->opencl_ready();
             acquisition_cc_ = std::move(acquisition_cc);

--- a/src/algorithms/acquisition/adapters/gps_l1_ca_pcps_opencl_acquisition.cc
+++ b/src/algorithms/acquisition/adapters/gps_l1_ca_pcps_opencl_acquisition.cc
@@ -20,6 +20,7 @@
 #include "configuration_interface.h"
 #include "gnss_sdr_flags.h"
 #include "gps_sdr_signal_replica.h"
+#include "pcps_opencl_acquisition_cc.h"
 #include <boost/math/distributions/exponential.hpp>
 #include <algorithm>
 
@@ -29,244 +30,53 @@
 #include <absl/log/log.h>
 #endif
 
-#if HAS_STD_SPAN
-#include <span>
-namespace own = std;
-#else
-#include <gsl-lite/gsl-lite.hpp>
-namespace own = gsl_lite;
-#endif
 
 GpsL1CaPcpsOpenClAcquisition::GpsL1CaPcpsOpenClAcquisition(
     const ConfigurationInterface* configuration,
     const std::string& role,
     unsigned int in_streams,
     unsigned int out_streams)
-    : configuration_(configuration),
-      gnss_synchro_(nullptr),
-      role_(role),
-      threshold_(0.0),
-      channel_(0),
-      doppler_max_(configuration->property(role + ".doppler_max", 5000)),
-      doppler_step_(configuration->property(role + ".doppler_step", 500))
+    : BasePcpsAcquisitionCustom(
+          configuration,
+          role,
+          in_streams,
+          out_streams,
+          configuration->property(role + ".coherent_integration_time_ms", GPS_L1_CA_CODE_PERIOD_MS),
+          GPS_L1_CA_CODE_RATE_CPS,
+          GPS_L1_CA_CODE_LENGTH_CHIPS,
+          GPS_L1_CA_CODE_PERIOD_MS,
+          true,
+          true),
+      opencl_ready_(false)
 {
-    const std::string default_item_type("gr_complex");
-    std::string default_dump_filename = "./data/acquisition.dat";
-
-    DLOG(INFO) << "role " << role;
-
-    item_type_ = configuration->property(role + ".item_type",
-        default_item_type);
-
-    int64_t fs_in_deprecated = configuration->property("GNSS-SDR.internal_fs_hz", 2048000);
-    fs_in_ = configuration->property("GNSS-SDR.internal_fs_sps", fs_in_deprecated);
-    dump_ = configuration->property(role + ".dump", false);
-#if USE_GLOG_AND_GFLAGS
-    if (FLAGS_doppler_max != 0)
+    if (is_type_gr_complex())
         {
-            doppler_max_ = FLAGS_doppler_max;
-        }
-    if (FLAGS_doppler_step != 0)
-        {
-            doppler_step_ = static_cast<uint32_t>(FLAGS_doppler_step);
-        }
-#else
-    if (absl::GetFlag(FLAGS_doppler_max) != 0)
-        {
-            doppler_max_ = absl::GetFlag(FLAGS_doppler_max);
-        }
-    if (absl::GetFlag(FLAGS_doppler_step) != 0)
-        {
-            doppler_step_ = static_cast<uint32_t>(absl::GetFlag(FLAGS_doppler_step));
-        }
-#endif
-    sampled_ms_ = configuration->property(role + ".coherent_integration_time_ms", 1);
+            const auto bit_transition_flag = configuration->property(role + ".bit_transition_flag", false);
 
-    bit_transition_flag_ = configuration->property("Acquisition.bit_transition_flag", false);
+            unsigned int max_dwells = 2;
 
-    unsigned int max_dwells = 2;
-
-    if (!bit_transition_flag_)
-        {
-            max_dwells = configuration->property(role + ".max_dwells", 1);
-        }
-
-    dump_filename_ = configuration->property(role + ".dump_filename",
-        default_dump_filename);
-
-    // -- Find number of samples per spreading code -------------------------
-    code_length_ = static_cast<unsigned int>(round(fs_in_ / (GPS_L1_CA_CODE_RATE_CPS / GPS_L1_CA_CODE_LENGTH_CHIPS)));
-
-    vector_length_ = code_length_ * sampled_ms_;
-
-    code_ = std::vector<std::complex<float>>(vector_length_);
-
-    if (item_type_ == "gr_complex")
-        {
-            item_size_ = sizeof(gr_complex);
-            acquisition_cc_ = pcps_make_opencl_acquisition_cc(sampled_ms_, max_dwells,
-                doppler_max_, doppler_step_, fs_in_, code_length_, code_length_,
-                bit_transition_flag_, dump_, dump_filename_, false);
-
-            stream_to_vector_ = gr::blocks::stream_to_vector::make(item_size_, vector_length_);
-
-            DLOG(INFO) << "stream_to_vector(" << stream_to_vector_->unique_id() << ")";
-            DLOG(INFO) << "acquisition(" << acquisition_cc_->unique_id() << ")";
-        }
-    else
-        {
-            item_size_ = sizeof(gr_complex);
-            LOG(WARNING) << item_type_ << " unknown acquisition item type";
-        }
-
-    if (in_streams > 1)
-        {
-            LOG(ERROR) << "This implementation only supports one input stream";
-        }
-    if (out_streams > 0)
-        {
-            LOG(ERROR) << "This implementation does not provide an output stream";
-        }
-}
-
-
-void GpsL1CaPcpsOpenClAcquisition::stop_acquisition()
-{
-    acquisition_cc_->set_active(false);
-    acquisition_cc_->set_state(0);
-}
-
-
-void GpsL1CaPcpsOpenClAcquisition::set_threshold(float threshold)
-{
-    float pfa = configuration_->property(role_ + std::to_string(channel_) + ".pfa", static_cast<float>(0.0));
-
-    if (pfa == 0.0)
-        {
-            pfa = configuration_->property(role_ + ".pfa", static_cast<float>(0.0));
-        }
-    if (pfa == 0.0)
-        {
-            threshold_ = threshold;
-        }
-    else
-        {
-            threshold_ = calculate_threshold(pfa);
-        }
-
-    DLOG(INFO) << "Channel " << channel_ << " Threshold = " << threshold_;
-
-    if (item_type_ == "gr_complex")
-        {
-            acquisition_cc_->set_threshold(threshold_);
-        }
-}
-
-
-void GpsL1CaPcpsOpenClAcquisition::set_gnss_synchro(Gnss_Synchro* gnss_synchro)
-{
-    gnss_synchro_ = gnss_synchro;
-    if (item_type_ == "gr_complex")
-        {
-            acquisition_cc_->set_gnss_synchro(gnss_synchro_);
-        }
-}
-
-
-signed int GpsL1CaPcpsOpenClAcquisition::mag()
-{
-    if (item_type_ == "gr_complex")
-        {
-            return acquisition_cc_->mag();
-        }
-    else
-        {
-            return 0;
-        }
-}
-
-
-void GpsL1CaPcpsOpenClAcquisition::init()
-{
-    acquisition_cc_->init();
-}
-
-
-void GpsL1CaPcpsOpenClAcquisition::set_local_code()
-{
-    if (item_type_ == "gr_complex")
-        {
-            std::vector<std::complex<float>> code(code_length_);
-
-            gps_l1_ca_code_gen_complex_sampled(code, gnss_synchro_->PRN, fs_in_, 0);
-
-            own::span<gr_complex> code_span(code_.data(), vector_length_);
-            for (unsigned int i = 0; i < sampled_ms_; i++)
+            if (!bit_transition_flag)
                 {
-                    std::copy_n(code.data(), code_length_, code_span.subspan(i * code_length_, code_length_).data());
+                    max_dwells = configuration->property(role + ".max_dwells", 1);
                 }
 
-            acquisition_cc_->set_local_code(code_.data());
+            const std::string default_dump_filename = "./acquisition.dat";
+            const auto dump_filename = configuration->property(role + ".dump_filename", default_dump_filename);
+            const auto dump = configuration->property(role + ".dump", false);
+
+            auto acquisition_cc = pcps_make_opencl_acquisition_cc(sampled_ms_, max_dwells,
+                doppler_max_, doppler_step_, fs_in_, code_length_, code_length_,
+                bit_transition_flag, dump, dump_filename, false);
+
+            opencl_ready_ = acquisition_cc->opencl_ready();
+            acquisition_cc_ = std::move(acquisition_cc);
+
+            DLOG(INFO) << "acquisition(" << acquisition_cc_->unique_id() << ")";
         }
 }
 
 
-void GpsL1CaPcpsOpenClAcquisition::reset()
+void GpsL1CaPcpsOpenClAcquisition::code_gen_complex_sampled(own::span<std::complex<float>> dest, uint32_t prn, int32_t sampling_freq)
 {
-    if (item_type_ == "gr_complex")
-        {
-            acquisition_cc_->set_active(true);
-        }
-}
-
-
-float GpsL1CaPcpsOpenClAcquisition::calculate_threshold(float pfa) const
-{
-    // Calculate the threshold
-    unsigned int frequency_bins = 0;
-    for (int doppler = static_cast<int>(-doppler_max_); doppler <= static_cast<int>(doppler_max_); doppler += static_cast<int>(doppler_step_))
-        {
-            frequency_bins++;
-        }
-
-    DLOG(INFO) << "Channel " << channel_ << "  Pfa = " << pfa;
-
-    unsigned int ncells = vector_length_ * frequency_bins;
-    double exponent = 1 / static_cast<double>(ncells);
-    double val = pow(1.0 - pfa, exponent);
-    auto lambda = static_cast<double>(vector_length_);
-    boost::math::exponential_distribution<double> mydist(lambda);
-    auto threshold = static_cast<float>(quantile(mydist, val));
-
-    return threshold;
-}
-
-
-void GpsL1CaPcpsOpenClAcquisition::connect(gr::top_block_sptr top_block)
-{
-    if (item_type_ == "gr_complex")
-        {
-            top_block->connect(stream_to_vector_, 0, acquisition_cc_, 0);
-        }
-}
-
-
-void GpsL1CaPcpsOpenClAcquisition::disconnect(gr::top_block_sptr top_block)
-{
-    if (item_type_ == "gr_complex")
-        {
-            top_block->disconnect(stream_to_vector_, 0, acquisition_cc_, 0);
-        }
-}
-
-
-gr::basic_block_sptr GpsL1CaPcpsOpenClAcquisition::get_left_block()
-{
-    return stream_to_vector_;
-}
-
-
-gr::basic_block_sptr GpsL1CaPcpsOpenClAcquisition::get_right_block()
-{
-    return acquisition_cc_;
+    gps_l1_ca_code_gen_complex_sampled(dest, prn, sampling_freq, 0);
 }

--- a/src/algorithms/acquisition/adapters/gps_l1_ca_pcps_opencl_acquisition.h
+++ b/src/algorithms/acquisition/adapters/gps_l1_ca_pcps_opencl_acquisition.h
@@ -18,28 +18,18 @@
 #ifndef GNSS_SDR_GPS_L1_CA_PCPS_OPENCL_ACQUISITION_H
 #define GNSS_SDR_GPS_L1_CA_PCPS_OPENCL_ACQUISITION_H
 
-#include "channel_fsm.h"
-#include "gnss_synchro.h"
-#include "pcps_opencl_acquisition_cc.h"
-#include <gnuradio/blocks/stream_to_vector.h>
-#include <memory>
-#include <string>
-#include <utility>
-#include <vector>
+#include "base_pcps_acquisition_custom.h"
 
 /** \addtogroup Acquisition
  * \{ */
 /** \addtogroup Acq_adapters
  * \{ */
 
-
-class ConfigurationInterface;
-
 /*!
  * \brief This class adapts an OpenCL PCPS acquisition block to an
  *  AcquisitionInterface for GPS L1 C/A signals
  */
-class GpsL1CaPcpsOpenClAcquisition : public AcquisitionInterface
+class GpsL1CaPcpsOpenClAcquisition : public BasePcpsAcquisitionCustom
 {
 public:
     GpsL1CaPcpsOpenClAcquisition(const ConfigurationInterface* configuration,
@@ -49,11 +39,6 @@ public:
 
     ~GpsL1CaPcpsOpenClAcquisition() = default;
 
-    inline std::string role() override
-    {
-        return role_;
-    }
-
     /*!
      * \brief Returns "GPS_L1_CA_PCPS_OpenCl_Acquisition"
      */
@@ -62,106 +47,15 @@ public:
         return "GPS_L1_CA_PCPS_OpenCl_Acquisition";
     }
 
-    inline size_t item_size() override
-    {
-        return item_size_;
-    }
-
-    void connect(gr::top_block_sptr top_block) override;
-    void disconnect(gr::top_block_sptr top_block) override;
-    gr::basic_block_sptr get_left_block() override;
-    gr::basic_block_sptr get_right_block() override;
-
-    /*!
-     * \brief Set acquisition/tracking common Gnss_Synchro object pointer
-     * to efficiently exchange synchronization data between acquisition and
-     *  tracking blocks
-     */
-    void set_gnss_synchro(Gnss_Synchro* p_gnss_synchro) override;
-
-    /*!
-     * \brief Set acquisition channel unique ID
-     */
-    inline void set_channel(unsigned int channel) override
-    {
-        channel_ = channel;
-        acquisition_cc_->set_channel(channel_);
-    }
-
-    /*!
-     * \brief Set channel fsm associated to this acquisition instance
-     */
-    inline void set_channel_fsm(std::weak_ptr<ChannelFsm> channel_fsm) override
-    {
-        channel_fsm_ = std::move(channel_fsm);
-        acquisition_cc_->set_channel_fsm(channel_fsm_);
-    }
-
-    /*!
-     * \brief Set statistics threshold of PCPS algorithm
-     */
-    void set_threshold(float threshold) override;
-
-    /*!
-     * \brief Initializes acquisition algorithm.
-     */
-    void init() override;
-
-    /*!
-     * \brief Sets local code for GPS L1/CA PCPS acquisition algorithm.
-     */
-    void set_local_code() override;
-
-    /*!
-     * \brief Returns the maximum peak of grid search
-     */
-    signed int mag() override;
-
-    /*!
-     * \brief Restart acquisition algorithm
-     */
-    void reset() override;
-    void set_state(int state __attribute__((unused))) override {};
-
-    /*!
-     * \brief Stop running acquisition
-     */
-    void stop_acquisition() override;
-
-    void set_resampler_latency(uint32_t latency_samples __attribute__((unused))) override {};
-
     inline bool opencl_ready() const
     {
-        bool ready = this->acquisition_cc_->opencl_ready();
-        return ready;
+        return opencl_ready_;
     }
 
 private:
-    float calculate_threshold(float pfa) const;
-    const ConfigurationInterface* configuration_;
-    pcps_opencl_acquisition_cc_sptr acquisition_cc_;
-    gr::blocks::stream_to_vector::sptr stream_to_vector_;
-    std::weak_ptr<ChannelFsm> channel_fsm_;
-    std::vector<std::complex<float>> code_;
-    Gnss_Synchro* gnss_synchro_;
+    void code_gen_complex_sampled(own::span<std::complex<float>> dest, uint32_t prn, int32_t sampling_freq) override;
 
-    std::string item_type_;
-    std::string dump_filename_;
-    std::string role_;
-
-    int64_t fs_in_;
-    size_t item_size_;
-
-    float threshold_;
-
-    unsigned int vector_length_;
-    unsigned int code_length_;
-    unsigned int channel_;
-    unsigned int doppler_max_;
-    unsigned int doppler_step_;
-    unsigned int sampled_ms_;
-    bool bit_transition_flag_;
-    bool dump_;
+    bool opencl_ready_;
 };
 
 

--- a/src/algorithms/acquisition/adapters/gps_l1_ca_pcps_tong_acquisition.cc
+++ b/src/algorithms/acquisition/adapters/gps_l1_ca_pcps_tong_acquisition.cc
@@ -17,11 +17,9 @@
 
 #include "gps_l1_ca_pcps_tong_acquisition.h"
 #include "GPS_L1_CA.h"
-#include "configuration_interface.h"
-#include "gnss_sdr_flags.h"
 #include "gps_sdr_signal_replica.h"
+#include "pcps_tong_acquisition_cc.h"
 #include <boost/math/distributions/exponential.hpp>
-#include <algorithm>
 
 #if USE_GLOG_AND_GFLAGS
 #include <glog/logging.h>
@@ -29,238 +27,44 @@
 #include <absl/log/log.h>
 #endif
 
-#if HAS_STD_SPAN
-#include <span>
-namespace own = std;
-#else
-#include <gsl-lite/gsl-lite.hpp>
-namespace own = gsl_lite;
-#endif
 
 GpsL1CaPcpsTongAcquisition::GpsL1CaPcpsTongAcquisition(
     const ConfigurationInterface* configuration,
     const std::string& role,
     unsigned int in_streams,
     unsigned int out_streams)
-    : configuration_(configuration),
-      gnss_synchro_(nullptr),
-      role_(role),
-      item_size_(sizeof(gr_complex)),
-      channel_(0),
-      doppler_max_(configuration->property(role + ".doppler_max", 5000)),
-      doppler_step_(configuration_->property(role + ".doppler_step", 500)),
-      sampled_ms_(configuration_->property(role + ".coherent_integration_time_ms", 1)),
-      dump_(configuration_->property(role + ".dump", false))
+    : BasePcpsAcquisitionCustom(
+          configuration,
+          role,
+          in_streams,
+          out_streams,
+          configuration->property(role + ".coherent_integration_time_ms", GPS_L1_CA_CODE_PERIOD_MS),
+          GPS_L1_CA_CODE_RATE_CPS,
+          GPS_L1_CA_CODE_LENGTH_CHIPS,
+          GPS_L1_CA_CODE_PERIOD_MS,
+          true,
+          true)
 {
-    const std::string default_item_type("gr_complex");
-    std::string default_dump_filename = "./data/acquisition.dat";
-
-    DLOG(INFO) << "role " << role_;
-
-    item_type_ = configuration_->property(role_ + ".item_type", default_item_type);
-    int64_t fs_in_deprecated = configuration_->property("GNSS-SDR.internal_fs_hz", 2048000);
-    fs_in_ = configuration_->property("GNSS-SDR.internal_fs_sps", fs_in_deprecated);
-    dump_filename_ = configuration_->property(role_ + ".dump_filename", std::move(default_dump_filename));
-
-#if USE_GLOG_AND_GFLAGS
-    if (FLAGS_doppler_max != 0)
+    if (is_type_gr_complex())
         {
-            doppler_max_ = FLAGS_doppler_max;
-        }
-    if (FLAGS_doppler_step != 0)
-        {
-            doppler_step_ = static_cast<uint32_t>(FLAGS_doppler_step);
-        }
-#else
-    if (absl::GetFlag(FLAGS_doppler_max) != 0)
-        {
-            doppler_max_ = absl::GetFlag(FLAGS_doppler_max);
-        }
-    if (absl::GetFlag(FLAGS_doppler_step) != 0)
-        {
-            doppler_step_ = static_cast<uint32_t>(absl::GetFlag(FLAGS_doppler_step));
-        }
-#endif
-    bool enable_monitor_output = configuration_->property("AcquisitionMonitor.enable_monitor", false);
+            const std::string default_dump_filename("./acquisition.dat");
+            const auto dump_filename = configuration->property(role + ".dump_filename", default_dump_filename);
+            const auto enable_monitor_output = configuration->property("AcquisitionMonitor.enable_monitor", false);
+            const auto dump = configuration->property(role + ".dump", false);
+            const auto tong_init_val = configuration->property(role + ".tong_init_val", 1U);
+            const auto tong_max_val = configuration->property(role + ".tong_max_val", 2U);
+            const auto tong_max_dwells = configuration->property(role + ".tong_max_dwells", tong_max_val + 1U);
 
-    // -- Find number of samples per spreading code -------------------------
-    code_length_ = static_cast<unsigned int>(round(fs_in_ / (GPS_L1_CA_CODE_RATE_CPS / GPS_L1_CA_CODE_LENGTH_CHIPS)));
-
-    vector_length_ = code_length_ * sampled_ms_;
-
-    code_ = std::vector<std::complex<float>>(vector_length_);
-
-    if (item_type_ == "gr_complex")
-        {
-            const unsigned int tong_init_val = configuration->property(role + ".tong_init_val", 1);
-            const unsigned int tong_max_val = configuration->property(role + ".tong_max_val", 2);
-            const unsigned int tong_max_dwells = configuration->property(role + ".tong_max_dwells", tong_max_val + 1);
             acquisition_cc_ = pcps_tong_make_acquisition_cc(sampled_ms_, doppler_max_, doppler_step_, fs_in_,
                 code_length_, code_length_, tong_init_val, tong_max_val, tong_max_dwells,
-                dump_, dump_filename_, enable_monitor_output);
+                dump, dump_filename, enable_monitor_output);
 
-            stream_to_vector_ = gr::blocks::stream_to_vector::make(item_size_, vector_length_);
-
-            DLOG(INFO) << "stream_to_vector(" << stream_to_vector_->unique_id() << ")";
             DLOG(INFO) << "acquisition(" << acquisition_cc_->unique_id() << ")";
         }
-    else
-        {
-            acquisition_cc_ = nullptr;
-            item_size_ = 0;
-            LOG(WARNING) << item_type_ << " unknown acquisition item type";
-        }
-
-    if (in_streams > 1)
-        {
-            LOG(ERROR) << "This implementation only supports one input stream";
-        }
-    if (out_streams > 0)
-        {
-            LOG(ERROR) << "This implementation does not provide an output stream";
-        }
 }
 
 
-void GpsL1CaPcpsTongAcquisition::stop_acquisition()
+void GpsL1CaPcpsTongAcquisition::code_gen_complex_sampled(own::span<std::complex<float>> dest, uint32_t prn, int32_t sampling_freq)
 {
-    acquisition_cc_->set_state(0);
-    acquisition_cc_->set_active(false);
-}
-
-
-void GpsL1CaPcpsTongAcquisition::set_threshold(float threshold)
-{
-    float pfa = configuration_->property(role_ + std::to_string(channel_) + ".pfa", static_cast<float>(0.0));
-
-    if (pfa == 0.0)
-        {
-            pfa = configuration_->property(role_ + ".pfa", static_cast<float>(0.0));
-        }
-    if (pfa != 0.0)
-        {
-            threshold = calculate_threshold(pfa);
-        }
-
-    DLOG(INFO) << "Channel " << channel_ << "  Threshold = " << threshold;
-
-    if (item_type_ == "gr_complex")
-        {
-            acquisition_cc_->set_threshold(threshold);
-        }
-}
-
-
-void GpsL1CaPcpsTongAcquisition::set_gnss_synchro(Gnss_Synchro* gnss_synchro)
-{
-    gnss_synchro_ = gnss_synchro;
-    if (item_type_ == "gr_complex")
-        {
-            acquisition_cc_->set_gnss_synchro(gnss_synchro_);
-        }
-}
-
-
-signed int GpsL1CaPcpsTongAcquisition::mag()
-{
-    if (item_type_ == "gr_complex")
-        {
-            return acquisition_cc_->mag();
-        }
-    return 0;
-}
-
-
-void GpsL1CaPcpsTongAcquisition::init()
-{
-    acquisition_cc_->init();
-}
-
-
-void GpsL1CaPcpsTongAcquisition::set_local_code()
-{
-    if (item_type_ == "gr_complex")
-        {
-            std::vector<std::complex<float>> code(code_length_);
-
-            gps_l1_ca_code_gen_complex_sampled(code, gnss_synchro_->PRN, fs_in_, 0);
-
-            own::span<gr_complex> code_span(code_.data(), vector_length_);
-            for (unsigned int i = 0; i < sampled_ms_; i++)
-                {
-                    std::copy_n(code.data(), code_length_, code_span.subspan(i * code_length_, code_length_).data());
-                }
-
-            acquisition_cc_->set_local_code(code_.data());
-        }
-}
-
-
-void GpsL1CaPcpsTongAcquisition::reset()
-{
-    if (item_type_ == "gr_complex")
-        {
-            acquisition_cc_->set_active(true);
-        }
-}
-
-
-void GpsL1CaPcpsTongAcquisition::set_state(int state)
-{
-    if (item_type_ == "gr_complex")
-        {
-            acquisition_cc_->set_state(state);
-        }
-}
-
-
-float GpsL1CaPcpsTongAcquisition::calculate_threshold(float pfa) const
-{
-    // Calculate the threshold
-    unsigned int frequency_bins = 0;
-    for (int doppler = static_cast<int>(-doppler_max_); doppler <= static_cast<int>(doppler_max_); doppler += static_cast<int>(doppler_step_))
-        {
-            frequency_bins++;
-        }
-
-    DLOG(INFO) << "Channel " << channel_ << "   Pfa = " << pfa;
-
-    unsigned int ncells = vector_length_ * frequency_bins;
-    double exponent = 1 / static_cast<double>(ncells);
-    double val = pow(1.0 - pfa, exponent);
-    auto lambda = static_cast<double>(vector_length_);
-    boost::math::exponential_distribution<double> mydist(lambda);
-    auto threshold = static_cast<float>(quantile(mydist, val));
-
-    return threshold;
-}
-
-
-void GpsL1CaPcpsTongAcquisition::connect(gr::top_block_sptr top_block)
-{
-    if (item_type_ == "gr_complex")
-        {
-            top_block->connect(stream_to_vector_, 0, acquisition_cc_, 0);
-        }
-}
-
-
-void GpsL1CaPcpsTongAcquisition::disconnect(gr::top_block_sptr top_block)
-{
-    if (item_type_ == "gr_complex")
-        {
-            top_block->disconnect(stream_to_vector_, 0, acquisition_cc_, 0);
-        }
-}
-
-
-gr::basic_block_sptr GpsL1CaPcpsTongAcquisition::get_left_block()
-{
-    return stream_to_vector_;
-}
-
-
-gr::basic_block_sptr GpsL1CaPcpsTongAcquisition::get_right_block()
-{
-    return acquisition_cc_;
+    gps_l1_ca_code_gen_complex_sampled(dest, prn, sampling_freq, 0);
 }

--- a/src/algorithms/acquisition/adapters/gps_l1_ca_pcps_tong_acquisition.cc
+++ b/src/algorithms/acquisition/adapters/gps_l1_ca_pcps_tong_acquisition.cc
@@ -38,7 +38,6 @@ GpsL1CaPcpsTongAcquisition::GpsL1CaPcpsTongAcquisition(
           role,
           in_streams,
           out_streams,
-          configuration->property(role + ".coherent_integration_time_ms", GPS_L1_CA_CODE_PERIOD_MS),
           GPS_L1_CA_CODE_RATE_CPS,
           GPS_L1_CA_CODE_LENGTH_CHIPS,
           GPS_L1_CA_CODE_PERIOD_MS,
@@ -47,17 +46,13 @@ GpsL1CaPcpsTongAcquisition::GpsL1CaPcpsTongAcquisition(
 {
     if (is_type_gr_complex())
         {
-            const std::string default_dump_filename("./acquisition.dat");
-            const auto dump_filename = configuration->property(role + ".dump_filename", default_dump_filename);
-            const auto enable_monitor_output = configuration->property("AcquisitionMonitor.enable_monitor", false);
-            const auto dump = configuration->property(role + ".dump", false);
             const auto tong_init_val = configuration->property(role + ".tong_init_val", 1U);
             const auto tong_max_val = configuration->property(role + ".tong_max_val", 2U);
             const auto tong_max_dwells = configuration->property(role + ".tong_max_dwells", tong_max_val + 1U);
 
-            acquisition_cc_ = pcps_tong_make_acquisition_cc(sampled_ms_, doppler_max_, doppler_step_, fs_in_,
+            acquisition_cc_ = pcps_tong_make_acquisition_cc(acq_parameters_.sampled_ms, acq_parameters_.doppler_max, acq_parameters_.doppler_step, acq_parameters_.fs_in,
                 code_length_, code_length_, tong_init_val, tong_max_val, tong_max_dwells,
-                dump, dump_filename, enable_monitor_output);
+                acq_parameters_.dump, acq_parameters_.dump_filename, acq_parameters_.enable_monitor_output);
 
             DLOG(INFO) << "acquisition(" << acquisition_cc_->unique_id() << ")";
         }

--- a/src/algorithms/acquisition/adapters/gps_l1_ca_pcps_tong_acquisition.h
+++ b/src/algorithms/acquisition/adapters/gps_l1_ca_pcps_tong_acquisition.h
@@ -18,29 +18,18 @@
 #ifndef GNSS_SDR_GPS_L1_CA_TONG_ACQUISITION_H
 #define GNSS_SDR_GPS_L1_CA_TONG_ACQUISITION_H
 
-#include "channel_fsm.h"
-#include "configuration_interface.h"
-#include "gnss_synchro.h"
-#include "pcps_tong_acquisition_cc.h"
-#include <gnuradio/blocks/stream_to_vector.h>
-#include <memory>
-#include <string>
-#include <utility>
-#include <vector>
+#include "base_pcps_acquisition_custom.h"
 
 /** \addtogroup Acquisition
  * \{ */
 /** \addtogroup Acq_adapters
  * \{ */
 
-
-class ConfigurationInterface;
-
 /*!
  * \brief This class adapts a PCPS Tong acquisition block to an
  *  AcquisitionInterface for GPS L1 C/A signals
  */
-class GpsL1CaPcpsTongAcquisition : public AcquisitionInterface
+class GpsL1CaPcpsTongAcquisition : public BasePcpsAcquisitionCustom
 {
 public:
     GpsL1CaPcpsTongAcquisition(const ConfigurationInterface* configuration,
@@ -50,11 +39,6 @@ public:
 
     ~GpsL1CaPcpsTongAcquisition() = default;
 
-    inline std::string role() override
-    {
-        return role_;
-    }
-
     /*!
      * \brief Returns "GPS_L1_CA_PCPS_Tong_Acquisition"
      */
@@ -63,99 +47,8 @@ public:
         return "GPS_L1_CA_PCPS_Tong_Acquisition";
     }
 
-    inline size_t item_size() override
-    {
-        return item_size_;
-    }
-
-    void connect(gr::top_block_sptr top_block) override;
-    void disconnect(gr::top_block_sptr top_block) override;
-    gr::basic_block_sptr get_left_block() override;
-    gr::basic_block_sptr get_right_block() override;
-
-    /*!
-     * \brief Set acquisition/tracking common Gnss_Synchro object pointer
-     * to efficiently exchange synchronization data between acquisition and
-     *  tracking blocks
-     */
-    void set_gnss_synchro(Gnss_Synchro* p_gnss_synchro) override;
-
-    /*!
-     * \brief Set acquisition channel unique ID
-     */
-    inline void set_channel(unsigned int channel) override
-    {
-        channel_ = channel;
-        acquisition_cc_->set_channel(channel_);
-    }
-
-    /*!
-     * \brief Set channel fsm associated to this acquisition instance
-     */
-    inline void set_channel_fsm(std::weak_ptr<ChannelFsm> channel_fsm) override
-    {
-        channel_fsm_ = std::move(channel_fsm);
-        acquisition_cc_->set_channel_fsm(channel_fsm_);
-    }
-
-    /*!
-     * \brief Set statistics threshold of TONG algorithm
-     */
-    void set_threshold(float threshold) override;
-
-    /*!
-     * \brief Initializes acquisition algorithm.
-     */
-    void init() override;
-
-    /*!
-     * \brief Sets local code for GPS L1/CA TONG acquisition algorithm.
-     */
-    void set_local_code() override;
-
-    /*!
-     * \brief Returns the maximum peak of grid search
-     */
-    signed int mag() override;
-
-    /*!
-     * \brief Restart acquisition algorithm
-     */
-    void reset() override;
-
-    /*!
-     * \brief If state = 1, it forces the block to start acquiring from the first sample
-     */
-    void set_state(int state) override;
-
-    /*!
-     * \brief Stop running acquisition
-     */
-    void stop_acquisition() override;
-
-    void set_resampler_latency(uint32_t latency_samples __attribute__((unused))) override {};
-
 private:
-    float calculate_threshold(float pfa) const;
-
-    const ConfigurationInterface* configuration_;
-    pcps_tong_acquisition_cc_sptr acquisition_cc_;
-    gr::blocks::stream_to_vector::sptr stream_to_vector_;
-    std::weak_ptr<ChannelFsm> channel_fsm_;
-    std::vector<std::complex<float>> code_;
-    Gnss_Synchro* gnss_synchro_;
-    std::string item_type_;
-    std::string dump_filename_;
-    std::string role_;
-    int64_t fs_in_;
-    size_t item_size_;
-    unsigned int vector_length_;
-    unsigned int code_length_;
-    unsigned int channel_;
-    unsigned int doppler_max_;
-    unsigned int doppler_step_;
-    unsigned int sampled_ms_;
-    bool dump_;
+    void code_gen_complex_sampled(own::span<std::complex<float>> dest, uint32_t prn, int32_t sampling_freq) override;
 };
 
 

--- a/src/algorithms/acquisition/adapters/gps_l2_m_pcps_acquisition.h
+++ b/src/algorithms/acquisition/adapters/gps_l2_m_pcps_acquisition.h
@@ -27,9 +27,6 @@
 /** \addtogroup Acq_adapters
  * \{ */
 
-
-class ConfigurationInterface;
-
 /*!
  * \brief This class adapts a PCPS acquisition block to an AcquisitionInterface
  *  for GPS L2 M signals

--- a/src/algorithms/acquisition/adapters/gps_l2_m_pcps_acquisition_fpga.h
+++ b/src/algorithms/acquisition/adapters/gps_l2_m_pcps_acquisition_fpga.h
@@ -27,9 +27,6 @@
 /** \addtogroup Acq_adapters
  * \{ */
 
-
-class ConfigurationInterface;
-
 /*!
  * \brief This class adapts a PCPS acquisition block off-loaded on an FPGA
  * to an AcquisitionInterface for GPS L2 M signals

--- a/src/algorithms/acquisition/adapters/gps_l5i_pcps_acquisition.h
+++ b/src/algorithms/acquisition/adapters/gps_l5i_pcps_acquisition.h
@@ -27,9 +27,6 @@
 /** \addtogroup Acq_adapters
  * \{ */
 
-
-class ConfigurationInterface;
-
 /*!
  * \brief This class adapts a PCPS acquisition block to an AcquisitionInterface
  *  for GPS L5i signals

--- a/src/algorithms/acquisition/adapters/gps_l5i_pcps_acquisition_fpga.h
+++ b/src/algorithms/acquisition/adapters/gps_l5i_pcps_acquisition_fpga.h
@@ -28,9 +28,6 @@
 /** \addtogroup Acq_adapters
  * \{ */
 
-
-class ConfigurationInterface;
-
 /*!
  * \brief This class adapts a PCPS acquisition block off-loaded on an FPGA
  * to an AcquisitionInterface for GPS L5i signals

--- a/src/algorithms/acquisition/gnuradio_blocks/CMakeLists.txt
+++ b/src/algorithms/acquisition/gnuradio_blocks/CMakeLists.txt
@@ -17,6 +17,7 @@ set(ACQ_GR_BLOCKS_SOURCES
 )
 
 set(ACQ_GR_BLOCKS_HEADERS
+    acquisition_impl_interface.h
     pcps_acquisition.h
     pcps_assisted_acquisition_cc.h
     pcps_acquisition_fine_doppler_cc.h

--- a/src/algorithms/acquisition/gnuradio_blocks/acquisition_impl_interface.h
+++ b/src/algorithms/acquisition/gnuradio_blocks/acquisition_impl_interface.h
@@ -1,0 +1,71 @@
+/*!
+ * \file acquisition_impl_interface.h
+ * \brief Header file of the interface to an acquisition implementation GNSS block.
+ * \author Mathieu Favraeu, 2025. favreau.mathieu(at)hotmail.com
+ *
+ * This header file contains the interface to an abstract class
+ * for acquisition algorithms. Since all its methods are virtual,
+ * this class cannot be instantiated directly, and a subclass can only be
+ * instantiated directly if all inherited pure virtual methods have been
+ * implemented by that class or a parent class.
+ *
+ * -----------------------------------------------------------------------------
+ *
+ * GNSS-SDR is a Global Navigation Satellite System software-defined receiver.
+ * This file is part of GNSS-SDR.
+ *
+ * Copyright (C) 2010-2025  (see AUTHORS file for a list of contributors)
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ *
+ * -----------------------------------------------------------------------------
+ */
+
+#ifndef GNSS_SDR_ACQUISITION_IMPL_INTERFACE_H
+#define GNSS_SDR_ACQUISITION_IMPL_INTERFACE_H
+
+#include "gnss_block_interface.h"
+#include "gnss_synchro.h"
+#include <gnuradio/block.h>
+#include <complex>
+#include <memory>
+
+/** \addtogroup Core
+ * \{ */
+/** \addtogroup GNSS_Block_Interfaces GNSS block interfaces
+ * GNSS block interfaces.
+ * \{ */
+
+class ChannelFsm;
+class acquisition_impl_interface;
+
+using acquisition_impl_interface_sptr = gnss_shared_ptr<acquisition_impl_interface>;
+
+/*! \brief This abstract class represents an interface to an acquisition GNSS block.
+ *
+ * Abstract class for acquisition algorithms. Since all its methods are virtual,
+ * this class cannot be instantiated directly, and a subclass can only be
+ * instantiated directly if all inherited pure virtual methods have been
+ * implemented by that class or a parent class.
+ */
+class acquisition_impl_interface : public gr::block
+{
+public:
+    acquisition_impl_interface(const std::string& name,
+        gr::io_signature::sptr input_signature,
+        gr::io_signature::sptr output_signature) : gr::block(name, std::move(input_signature), std::move(output_signature)) {}
+
+    virtual void set_gnss_synchro(Gnss_Synchro* gnss_synchro) = 0;
+    virtual void set_channel(uint32_t channel_id) = 0;
+    virtual void set_channel_fsm(std::weak_ptr<ChannelFsm> channel_fsm) = 0;
+    virtual void set_threshold(float threshold) = 0;
+    virtual void init() = 0;
+    virtual void set_local_code(std::complex<float>* code) = 0;
+    virtual void set_state(int32_t state) = 0;
+    virtual uint32_t mag() const = 0;
+    virtual void set_active(bool active) = 0;
+};
+
+
+/** \} */
+/** \} */
+#endif  // GNSS_SDR_ACQUISITION_INTERFACE */

--- a/src/algorithms/acquisition/gnuradio_blocks/galileo_pcps_8ms_acquisition_cc.cc
+++ b/src/algorithms/acquisition/gnuradio_blocks/galileo_pcps_8ms_acquisition_cc.cc
@@ -60,7 +60,7 @@ galileo_pcps_8ms_acquisition_cc::galileo_pcps_8ms_acquisition_cc(
     bool dump,
     const std::string &dump_filename,
     bool enable_monitor_output)
-    : gr::block("galileo_pcps_8ms_acquisition_cc",
+    : acquisition_impl_interface("galileo_pcps_8ms_acquisition_cc",
           gr::io_signature::make(1, 1, static_cast<int>(sizeof(gr_complex) * sampled_ms * samples_per_ms)),
           gr::io_signature::make(0, 1, sizeof(Gnss_Synchro))),
       d_dump_filename(dump_filename),

--- a/src/algorithms/acquisition/gnuradio_blocks/galileo_pcps_8ms_acquisition_cc.h
+++ b/src/algorithms/acquisition/gnuradio_blocks/galileo_pcps_8ms_acquisition_cc.h
@@ -18,6 +18,7 @@
 #ifndef GNSS_SDR_PCPS_8MS_ACQUISITION_CC_H
 #define GNSS_SDR_PCPS_8MS_ACQUISITION_CC_H
 
+#include "acquisition_impl_interface.h"
 #include "channel_fsm.h"
 #include "gnss_sdr_fft.h"
 #include "gnss_synchro.h"
@@ -55,7 +56,7 @@ galileo_pcps_8ms_make_acquisition_cc(uint32_t sampled_ms,
  * \brief This class implements a Parallel Code Phase Search Acquisition for
  * Galileo E1 signals with coherent integration time = 8 ms (two codes)
  */
-class galileo_pcps_8ms_acquisition_cc : public gr::block
+class galileo_pcps_8ms_acquisition_cc : public acquisition_impl_interface
 {
 public:
     /*!
@@ -68,7 +69,7 @@ public:
      * to exchange synchronization data between acquisition and tracking blocks.
      * \param p_gnss_synchro Satellite information shared by the processing blocks.
      */
-    inline void set_gnss_synchro(Gnss_Synchro* p_gnss_synchro)
+    inline void set_gnss_synchro(Gnss_Synchro* p_gnss_synchro) override
     {
         d_gnss_synchro = p_gnss_synchro;
     }
@@ -76,7 +77,7 @@ public:
     /*!
      * \brief Returns the maximum peak of grid search.
      */
-    inline uint32_t mag() const
+    inline uint32_t mag() const override
     {
         return d_mag;
     }
@@ -84,20 +85,20 @@ public:
     /*!
      * \brief Initializes acquisition algorithm.
      */
-    void init();
+    void init() override;
 
     /*!
      * \brief Sets local code for PCPS acquisition algorithm.
      * \param code - Pointer to the PRN code.
      */
-    void set_local_code(std::complex<float>* code);
+    void set_local_code(std::complex<float>* code) override;
 
     /*!
      * \brief Starts acquisition algorithm, turning from standby mode to
      * active mode
      * \param active - bool that activates/deactivates the block.
      */
-    inline void set_active(bool active)
+    inline void set_active(bool active) override
     {
         d_active = active;
     }
@@ -107,13 +108,13 @@ public:
      * first available sample.
      * \param state - int=1 forces start of acquisition
      */
-    void set_state(int32_t state);
+    void set_state(int32_t state) override;
 
     /*!
      * \brief Set acquisition channel unique ID
      * \param channel - receiver channel.
      */
-    inline void set_channel(uint32_t channel)
+    inline void set_channel(uint32_t channel) override
     {
         d_channel = channel;
     }
@@ -121,7 +122,7 @@ public:
     /*!
      * \brief Set channel fsm associated to this acquisition instance
      */
-    inline void set_channel_fsm(std::weak_ptr<ChannelFsm> channel_fsm)
+    inline void set_channel_fsm(std::weak_ptr<ChannelFsm> channel_fsm) override
     {
         d_channel_fsm = std::move(channel_fsm);
     }
@@ -131,7 +132,7 @@ public:
      * \param threshold - Threshold for signal detection (check \ref Navitec2012,
      * Algorithm 1, for a definition of this threshold).
      */
-    inline void set_threshold(float threshold)
+    inline void set_threshold(float threshold) override
     {
         d_threshold = threshold;
     }
@@ -141,7 +142,7 @@ public:
      */
     int general_work(int noutput_items, gr_vector_int& ninput_items,
         gr_vector_const_void_star& input_items,
-        gr_vector_void_star& output_items);
+        gr_vector_void_star& output_items) override;
 
 private:
     friend galileo_pcps_8ms_acquisition_cc_sptr

--- a/src/algorithms/acquisition/gnuradio_blocks/pcps_acquisition.cc
+++ b/src/algorithms/acquisition/gnuradio_blocks/pcps_acquisition.cc
@@ -54,7 +54,7 @@ pcps_acquisition_sptr pcps_make_acquisition(const Acq_Conf& conf_)
 
 
 pcps_acquisition::pcps_acquisition(const Acq_Conf& conf_)
-    : gr::block("pcps_acquisition",
+    : acquisition_impl_interface("pcps_acquisition",
           gr::io_signature::make(1, 1, conf_.it_size),
           gr::io_signature::make(0, 1, sizeof(Gnss_Synchro))),
       d_acq_parameters(conf_),

--- a/src/algorithms/acquisition/gnuradio_blocks/pcps_acquisition.h
+++ b/src/algorithms/acquisition/gnuradio_blocks/pcps_acquisition.h
@@ -38,6 +38,7 @@
 #ifndef GNSS_SDR_PCPS_ACQUISITION_H
 #define GNSS_SDR_PCPS_ACQUISITION_H
 
+#include "acquisition_impl_interface.h"
 #if ARMA_NO_BOUND_CHECKING
 #define ARMA_NO_DEBUG 1
 #endif
@@ -89,7 +90,7 @@ pcps_acquisition_sptr pcps_make_acquisition(const Acq_Conf& conf_);
  * Check \ref Navitec2012 "An Open Source Galileo E1 Software Receiver",
  * Algorithm 1, for a pseudocode description of this implementation.
  */
-class pcps_acquisition : public gr::block
+class pcps_acquisition : public acquisition_impl_interface
 {
 public:
     ~pcps_acquisition() override = default;
@@ -97,14 +98,14 @@ public:
     /*!
      * \brief Initializes acquisition algorithm and reserves memory.
      */
-    void init();
+    void init() override;
 
     /*!
      * \brief Set acquisition/tracking common Gnss_Synchro object pointer
      * to exchange synchronization data between acquisition and tracking blocks.
      * \param p_gnss_synchro Satellite information shared by the processing blocks.
      */
-    inline void set_gnss_synchro(Gnss_Synchro* p_gnss_synchro)
+    inline void set_gnss_synchro(Gnss_Synchro* p_gnss_synchro) override
     {
         gr::thread::scoped_lock lock(d_setlock);  // require mutex with work function called by the scheduler
         d_gnss_synchro = p_gnss_synchro;
@@ -114,21 +115,21 @@ public:
      * \brief Sets local code for PCPS acquisition algorithm.
      * \param code - Pointer to the PRN code.
      */
-    void set_local_code(std::complex<float>* code);
+    void set_local_code(std::complex<float>* code) override;
 
     /*!
      * \brief If set to 1, ensures that acquisition starts at the
      * first available sample.
      * \param state - int=1 forces start of acquisition
      */
-    void set_state(int32_t state);
+    void set_state(int32_t state) override;
 
     void set_resampler_latency(uint32_t latency_samples);
 
     /*!
      * \brief Returns the maximum peak of grid search.
      */
-    inline uint32_t mag() const
+    inline uint32_t mag() const override
     {
         return d_mag;
     }
@@ -138,7 +139,7 @@ public:
      * active mode
      * \param active - bool that activates/deactivates the block.
      */
-    inline void set_active(bool active)
+    inline void set_active(bool active) override
     {
         gr::thread::scoped_lock lock(d_setlock);  // require mutex with work function called by the scheduler
         d_active = active;
@@ -148,7 +149,7 @@ public:
      * \brief Set acquisition channel unique ID
      * \param channel - receiver channel.
      */
-    inline void set_channel(uint32_t channel)
+    inline void set_channel(uint32_t channel) override
     {
         d_channel = channel;
     }
@@ -156,7 +157,7 @@ public:
     /*!
      * \brief Set channel fsm associated to this acquisition instance
      */
-    inline void set_channel_fsm(std::weak_ptr<ChannelFsm> channel_fsm)
+    inline void set_channel_fsm(std::weak_ptr<ChannelFsm> channel_fsm) override
     {
         d_channel_fsm = std::move(channel_fsm);
     }
@@ -166,7 +167,7 @@ public:
      * \param threshold - Threshold for signal detection (check \ref Navitec2012,
      * Algorithm 1, for a definition of this threshold).
      */
-    inline void set_threshold(float threshold)
+    inline void set_threshold(float threshold) override
     {
         gr::thread::scoped_lock lock(d_setlock);  // require mutex with work function called by the scheduler
         d_threshold = threshold;

--- a/src/algorithms/acquisition/gnuradio_blocks/pcps_acquisition_fine_doppler_cc.cc
+++ b/src/algorithms/acquisition/gnuradio_blocks/pcps_acquisition_fine_doppler_cc.cc
@@ -26,8 +26,6 @@
 #include <volk/volk.h>
 #include <algorithm>  // std::rotate, std::fill_n
 #include <array>
-#include <sstream>
-#include <vector>
 
 #if USE_GLOG_AND_GFLAGS
 #include <glog/logging.h>
@@ -44,7 +42,7 @@ pcps_acquisition_fine_doppler_cc_sptr pcps_make_acquisition_fine_doppler_cc(cons
 
 
 pcps_acquisition_fine_doppler_cc::pcps_acquisition_fine_doppler_cc(const Acq_Conf &conf_)
-    : gr::block("pcps_acquisition_fine_doppler_cc",
+    : acquisition_impl_interface("pcps_acquisition_fine_doppler_cc",
           gr::io_signature::make(1, 1, sizeof(gr_complex)),
           gr::io_signature::make(0, 1, sizeof(Gnss_Synchro))),
       d_dump_filename(conf_.dump_filename),

--- a/src/algorithms/acquisition/gnuradio_blocks/pcps_acquisition_fine_doppler_cc.h
+++ b/src/algorithms/acquisition/gnuradio_blocks/pcps_acquisition_fine_doppler_cc.h
@@ -35,6 +35,7 @@
 #ifndef GNSS_SDR_PCPS_ACQUISITION_FINE_DOPPLER_CC_H
 #define GNSS_SDR_PCPS_ACQUISITION_FINE_DOPPLER_CC_H
 
+#include "acquisition_impl_interface.h"
 #if ARMA_NO_BOUND_CHECKING
 #define ARMA_NO_DEBUG 1
 #endif
@@ -70,7 +71,7 @@ pcps_acquisition_fine_doppler_cc_sptr pcps_make_acquisition_fine_doppler_cc(cons
  * \brief This class implements a Parallel Code Phase Search Acquisition.
  *
  */
-class pcps_acquisition_fine_doppler_cc : public gr::block
+class pcps_acquisition_fine_doppler_cc : public acquisition_impl_interface
 {
 public:
     /*!
@@ -83,7 +84,7 @@ public:
      * to exchange synchronization data between acquisition and tracking blocks.
      * \param p_gnss_synchro Satellite information shared by the processing blocks.
      */
-    inline void set_gnss_synchro(Gnss_Synchro* p_gnss_synchro)
+    inline void set_gnss_synchro(Gnss_Synchro* p_gnss_synchro) override
     {
         d_gnss_synchro = p_gnss_synchro;
     }
@@ -91,7 +92,7 @@ public:
     /*!
      * \brief Returns the maximum peak of grid search.
      */
-    inline unsigned int mag() const
+    inline unsigned int mag() const override
     {
         return d_test_statistics;
     }
@@ -99,20 +100,20 @@ public:
     /*!
      * \brief Initializes acquisition algorithm.
      */
-    void init();
+    void init() override;
 
     /*!
      * \brief Sets local code for PCPS acquisition algorithm.
      * \param code - Pointer to the PRN code.
      */
-    void set_local_code(std::complex<float>* code);
+    void set_local_code(std::complex<float>* code) override;
 
     /*!
      * \brief Starts acquisition algorithm, turning from standby mode to
      * active mode
      * \param active - bool that activates/deactivates the block.
      */
-    inline void set_active(bool active)
+    inline void set_active(bool active) override
     {
         d_active = active;
     }
@@ -121,7 +122,7 @@ public:
      * \brief Set acquisition channel unique ID
      * \param channel - receiver channel.
      */
-    inline void set_channel(unsigned int channel)
+    inline void set_channel(unsigned int channel) override
     {
         d_channel = channel;
         d_dump_channel = d_channel;
@@ -130,7 +131,7 @@ public:
     /*!
      * \brief Set channel fsm associated to this acquisition instance
      */
-    inline void set_channel_fsm(std::weak_ptr<ChannelFsm> channel_fsm)
+    inline void set_channel_fsm(std::weak_ptr<ChannelFsm> channel_fsm) override
     {
         d_channel_fsm = std::move(channel_fsm);
     }
@@ -140,7 +141,7 @@ public:
      * \param threshold - Threshold for signal detection (check \ref Navitec2012,
      * Algorithm 1, for a definition of this threshold).
      */
-    inline void set_threshold(float threshold)
+    inline void set_threshold(float threshold) override
     {
         d_threshold = threshold;
     }
@@ -150,8 +151,16 @@ public:
      * first available sample.
      * \param state - int=1 forces start of acquisition
      */
-    void set_state(int state);
+    void set_state(int state) override;
 
+    /*!
+     * \brief Parallel Code Phase Search Acquisition signal processing.
+     */
+    int general_work(int noutput_items, gr_vector_int& ninput_items,
+        gr_vector_const_void_star& input_items,
+        gr_vector_void_star& output_items) override;
+
+private:
     /*!
      * \brief Obtains the next power of 2 greater or equal to the input parameter
      * \param n - Integer value to obtain the next power of 2.
@@ -160,16 +169,8 @@ public:
 
     void dump_results(int effective_fft_size);
 
-    void forecast(int noutput_items, gr_vector_int& ninput_items_required);
+    void forecast(int noutput_items, gr_vector_int& ninput_items_required) override;
 
-    /*!
-     * \brief Parallel Code Phase Search Acquisition signal processing.
-     */
-    int general_work(int noutput_items, gr_vector_int& ninput_items,
-        gr_vector_const_void_star& input_items,
-        gr_vector_void_star& output_items);
-
-private:
     friend pcps_acquisition_fine_doppler_cc_sptr pcps_make_acquisition_fine_doppler_cc(const Acq_Conf& conf_);
     explicit pcps_acquisition_fine_doppler_cc(const Acq_Conf& conf_);
 

--- a/src/algorithms/acquisition/gnuradio_blocks/pcps_assisted_acquisition_cc.cc
+++ b/src/algorithms/acquisition/gnuradio_blocks/pcps_assisted_acquisition_cc.cc
@@ -53,7 +53,7 @@ pcps_assisted_acquisition_cc::pcps_assisted_acquisition_cc(
     int32_t max_dwells, uint32_t sampled_ms, int32_t doppler_max, int32_t doppler_min,
     int32_t doppler_step, int64_t fs_in, int32_t samples_per_ms, bool dump,
     const std::string &dump_filename, bool enable_monitor_output)
-    : gr::block("pcps_assisted_acquisition_cc",
+    : acquisition_impl_interface("pcps_assisted_acquisition_cc",
           gr::io_signature::make(1, 1, sizeof(gr_complex)),
           gr::io_signature::make(0, 1, sizeof(Gnss_Synchro))),
       d_dump_filename(dump_filename),

--- a/src/algorithms/acquisition/gnuradio_blocks/pcps_assisted_acquisition_cc.h
+++ b/src/algorithms/acquisition/gnuradio_blocks/pcps_assisted_acquisition_cc.h
@@ -34,6 +34,7 @@
 #ifndef GNSS_SDR_PCPS_ASSISTED_ACQUISITION_CC_H
 #define GNSS_SDR_PCPS_ASSISTED_ACQUISITION_CC_H
 
+#include "acquisition_impl_interface.h"
 #include "channel_fsm.h"
 #include "gnss_sdr_fft.h"
 #include "gnss_synchro.h"
@@ -73,7 +74,7 @@ pcps_assisted_acquisition_cc_sptr pcps_make_assisted_acquisition_cc(
  * Check \ref Navitec2012 "An Open Source Galileo E1 Software Receiver",
  * Algorithm 1, for a pseudocode description of this implementation.
  */
-class pcps_assisted_acquisition_cc : public gr::block
+class pcps_assisted_acquisition_cc : public acquisition_impl_interface
 {
 public:
     /*!
@@ -86,7 +87,7 @@ public:
      * to exchange synchronization data between acquisition and tracking blocks.
      * \param p_gnss_synchro Satellite information shared by the processing blocks.
      */
-    inline void set_gnss_synchro(Gnss_Synchro* p_gnss_synchro)
+    inline void set_gnss_synchro(Gnss_Synchro* p_gnss_synchro) override
     {
         d_gnss_synchro = p_gnss_synchro;
     }
@@ -94,7 +95,7 @@ public:
     /*!
      * \brief Returns the maximum peak of grid search.
      */
-    inline uint32_t mag() const
+    inline uint32_t mag() const override
     {
         return d_test_statistics;
     }
@@ -102,20 +103,20 @@ public:
     /*!
      * \brief Initializes acquisition algorithm.
      */
-    void init();
+    void init() override;
 
     /*!
      * \brief Sets local code for PCPS acquisition algorithm.
      * \param code - Pointer to the PRN code.
      */
-    void set_local_code(std::complex<float>* code);
+    void set_local_code(std::complex<float>* code) override;
 
     /*!
      * \brief Starts acquisition algorithm, turning from standby mode to
      * active mode
      * \param active - bool that activates/deactivates the block.
      */
-    inline void set_active(bool active)
+    inline void set_active(bool active) override
     {
         d_active = active;
     }
@@ -124,7 +125,7 @@ public:
      * \brief Set acquisition channel unique ID
      * \param channel - receiver channel.
      */
-    inline void set_channel(uint32_t channel)
+    inline void set_channel(uint32_t channel) override
     {
         d_channel = channel;
     }
@@ -132,7 +133,7 @@ public:
     /*!
      * \brief Set channel fsm associated to this acquisition instance
      */
-    inline void set_channel_fsm(std::weak_ptr<ChannelFsm> channel_fsm)
+    inline void set_channel_fsm(std::weak_ptr<ChannelFsm> channel_fsm) override
     {
         d_channel_fsm = std::move(channel_fsm);
     }
@@ -142,12 +143,12 @@ public:
      * \param threshold - Threshold for signal detection (check \ref Navitec2012,
      * Algorithm 1, for a definition of this threshold).
      */
-    inline void set_threshold(float threshold)
+    inline void set_threshold(float threshold) override
     {
         d_threshold = threshold;
     }
 
-    inline void set_state(int32_t state)
+    inline void set_state(int32_t state) override
     {
         d_state = state;
     }
@@ -157,11 +158,12 @@ public:
      */
     int general_work(int noutput_items, gr_vector_int& ninput_items,
         gr_vector_const_void_star& input_items,
-        gr_vector_void_star& output_items);
+        gr_vector_void_star& output_items) override;
 
-    void forecast(int noutput_items, gr_vector_int& ninput_items_required);
 
 private:
+    void forecast(int noutput_items, gr_vector_int& ninput_items_required) override;
+
     friend pcps_assisted_acquisition_cc_sptr
     pcps_make_assisted_acquisition_cc(int32_t max_dwells, uint32_t sampled_ms,
         int32_t doppler_max, int32_t doppler_min, int32_t doppler_step,

--- a/src/algorithms/acquisition/gnuradio_blocks/pcps_opencl_acquisition_cc.cc
+++ b/src/algorithms/acquisition/gnuradio_blocks/pcps_opencl_acquisition_cc.cc
@@ -83,7 +83,7 @@ pcps_opencl_acquisition_cc::pcps_opencl_acquisition_cc(
     bool dump,
     const std::string &dump_filename,
     bool enable_monitor_output)
-    : gr::block("pcps_opencl_acquisition_cc",
+    : acquisition_impl_interface("pcps_opencl_acquisition_cc",
           gr::io_signature::make(1, 1, static_cast<int>(sizeof(gr_complex) * sampled_ms * samples_per_ms)),
           gr::io_signature::make(0, 1, sizeof(Gnss_Synchro))),
       d_cl_fft_batch_size(1),

--- a/src/algorithms/acquisition/gnuradio_blocks/pcps_opencl_acquisition_cc.h
+++ b/src/algorithms/acquisition/gnuradio_blocks/pcps_opencl_acquisition_cc.h
@@ -38,6 +38,7 @@
 #define GNSS_SDR_PCPS_OPENCL_ACQUISITION_CC_H
 
 #define CL_SILENCE_DEPRECATION
+#include "acquisition_impl_interface.h"
 #include "channel_fsm.h"
 #include "gnss_block_interface.h"
 #include "gnss_sdr_fft.h"
@@ -81,7 +82,7 @@ pcps_opencl_acquisition_cc_sptr pcps_make_opencl_acquisition_cc(
  * Check \ref Navitec2012 "An Open Source Galileo E1 Software Receiver",
  * Algorithm 1, for a pseudocode description of this implementation.
  */
-class pcps_opencl_acquisition_cc : public gr::block
+class pcps_opencl_acquisition_cc : public acquisition_impl_interface
 {
 public:
     /*!
@@ -94,7 +95,7 @@ public:
      * to exchange synchronization data between acquisition and tracking blocks.
      * \param p_gnss_synchro Satellite information shared by the processing blocks.
      */
-    inline void set_gnss_synchro(Gnss_Synchro* p_gnss_synchro)
+    inline void set_gnss_synchro(Gnss_Synchro* p_gnss_synchro) override
     {
         d_gnss_synchro = p_gnss_synchro;
     }
@@ -102,7 +103,7 @@ public:
     /*!
      * \brief Returns the maximum peak of grid search.
      */
-    inline uint32_t mag() const
+    inline uint32_t mag() const override
     {
         return d_mag;
     }
@@ -110,20 +111,20 @@ public:
     /*!
      * \brief Initializes acquisition algorithm.
      */
-    void init();
+    void init() override;
 
     /*!
      * \brief Sets local code for PCPS acquisition algorithm.
      * \param code - Pointer to the PRN code.
      */
-    void set_local_code(std::complex<float>* code);
+    void set_local_code(std::complex<float>* code) override;
 
     /*!
      * \brief Starts acquisition algorithm, turning from standby mode to
      * active mode
      * \param active - bool that activates/deactivates the block.
      */
-    inline void set_active(bool active)
+    inline void set_active(bool active) override
     {
         d_active = active;
     }
@@ -133,13 +134,13 @@ public:
      * first available sample.
      * \param state - int=1 forces start of acquisition
      */
-    void set_state(int state);
+    void set_state(int state) override;
 
     /*!
      * \brief Set acquisition channel unique ID
      * \param channel - receiver channel.
      */
-    inline void set_channel(uint32_t channel)
+    inline void set_channel(uint32_t channel) override
     {
         d_channel = channel;
     }
@@ -147,7 +148,7 @@ public:
     /*!
      * \brief Set channel fsm associated to this acquisition instance
      */
-    inline void set_channel_fsm(std::weak_ptr<ChannelFsm> channel_fsm)
+    inline void set_channel_fsm(std::weak_ptr<ChannelFsm> channel_fsm) override
     {
         d_channel_fsm = channel_fsm;
     }
@@ -157,7 +158,7 @@ public:
      * \param threshold - Threshold for signal detection (check \ref Navitec2012,
      * Algorithm 1, for a definition of this threshold).
      */
-    inline void set_threshold(float threshold)
+    inline void set_threshold(float threshold) override
     {
         d_threshold = threshold;
     }
@@ -181,7 +182,7 @@ public:
      */
     int general_work(int noutput_items, gr_vector_int& ninput_items,
         gr_vector_const_void_star& input_items,
-        gr_vector_void_star& output_items);
+        gr_vector_void_star& output_items) override;
 
 private:
     friend pcps_opencl_acquisition_cc_sptr

--- a/src/algorithms/acquisition/gnuradio_blocks/pcps_tong_acquisition_cc.cc
+++ b/src/algorithms/acquisition/gnuradio_blocks/pcps_tong_acquisition_cc.cc
@@ -84,7 +84,7 @@ pcps_tong_acquisition_cc::pcps_tong_acquisition_cc(
     bool dump,
     const std::string &dump_filename,
     bool enable_monitor_output)
-    : gr::block("pcps_tong_acquisition_cc",
+    : acquisition_impl_interface("pcps_tong_acquisition_cc",
           gr::io_signature::make(1, 1, static_cast<int>(sizeof(gr_complex) * sampled_ms * samples_per_ms)),
           gr::io_signature::make(0, 1, sizeof(Gnss_Synchro))),
       d_dump_filename(dump_filename),

--- a/src/algorithms/acquisition/gnuradio_blocks/pcps_tong_acquisition_cc.h
+++ b/src/algorithms/acquisition/gnuradio_blocks/pcps_tong_acquisition_cc.h
@@ -37,6 +37,7 @@
 #ifndef GNSS_SDR_PCPS_TONG_ACQUISITION_CC_H
 #define GNSS_SDR_PCPS_TONG_ACQUISITION_CC_H
 
+#include "acquisition_impl_interface.h"
 #include "channel_fsm.h"
 #include "gnss_sdr_fft.h"
 #include "gnss_synchro.h"
@@ -76,7 +77,7 @@ pcps_tong_acquisition_cc_sptr pcps_tong_make_acquisition_cc(
  * \brief This class implements a Parallel Code Phase Search Acquisition with
  * Tong algorithm.
  */
-class pcps_tong_acquisition_cc : public gr::block
+class pcps_tong_acquisition_cc : public acquisition_impl_interface
 {
 public:
     /*!
@@ -89,7 +90,7 @@ public:
      * to exchange synchronization data between acquisition and tracking blocks.
      * \param p_gnss_synchro Satellite information shared by the processing blocks.
      */
-    inline void set_gnss_synchro(Gnss_Synchro* p_gnss_synchro)
+    inline void set_gnss_synchro(Gnss_Synchro* p_gnss_synchro) override
     {
         d_gnss_synchro = p_gnss_synchro;
     }
@@ -97,7 +98,7 @@ public:
     /*!
      * \brief Returns the maximum peak of grid search.
      */
-    inline uint32_t mag() const
+    inline uint32_t mag() const override
     {
         return d_mag;
     }
@@ -105,20 +106,20 @@ public:
     /*!
      * \brief Initializes acquisition algorithm.
      */
-    void init();
+    void init() override;
 
     /*!
      * \brief Sets local code for TONG acquisition algorithm.
      * \param code - Pointer to the PRN code.
      */
-    void set_local_code(std::complex<float>* code);
+    void set_local_code(std::complex<float>* code) override;
 
     /*!
      * \brief Starts acquisition algorithm, turning from standby mode to
      * active mode
      * \param active - bool that activates/deactivates the block.
      */
-    inline void set_active(bool active)
+    inline void set_active(bool active) override
     {
         d_active = active;
     }
@@ -128,13 +129,13 @@ public:
      * first available sample.
      * \param state - int=1 forces start of acquisition
      */
-    void set_state(int32_t state);
+    void set_state(int32_t state) override;
 
     /*!
      * \brief Set acquisition channel unique ID
      * \param channel - receiver channel.
      */
-    inline void set_channel(uint32_t channel)
+    inline void set_channel(uint32_t channel) override
     {
         d_channel = channel;
     }
@@ -142,7 +143,7 @@ public:
     /*!
      * \brief Set channel fsm associated to this acquisition instance
      */
-    inline void set_channel_fsm(std::weak_ptr<ChannelFsm> channel_fsm)
+    inline void set_channel_fsm(std::weak_ptr<ChannelFsm> channel_fsm) override
     {
         d_channel_fsm = std::move(channel_fsm);
     }
@@ -152,7 +153,7 @@ public:
      * \param threshold - Threshold for signal detection (check \ref Navitec2012,
      * Algorithm 1, for a definition of this threshold).
      */
-    inline void set_threshold(float threshold)
+    inline void set_threshold(float threshold) override
     {
         d_threshold = threshold;
     }
@@ -162,7 +163,7 @@ public:
      */
     int general_work(int noutput_items, gr_vector_int& ninput_items,
         gr_vector_const_void_star& input_items,
-        gr_vector_void_star& output_items);
+        gr_vector_void_star& output_items) override;
 
 private:
     friend pcps_tong_acquisition_cc_sptr


### PR DESCRIPTION
For now I've added a new class `BasePcpsAcquisitionCustom` (yeah I know, didn't have much inspiration) which we should be able to merge with `BasePcpsAcquisition`, but for now kept separated as a first step.

I've added an interface `acquisition_impl_interface` in order for `BasePcpsAcquisitionCustom` to be able to generalize access to the acquisition implementation classes.

I am not sure about `GpsL1CaPcpsAcquisitionFineDoppler`, the previous implementation was reading `.coherent_integration_time_ms` from the config but never used it, can the implementation work with integration times larger then 1ms? The documentation list that parameter so that's why I am unsure.

Also I wanted to use this base class with `GalileoE1PcpsQuickSyncAmbiguousAcquisition` and `GpsL1CaPcpsQuickSyncAcquisition`, but I am wondering if there might be bugs in the implementations and wanted to ask before I touch them:
- In `GpsL1CaPcpsQuickSyncAcquisition`, `code_` is initialized a size `code_length_` but the span in `set_local_code` is initialized at size `vector_length_`, which is `code_length_ * sampled_ms_`. With the test `GpsL1CaPcpsQuickSyncAcquisitionGSoC2014Test` it isn't an issue since `sampled_ms_` and `folding_factor_` are equal, so `for (unsigned int i = 0; i < (sampled_ms_ / folding_factor_); i++)` will only access the allocated code. Should `code_` be initialized with size `vector_length_`, and `vector_length_` actually be `code_length_ * sampled_ms_ / folding_factor_`?
- Same issue for `GalileoE1PcpsQuickSyncAmbiguousAcquisition`