### PR TITLE
Cleanup and fix QuickSync acquisition

### DIFF
--- a/src/algorithms/acquisition/adapters/base_pcps_acquisition_custom.h
+++ b/src/algorithms/acquisition/adapters/base_pcps_acquisition_custom.h
@@ -130,7 +130,7 @@ protected:
     unsigned int channel_;
 
 private:
-    float calculate_threshold(float pfa) const;
+    virtual float calculate_threshold(float pfa) const;
 
     /*!
      * \brief Generate code

--- a/src/algorithms/acquisition/adapters/galileo_e1_pcps_quicksync_ambiguous_acquisition.cc
+++ b/src/algorithms/acquisition/adapters/galileo_e1_pcps_quicksync_ambiguous_acquisition.cc
@@ -19,9 +19,8 @@
 #include "Galileo_E1.h"
 #include "configuration_interface.h"
 #include "galileo_e1_signal_replica.h"
-#include "gnss_sdr_flags.h"
+#include "pcps_quicksync_acquisition_cc.h"
 #include <boost/math/distributions/exponential.hpp>
-#include <algorithm>
 
 #if USE_GLOG_AND_GFLAGS
 #include <glog/logging.h>
@@ -29,252 +28,69 @@
 #include <absl/log/log.h>
 #endif
 
-#if HAS_STD_SPAN
-#include <span>
-namespace own = std;
-#else
-#include <gsl-lite/gsl-lite.hpp>
-namespace own = gsl_lite;
-#endif
+namespace
+{
+uint32_t get_folding_factor(const ConfigurationInterface* configuration, const std::string& role)
+{
+    /*  Calculate the folding factor value based on the formula described in the paper.
+        This may be a bug, but acquisition also work by variying the folding factor at va-
+        lues different that the expressed in the paper. In addition, it is important to point
+        out that by making the folding factor smaller we were able to get QuickSync work with
+        Galileo. Future work should be directed to test this assumption statistically. */
+
+    // return static_cast<unsigned int>(ceil(sqrt(log2(code_length_))));
+    return configuration->property(role + ".folding_factor", 2);
+}
+}  // namespace
 
 GalileoE1PcpsQuickSyncAmbiguousAcquisition::GalileoE1PcpsQuickSyncAmbiguousAcquisition(
     const ConfigurationInterface* configuration,
     const std::string& role,
     unsigned int in_streams,
     unsigned int out_streams)
-    : configuration_(configuration),
-      role_(role),
-      gnss_synchro_(nullptr),
-      item_size_(sizeof(gr_complex)),
-      threshold_(0.0),
-      channel_(0),
-      doppler_max_(configuration_->property(role + ".doppler_max", 5000)),
-      doppler_step_(configuration_->property(role + ".doppler_step", 500)),
-      sampled_ms_(configuration_->property(role + ".coherent_integration_time_ms", 8)),
-      bit_transition_flag_(configuration_->property(role + ".bit_transition_flag", false)),
-      dump_(configuration_->property(role + ".dump", false)),
-      cboc_(configuration_->property(role + ".cboc", false))
+    : BasePcpsAcquisitionCustom(
+          configuration,
+          role,
+          in_streams,
+          out_streams,
+          GALILEO_E1_CODE_CHIP_RATE_CPS,
+          GALILEO_E1_B_CODE_LENGTH_CHIPS,
+          GALILEO_E1_CODE_PERIOD_MS * get_folding_factor(configuration, role),
+          true,
+          true),
+      folding_factor_(get_folding_factor(configuration, role)),
+      cboc_(configuration->property(role + ".cboc", false))
 {
-    const std::string default_item_type("gr_complex");
-    const std::string default_dump_filename("./acquisition.dat");
-    item_type_ = configuration_->property(role + ".item_type", default_item_type);
-    int64_t fs_in_deprecated = configuration_->property("GNSS-SDR.internal_fs_hz", 4000000);
-    fs_in_ = configuration_->property("GNSS-SDR.internal_fs_sps", fs_in_deprecated);
-    dump_filename_ = configuration_->property(role + ".dump_filename", default_dump_filename);
-
-#if USE_GLOG_AND_GFLAGS
-    if (FLAGS_doppler_max != 0)
+    if (is_type_gr_complex())
         {
-            doppler_max_ = FLAGS_doppler_max;
-        }
-    if (FLAGS_doppler_step != 0)
-        {
-            doppler_step_ = static_cast<uint32_t>(FLAGS_doppler_step);
-        }
-#else
-    if (absl::GetFlag(FLAGS_doppler_max) != 0)
-        {
-            doppler_max_ = absl::GetFlag(FLAGS_doppler_max);
-        }
-    if (absl::GetFlag(FLAGS_doppler_step) != 0)
-        {
-            doppler_step_ = static_cast<uint32_t>(absl::GetFlag(FLAGS_doppler_step));
-        }
-#endif
+            // const auto samples_per_ms = static_cast<int>(round(code_length_ / acq_parameters_.sampled_ms));
+            const unsigned int max_dwells = acq_parameters_.bit_transition_flag ? 2 : acq_parameters_.max_dwells;
 
-    /* --- Find number of samples per spreading code (4 ms)  -----------------*/
-    code_length_ = static_cast<unsigned int>(round(
-        fs_in_ / (GALILEO_E1_CODE_CHIP_RATE_CPS / GALILEO_E1_B_CODE_LENGTH_CHIPS)));
-
-    auto samples_per_ms = static_cast<int>(round(code_length_ / 4.0));
-
-    DLOG(INFO) << "role " << role;
-    /*Calculate the folding factor value based on the formula described in the paper.
-    This may be a bug, but acquisition also work by variying the folding factor at va-
-    lues different that the expressed in the paper. In addition, it is important to point
-    out that by making the folding factor smaller we were able to get QuickSync work with
-    Galileo. Future work should be directed to test this assumption statistically.*/
-
-    // folding_factor_ = static_cast<unsigned int>(ceil(sqrt(log2(code_length_))));
-    folding_factor_ = configuration_->property(role + ".folding_factor", 2);
-
-    if (sampled_ms_ % (folding_factor_ * 4) != 0)
-        {
-            LOG(WARNING) << "QuickSync Algorithm requires a coherent_integration_time"
-                         << " multiple of " << (folding_factor_ * 4) << "ms, Value entered "
-                         << sampled_ms_ << " ms";
-
-            if (sampled_ms_ < (folding_factor_ * 4))
-                {
-                    sampled_ms_ = static_cast<int>(folding_factor_ * 4);
-                }
-            else
-                {
-                    sampled_ms_ = static_cast<int>(sampled_ms_ / (folding_factor_ * 4)) * (folding_factor_ * 4);
-                }
-            LOG(WARNING) << "coherent_integration_time should be multiple of "
-                         << "Galileo code length (4 ms). coherent_integration_time = "
-                         << sampled_ms_ << " ms will be used.";
-        }
-    // vector_length_ = (sampled_ms_/folding_factor_) * code_length_;
-    vector_length_ = sampled_ms_ * samples_per_ms;
-
-    // 8/2 * code_length_
-    // 8 * code_length_ / 4
-
-    unsigned int max_dwells = 2;
-
-    if (!bit_transition_flag_)
-        {
-            max_dwells = configuration_->property(role + ".max_dwells", 1);
-        }
-
-    bool enable_monitor_output = configuration_->property("AcquisitionMonitor.enable_monitor", false);
-
-    code_ = std::vector<std::complex<float>>(code_length_);
-    LOG(INFO) << "Vector Length: " << vector_length_
-              << ", Samples per ms: " << samples_per_ms
-              << ", Folding factor: " << folding_factor_
-              << ", Sampled  ms: " << sampled_ms_
-              << ", Code Length: " << code_length_;
-    if (item_type_ == "gr_complex")
-        {
             acquisition_cc_ = pcps_quicksync_make_acquisition_cc(folding_factor_,
-                sampled_ms_, max_dwells, doppler_max_, doppler_step_, fs_in_,
-                samples_per_ms, code_length_, bit_transition_flag_,
-                dump_, dump_filename_, enable_monitor_output);
-            stream_to_vector_ = gr::blocks::stream_to_vector::make(item_size_,
-                vector_length_);
-            DLOG(INFO) << "stream_to_vector_quicksync("
-                       << stream_to_vector_->unique_id() << ")";
-            DLOG(INFO) << "acquisition_quicksync(" << acquisition_cc_->unique_id()
-                       << ")";
-        }
-    else
-        {
-            acquisition_cc_ = nullptr;
-            item_size_ = 0;
-            LOG(WARNING) << item_type_ << " unknown acquisition item type";
-        }
+                vector_length_, max_dwells, acq_parameters_.doppler_max, acq_parameters_.doppler_step,
+                acq_parameters_.fs_in, code_length_, acq_parameters_.bit_transition_flag,
+                acq_parameters_.dump, acq_parameters_.dump_filename, acq_parameters_.enable_monitor_output);
 
