### PR TITLE
Remove set_state from acquisition

### DIFF
--- a/src/algorithms/acquisition/adapters/base_pcps_acquisition.cc
+++ b/src/algorithms/acquisition/adapters/base_pcps_acquisition.cc
@@ -147,12 +147,6 @@ void BasePcpsAcquisition::reset()
 }
 
 
-void BasePcpsAcquisition::set_state(int state)
-{
-    acquisition_->set_state(state);
-}
-
-
 void BasePcpsAcquisition::connect(gr::top_block_sptr top_block)
 {
     if (acq_parameters_.item_type == "gr_complex" || acq_parameters_.item_type == "cshort")

--- a/src/algorithms/acquisition/adapters/base_pcps_acquisition.h
+++ b/src/algorithms/acquisition/adapters/base_pcps_acquisition.h
@@ -119,11 +119,6 @@ public:
     void reset() override;
 
     /*!
-     * \brief If state = 1, it forces the block to start acquiring from the first sample
-     */
-    void set_state(int state) override;
-
-    /*!
      * \brief Stop running acquisition
      */
     void stop_acquisition() override;

--- a/src/algorithms/acquisition/adapters/base_pcps_acquisition_custom.cc
+++ b/src/algorithms/acquisition/adapters/base_pcps_acquisition_custom.cc
@@ -224,17 +224,7 @@ void BasePcpsAcquisitionCustom::stop_acquisition()
 {
     if (is_type_gr_complex_)
         {
-            acquisition_cc_->set_state(0);
             acquisition_cc_->set_active(false);
-        }
-}
-
-
-void BasePcpsAcquisitionCustom::set_state(int state)
-{
-    if (is_type_gr_complex_)
-        {
-            acquisition_cc_->set_state(state);
         }
 }
 

--- a/src/algorithms/acquisition/adapters/base_pcps_acquisition_custom.h
+++ b/src/algorithms/acquisition/adapters/base_pcps_acquisition_custom.h
@@ -103,11 +103,6 @@ public:
     void stop_acquisition() override;
 
     /*!
-     * \brief If state = 1, it forces the block to start acquiring from the first sample
-     */
-    void set_state(int state) override;
-
-    /*!
      * \brief Set statistics threshold of PCPS algorithm
      */
     void set_threshold(float threshold) override;

--- a/src/algorithms/acquisition/adapters/base_pcps_acquisition_fpga.cc
+++ b/src/algorithms/acquisition/adapters/base_pcps_acquisition_fpga.cc
@@ -175,15 +175,6 @@ void BasePcpsAcquisitionFpga::set_doppler_center(int doppler_center)
 }
 
 
-void BasePcpsAcquisitionFpga::set_state(int state)
-{
-    if (acquisition_fpga_)
-        {
-            acquisition_fpga_->set_state(state);
-        }
-}
-
-
 void BasePcpsAcquisitionFpga::reset()
 {
     if (acquisition_fpga_)

--- a/src/algorithms/acquisition/adapters/base_pcps_acquisition_fpga.h
+++ b/src/algorithms/acquisition/adapters/base_pcps_acquisition_fpga.h
@@ -72,7 +72,6 @@ public:
     void set_channel_fsm(std::weak_ptr<ChannelFsm> channel_fsm) override;
     void set_threshold(float threshold) override;
     void set_doppler_center(int doppler_center) override;
-    void set_state(int state) override;
     void reset() override;
     void stop_acquisition() override;
     void init() override;

--- a/src/algorithms/acquisition/gnuradio_blocks/acquisition_impl_interface.h
+++ b/src/algorithms/acquisition/gnuradio_blocks/acquisition_impl_interface.h
@@ -61,7 +61,6 @@ public:
     virtual void init() = 0;
     virtual void set_local_code(std::complex<float>* /*code*/) {};
     virtual void set_local_code(std::complex<float>* /*code_data*/, std::complex<float>* /*code_pilot*/) {};
-    virtual void set_state(int32_t state) = 0;
     virtual uint32_t mag() const = 0;
     virtual void set_active(bool active) = 0;
 };

--- a/src/algorithms/acquisition/gnuradio_blocks/galileo_e5a_noncoherent_iq_acquisition_caf_cc.cc
+++ b/src/algorithms/acquisition/gnuradio_blocks/galileo_e5a_noncoherent_iq_acquisition_caf_cc.cc
@@ -244,30 +244,6 @@ void galileo_e5a_noncoherentIQ_acquisition_caf_cc::init()
 }
 
 
-void galileo_e5a_noncoherentIQ_acquisition_caf_cc::set_state(int state)
-{
-    d_state = state;
-    if (d_state == 1)
-        {
-            d_gnss_synchro->Acq_delay_samples = 0.0;
-            d_gnss_synchro->Acq_doppler_hz = 0.0;
-            d_gnss_synchro->Acq_samplestamp_samples = 0ULL;
-            d_gnss_synchro->Acq_doppler_step = 0U;
-            d_well_count = 0;
-            d_mag = 0.0;
-            d_input_power = 0.0;
-            d_test_statistics = 0.0;
-        }
-    else if (d_state == 0)
-        {
-        }
-    else
-        {
-            LOG(ERROR) << "State can only be set to 0 or 1";
-        }
-}
-
-
 int galileo_e5a_noncoherentIQ_acquisition_caf_cc::general_work(int noutput_items __attribute__((unused)),
     gr_vector_int &ninput_items, gr_vector_const_void_star &input_items,
     gr_vector_void_star &output_items)
@@ -286,6 +262,14 @@ int galileo_e5a_noncoherentIQ_acquisition_caf_cc::general_work(int noutput_items
 
     int acquisition_message = -1;  // 0=STOP_CHANNEL 1=ACQ_SUCCEES 2=ACQ_FAIL
     int return_value = 0;          // 0=Produces no Gnss_Synchro objects
+
+    if (!d_active)
+        {
+            d_sample_counter += static_cast<uint64_t>(ninput_items[0]);  // sample counter
+            consume_each(ninput_items[0]);
+            return 0;
+        }
+
     /* States: 0 Stop Channel
      *         1 Load the buffer until it reaches fft_size
      *         2 Acquisition algorithm
@@ -296,22 +280,16 @@ int galileo_e5a_noncoherentIQ_acquisition_caf_cc::general_work(int noutput_items
         {
         case 0:
             {
-                if (d_active)
-                    {
-                        // restart acquisition variables
-                        d_gnss_synchro->Acq_delay_samples = 0.0;
-                        d_gnss_synchro->Acq_doppler_hz = 0.0;
-                        d_gnss_synchro->Acq_samplestamp_samples = 0ULL;
-                        d_gnss_synchro->Acq_doppler_step = 0U;
-                        d_well_count = 0;
-                        d_mag = 0.0;
-                        d_input_power = 0.0;
-                        d_test_statistics = 0.0;
-                        d_state = 1;
-                    }
-                d_sample_counter += static_cast<uint64_t>(ninput_items[0]);  // sample counter
-                consume_each(ninput_items[0]);
-
+                // restart acquisition variables
+                d_gnss_synchro->Acq_delay_samples = 0.0;
+                d_gnss_synchro->Acq_doppler_hz = 0.0;
+                d_gnss_synchro->Acq_samplestamp_samples = 0ULL;
+                d_gnss_synchro->Acq_doppler_step = 0U;
+                d_well_count = 0;
+                d_mag = 0.0;
+                d_input_power = 0.0;
+                d_test_statistics = 0.0;
+                d_state = 1;
                 break;
             }
         case 1:

--- a/src/algorithms/acquisition/gnuradio_blocks/galileo_e5a_noncoherent_iq_acquisition_caf_cc.h
+++ b/src/algorithms/acquisition/gnuradio_blocks/galileo_e5a_noncoherent_iq_acquisition_caf_cc.h
@@ -103,15 +103,13 @@ public:
      */
     inline void set_active(bool active) override
     {
+        if (!active)
+            {
+                d_state = 0;
+            }
+
         d_active = active;
     }
-
-    /*!
-     * \brief If set to 1, ensures that acquisition starts at the
-     * first available sample.
-     * \param state - int=1 forces start of acquisition
-     */
-    void set_state(int state) override;
 
     /*!
      * \brief Set acquisition channel unique ID

--- a/src/algorithms/acquisition/gnuradio_blocks/galileo_pcps_8ms_acquisition_cc.cc
+++ b/src/algorithms/acquisition/gnuradio_blocks/galileo_pcps_8ms_acquisition_cc.cc
@@ -146,58 +146,33 @@ void galileo_pcps_8ms_acquisition_cc::init()
 }
 
 
-void galileo_pcps_8ms_acquisition_cc::set_state(int32_t state)
-{
-    d_state = state;
-    if (d_state == 1)
-        {
-            d_gnss_synchro->Acq_delay_samples = 0.0;
-            d_gnss_synchro->Acq_doppler_hz = 0.0;
-            d_gnss_synchro->Acq_samplestamp_samples = 0ULL;
-            d_gnss_synchro->Acq_doppler_step = 0U;
-            d_well_count = 0;
-            d_mag = 0.0;
-            d_input_power = 0.0;
-            d_test_statistics = 0.0;
-        }
-    else if (d_state == 0)
-        {
-        }
-    else
-        {
-            LOG(ERROR) << "State can only be set to 0 or 1";
-        }
-}
-
-
 int galileo_pcps_8ms_acquisition_cc::general_work(int noutput_items,
     gr_vector_int &ninput_items, gr_vector_const_void_star &input_items,
     gr_vector_void_star &output_items)
 {
     int32_t acquisition_message = -1;  // 0=STOP_CHANNEL 1=ACQ_SUCCEES 2=ACQ_FAIL
 
+    if (!d_active)
+        {
+            d_sample_counter += static_cast<uint64_t>(d_fft_size) * ninput_items[0];  // sample counter
+            consume_each(ninput_items[0]);
+            return 0;
+        }
+
     switch (d_state)
         {
         case 0:
             {
-                if (d_active)
-                    {
-                        // restart acquisition variables
-                        d_gnss_synchro->Acq_delay_samples = 0.0;
-                        d_gnss_synchro->Acq_doppler_hz = 0.0;
-                        d_gnss_synchro->Acq_samplestamp_samples = 0ULL;
-                        d_gnss_synchro->Acq_doppler_step = 0U;
-                        d_well_count = 0;
-                        d_mag = 0.0;
-                        d_input_power = 0.0;
-                        d_test_statistics = 0.0;
-
-                        d_state = 1;
-                    }
-
-                d_sample_counter += static_cast<uint64_t>(d_fft_size) * ninput_items[0];  // sample counter
-                consume_each(ninput_items[0]);
-
+                // restart acquisition variables
+                d_gnss_synchro->Acq_delay_samples = 0.0;
+                d_gnss_synchro->Acq_doppler_hz = 0.0;
+                d_gnss_synchro->Acq_samplestamp_samples = 0ULL;
+                d_gnss_synchro->Acq_doppler_step = 0U;
+                d_well_count = 0;
+                d_mag = 0.0;
+                d_input_power = 0.0;
+                d_test_statistics = 0.0;
+                d_state = 1;
                 break;
             }
 

--- a/src/algorithms/acquisition/gnuradio_blocks/galileo_pcps_8ms_acquisition_cc.h
+++ b/src/algorithms/acquisition/gnuradio_blocks/galileo_pcps_8ms_acquisition_cc.h
@@ -92,15 +92,13 @@ public:
      */
     inline void set_active(bool active) override
     {
+        if (!active)
+            {
+                d_state = 0;
+            }
+
         d_active = active;
     }
-
-    /*!
-     * \brief If set to 1, ensures that acquisition starts at the
-     * first available sample.
-     * \param state - int=1 forces start of acquisition
-     */
-    void set_state(int32_t state) override;
 
     /*!
      * \brief Set acquisition channel unique ID

--- a/src/algorithms/acquisition/gnuradio_blocks/pcps_acquisition.cc
+++ b/src/algorithms/acquisition/gnuradio_blocks/pcps_acquisition.cc
@@ -303,29 +303,6 @@ void pcps_acquisition::update_grid_doppler_wipeoffs_step2()
 }
 
 
-void pcps_acquisition::set_state(int32_t state)
-{
-    gr::thread::scoped_lock lock(d_setlock);  // require mutex with work function called by the scheduler
-    d_state = state;
-    if (d_state == 1)
-        {
-            d_gnss_synchro->Acq_delay_samples = 0.0;
-            d_gnss_synchro->Acq_doppler_hz = 0.0;
-            d_gnss_synchro->Acq_samplestamp_samples = 0ULL;
-            d_gnss_synchro->Acq_doppler_step = 0U;
-            d_mag = 0.0;
-            d_active = true;
-        }
-    else if (d_state == 0)
-        {
-        }
-    else
-        {
-            LOG(ERROR) << "State can only be set to 0 or 1";
-        }
-}
-
-
 void pcps_acquisition::send_positive_acquisition(float test_statistics)
 {
     // Declare positive acquisition using a message port
@@ -916,11 +893,6 @@ int pcps_acquisition::general_work(int noutput_items __attribute__((unused)),
                 d_mag = 0.0;
                 d_state = 1;
                 d_buffer_count = 0U;
-                if (!d_acq_parameters.blocking_on_standby)
-                    {
-                        d_sample_counter += static_cast<uint64_t>(ninput_items[0]);  // sample counter
-                        consume_each(ninput_items[0]);
-                    }
                 break;
             }
         case 1:

--- a/src/algorithms/acquisition/gnuradio_blocks/pcps_acquisition.h
+++ b/src/algorithms/acquisition/gnuradio_blocks/pcps_acquisition.h
@@ -117,13 +117,6 @@ public:
      */
     void set_local_code(std::complex<float>* code) override;
 
-    /*!
-     * \brief If set to 1, ensures that acquisition starts at the
-     * first available sample.
-     * \param state - int=1 forces start of acquisition
-     */
-    void set_state(int32_t state) override;
-
     void set_resampler_latency(uint32_t latency_samples);
 
     /*!

--- a/src/algorithms/acquisition/gnuradio_blocks/pcps_acquisition_fine_doppler_cc.cc
+++ b/src/algorithms/acquisition/gnuradio_blocks/pcps_acquisition_fine_doppler_cc.cc
@@ -411,32 +411,6 @@ bool pcps_acquisition_fine_doppler_cc::start()
 }
 
 
-void pcps_acquisition_fine_doppler_cc::set_state(int state)
-{
-    // gr::thread::scoped_lock lock(d_setlock);  // require mutex with work function called by the scheduler
-    d_state = state;
-
-    if (d_state == 1)
-        {
-            d_gnss_synchro->Acq_delay_samples = 0.0;
-            d_gnss_synchro->Acq_doppler_hz = 0.0;
-            d_gnss_synchro->Acq_samplestamp_samples = 0ULL;
-            d_gnss_synchro->Acq_doppler_step = 0U;
-            d_well_count = 0;
-            d_test_statistics = 0.0;
-            d_active = true;
-            reset_grid();
-        }
-    else if (d_state == 0)
-        {
-        }
-    else
-        {
-            LOG(ERROR) << "State can only be set to 0 or 1";
-        }
-}
-
-
 int pcps_acquisition_fine_doppler_cc::general_work(int noutput_items,
     gr_vector_int &ninput_items __attribute__((unused)), gr_vector_const_void_star &input_items,
     gr_vector_void_star &output_items)
@@ -458,20 +432,26 @@ int pcps_acquisition_fine_doppler_cc::general_work(int noutput_items,
     int return_value = 0;  // Number of Gnss_Syncro objects produced
     int samples_remaining;
     const auto *in_aux = reinterpret_cast<const gr_complex *>(input_items[0]);
+
+    if (!d_active)
+        {
+            d_sample_counter += static_cast<uint64_t>(d_fft_size);  // sample counter
+            consume_each(ninput_items[0]);
+            return 0;
+        }
+
     switch (d_state)
         {
         case 0:  // S0. StandBy
-            if (d_active == true)
-                {
-                    reset_grid();
-                    d_n_samples_in_buffer = 0;
-                    d_state = 1;
-                }
-            if (!d_acq_params.blocking_on_standby)
-                {
-                    d_sample_counter += static_cast<uint64_t>(d_fft_size);  // sample counter
-                    consume_each(d_fft_size);
-                }
+            d_gnss_synchro->Acq_delay_samples = 0.0;
+            d_gnss_synchro->Acq_doppler_hz = 0.0;
+            d_gnss_synchro->Acq_samplestamp_samples = 0ULL;
+            d_gnss_synchro->Acq_doppler_step = 0U;
+            d_well_count = 0;
+            d_test_statistics = 0.0;
+            reset_grid();
+            d_n_samples_in_buffer = 0;
+            d_state = 1;
             break;
         case 1:  // S1. ComputeGrid
             compute_and_accumulate_grid(input_items);

--- a/src/algorithms/acquisition/gnuradio_blocks/pcps_acquisition_fine_doppler_cc.h
+++ b/src/algorithms/acquisition/gnuradio_blocks/pcps_acquisition_fine_doppler_cc.h
@@ -115,6 +115,11 @@ public:
      */
     inline void set_active(bool active) override
     {
+        if (!active)
+            {
+                d_state = 0;
+            }
+
         d_active = active;
     }
 
@@ -145,13 +150,6 @@ public:
     {
         d_threshold = threshold;
     }
-
-    /*!
-     * \brief If set to 1, ensures that acquisition starts at the
-     * first available sample.
-     * \param state - int=1 forces start of acquisition
-     */
-    void set_state(int state) override;
 
     /*!
      * \brief Parallel Code Phase Search Acquisition signal processing.

--- a/src/algorithms/acquisition/gnuradio_blocks/pcps_acquisition_fpga.cc
+++ b/src/algorithms/acquisition/gnuradio_blocks/pcps_acquisition_fpga.cc
@@ -87,28 +87,6 @@ void pcps_acquisition_fpga::init()
     d_input_power = 0.0;
 }
 
-void pcps_acquisition_fpga::set_state(int32_t state)
-{
-    d_state = state;
-    if (d_state == 1)
-        {
-            d_gnss_synchro->Acq_delay_samples = 0.0;
-            d_gnss_synchro->Acq_doppler_hz = 0.0;
-            d_gnss_synchro->Acq_samplestamp_samples = 0;
-            d_mag = 0.0;
-            d_input_power = 0.0;
-            d_test_statistics = 0.0;
-            d_active = true;
-        }
-    else if (d_state == 0)
-        {
-        }
-    else
-        {
-            LOG(ERROR) << "State can only be set to 0 or 1";
-        }
-}
-
 
 void pcps_acquisition_fpga::send_positive_acquisition()
 {

--- a/src/algorithms/acquisition/gnuradio_blocks/pcps_acquisition_fpga.h
+++ b/src/algorithms/acquisition/gnuradio_blocks/pcps_acquisition_fpga.h
@@ -92,13 +92,6 @@ public:
     void set_local_code();
 
     /*!
-     * \brief If set to 1, ensures that acquisition starts at the
-     * first available sample.
-     * \param state - int=1 forces start of acquisition
-     */
-    void set_state(int32_t state);
-
-    /*!
      * \brief Starts acquisition algorithm, turning from standby mode to
      * active mode
      * \param active - bool that activates/deactivates the block.

--- a/src/algorithms/acquisition/gnuradio_blocks/pcps_assisted_acquisition_cc.cc
+++ b/src/algorithms/acquisition/gnuradio_blocks/pcps_assisted_acquisition_cc.cc
@@ -325,15 +325,17 @@ int pcps_assisted_acquisition_cc::general_work(int noutput_items,
      *             S5. Negative_Acq: Send message and stop acq -> S0
      */
 
+    if (!d_active)
+        {
+            d_sample_counter += static_cast<uint64_t>(ninput_items[0]);  // sample counter
+            consume_each(ninput_items[0]);
+            return 0;
+        }
+
     switch (d_state)
         {
         case 0:  // S0. StandBy
-            if (d_active == true)
-                {
-                    d_state = 1;
-                }
-            d_sample_counter += static_cast<uint64_t>(ninput_items[0]);  // sample counter
-            consume_each(ninput_items[0]);
+            d_state = 1;
             break;
         case 1:  // S1. GetAssist
             get_assistance();

--- a/src/algorithms/acquisition/gnuradio_blocks/pcps_assisted_acquisition_cc.h
+++ b/src/algorithms/acquisition/gnuradio_blocks/pcps_assisted_acquisition_cc.h
@@ -109,6 +109,11 @@ public:
      */
     inline void set_active(bool active) override
     {
+        if (!active)
+            {
+                d_state = 0;
+            }
+
         d_active = active;
     }
 
@@ -137,11 +142,6 @@ public:
     inline void set_threshold(float threshold) override
     {
         d_threshold = threshold;
-    }
-
-    inline void set_state(int32_t state) override
-    {
-        d_state = state;
     }
 
     /*!

--- a/src/algorithms/acquisition/gnuradio_blocks/pcps_cccwsr_acquisition_cc.cc
+++ b/src/algorithms/acquisition/gnuradio_blocks/pcps_cccwsr_acquisition_cc.cc
@@ -153,58 +153,33 @@ void pcps_cccwsr_acquisition_cc::init()
 }
 
 
-void pcps_cccwsr_acquisition_cc::set_state(int32_t state)
-{
-    d_state = state;
-    if (d_state == 1)
-        {
-            d_gnss_synchro->Acq_delay_samples = 0.0;
-            d_gnss_synchro->Acq_doppler_hz = 0.0;
-            d_gnss_synchro->Acq_samplestamp_samples = 0ULL;
-            d_gnss_synchro->Acq_doppler_step = 0U;
-            d_well_count = 0;
-            d_mag = 0.0;
-            d_input_power = 0.0;
-            d_test_statistics = 0.0;
-        }
-    else if (d_state == 0)
-        {
-        }
-    else
-        {
-            LOG(ERROR) << "State can only be set to 0 or 1";
-        }
-}
-
-
 int pcps_cccwsr_acquisition_cc::general_work(int noutput_items,
     gr_vector_int &ninput_items, gr_vector_const_void_star &input_items,
     gr_vector_void_star &output_items)
 {
     int32_t acquisition_message = -1;  // 0=STOP_CHANNEL 1=ACQ_SUCCEES 2=ACQ_FAIL
 
+    if (!d_active)
+        {
+            d_sample_counter += static_cast<uint64_t>(d_fft_size) * ninput_items[0];  // sample counter
+            consume_each(ninput_items[0]);
+            return 0;
+        }
+
     switch (d_state)
         {
         case 0:
             {
-                if (d_active)
-                    {
-                        // restart acquisition variables
-                        d_gnss_synchro->Acq_delay_samples = 0.0;
-                        d_gnss_synchro->Acq_doppler_hz = 0.0;
-                        d_gnss_synchro->Acq_samplestamp_samples = 0ULL;
-                        d_gnss_synchro->Acq_doppler_step = 0U;
-                        d_well_count = 0;
-                        d_mag = 0.0;
-                        d_input_power = 0.0;
-                        d_test_statistics = 0.0;
-
-                        d_state = 1;
-                    }
-
-                d_sample_counter += static_cast<uint64_t>(d_fft_size) * ninput_items[0];  // sample counter
-                consume_each(ninput_items[0]);
-
+                // restart acquisition variables
+                d_gnss_synchro->Acq_delay_samples = 0.0;
+                d_gnss_synchro->Acq_doppler_hz = 0.0;
+                d_gnss_synchro->Acq_samplestamp_samples = 0ULL;
+                d_gnss_synchro->Acq_doppler_step = 0U;
+                d_well_count = 0;
+                d_mag = 0.0;
+                d_input_power = 0.0;
+                d_test_statistics = 0.0;
+                d_state = 1;
                 break;
             }
         case 1:

--- a/src/algorithms/acquisition/gnuradio_blocks/pcps_cccwsr_acquisition_cc.h
+++ b/src/algorithms/acquisition/gnuradio_blocks/pcps_cccwsr_acquisition_cc.h
@@ -97,15 +97,13 @@ public:
      */
     inline void set_active(bool active) override
     {
+        if (!active)
+            {
+                d_state = 0;
+            }
+
         d_active = active;
     }
-
-    /*!
-     * \brief If set to 1, ensures that acquisition starts at the
-     * first available sample.
-     * \param state - int=1 forces start of acquisition
-     */
-    void set_state(int32_t state) override;
 
     /*!
      * \brief Set acquisition channel unique ID

--- a/src/algorithms/acquisition/gnuradio_blocks/pcps_opencl_acquisition_cc.cc
+++ b/src/algorithms/acquisition/gnuradio_blocks/pcps_opencl_acquisition_cc.cc
@@ -604,32 +604,6 @@ void pcps_opencl_acquisition_cc::acquisition_core_opencl()
 }
 
 
-void pcps_opencl_acquisition_cc::set_state(int state)
-{
-    d_state = state;
-    if (d_state == 1)
-        {
-            d_gnss_synchro->Acq_delay_samples = 0.0;
-            d_gnss_synchro->Acq_doppler_hz = 0.0;
-            d_gnss_synchro->Acq_samplestamp_samples = 0ULL;
-            d_gnss_synchro->Acq_doppler_step = 0U;
-            d_well_count = 0;
-            d_mag = 0.0;
-            d_input_power = 0.0;
-            d_test_statistics = 0.0;
-            d_in_dwell_count = 0;
-            d_sample_counter_buffer.clear();
-        }
-    else if (d_state == 0)
-        {
-        }
-    else
-        {
-            LOG(ERROR) << "State can only be set to 0 or 1";
-        }
-}
-
-
 int pcps_opencl_acquisition_cc::general_work(int noutput_items,
     gr_vector_int &ninput_items, gr_vector_const_void_star &input_items,
     gr_vector_void_star &output_items)

--- a/src/algorithms/acquisition/gnuradio_blocks/pcps_opencl_acquisition_cc.h
+++ b/src/algorithms/acquisition/gnuradio_blocks/pcps_opencl_acquisition_cc.h
@@ -116,15 +116,13 @@ public:
      */
     inline void set_active(bool active) override
     {
+        if (!active)
+            {
+                d_state = 0;
+            }
+
         d_active = active;
     }
-
-    /*!
-     * \brief If set to 1, ensures that acquisition starts at the
-     * first available sample.
-     * \param state - int=1 forces start of acquisition
-     */
-    void set_state(int state) override;
 
     /*!
      * \brief Set acquisition channel unique ID

--- a/src/algorithms/acquisition/gnuradio_blocks/pcps_quicksync_acquisition_cc.cc
+++ b/src/algorithms/acquisition/gnuradio_blocks/pcps_quicksync_acquisition_cc.cc
@@ -161,30 +161,6 @@ void pcps_quicksync_acquisition_cc::init()
 }
 
 
-void pcps_quicksync_acquisition_cc::set_state(int32_t state)
-{
-    d_state = state;
-    if (d_state == 1)
-        {
-            d_gnss_synchro->Acq_delay_samples = 0.0;
-            d_gnss_synchro->Acq_doppler_hz = 0.0;
-            d_gnss_synchro->Acq_samplestamp_samples = 0ULL;
-            d_gnss_synchro->Acq_doppler_step = 0U;
-            d_well_count = 0;
-            d_mag = 0.0;
-            d_input_power = 0.0;
-            d_test_statistics = 0.0;
-            d_active = true;
-        }
-    else if (d_state == 0)
-        {
-        }
-    else
-        {
-            LOG(ERROR) << "State can only be set to 0 or 1";
-        }
-}
-
 int pcps_quicksync_acquisition_cc::general_work(int noutput_items,
     gr_vector_int& ninput_items, gr_vector_const_void_star& input_items,
     gr_vector_void_star& output_items)
@@ -201,29 +177,29 @@ int pcps_quicksync_acquisition_cc::general_work(int noutput_items,
      */
     // DLOG(INFO) << "START GENERAL WORK";
     int32_t acquisition_message = -1;  // 0=STOP_CHANNEL 1=ACQ_SUCCEES 2=ACQ_FAIL
+
+    if (!d_active)
+        {
+            d_sample_counter += static_cast<uint64_t>(d_vector_length) * ninput_items[0];  // sample counter
+            consume_each(ninput_items[0]);
+            return 0;
+        }
+
     switch (d_state)
         {
         case 0:
             {
-                // DLOG(INFO) << "START CASE 0";
-                if (d_active)
-                    {
-                        // restart acquisition variables
-                        d_gnss_synchro->Acq_delay_samples = 0.0;
-                        d_gnss_synchro->Acq_doppler_hz = 0.0;
-                        d_gnss_synchro->Acq_samplestamp_samples = 0ULL;
-                        d_gnss_synchro->Acq_doppler_step = 0U;
-                        d_well_count = 0;
-                        d_mag = 0.0;
-                        d_input_power = 0.0;
-                        d_test_statistics = 0.0;
+                // restart acquisition variables
+                d_gnss_synchro->Acq_delay_samples = 0.0;
+                d_gnss_synchro->Acq_doppler_hz = 0.0;
+                d_gnss_synchro->Acq_samplestamp_samples = 0ULL;
+                d_gnss_synchro->Acq_doppler_step = 0U;
+                d_well_count = 0;
+                d_mag = 0.0;
+                d_input_power = 0.0;
+                d_test_statistics = 0.0;
 
-                        d_state = 1;
-                    }
-
-                d_sample_counter += static_cast<uint64_t>(d_vector_length) * ninput_items[0];  // sample counter
-                consume_each(ninput_items[0]);
-                // DLOG(INFO) << "END CASE 0";
+                d_state = 1;
                 break;
             }
 

--- a/src/algorithms/acquisition/gnuradio_blocks/pcps_quicksync_acquisition_cc.h
+++ b/src/algorithms/acquisition/gnuradio_blocks/pcps_quicksync_acquisition_cc.h
@@ -115,15 +115,13 @@ public:
      */
     inline void set_active(bool active) override
     {
+        if (!active)
+            {
+                d_state = 0;
+            }
+
         d_active = active;
     }
-
-    /*!
-     * \brief If set to 1, ensures that acquisition starts at the
-     * first available sample.
-     * \param state - int=1 forces start of acquisition
-     */
-    void set_state(int32_t state) override;
 
     /*!
      * \brief Set acquisition channel unique ID

--- a/src/algorithms/acquisition/gnuradio_blocks/pcps_tong_acquisition_cc.cc
+++ b/src/algorithms/acquisition/gnuradio_blocks/pcps_tong_acquisition_cc.cc
@@ -163,76 +163,43 @@ void pcps_tong_acquisition_cc::init()
 }
 
 
-void pcps_tong_acquisition_cc::set_state(int32_t state)
-{
-    d_state = state;
-    if (d_state == 1)
-        {
-            d_gnss_synchro->Acq_delay_samples = 0.0;
-            d_gnss_synchro->Acq_doppler_hz = 0.0;
-            d_gnss_synchro->Acq_samplestamp_samples = 0ULL;
-            d_gnss_synchro->Acq_doppler_step = 0U;
-            d_dwell_count = 0;
-            d_tong_count = d_tong_init_val;
-            d_mag = 0.0;
-            d_input_power = 0.0;
-            d_test_statistics = 0.0;
-
-            for (uint32_t doppler_index = 0; doppler_index < d_num_doppler_bins; doppler_index++)
-                {
-                    for (uint32_t i = 0; i < d_fft_size; i++)
-                        {
-                            d_grid_data[doppler_index][i] = 0.0;
-                        }
-                }
-        }
-    else if (d_state == 0)
-        {
-        }
-    else
-        {
-            LOG(ERROR) << "State can only be set to 0 or 1";
-        }
-}
-
-
 int pcps_tong_acquisition_cc::general_work(int noutput_items,
     gr_vector_int &ninput_items, gr_vector_const_void_star &input_items,
     gr_vector_void_star &output_items)
 {
     int32_t acquisition_message = -1;  // 0=STOP_CHANNEL 1=ACQ_SUCCEES 2=ACQ_FAIL
 
+    if (!d_active)
+        {
+            d_sample_counter += static_cast<uint64_t>(d_fft_size) * ninput_items[0];  // sample counter
+            consume_each(ninput_items[0]);
+            return 0;
+        }
+
     switch (d_state)
         {
         case 0:
             {
-                if (d_active)
+                // restart acquisition variables
+                d_gnss_synchro->Acq_delay_samples = 0.0;
+                d_gnss_synchro->Acq_doppler_hz = 0.0;
+                d_gnss_synchro->Acq_samplestamp_samples = 0ULL;
+                d_gnss_synchro->Acq_doppler_step = 0U;
+                d_dwell_count = 0;
+                d_tong_count = d_tong_init_val;
+                d_mag = 0.0;
+                d_input_power = 0.0;
+                d_test_statistics = 0.0;
+
+                for (uint32_t doppler_index = 0; doppler_index < d_num_doppler_bins; doppler_index++)
                     {
-                        // restart acquisition variables
-                        d_gnss_synchro->Acq_delay_samples = 0.0;
-                        d_gnss_synchro->Acq_doppler_hz = 0.0;
-                        d_gnss_synchro->Acq_samplestamp_samples = 0ULL;
-                        d_gnss_synchro->Acq_doppler_step = 0U;
-                        d_dwell_count = 0;
-                        d_tong_count = d_tong_init_val;
-                        d_mag = 0.0;
-                        d_input_power = 0.0;
-                        d_test_statistics = 0.0;
-
-                        for (uint32_t doppler_index = 0; doppler_index < d_num_doppler_bins; doppler_index++)
+                        for (uint32_t i = 0; i < d_fft_size; i++)
                             {
-                                for (uint32_t i = 0; i < d_fft_size; i++)
-                                    {
-                                        d_grid_data[doppler_index][i] = 0.0;
-                                    }
+                                d_grid_data[doppler_index][i] = 0.0;
                             }
-
-                        d_state = 1;
                     }
 
-                d_sample_counter += static_cast<uint64_t>(d_fft_size) * ninput_items[0];  // sample counter
-                consume_each(ninput_items[0]);
-
+                d_state = 1;
                 break;
             }
 

--- a/src/algorithms/acquisition/gnuradio_blocks/pcps_tong_acquisition_cc.h
+++ b/src/algorithms/acquisition/gnuradio_blocks/pcps_tong_acquisition_cc.h
@@ -114,15 +114,13 @@ public:
      */
     inline void set_active(bool active) override
     {
+        if (!active)
+            {
+                d_state = 0;
+            }
+
         d_active = active;
     }
-
-    /*!
-     * \brief If set to 1, ensures that acquisition starts at the
-     * first available sample.
-     * \param state - int=1 forces start of acquisition
-     */
-    void set_state(int32_t state) override;
 
     /*!
      * \brief Set acquisition channel unique ID

--- a/src/core/interfaces/acquisition_interface.h
+++ b/src/core/interfaces/acquisition_interface.h
@@ -57,7 +57,6 @@ public:
     virtual void set_doppler_center(int /*doppler_center*/) {}
     virtual void init() = 0;
     virtual void set_local_code() = 0;
-    virtual void set_state(int state) = 0;
     virtual signed int mag() = 0;
     virtual void reset() = 0;
     virtual void stop_acquisition() = 0;

--- a/tests/unit-tests/signal-processing-blocks/acquisition/acq_performance_test.cc
+++ b/tests/unit-tests/signal-processing-blocks/acquisition/acq_performance_test.cc
@@ -593,7 +593,6 @@ void AcquisitionPerformanceTest::process_message()
 {
     measurement_counter++;
     acquisition->reset();
-    acquisition->set_state(1);
     std::cout << "Progress: " << round(static_cast<float>(measurement_counter) / static_cast<float>(num_of_measurements) * 100.0) << "% \r" << std::flush;
     if (measurement_counter == num_of_measurements)
         {
@@ -857,8 +856,8 @@ int AcquisitionPerformanceTest::run_receiver()
     acquisition->set_threshold(config->property("Acquisition.threshold", 0.0));
     acquisition->init();
     acquisition->set_local_code();
+    acquisition->reset();
 
-    acquisition->set_state(1);  // Ensure that acquisition starts at the first sample
     acquisition->connect(top_block);
 
     acquisition->reset();

--- a/tests/unit-tests/signal-processing-blocks/acquisition/beidou_b1i_pcps_acquisition_test.cc
+++ b/tests/unit-tests/signal-processing-blocks/acquisition/beidou_b1i_pcps_acquisition_test.cc
@@ -249,7 +249,7 @@ void BeidouB1iPcpsAcquisitionTest::plot_grid()
 TEST_F(BeidouB1iPcpsAcquisitionTest, Instantiate)
 {
     init();
-    std::shared_ptr<BeidouB1iPcpsAcquisition> acquisition = boost::make_shared<BeidouB1iPcpsAcquisition>(config.get(), "Acquisition_B1", 1, 0);
+    std::shared_ptr<BeidouB1iPcpsAcquisition> acquisition = std::make_shared<BeidouB1iPcpsAcquisition>(config.get(), "Acquisition_B1", 1, 0);
 }
 
 
@@ -263,7 +263,7 @@ TEST_F(BeidouB1iPcpsAcquisitionTest, ConnectAndRun)
 
     top_block = gr::make_top_block("Acquisition test");
     init();
-    std::shared_ptr<BeidouB1iPcpsAcquisition> acquisition = boost::make_shared<BeidouB1iPcpsAcquisition>(config.get(), "Acquisition_B1", 1, 0);
+    std::shared_ptr<BeidouB1iPcpsAcquisition> acquisition = std::make_shared<BeidouB1iPcpsAcquisition>(config.get(), "Acquisition_B1", 1, 0);
     std::shared_ptr<BeidouB1iPcpsAcquisitionTest_msg_rx> msg_rx = BeidouB1iPcpsAcquisitionTest_msg_rx_make();
 
     ASSERT_NO_THROW({
@@ -336,8 +336,8 @@ TEST_F(BeidouB1iPcpsAcquisitionTest, ValidationOfResults)
     }) << "Failure connecting the blocks of acquisition test.";
 
     acquisition->set_local_code();
-    acquisition->set_state(1);  // Ensure that acquisition starts at the first sample
     acquisition->init();
+    acquisition->reset();
 
     EXPECT_NO_THROW({
         start = std::chrono::system_clock::now();

--- a/tests/unit-tests/signal-processing-blocks/acquisition/beidou_b3i_pcps_acquisition_test.cc
+++ b/tests/unit-tests/signal-processing-blocks/acquisition/beidou_b3i_pcps_acquisition_test.cc
@@ -247,7 +247,7 @@ void BeidouB3iPcpsAcquisitionTest::plot_grid()
 TEST_F(BeidouB3iPcpsAcquisitionTest, Instantiate)
 {
     init();
-    std::shared_ptr<BeidouB3iPcpsAcquisition> acquisition = boost::make_shared<BeidouB3iPcpsAcquisition>(config.get(), "Acquisition_B3", 1, 0);
+    std::shared_ptr<BeidouB3iPcpsAcquisition> acquisition = std::make_shared<BeidouB3iPcpsAcquisition>(config.get(), "Acquisition_B3", 1, 0);
 }
 
 
@@ -261,7 +261,7 @@ TEST_F(BeidouB3iPcpsAcquisitionTest, ConnectAndRun)
 
     top_block = gr::make_top_block("Acquisition test");
     init();
-    std::shared_ptr<BeidouB3iPcpsAcquisition> acquisition = boost::make_shared<BeidouB3iPcpsAcquisition>(config.get(), "Acquisition_B3", 1, 0);
+    std::shared_ptr<BeidouB3iPcpsAcquisition> acquisition = std::make_shared<BeidouB3iPcpsAcquisition>(config.get(), "Acquisition_B3", 1, 0);
     std::shared_ptr<BeidouB3iPcpsAcquisitionTest_msg_rx> msg_rx = BeidouB3iPcpsAcquisitionTest_msg_rx_make();
 
     ASSERT_NO_THROW({
@@ -334,7 +334,7 @@ TEST_F(BeidouB3iPcpsAcquisitionTest, ValidationOfResults)
     }) << "Failure connecting the blocks of acquisition test.";
 
     acquisition->set_local_code();
-    acquisition->set_state(1);  // Ensure that acquisition starts at the first sample
+    acquisition->reset();
     acquisition->init();
 
     EXPECT_NO_THROW({

--- a/tests/unit-tests/signal-processing-blocks/acquisition/galileo_e1_pcps_8ms_ambiguous_acquisition_gsoc2013_test.cc
+++ b/tests/unit-tests/signal-processing-blocks/acquisition/galileo_e1_pcps_8ms_ambiguous_acquisition_gsoc2013_test.cc
@@ -533,7 +533,7 @@ TEST_F(GalileoE1Pcps8msAmbiguousAcquisitionGSoC2013Test, ValidationOfResults)
                 }
 
             acquisition->set_local_code();
-            // acquisition->set_state(1);
+            acquisition->reset();
             start_queue();
 
             EXPECT_NO_THROW({
@@ -614,7 +614,7 @@ TEST_F(GalileoE1Pcps8msAmbiguousAcquisitionGSoC2013Test, ValidationOfResultsProb
                 }
 
             acquisition->set_local_code();
-            // acquisition->set_state(1);
+            acquisition->reset();
             start_queue();
 
             EXPECT_NO_THROW({

--- a/tests/unit-tests/signal-processing-blocks/acquisition/galileo_e1_pcps_ambiguous_acquisition_gsoc2013_test.cc
+++ b/tests/unit-tests/signal-processing-blocks/acquisition/galileo_e1_pcps_ambiguous_acquisition_gsoc2013_test.cc
@@ -515,7 +515,7 @@ TEST_F(GalileoE1PcpsAmbiguousAcquisitionGSoC2013Test, ValidationOfResults)
                 }
 
             acquisition->set_local_code();
-            acquisition->set_state(1);
+            acquisition->reset();
             start_queue();
 
             EXPECT_NO_THROW({
@@ -589,7 +589,7 @@ TEST_F(GalileoE1PcpsAmbiguousAcquisitionGSoC2013Test, ValidationOfResultsProbabi
                 }
 
             acquisition->set_local_code();
-            acquisition->set_state(1);
+            acquisition->reset();
             start_queue();
 
             EXPECT_NO_THROW({

--- a/tests/unit-tests/signal-processing-blocks/acquisition/galileo_e1_pcps_ambiguous_acquisition_gsoc_test.cc
+++ b/tests/unit-tests/signal-processing-blocks/acquisition/galileo_e1_pcps_ambiguous_acquisition_gsoc_test.cc
@@ -294,7 +294,6 @@ TEST_F(GalileoE1PcpsAmbiguousAcquisitionGSoCTest, ValidationOfResults)
         acquisition->set_local_code();
         acquisition->init();
         acquisition->reset();
-        acquisition->set_state(1);
     }) << "Failure starting acquisition";
 
     EXPECT_NO_THROW({

--- a/tests/unit-tests/signal-processing-blocks/acquisition/galileo_e1_pcps_ambiguous_acquisition_test.cc
+++ b/tests/unit-tests/signal-processing-blocks/acquisition/galileo_e1_pcps_ambiguous_acquisition_test.cc
@@ -352,7 +352,6 @@ TEST_F(GalileoE1PcpsAmbiguousAcquisitionTest, ValidationOfResults)
     acquisition->set_local_code();
     acquisition->init();
     acquisition->reset();
-    acquisition->set_state(1);
 
     EXPECT_NO_THROW({
         start = std::chrono::system_clock::now();

--- a/tests/unit-tests/signal-processing-blocks/acquisition/galileo_e1_pcps_cccwsr_ambiguous_acquisition_gsoc2013_test.cc
+++ b/tests/unit-tests/signal-processing-blocks/acquisition/galileo_e1_pcps_cccwsr_ambiguous_acquisition_gsoc2013_test.cc
@@ -524,7 +524,6 @@ TEST_F(GalileoE1PcpsCccwsrAmbiguousAcquisitionTest, ValidationOfResults)
             acquisition->set_gnss_synchro(&gnss_synchro);
             acquisition->set_local_code();
             acquisition->reset();
-            acquisition->set_state(1);
             start_queue();
 
             EXPECT_NO_THROW({
@@ -612,7 +611,6 @@ TEST_F(GalileoE1PcpsCccwsrAmbiguousAcquisitionTest, ValidationOfResultsProbabili
             acquisition->init();
             acquisition->reset();
             acquisition->set_local_code();
-            acquisition->set_state(1);
             start_queue();
 
             EXPECT_NO_THROW({

--- a/tests/unit-tests/signal-processing-blocks/acquisition/galileo_e1_pcps_quicksync_ambiguous_acquisition_gsoc2014_test.cc
+++ b/tests/unit-tests/signal-processing-blocks/acquisition/galileo_e1_pcps_quicksync_ambiguous_acquisition_gsoc2014_test.cc
@@ -704,7 +704,6 @@ TEST_F(GalileoE1PcpsQuickSyncAmbiguousAcquisitionGSoC2014Test, ValidationOfResul
 {
     LOG(INFO) << "Start validation of results with noise+interference test";
     config_3();
-    config->set_property("Acquisition_1B.blocking_on_standby", "true");  // Ensure that acquisition starts at the first sample
     top_block = gr::make_top_block("Acquisition test");
     queue = std::make_shared<Concurrent_Queue<pmt::pmt_t>>();
 
@@ -783,7 +782,6 @@ TEST_F(GalileoE1PcpsQuickSyncAmbiguousAcquisitionGSoC2014Test, ValidationOfResul
 TEST_F(GalileoE1PcpsQuickSyncAmbiguousAcquisitionGSoC2014Test, ValidationOfResultsProbabilities)
 {
     config_2();
-    config->set_property("Acquisition_1B.blocking_on_standby", "true");  // Ensure that acquisition starts at the first sample
     top_block = gr::make_top_block("Acquisition test");
     queue = std::make_shared<Concurrent_Queue<pmt::pmt_t>>();
 

--- a/tests/unit-tests/signal-processing-blocks/acquisition/galileo_e1_pcps_quicksync_ambiguous_acquisition_gsoc2014_test.cc
+++ b/tests/unit-tests/signal-processing-blocks/acquisition/galileo_e1_pcps_quicksync_ambiguous_acquisition_gsoc2014_test.cc
@@ -676,7 +676,6 @@ TEST_F(GalileoE1PcpsQuickSyncAmbiguousAcquisitionGSoC2014Test, ValidationOfResul
             acquisition->set_gnss_synchro(&gnss_synchro);
             acquisition->set_local_code();
             acquisition->reset();
-            acquisition->set_state(1);
             start_queue();
 
             EXPECT_NO_THROW({
@@ -705,6 +704,7 @@ TEST_F(GalileoE1PcpsQuickSyncAmbiguousAcquisitionGSoC2014Test, ValidationOfResul
 {
     LOG(INFO) << "Start validation of results with noise+interference test";
     config_3();
+    config->set_property("Acquisition_1B.blocking_on_standby", "true");  // Ensure that acquisition starts at the first sample
     top_block = gr::make_top_block("Acquisition test");
     queue = std::make_shared<Concurrent_Queue<pmt::pmt_t>>();
 
@@ -758,7 +758,6 @@ TEST_F(GalileoE1PcpsQuickSyncAmbiguousAcquisitionGSoC2014Test, ValidationOfResul
             acquisition->set_gnss_synchro(&gnss_synchro);
             acquisition->set_local_code();
             acquisition->reset();
-            acquisition->set_state(1);
             start_queue();
 
             EXPECT_NO_THROW({
@@ -784,6 +783,7 @@ TEST_F(GalileoE1PcpsQuickSyncAmbiguousAcquisitionGSoC2014Test, ValidationOfResul
 TEST_F(GalileoE1PcpsQuickSyncAmbiguousAcquisitionGSoC2014Test, ValidationOfResultsProbabilities)
 {
     config_2();
+    config->set_property("Acquisition_1B.blocking_on_standby", "true");  // Ensure that acquisition starts at the first sample
     top_block = gr::make_top_block("Acquisition test");
     queue = std::make_shared<Concurrent_Queue<pmt::pmt_t>>();
 
@@ -838,7 +838,6 @@ TEST_F(GalileoE1PcpsQuickSyncAmbiguousAcquisitionGSoC2014Test, ValidationOfResul
             acquisition->set_gnss_synchro(&gnss_synchro);
             acquisition->set_local_code();
             acquisition->reset();
-            acquisition->set_state(1);
             start_queue();
 
             EXPECT_NO_THROW({

--- a/tests/unit-tests/signal-processing-blocks/acquisition/galileo_e1_pcps_tong_ambiguous_acquisition_gsoc2013_test.cc
+++ b/tests/unit-tests/signal-processing-blocks/acquisition/galileo_e1_pcps_tong_ambiguous_acquisition_gsoc2013_test.cc
@@ -522,7 +522,7 @@ TEST_F(GalileoE1PcpsTongAmbiguousAcquisitionGSoC2013Test, ValidationOfResults)
             acquisition->reset();
             acquisition->set_gnss_synchro(&gnss_synchro);
             acquisition->set_local_code();
-            acquisition->set_state(1);
+            acquisition->reset();
             start_queue();
 
             EXPECT_NO_THROW({
@@ -551,6 +551,7 @@ TEST_F(GalileoE1PcpsTongAmbiguousAcquisitionGSoC2013Test, ValidationOfResults)
 TEST_F(GalileoE1PcpsTongAmbiguousAcquisitionGSoC2013Test, ValidationOfResultsProbabilities)
 {
     config_2();
+    config->set_property("Acquisition_1B.blocking_on_standby", "true");  // Ensure that acquisition starts at the first sample
     top_block = gr::make_top_block("Acquisition test");
     queue = std::make_shared<Concurrent_Queue<pmt::pmt_t>>();
     std::shared_ptr<GNSSBlockInterface> acq_ = factory->GetBlock(config.get(), "Acquisition_1B", 1, 0);
@@ -602,7 +603,6 @@ TEST_F(GalileoE1PcpsTongAmbiguousAcquisitionGSoC2013Test, ValidationOfResultsPro
                 }
 
             acquisition->set_local_code();
-            acquisition->set_state(1);
             start_queue();
 
             EXPECT_NO_THROW({

--- a/tests/unit-tests/signal-processing-blocks/acquisition/galileo_e1_pcps_tong_ambiguous_acquisition_gsoc2013_test.cc
+++ b/tests/unit-tests/signal-processing-blocks/acquisition/galileo_e1_pcps_tong_ambiguous_acquisition_gsoc2013_test.cc
@@ -550,7 +550,6 @@ TEST_F(GalileoE1PcpsTongAmbiguousAcquisitionGSoC2013Test, ValidationOfResults)
 TEST_F(GalileoE1PcpsTongAmbiguousAcquisitionGSoC2013Test, ValidationOfResultsProbabilities)
 {
     config_2();
-    config->set_property("Acquisition_1B.blocking_on_standby", "true");  // Ensure that acquisition starts at the first sample
     top_block = gr::make_top_block("Acquisition test");
     queue = std::make_shared<Concurrent_Queue<pmt::pmt_t>>();
     std::shared_ptr<GNSSBlockInterface> acq_ = factory->GetBlock(config.get(), "Acquisition_1B", 1, 0);
@@ -602,6 +601,7 @@ TEST_F(GalileoE1PcpsTongAmbiguousAcquisitionGSoC2013Test, ValidationOfResultsPro
                 }
 
             acquisition->set_local_code();
+            acquisition->reset();
             start_queue();
 
             EXPECT_NO_THROW({

--- a/tests/unit-tests/signal-processing-blocks/acquisition/galileo_e1_pcps_tong_ambiguous_acquisition_gsoc2013_test.cc
+++ b/tests/unit-tests/signal-processing-blocks/acquisition/galileo_e1_pcps_tong_ambiguous_acquisition_gsoc2013_test.cc
@@ -522,7 +522,6 @@ TEST_F(GalileoE1PcpsTongAmbiguousAcquisitionGSoC2013Test, ValidationOfResults)
             acquisition->reset();
             acquisition->set_gnss_synchro(&gnss_synchro);
             acquisition->set_local_code();
-            acquisition->reset();
             start_queue();
 
             EXPECT_NO_THROW({

--- a/tests/unit-tests/signal-processing-blocks/acquisition/galileo_e5a_pcps_acquisition_gsoc2014_gensource_test.cc
+++ b/tests/unit-tests/signal-processing-blocks/acquisition/galileo_e5a_pcps_acquisition_gsoc2014_gensource_test.cc
@@ -630,7 +630,7 @@ TEST_F(GalileoE5aPcpsAcquisitionGSoC2014GensourceTest, ValidationOfSIM)
 
             acquisition->set_gnss_synchro(&gnss_synchro);
             acquisition->set_local_code();
-            acquisition->set_state(1);
+            acquisition->reset();
             start_queue();
 
             EXPECT_NO_THROW({

--- a/tests/unit-tests/signal-processing-blocks/acquisition/galileo_e5b_pcps_acquisition_test.cc
+++ b/tests/unit-tests/signal-processing-blocks/acquisition/galileo_e5b_pcps_acquisition_test.cc
@@ -416,7 +416,7 @@ TEST_F(GalileoE5bPcpsAcquisitionTest, ValidationOfResults)
 
             acquisition->set_gnss_synchro(&gnss_synchro);
             acquisition->set_local_code();
-            acquisition->set_state(1);
+            acquisition->reset();
             start_queue();
 
             EXPECT_NO_THROW({

--- a/tests/unit-tests/signal-processing-blocks/acquisition/galileo_e6_pcps_acquisition_test.cc
+++ b/tests/unit-tests/signal-processing-blocks/acquisition/galileo_e6_pcps_acquisition_test.cc
@@ -411,7 +411,7 @@ TEST_F(GalileoE6PcpsAcquisitionTest, ValidationOfResults)
 
             acquisition->set_gnss_synchro(&gnss_synchro);
             acquisition->set_local_code();
-            acquisition->set_state(1);
+            acquisition->reset();
             start_queue();
 
             EXPECT_NO_THROW({

--- a/tests/unit-tests/signal-processing-blocks/acquisition/glonass_l1_ca_pcps_acquisition_gsoc2017_test.cc
+++ b/tests/unit-tests/signal-processing-blocks/acquisition/glonass_l1_ca_pcps_acquisition_gsoc2017_test.cc
@@ -522,7 +522,7 @@ TEST_F(GlonassL1CaPcpsAcquisitionGSoC2017Test, ValidationOfResults)
                 }
 
             acquisition->set_local_code();
-            acquisition->set_state(1);  // Ensure that acquisition starts at the first sample
+            acquisition->reset();
             start_queue();
 
             EXPECT_NO_THROW({

--- a/tests/unit-tests/signal-processing-blocks/acquisition/glonass_l1_ca_pcps_acquisition_test.cc
+++ b/tests/unit-tests/signal-processing-blocks/acquisition/glonass_l1_ca_pcps_acquisition_test.cc
@@ -243,7 +243,7 @@ TEST_F(GlonassL1CaPcpsAcquisitionTest, ValidationOfResults)
     }) << "Failure connecting acquisition to the top_block.";
 
     acquisition->set_local_code();
-    acquisition->set_state(1);  // Ensure that acquisition starts at the first sample
+    acquisition->reset();
     acquisition->init();
 
     ASSERT_NO_THROW({

--- a/tests/unit-tests/signal-processing-blocks/acquisition/glonass_l2_ca_pcps_acquisition_test.cc
+++ b/tests/unit-tests/signal-processing-blocks/acquisition/glonass_l2_ca_pcps_acquisition_test.cc
@@ -524,7 +524,7 @@ TEST_F(GlonassL2CaPcpsAcquisitionTest, ValidationOfResults)
                 }
 
             acquisition->set_local_code();
-            acquisition->set_state(1);  // Ensure that acquisition starts at the first sample
+            acquisition->reset();
             start_queue();
 
             EXPECT_NO_THROW({

--- a/tests/unit-tests/signal-processing-blocks/acquisition/gps_l1_ca_pcps_acquisition_gsoc2013_test.cc
+++ b/tests/unit-tests/signal-processing-blocks/acquisition/gps_l1_ca_pcps_acquisition_gsoc2013_test.cc
@@ -514,7 +514,7 @@ TEST_F(GpsL1CaPcpsAcquisitionGSoC2013Test, ValidationOfResults)
                 }
 
             acquisition->set_local_code();
-            acquisition->set_state(1);  // Ensure that acquisition starts at the first sample
+            acquisition->reset();
             start_queue();
 
             EXPECT_NO_THROW({

--- a/tests/unit-tests/signal-processing-blocks/acquisition/gps_l1_ca_pcps_acquisition_test.cc
+++ b/tests/unit-tests/signal-processing-blocks/acquisition/gps_l1_ca_pcps_acquisition_test.cc
@@ -347,8 +347,8 @@ TEST_F(GpsL1CaPcpsAcquisitionTest /*unused*/, ValidationOfResults /*unused*/)
     }) << "Failure connecting the blocks of acquisition test.";
 
     acquisition->set_local_code();
-    acquisition->set_state(1);  // Ensure that acquisition starts at the first sample
     acquisition->init();
+    acquisition->reset();
 
     EXPECT_NO_THROW({
         start = std::chrono::system_clock::now();

--- a/tests/unit-tests/signal-processing-blocks/acquisition/gps_l1_ca_pcps_quicksync_acquisition_gsoc2014_test.cc
+++ b/tests/unit-tests/signal-processing-blocks/acquisition/gps_l1_ca_pcps_quicksync_acquisition_gsoc2014_test.cc
@@ -649,7 +649,6 @@ TEST_F(GpsL1CaPcpsQuickSyncAcquisitionGSoC2014Test, ValidationOfResults)
             acquisition->reset();
             acquisition->set_gnss_synchro(&gnss_synchro);
             acquisition->set_local_code();
-            acquisition->set_state(1);
             start_queue();
 
             EXPECT_NO_THROW({
@@ -734,7 +733,6 @@ TEST_F(GpsL1CaPcpsQuickSyncAcquisitionGSoC2014Test, ValidationOfResultsWithNoise
             acquisition->reset();
             acquisition->set_gnss_synchro(&gnss_synchro);
             acquisition->set_local_code();
-            acquisition->set_state(1);
             start_queue();
 
             EXPECT_NO_THROW({
@@ -813,7 +811,6 @@ TEST_F(GpsL1CaPcpsQuickSyncAcquisitionGSoC2014Test, ValidationOfResultsProbabili
             acquisition->reset();
             acquisition->set_gnss_synchro(&gnss_synchro);
             acquisition->set_local_code();
-            acquisition->set_state(1);
             start_queue();
 
             EXPECT_NO_THROW({

--- a/tests/unit-tests/signal-processing-blocks/acquisition/gps_l1_ca_pcps_tong_acquisition_gsoc2013_test.cc
+++ b/tests/unit-tests/signal-processing-blocks/acquisition/gps_l1_ca_pcps_tong_acquisition_gsoc2013_test.cc
@@ -514,7 +514,7 @@ TEST_F(GpsL1CaPcpsTongAcquisitionGSoC2013Test, ValidationOfResults)
                 }
 
             acquisition->set_local_code();
-            acquisition->set_state(1);
+            acquisition->reset();
 
             start_queue();
 
@@ -595,7 +595,7 @@ TEST_F(GpsL1CaPcpsTongAcquisitionGSoC2013Test, ValidationOfResultsProbabilities)
                 }
 
             acquisition->set_local_code();
-            acquisition->set_state(1);
+            acquisition->reset();
             start_queue();
 
             EXPECT_NO_THROW({

--- a/tests/unit-tests/signal-processing-blocks/acquisition/gps_l2_m_pcps_acquisition_test.cc
+++ b/tests/unit-tests/signal-processing-blocks/acquisition/gps_l2_m_pcps_acquisition_test.cc
@@ -355,8 +355,8 @@ TEST_F(GpsL2MPcpsAcquisitionTest, ValidationOfResults)
 
     ASSERT_NO_THROW({
         acquisition->set_local_code();
-        acquisition->set_state(1);  // Ensure that acquisition starts at the first sample
         acquisition->init();
+        acquisition->reset();
     }) << "Failure set_state and init acquisition test";
 
     EXPECT_NO_THROW({

--- a/tests/unit-tests/signal-processing-blocks/observables/hybrid_observables_test.cc
+++ b/tests/unit-tests/signal-processing-blocks/observables/hybrid_observables_test.cc
@@ -549,7 +549,7 @@ bool HybridObservablesTest::acquire_signal()
 #endif
     acquisition->init();
     acquisition->set_local_code();
-    acquisition->set_state(1);  // Ensure that acquisition starts at the first sample
+    acquisition->reset();
     acquisition->connect(top_block_acq);
 
     gr::blocks::file_source::sptr file_source;
@@ -695,7 +695,6 @@ bool HybridObservablesTest::acquire_signal()
             acquisition->init();
             acquisition->set_local_code();
             acquisition->reset();
-            acquisition->set_state(1);
             msg_rx->rx_message = 0;
             top_block_acq->run();
             if (start_msg == true)

--- a/tests/unit-tests/signal-processing-blocks/tracking/tracking_pull-in_test.cc
+++ b/tests/unit-tests/signal-processing-blocks/tracking/tracking_pull-in_test.cc
@@ -542,7 +542,7 @@ bool TrackingPullInTest::acquire_signal(int SV_ID)
 #endif
     acquisition->init();
     acquisition->set_local_code();
-    acquisition->set_state(1);  // Ensure that acquisition starts at the first sample
+    acquisition->reset();
     acquisition->connect(top_block_acq);
 
     gr::blocks::file_source::sptr file_source;
@@ -691,7 +691,6 @@ bool TrackingPullInTest::acquire_signal(int SV_ID)
             acquisition->init();
             acquisition->set_local_code();
             acquisition->reset();
-            acquisition->set_state(1);
             msg_rx->rx_message = 0;
             top_block_acq->run();
             if (start_msg == true)


### PR DESCRIPTION
I think this function was added for testing purposes, but it isn't necessary since state 0 will reset the variables and with a simple change we can make so we don't consume samples in state 0.