-    if (in_streams > 1)
-        {
-            LOG(ERROR) << "This implementation only supports one input stream";
-        }
-    if (out_streams > 0)
-        {
-            LOG(ERROR) << "This implementation does not provide an output stream";
+            DLOG(INFO) << "acquisition_quicksync(" << acquisition_cc_->unique_id() << ")";
         }
 }
 
 
-void GalileoE1PcpsQuickSyncAmbiguousAcquisition::stop_acquisition()
+void GalileoE1PcpsQuickSyncAmbiguousAcquisition::code_gen_complex_sampled(own::span<std::complex<float>> dest, uint32_t prn, int32_t sampling_freq)
 {
-    acquisition_cc_->set_state(0);
-    acquisition_cc_->set_active(false);
-}
+    std::array<char, 3> Signal_{};
+    Signal_[0] = gnss_synchro_->Signal[0];
+    Signal_[1] = gnss_synchro_->Signal[1];
+    Signal_[2] = '\0';
 
-
-void GalileoE1PcpsQuickSyncAmbiguousAcquisition::set_threshold(float threshold)
-{
-    float pfa = configuration_->property(role_ + std::to_string(channel_) + ".pfa", static_cast<float>(0.0));
-
-    if (pfa == 0.0)
-        {
-            pfa = configuration_->property(role_ + ".pfa", static_cast<float>(0.0));
-        }
-
-    if (pfa == 0.0)
-        {
-            threshold_ = threshold;
-        }
-    else
-        {
-            threshold_ = calculate_threshold(pfa);
-        }
-
-    DLOG(INFO) << "Channel " << channel_ << " Threshold = " << threshold_;
-
-    if (item_type_ == "gr_complex")
-        {
-            acquisition_cc_->set_threshold(threshold_);
-        }
-}
-
-
-void GalileoE1PcpsQuickSyncAmbiguousAcquisition::set_gnss_synchro(
-    Gnss_Synchro* gnss_synchro)
-{
-    gnss_synchro_ = gnss_synchro;
-    if (item_type_ == "gr_complex")
-        {
-            acquisition_cc_->set_gnss_synchro(gnss_synchro_);
-        }
-}
-
-
-signed int
-GalileoE1PcpsQuickSyncAmbiguousAcquisition::mag()
-{
-    if (item_type_ == "gr_complex")
-        {
-            return acquisition_cc_->mag();
-        }
-    return 0;
-}
-
-
-void GalileoE1PcpsQuickSyncAmbiguousAcquisition::init()
-{
-    acquisition_cc_->init();
-}
-
-
-void GalileoE1PcpsQuickSyncAmbiguousAcquisition::set_local_code()
-{
-    if (item_type_ == "gr_complex")
-        {
-            std::vector<std::complex<float>> code(code_length_);
-            std::array<char, 3> Signal_{};
-            Signal_[0] = gnss_synchro_->Signal[0];
-            Signal_[1] = gnss_synchro_->Signal[1];
-            Signal_[2] = '\0';
-
-            galileo_e1_code_gen_complex_sampled(code, Signal_, cboc_, gnss_synchro_->PRN, fs_in_, 0, false);
-
-            own::span<gr_complex> code_span(code_.data(), vector_length_);
-            for (unsigned int i = 0; i < (sampled_ms_ / (folding_factor_ * 4)); i++)
-                {
-                    std::copy_n(code.data(), code_length_, code_span.subspan(i * code_length_, code_length_).data());
-                }
-
-            acquisition_cc_->set_local_code(code_.data());
-        }
-}
-
-
-void GalileoE1PcpsQuickSyncAmbiguousAcquisition::reset()
-{
-    if (item_type_ == "gr_complex")
-        {
-            acquisition_cc_->set_active(true);
-        }
-}
-
-
-void GalileoE1PcpsQuickSyncAmbiguousAcquisition::set_state(int state)
-{
-    if (item_type_ == "gr_complex")
-        {
-            acquisition_cc_->set_state(state);
-        }
+    galileo_e1_code_gen_complex_sampled(dest, Signal_, cboc_, prn, sampling_freq, 0, false);
 }
 
 
 float GalileoE1PcpsQuickSyncAmbiguousAcquisition::calculate_threshold(float pfa) const
 {
     unsigned int frequency_bins = 0;
-    for (int doppler = static_cast<int>(-doppler_max_); doppler <= static_cast<int>(doppler_max_); doppler += static_cast<int>(doppler_step_))
+    for (int doppler = -acq_parameters_.doppler_max; doppler <= acq_parameters_.doppler_max; doppler += static_cast<int>(acq_parameters_.doppler_step))
         {
             frequency_bins++;
         }
@@ -289,34 +105,4 @@ float GalileoE1PcpsQuickSyncAmbiguousAcquisition::calculate_threshold(float pfa)
     auto threshold = static_cast<float>(quantile(mydist, val));
 
     return threshold;
-}
-
-
-void GalileoE1PcpsQuickSyncAmbiguousAcquisition::connect(gr::top_block_sptr top_block)
-{
-    if (item_type_ == "gr_complex")
-        {
-            top_block->connect(stream_to_vector_, 0, acquisition_cc_, 0);
-        }
-}
-
-
-void GalileoE1PcpsQuickSyncAmbiguousAcquisition::disconnect(gr::top_block_sptr top_block)
-{
-    if (item_type_ == "gr_complex")
-        {
-            top_block->disconnect(stream_to_vector_, 0, acquisition_cc_, 0);
-        }
-}
-
-
-gr::basic_block_sptr GalileoE1PcpsQuickSyncAmbiguousAcquisition::get_left_block()
-{
-    return stream_to_vector_;
-}
-
-
-gr::basic_block_sptr GalileoE1PcpsQuickSyncAmbiguousAcquisition::get_right_block()
-{
-    return acquisition_cc_;
 }

--- a/src/algorithms/acquisition/adapters/galileo_e1_pcps_quicksync_ambiguous_acquisition.h
+++ b/src/algorithms/acquisition/adapters/galileo_e1_pcps_quicksync_ambiguous_acquisition.h
@@ -18,28 +18,18 @@
 #ifndef GNSS_SDR_GALILEO_E1_PCPS_QUICKSYNC_AMBIGUOUS_ACQUISITION_H
 #define GNSS_SDR_GALILEO_E1_PCPS_QUICKSYNC_AMBIGUOUS_ACQUISITION_H
 
-#include "channel_fsm.h"
-#include "gnss_synchro.h"
-#include "pcps_quicksync_acquisition_cc.h"
-#include <gnuradio/blocks/stream_to_vector.h>
-#include <memory>
-#include <string>
-#include <utility>
-#include <vector>
+#include "base_pcps_acquisition_custom.h"
 
 /** \addtogroup Acquisition
  * \{ */
 /** \addtogroup Acq_adapters
  * \{ */
 
-
-class ConfigurationInterface;
-
 /*!
  * \brief This class adapts a PCPS acquisition block to an
  *  AcquisitionInterface for Galileo E1 Signals
  */
-class GalileoE1PcpsQuickSyncAmbiguousAcquisition : public AcquisitionInterface
+class GalileoE1PcpsQuickSyncAmbiguousAcquisition : public BasePcpsAcquisitionCustom
 {
 public:
     GalileoE1PcpsQuickSyncAmbiguousAcquisition(
@@ -50,11 +40,6 @@ public:
 
     ~GalileoE1PcpsQuickSyncAmbiguousAcquisition() = default;
 
-    inline std::string role() override
-    {
-        return role_;
-    }
-
     /*!
      * \brief Returns "Galileo_E1_PCPS_Ambiguous_Acquisition"
      */
@@ -63,102 +48,11 @@ public:
         return "Galileo_E1_PCPS_QuickSync_Ambiguous_Acquisition";
     }
 
-    inline size_t item_size() override
-    {
-        return item_size_;
-    }
-
-    void connect(gr::top_block_sptr top_block) override;
-    void disconnect(gr::top_block_sptr top_block) override;
-    gr::basic_block_sptr get_left_block() override;
-    gr::basic_block_sptr get_right_block() override;
-
-    /*!
-     * \brief Set acquisition/tracking common Gnss_Synchro object pointer
-     * to efficiently exchange synchronization data between acquisition and
-     *  tracking blocks
-     */
-    void set_gnss_synchro(Gnss_Synchro* p_gnss_synchro) override;
-
-    /*!
-     * \brief Set acquisition channel unique ID
-     */
-    inline void set_channel(unsigned int channel) override
-    {
-        channel_ = channel;
-        acquisition_cc_->set_channel(channel_);
-    }
-
-    /*!
-     * \brief Set channel fsm associated to this acquisition instance
-     */
-    inline void set_channel_fsm(std::weak_ptr<ChannelFsm> channel_fsm) override
-    {
-        channel_fsm_ = std::move(channel_fsm);
-        acquisition_cc_->set_channel_fsm(channel_fsm_);
-    }
-
-    /*!
-     * \brief Set statistics threshold of PCPS algorithm
-     */
-    void set_threshold(float threshold) override;
-
-    /*!
-     * \brief Initializes acquisition algorithm.
-     */
-    void init() override;
-
-    /*!
-     * \brief Sets local code for Galileo E1 PCPS acquisition algorithm.
-     */
-    void set_local_code() override;
-
-    /*!
-     * \brief Returns the maximum peak of grid search
-     */
-    signed int mag() override;
-
-    /*!
-     * \brief Restart acquisition algorithm
-     */
-    void reset() override;
-
-    /*!
-     * \brief If state = 1, it forces the block to start acquiring from the first sample
-     */
-    void set_state(int state) override;
-
-    /*!
-     * \brief Stop running acquisition
-     */
-    void stop_acquisition() override;
-
-    void set_resampler_latency(uint32_t latency_samples __attribute__((unused))) override {};
-
 private:
-    float calculate_threshold(float pfa) const;
+    float calculate_threshold(float pfa) const override;
+    void code_gen_complex_sampled(own::span<std::complex<float>> dest, uint32_t prn, int32_t sampling_freq) override;
 
-    const ConfigurationInterface* configuration_;
-    pcps_quicksync_acquisition_cc_sptr acquisition_cc_;
-    gr::blocks::stream_to_vector::sptr stream_to_vector_;
-    std::weak_ptr<ChannelFsm> channel_fsm_;
-    std::vector<std::complex<float>> code_;
-    std::string item_type_;
-    std::string role_;
-    std::string dump_filename_;
-    Gnss_Synchro* gnss_synchro_;
-    int64_t fs_in_;
-    size_t item_size_;
-    float threshold_;
-    unsigned int vector_length_;
-    unsigned int code_length_;
-    unsigned int channel_;
-    unsigned int doppler_max_;
-    unsigned int doppler_step_;
-    unsigned int sampled_ms_;
-    unsigned int folding_factor_;
-    bool bit_transition_flag_;
-    bool dump_;
+    const unsigned int folding_factor_;
     const bool cboc_;
 };
 

--- a/src/algorithms/acquisition/adapters/gps_l1_ca_pcps_quicksync_acquisition.cc
+++ b/src/algorithms/acquisition/adapters/gps_l1_ca_pcps_quicksync_acquisition.cc
@@ -64,8 +64,8 @@ GpsL1CaPcpsQuickSyncAcquisition::GpsL1CaPcpsQuickSyncAcquisition(
             const unsigned int max_dwells = acq_parameters_.bit_transition_flag ? 2 : acq_parameters_.max_dwells;
 
             acquisition_cc_ = pcps_quicksync_make_acquisition_cc(folding_factor_,
-                vector_length_, max_dwells, acq_parameters_.doppler_max, acq_parameters_.doppler_step, acq_parameters_.fs_in, code_length_, acq_parameters_.bit_transition_flag,
-                acq_parameters_.dump, acq_parameters_.dump_filename, acq_parameters_.enable_monitor_output);
+                vector_length_, max_dwells, acq_parameters_.doppler_max, acq_parameters_.doppler_step, acq_parameters_.fs_in, code_length_,
+                acq_parameters_.bit_transition_flag, acq_parameters_.dump, acq_parameters_.dump_filename, acq_parameters_.enable_monitor_output);
 
             DLOG(INFO) << "acquisition(" << acquisition_cc_->unique_id() << ")";
         }
@@ -82,7 +82,7 @@ float GpsL1CaPcpsQuickSyncAcquisition::calculate_threshold(float pfa) const
 {
     // Calculate the threshold
     unsigned int frequency_bins = 0;
-    for (int doppler = -acq_parameters_.doppler_max; doppler <= acq_parameters_.doppler_max; doppler += acq_parameters_.doppler_step)
+    for (int doppler = -acq_parameters_.doppler_max; doppler <= acq_parameters_.doppler_max; doppler += static_cast<int>(acq_parameters_.doppler_step))
         {
             frequency_bins++;
         }

--- a/src/algorithms/acquisition/adapters/gps_l1_ca_pcps_quicksync_acquisition.cc
+++ b/src/algorithms/acquisition/adapters/gps_l1_ca_pcps_quicksync_acquisition.cc
@@ -19,10 +19,9 @@
 #include "gps_l1_ca_pcps_quicksync_acquisition.h"
 #include "GPS_L1_CA.h"
 #include "configuration_interface.h"
-#include "gnss_sdr_flags.h"
 #include "gps_sdr_signal_replica.h"
+#include "pcps_quicksync_acquisition_cc.h"
 #include <boost/math/distributions/exponential.hpp>
-#include <algorithm>
 
 #if USE_GLOG_AND_GFLAGS
 #include <glog/logging.h>
@@ -30,231 +29,52 @@
 #include <absl/log/log.h>
 #endif
 
-#if HAS_STD_SPAN
-#include <span>
-namespace own = std;
-#else
-#include <gsl-lite/gsl-lite.hpp>
-namespace own = gsl_lite;
-#endif
+namespace
+{
+uint32_t get_folding_factor(const ConfigurationInterface* configuration, const std::string& role)
+{
+    const int64_t fs_in_deprecated = configuration->property("GNSS-SDR.internal_fs_hz", static_cast<int64_t>(4000000));
+    const auto fs_in = configuration->property("GNSS-SDR.internal_fs_sps", fs_in_deprecated);
+    const auto code_length = static_cast<unsigned int>(round(fs_in / (GPS_L1_CA_CODE_RATE_CPS / GPS_L1_CA_CODE_LENGTH_CHIPS)));
+    const auto folding_factor = static_cast<unsigned int>(ceil(sqrt(log2(code_length))));
+    return configuration->property(role + ".folding_factor", folding_factor);
+}
+}  // namespace
 
 GpsL1CaPcpsQuickSyncAcquisition::GpsL1CaPcpsQuickSyncAcquisition(
     const ConfigurationInterface* configuration,
     const std::string& role,
     unsigned int in_streams,
     unsigned int out_streams)
-    : configuration_(configuration),
-      role_(role),
-      gnss_synchro_(nullptr),
-      item_size_(sizeof(gr_complex)),
-      threshold_(0.0),
-      channel_(0),
-      doppler_max_(configuration->property(role + ".doppler_max", 5000)),
-      doppler_step_(configuration_->property(role + ".doppler_step", 500)),
-      sampled_ms_(configuration_->property(role + ".coherent_integration_time_ms", 4)),
-      bit_transition_flag_(configuration_->property(role + ".bit_transition_flag", false)),
-      dump_(configuration_->property(role + ".dump", false))
+    : BasePcpsAcquisitionCustom(
+          configuration,
+          role,
+          in_streams,
+          out_streams,
+          GPS_L1_CA_CODE_RATE_CPS,
+          GPS_L1_CA_CODE_LENGTH_CHIPS,
+          GPS_L1_CA_CODE_PERIOD_MS * get_folding_factor(configuration, role),
+          true,
+          true),
+      folding_factor_(get_folding_factor(configuration, role))
 {
-    const std::string default_item_type("gr_complex");
-    std::string default_dump_filename = "./data/acquisition.dat";
-    item_type_ = configuration_->property(role_ + ".item_type", default_item_type);
-    int64_t fs_in_deprecated = configuration_->property("GNSS-SDR.internal_fs_hz", 2048000);
-    fs_in_ = configuration_->property("GNSS-SDR.internal_fs_sps", fs_in_deprecated);
-
-#if USE_GLOG_AND_GFLAGS
-    if (FLAGS_doppler_max != 0)
+    if (is_type_gr_complex())
         {
-            doppler_max_ = FLAGS_doppler_max;
-        }
-    if (FLAGS_doppler_step != 0)
-        {
-            doppler_step_ = static_cast<uint32_t>(FLAGS_doppler_step);
-        }
-#else
-    if (absl::GetFlag(FLAGS_doppler_max) != 0)
-        {
-            doppler_max_ = absl::GetFlag(FLAGS_doppler_max);
-        }
-    if (absl::GetFlag(FLAGS_doppler_step) != 0)
-        {
-            doppler_step_ = static_cast<uint32_t>(absl::GetFlag(FLAGS_doppler_step));
-        }
-#endif
+            // const int samples_per_ms = round(code_length_ / acq_parameters_.sampled_ms);
+            const unsigned int max_dwells = acq_parameters_.bit_transition_flag ? 2 : acq_parameters_.max_dwells;
 
-    // -- Find number of samples per spreading code -------------------------
-    code_length_ = static_cast<unsigned int>(round(fs_in_ / (GPS_L1_CA_CODE_RATE_CPS / GPS_L1_CA_CODE_LENGTH_CHIPS)));
-
-    /* Calculate the folding factor value */
-    auto temp = static_cast<unsigned int>(ceil(sqrt(log2(code_length_))));
-    folding_factor_ = configuration_->property(role_ + ".folding_factor", temp);
-
-    if (sampled_ms_ % folding_factor_ != 0)
-        {
-            LOG(WARNING) << "QuickSync Algorithm requires a coherent_integration_time"
-                         << " multiple of " << folding_factor_ << "ms, Value entered "
-                         << sampled_ms_ << " ms";
-            if (sampled_ms_ < folding_factor_)
-                {
-                    sampled_ms_ = static_cast<int>(folding_factor_);
-                }
-            else
-                {
-                    sampled_ms_ = static_cast<int>(sampled_ms_ / folding_factor_) * folding_factor_;
-                }
-
-            LOG(WARNING) << " Coherent_integration_time of "
-                         << sampled_ms_ << " ms will be used instead.";
-        }
-
-    vector_length_ = code_length_ * sampled_ms_;
-
-    unsigned int max_dwells = 2;
-
-    if (!bit_transition_flag_)
-        {
-            max_dwells = configuration->property(role + ".max_dwells", 1);
-        }
-
-    dump_filename_ = configuration_->property(role_ + ".dump_filename", std::move(default_dump_filename));
-
-    bool enable_monitor_output = configuration_->property("AcquisitionMonitor.enable_monitor", false);
-
-    int samples_per_ms = round(code_length_);
-    code_ = std::vector<std::complex<float>>(code_length_);
-
-    DLOG(INFO) << "role " << role_;
-    /* Object relevant information for debugging */
-    LOG(INFO) << "Implementation: " << this->implementation()
-              << ", Vector Length: " << vector_length_
-              << ", Samples per ms: " << samples_per_ms
-              << ", Folding factor: " << folding_factor_
-              << ", Sampled  ms: " << sampled_ms_
-              << ", Code Length: " << code_length_;
-
-    if (item_type_ == "gr_complex")
-        {
             acquisition_cc_ = pcps_quicksync_make_acquisition_cc(folding_factor_,
-                sampled_ms_, max_dwells, doppler_max_, doppler_step_, fs_in_,
-                samples_per_ms, code_length_, bit_transition_flag_,
-                dump_, dump_filename_, enable_monitor_output);
+                vector_length_, max_dwells, acq_parameters_.doppler_max, acq_parameters_.doppler_step, acq_parameters_.fs_in, code_length_, acq_parameters_.bit_transition_flag,
+                acq_parameters_.dump, acq_parameters_.dump_filename, acq_parameters_.enable_monitor_output);
 
-            stream_to_vector_ = gr::blocks::stream_to_vector::make(item_size_,
-                code_length_ * folding_factor_);
-
-            DLOG(INFO) << "stream_to_vector_quicksync(" << stream_to_vector_->unique_id() << ")";
             DLOG(INFO) << "acquisition(" << acquisition_cc_->unique_id() << ")";
         }
-    else
-        {
-            item_size_ = 0;
-            acquisition_cc_ = nullptr;
-            LOG(WARNING) << item_type_ << " unknown acquisition item type";
-        }
-
-    if (in_streams > 1)
-        {
-            LOG(ERROR) << "This implementation only supports one input stream";
-        }
-    if (out_streams > 0)
-        {
-            LOG(ERROR) << "This implementation does not provide an output stream";
-        }
 }
 
 
-void GpsL1CaPcpsQuickSyncAcquisition::stop_acquisition()
+void GpsL1CaPcpsQuickSyncAcquisition::code_gen_complex_sampled(own::span<std::complex<float>> dest, uint32_t prn, int32_t sampling_freq)
 {
-    acquisition_cc_->set_state(0);
-    acquisition_cc_->set_active(false);
-}
-
-
-void GpsL1CaPcpsQuickSyncAcquisition::set_threshold(float threshold)
-{
-    float pfa = configuration_->property(role_ + std::to_string(channel_) + ".pfa", static_cast<float>(0.0));
-
-    if (pfa == 0.0)
-        {
-            pfa = configuration_->property(role_ + ".pfa", static_cast<float>(0.0));
-        }
-    if (pfa == 0.0)
-        {
-            threshold_ = threshold;
-        }
-    else
-        {
-            threshold_ = calculate_threshold(pfa);
-        }
-
-    DLOG(INFO) << "Channel " << channel_ << " Threshold = " << threshold_;
-
-    if (item_type_ == "gr_complex")
-        {
-            acquisition_cc_->set_threshold(threshold_);
-        }
-}
-
-
-void GpsL1CaPcpsQuickSyncAcquisition::set_gnss_synchro(Gnss_Synchro* gnss_synchro)
-{
-    gnss_synchro_ = gnss_synchro;
-    if (item_type_ == "gr_complex")
-        {
-            acquisition_cc_->set_gnss_synchro(gnss_synchro_);
-        }
-}
-
-
-signed int GpsL1CaPcpsQuickSyncAcquisition::mag()
-{
-    if (item_type_ == "gr_complex")
-        {
-            return acquisition_cc_->mag();
-        }
-    return 0;
-}
-
-
-void GpsL1CaPcpsQuickSyncAcquisition::init()
-{
-    acquisition_cc_->init();
-}
-
-
-void GpsL1CaPcpsQuickSyncAcquisition::set_local_code()
-{
-    if (item_type_ == "gr_complex")
-        {
-            std::vector<std::complex<float>> code(code_length_);
-
-            gps_l1_ca_code_gen_complex_sampled(code, gnss_synchro_->PRN, fs_in_, 0);
-
-            own::span<gr_complex> code_span(code_.data(), vector_length_);
-            for (unsigned int i = 0; i < (sampled_ms_ / folding_factor_); i++)
-                {
-                    std::copy_n(code.data(), code_length_, code_span.subspan(i * code_length_, code_length_).data());
-                }
-
-            acquisition_cc_->set_local_code(code_.data());
-        }
-}
-
-
-void GpsL1CaPcpsQuickSyncAcquisition::reset()
-{
-    if (item_type_ == "gr_complex")
-        {
-            acquisition_cc_->set_active(true);
-        }
-}
-
-
-void GpsL1CaPcpsQuickSyncAcquisition::set_state(int state)
-{
-    if (item_type_ == "gr_complex")
-        {
-            acquisition_cc_->set_state(state);
-        }
+    gps_l1_ca_code_gen_complex_sampled(dest, prn, sampling_freq, 0);
 }
 
 
@@ -262,7 +82,7 @@ float GpsL1CaPcpsQuickSyncAcquisition::calculate_threshold(float pfa) const
 {
     // Calculate the threshold
     unsigned int frequency_bins = 0;
-    for (int doppler = static_cast<int>(-doppler_max_); doppler <= static_cast<int>(doppler_max_); doppler += static_cast<int>(doppler_step_))
+    for (int doppler = -acq_parameters_.doppler_max; doppler <= acq_parameters_.doppler_max; doppler += acq_parameters_.doppler_step)
         {
             frequency_bins++;
         }
@@ -275,34 +95,4 @@ float GpsL1CaPcpsQuickSyncAcquisition::calculate_threshold(float pfa) const
     auto threshold = static_cast<float>(quantile(mydist, val));
 
     return threshold;
-}
-
-
-void GpsL1CaPcpsQuickSyncAcquisition::connect(gr::top_block_sptr top_block)
-{
-    if (item_type_ == "gr_complex")
-        {
-            top_block->connect(stream_to_vector_, 0, acquisition_cc_, 0);
-        }
-}
-
-
-void GpsL1CaPcpsQuickSyncAcquisition::disconnect(gr::top_block_sptr top_block)
-{
-    if (item_type_ == "gr_complex")
-        {
-            top_block->disconnect(stream_to_vector_, 0, acquisition_cc_, 0);
-        }
-}
-
-
-gr::basic_block_sptr GpsL1CaPcpsQuickSyncAcquisition::get_left_block()
-{
-    return stream_to_vector_;
-}
-
-
-gr::basic_block_sptr GpsL1CaPcpsQuickSyncAcquisition::get_right_block()
-{
-    return acquisition_cc_;
 }

--- a/src/algorithms/acquisition/adapters/gps_l1_ca_pcps_quicksync_acquisition.h
+++ b/src/algorithms/acquisition/adapters/gps_l1_ca_pcps_quicksync_acquisition.h
@@ -19,29 +19,18 @@
 #ifndef GNSS_SDR_GPS_L1_CA_PCPS_QUICKSYNC_ACQUISITION_H
 #define GNSS_SDR_GPS_L1_CA_PCPS_QUICKSYNC_ACQUISITION_H
 
-#include "channel_fsm.h"
-#include "configuration_interface.h"
-#include "gnss_synchro.h"
-#include "pcps_quicksync_acquisition_cc.h"
-#include <gnuradio/blocks/stream_to_vector.h>
-#include <memory>
-#include <string>
-#include <utility>
-#include <vector>
+#include "base_pcps_acquisition_custom.h"
 
 /** \addtogroup Acquisition
  * \{ */
 /** \addtogroup Acq_adapters
  * \{ */
 
-
-class ConfigurationInterface;
-
 /*!
  * \brief This class adapts a PCPS acquisition block to an AcquisitionInterface
  *  for GPS L1 C/A signals
  */
-class GpsL1CaPcpsQuickSyncAcquisition : public AcquisitionInterface
+class GpsL1CaPcpsQuickSyncAcquisition : public BasePcpsAcquisitionCustom
 {
 public:
     GpsL1CaPcpsQuickSyncAcquisition(
@@ -52,11 +41,6 @@ public:
 
     ~GpsL1CaPcpsQuickSyncAcquisition() = default;
 
-    inline std::string role() override
-    {
-        return role_;
-    }
-
     /*!
      * \brief Returns "GPS_L1_CA_PCPS_QuickSync_Acquisition"
      */
@@ -65,105 +49,11 @@ public:
         return "GPS_L1_CA_PCPS_QuickSync_Acquisition";
     }
 
-    inline size_t item_size() override
-    {
-        return item_size_;
-    }
-
-    void connect(gr::top_block_sptr top_block) override;
-    void disconnect(gr::top_block_sptr top_block) override;
-    gr::basic_block_sptr get_left_block() override;
-    gr::basic_block_sptr get_right_block() override;
-
-    /*!
-     * \brief Set acquisition/tracking common Gnss_Synchro object pointer
-     * to efficiently exchange synchronization data between acquisition and
-     *  tracking blocks
-     */
-    void set_gnss_synchro(Gnss_Synchro* p_gnss_synchro) override;
-
-    /*!
-     * \brief Set acquisition channel unique ID
-     */
-    inline void set_channel(unsigned int channel) override
-    {
-        channel_ = channel;
-        acquisition_cc_->set_channel(channel_);
-    }
-
-    /*!
-     * \brief Set channel fsm associated to this acquisition instance
-     */
-    inline void set_channel_fsm(std::weak_ptr<ChannelFsm> channel_fsm) override
-    {
-        channel_fsm_ = std::move(channel_fsm);
-        acquisition_cc_->set_channel_fsm(channel_fsm_);
-    }
-
-    /*!
-     * \brief Set statistics threshold of PCPS algorithm
-     */
-    void set_threshold(float threshold) override;
-
-    /*!
-     * \brief Initializes acquisition algorithm.
-     */
-    void init() override;
-
-    /*!
-     * \brief Sets local code for GPS L1/CA PCPS acquisition algorithm.
-     */
-    void set_local_code() override;
-
-    /*!
-     * \brief Returns the maximum peak of grid search
-     */
-    signed int mag() override;
-
-    /*!
-     * \brief Restart acquisition algorithm
-     */
-    void reset() override;
-
-    /*!
-     * \brief If state = 1, it forces the block to start acquiring from the first sample
-     */
-    void set_state(int state) override;
-
-    /*!
-     * \brief Stop running acquisition
-     */
-    void stop_acquisition() override;
-
-    void set_resampler_latency(uint32_t latency_samples __attribute__((unused))) override {};
-
 private:
-    float calculate_threshold(float pfa) const;
+    float calculate_threshold(float pfa) const override;
+    void code_gen_complex_sampled(own::span<std::complex<float>> dest, uint32_t prn, int32_t sampling_freq) override;
 
-    const ConfigurationInterface* configuration_;
-    pcps_quicksync_acquisition_cc_sptr acquisition_cc_;
-    std::weak_ptr<ChannelFsm> channel_fsm_;
-
-    gr::blocks::stream_to_vector::sptr stream_to_vector_;
-    std::vector<std::complex<float>> code_;
-    std::string item_type_;
-    std::string dump_filename_;
-    std::string role_;
-
-    Gnss_Synchro* gnss_synchro_;
-
-    int64_t fs_in_;
-    size_t item_size_;
-    float threshold_;
-    unsigned int vector_length_;
-    unsigned int code_length_;
-    unsigned int channel_;
-    unsigned int doppler_max_;
-    unsigned int doppler_step_;
-    unsigned int sampled_ms_;
-    unsigned int folding_factor_;
-    bool bit_transition_flag_;
-    bool dump_;
+    const unsigned int folding_factor_;
 };
 
 

--- a/src/algorithms/acquisition/gnuradio_blocks/pcps_quicksync_acquisition_cc.cc
+++ b/src/algorithms/acquisition/gnuradio_blocks/pcps_quicksync_acquisition_cc.cc
@@ -33,12 +33,11 @@
 
 pcps_quicksync_acquisition_cc_sptr pcps_quicksync_make_acquisition_cc(
     uint32_t folding_factor,
-    uint32_t sampled_ms,
+    uint32_t vector_length,
     uint32_t max_dwells,
     uint32_t doppler_max,
     uint32_t doppler_step,
     int64_t fs_in,
-    int32_t samples_per_ms,
     int32_t samples_per_code,
     bool bit_transition_flag,
     bool dump,
@@ -48,8 +47,8 @@ pcps_quicksync_acquisition_cc_sptr pcps_quicksync_make_acquisition_cc(
     return pcps_quicksync_acquisition_cc_sptr(
         new pcps_quicksync_acquisition_cc(
             folding_factor,
-            sampled_ms, max_dwells, doppler_max,
-            doppler_step, fs_in, samples_per_ms,
+            vector_length, max_dwells, doppler_max,
+            doppler_step, fs_in,
             samples_per_code,
             bit_transition_flag,
             dump, dump_filename,
@@ -58,16 +57,15 @@ pcps_quicksync_acquisition_cc_sptr pcps_quicksync_make_acquisition_cc(
 
 
 pcps_quicksync_acquisition_cc::pcps_quicksync_acquisition_cc(
-    uint32_t folding_factor,
-    uint32_t sampled_ms, uint32_t max_dwells,
+    uint32_t folding_factor, uint32_t vector_length, uint32_t max_dwells,
     uint32_t doppler_max, uint32_t doppler_step, int64_t fs_in,
-    int32_t samples_per_ms, int32_t samples_per_code,
+    int32_t samples_per_code,
     bool bit_transition_flag,
     bool dump,
     const std::string& dump_filename,
     bool enable_monitor_output)
-    : gr::block("pcps_quicksync_acquisition_cc",
-          gr::io_signature::make(1, 1, static_cast<int>(sizeof(gr_complex) * sampled_ms * samples_per_ms)),
+    : acquisition_impl_interface("pcps_quicksync_acquisition_cc",
+          gr::io_signature::make(1, 1, static_cast<int>(sizeof(gr_complex) * vector_length)),
           gr::io_signature::make(0, 1, sizeof(Gnss_Synchro))),
       d_dump_filename(dump_filename),
       d_gnss_synchro(nullptr),
@@ -79,7 +77,7 @@ pcps_quicksync_acquisition_cc::pcps_quicksync_acquisition_cc(
       d_mag(0),
       d_input_power(0.0),
       d_test_statistics(0),
-      d_samples_per_ms(samples_per_ms),
+      d_vector_length(vector_length),
       d_samples_per_code(samples_per_code),
       d_state(0),
       d_channel(0),
@@ -87,7 +85,6 @@ pcps_quicksync_acquisition_cc::pcps_quicksync_acquisition_cc(
       d_doppler_resolution(0),
       d_doppler_max(doppler_max),
       d_doppler_step(doppler_step),
-      d_sampled_ms(sampled_ms),
       d_max_dwells(max_dwells),
       d_well_count(0),
       d_fft_size((d_samples_per_code) / d_folding_factor),
@@ -257,7 +254,7 @@ int pcps_quicksync_acquisition_cc::general_work(int noutput_items,
                         d_state = 1;
                     }
 
-                d_sample_counter += static_cast<uint64_t>(d_sampled_ms) * d_samples_per_ms * ninput_items[0];  // sample counter
+                d_sample_counter += static_cast<uint64_t>(d_vector_length) * ninput_items[0];  // sample counter
                 consume_each(ninput_items[0]);
                 // DLOG(INFO) << "END CASE 0";
                 break;
@@ -291,7 +288,7 @@ int pcps_quicksync_acquisition_cc::general_work(int noutput_items,
                 d_test_statistics = 0.0;
                 d_noise_floor_power = 0.0;
 
-                d_sample_counter += static_cast<uint64_t>(d_sampled_ms) * d_samples_per_ms;  // sample counter
+                d_sample_counter += static_cast<uint64_t>(d_vector_length);  // sample counter
 
                 d_well_count++;
 
@@ -495,7 +492,7 @@ int pcps_quicksync_acquisition_cc::general_work(int noutput_items,
                 d_active = false;
                 d_state = 0;
 
-                d_sample_counter += static_cast<uint64_t>(d_sampled_ms) * d_samples_per_ms * ninput_items[0];  // sample counter
+                d_sample_counter += static_cast<uint64_t>(d_vector_length) * ninput_items[0];  // sample counter
                 consume_each(ninput_items[0]);
 
                 acquisition_message = 1;
@@ -538,7 +535,7 @@ int pcps_quicksync_acquisition_cc::general_work(int noutput_items,
                 d_active = false;
                 d_state = 0;
 
-                d_sample_counter += static_cast<uint64_t>(d_sampled_ms) * d_samples_per_ms * ninput_items[0];  // sample counter
+                d_sample_counter += static_cast<uint64_t>(d_vector_length) * ninput_items[0];  // sample counter
                 consume_each(ninput_items[0]);
 
                 acquisition_message = 2;

--- a/src/algorithms/acquisition/gnuradio_blocks/pcps_quicksync_acquisition_cc.h
+++ b/src/algorithms/acquisition/gnuradio_blocks/pcps_quicksync_acquisition_cc.h
@@ -37,6 +37,7 @@
 #ifndef GNSS_SDR_PCPS_QUICKSYNC_ACQUISITION_CC_H
 #define GNSS_SDR_PCPS_QUICKSYNC_ACQUISITION_CC_H
 
+#include "acquisition_impl_interface.h"
 #include "channel_fsm.h"
 #include "gnss_sdr_fft.h"
 #include "gnss_synchro.h"
@@ -63,12 +64,11 @@ using pcps_quicksync_acquisition_cc_sptr = gnss_shared_ptr<pcps_quicksync_acquis
 
 pcps_quicksync_acquisition_cc_sptr pcps_quicksync_make_acquisition_cc(
     uint32_t folding_factor,
-    uint32_t sampled_ms,
+    uint32_t vector_length,
     uint32_t max_dwells,
     uint32_t doppler_max,
     uint32_t doppler_step,
     int64_t fs_in,
-    int32_t samples_per_ms,
     int32_t samples_per_code,
     bool bit_transition_flag,
     bool dump,
@@ -82,7 +82,7 @@ pcps_quicksync_acquisition_cc_sptr pcps_quicksync_make_acquisition_cc(
  * Check \ref Navitec2012 "Faster GPS via the Sparse Fourier Transform",
  * for details of its implementation and functionality.
  */
-class pcps_quicksync_acquisition_cc : public gr::block
+class pcps_quicksync_acquisition_cc : public acquisition_impl_interface
 {
 public:
     /*!
@@ -95,7 +95,7 @@ public:
      * to exchange synchronization data between acquisition and tracking blocks.
      * \param p_gnss_synchro Satellite information shared by the processing blocks.
      */
-    inline void set_gnss_synchro(Gnss_Synchro* p_gnss_synchro)
+    inline void set_gnss_synchro(Gnss_Synchro* p_gnss_synchro) override
     {
         d_gnss_synchro = p_gnss_synchro;
     }
@@ -103,7 +103,7 @@ public:
     /*!
      * \brief Returns the maximum peak of grid search.
      */
-    inline uint32_t mag() const
+    inline uint32_t mag() const override
     {
         return d_mag;
     }
@@ -111,20 +111,20 @@ public:
     /*!
      * \brief Initializes acquisition algorithm.
      */
-    void init();
+    void init() override;
 
     /*!
      * \brief Sets local code for PCPS acquisition algorithm.
      * \param code - Pointer to the PRN code.
      */
-    void set_local_code(std::complex<float>* code);
+    void set_local_code(std::complex<float>* code) override;
 
     /*!
      * \brief Starts acquisition algorithm, turning from standby mode to
      * active mode
      * \param active - bool that activates/deactivates the block.
      */
-    inline void set_active(bool active)
+    inline void set_active(bool active) override
     {
         d_active = active;
     }
@@ -134,13 +134,13 @@ public:
      * first available sample.
      * \param state - int=1 forces start of acquisition
      */
-    void set_state(int32_t state);
+    void set_state(int32_t state) override;
 
     /*!
      * \brief Set acquisition channel unique ID
      * \param channel - receiver channel.
      */
-    inline void set_channel(uint32_t channel)
+    inline void set_channel(uint32_t channel) override
     {
         d_channel = channel;
     }
@@ -148,7 +148,7 @@ public:
     /*!
      * \brief Set channel fsm associated to this acquisition instance
      */
-    inline void set_channel_fsm(std::weak_ptr<ChannelFsm> channel_fsm)
+    inline void set_channel_fsm(std::weak_ptr<ChannelFsm> channel_fsm) override
     {
         d_channel_fsm = std::move(channel_fsm);
     }
@@ -158,7 +158,7 @@ public:
      * \param threshold - Threshold for signal detection (check \ref Navitec2012,
      * Algorithm 1, for a definition of this threshold).
      */
-    inline void set_threshold(float threshold)
+    inline void set_threshold(float threshold) override
     {
         d_threshold = threshold;
     }
@@ -168,23 +168,23 @@ public:
      */
     int general_work(int noutput_items, gr_vector_int& ninput_items,
         gr_vector_const_void_star& input_items,
-        gr_vector_void_star& output_items);
+        gr_vector_void_star& output_items) override;
 
 private:
     friend pcps_quicksync_acquisition_cc_sptr
     pcps_quicksync_make_acquisition_cc(uint32_t folding_factor,
-        uint32_t sampled_ms, uint32_t max_dwells,
+        uint32_t vector_length, uint32_t max_dwells,
         uint32_t doppler_max, uint32_t doppler_step, int64_t fs_in,
-        int32_t samples_per_ms, int32_t samples_per_code,
+        int32_t samples_per_code,
         bool bit_transition_flag,
         bool dump,
         const std::string& dump_filename,
         bool enable_monitor_output);
 
     pcps_quicksync_acquisition_cc(uint32_t folding_factor,
-        uint32_t sampled_ms, uint32_t max_dwells,
+        uint32_t vector_length, uint32_t max_dwells,
         uint32_t doppler_max, uint32_t doppler_step, int64_t fs_in,
-        int32_t samples_per_ms, int32_t samples_per_code,
+        int32_t samples_per_code,
         bool bit_transition_flag,
         bool dump,
         const std::string& dump_filename,
@@ -224,7 +224,7 @@ private:
     float d_mag;
     float d_input_power;
     float d_test_statistics;
-    int32_t d_samples_per_ms;
+    const int32_t d_vector_length;
     int32_t d_samples_per_code;
     int32_t d_state;
     uint32_t d_channel;
@@ -232,7 +232,6 @@ private:
     uint32_t d_doppler_resolution;
     const uint32_t d_doppler_max;
     const uint32_t d_doppler_step;
-    uint32_t d_sampled_ms;
     uint32_t d_max_dwells;
     uint32_t d_well_count;
     uint32_t d_fft_size;


### PR DESCRIPTION
As discussed in this [PR](https://github.com/gnss-sdr/gnss-sdr/pull/942), there was an issue with the QuickSync classes where the size of the code wasn't correct. As we noted in that discussion, `vector_length_` should be `code_length_ * sampled_ms_ / folding_factor_`, or actually `code_length_ * sampled_ms_ / (folding_factor_ * ms_per_code)` for the more generic case (`code_period_ms` is 1 for GPS L1CA).

Using the `BasePcpsAcquisitionCustom` base class constructor, when setting `ms_per_code` I multiply it by the `folding_factor`, so that `ms_per_code` is actually `ms_per_code * folding_factor`. It will then force `sampled_ms` to a multiple of `ms_per_code` just like it used to, and set the `vector_length` to what we defined above.

It seems the size passed in `pcps_quicksync_acquisition_cc` constructor was off to match the incorrect buffer size. I simply passed the size of the vector which we know to be the correct size to fix that issue.