### PR TITLE
Remove init from acquisition

### DIFF
--- a/src/algorithms/acquisition/adapters/base_pcps_acquisition.cc
+++ b/src/algorithms/acquisition/adapters/base_pcps_acquisition.cc
@@ -135,12 +135,6 @@ signed int BasePcpsAcquisition::mag()
 }
 
 
-void BasePcpsAcquisition::init()
-{
-    acquisition_->init();
-}
-
-
 void BasePcpsAcquisition::reset()
 {
     acquisition_->set_active(true);

--- a/src/algorithms/acquisition/adapters/base_pcps_acquisition.h
+++ b/src/algorithms/acquisition/adapters/base_pcps_acquisition.h
@@ -103,10 +103,6 @@ public:
      */
     void set_doppler_center(int doppler_center) override;
 
-    /*!
-     * \brief Initializes acquisition algorithm.
-     */
-    void init() override;
 
     /*!
      * \brief Returns the maximum peak of grid search

--- a/src/algorithms/acquisition/adapters/base_pcps_acquisition_custom.cc
+++ b/src/algorithms/acquisition/adapters/base_pcps_acquisition_custom.cc
@@ -192,15 +192,6 @@ void BasePcpsAcquisitionCustom::set_channel_fsm(std::weak_ptr<ChannelFsm> channe
 }
 
 
-void BasePcpsAcquisitionCustom::init()
-{
-    if (is_type_gr_complex_)
-        {
-            acquisition_cc_->init();
-        }
-}
-
-
 signed int BasePcpsAcquisitionCustom::mag()
 {
     if (is_type_gr_complex_)

--- a/src/algorithms/acquisition/adapters/base_pcps_acquisition_custom.h
+++ b/src/algorithms/acquisition/adapters/base_pcps_acquisition_custom.h
@@ -83,11 +83,6 @@ public:
     void set_channel_fsm(std::weak_ptr<ChannelFsm> channel_fsm) override;
 
     /*!
-     * \brief Initializes acquisition algorithm.
-     */
-    void init() override;
-
-    /*!
      * \brief Returns the maximum peak of grid search
      */
     signed int mag() override;

--- a/src/algorithms/acquisition/adapters/base_pcps_acquisition_fpga.cc
+++ b/src/algorithms/acquisition/adapters/base_pcps_acquisition_fpga.cc
@@ -193,15 +193,6 @@ void BasePcpsAcquisitionFpga::stop_acquisition()
 }
 
 
-void BasePcpsAcquisitionFpga::init()
-{
-    if (acquisition_fpga_)
-        {
-            acquisition_fpga_->init();
-        }
-}
-
-
 signed int BasePcpsAcquisitionFpga::mag()
 {
     if (acquisition_fpga_)

--- a/src/algorithms/acquisition/adapters/base_pcps_acquisition_fpga.h
+++ b/src/algorithms/acquisition/adapters/base_pcps_acquisition_fpga.h
@@ -74,7 +74,6 @@ public:
     void set_doppler_center(int doppler_center) override;
     void reset() override;
     void stop_acquisition() override;
-    void init() override;
     void set_resampler_latency(uint32_t latency_samples __attribute__((unused))) override {}
     void set_local_code() override;
 

--- a/src/algorithms/acquisition/gnuradio_blocks/acquisition_impl_interface.h
+++ b/src/algorithms/acquisition/gnuradio_blocks/acquisition_impl_interface.h
@@ -58,7 +58,6 @@ public:
     virtual void set_channel(uint32_t channel_id) = 0;
     virtual void set_channel_fsm(std::weak_ptr<ChannelFsm> channel_fsm) = 0;
     virtual void set_threshold(float threshold) = 0;
-    virtual void init() = 0;
     virtual void set_local_code(std::complex<float>* /*code*/) {};
     virtual void set_local_code(std::complex<float>* /*code_data*/, std::complex<float>* /*code_pilot*/) {};
     virtual uint32_t mag() const = 0;

--- a/src/algorithms/acquisition/gnuradio_blocks/galileo_e5a_noncoherent_iq_acquisition_caf_cc.cc
+++ b/src/algorithms/acquisition/gnuradio_blocks/galileo_e5a_noncoherent_iq_acquisition_caf_cc.cc
@@ -75,7 +75,12 @@ galileo_e5a_noncoherentIQ_acquisition_caf_cc::galileo_e5a_noncoherentIQ_acquisit
       d_well_count(0),
       d_code_phase(0),
       d_active(false),
-      d_both_signal_components(both_signal_components)
+      d_both_signal_components(both_signal_components),
+      d_fft_if(gnss_fft_fwd_make_unique(d_fft_size)),
+      d_ifft(gnss_fft_rev_make_unique(d_fft_size)),
+      d_fft_code_I_A(d_fft_size),
+      d_inbuffer(d_fft_size),
+      d_magnitudeIA(d_fft_size)
 {
     this->message_port_register_out(pmt::mp("events"));
 
@@ -87,10 +92,6 @@ galileo_e5a_noncoherentIQ_acquisition_caf_cc::galileo_e5a_noncoherentIQ_acquisit
         {
             d_sampled_ms = conf.sampled_ms;
         }
-
-    d_inbuffer = std::vector<gr_complex>(d_fft_size);
-    d_fft_code_I_A = std::vector<gr_complex>(d_fft_size);
-    d_magnitudeIA = std::vector<float>(d_fft_size);
 
     if (d_both_signal_components == true)
         {
@@ -110,8 +111,34 @@ galileo_e5a_noncoherentIQ_acquisition_caf_cc::galileo_e5a_noncoherentIQ_acquisit
                 }
         }
 
-    d_fft_if = gnss_fft_fwd_make_unique(d_fft_size);
-    d_ifft = gnss_fft_rev_make_unique(d_fft_size);
+    // Count the number of bins
+    d_num_doppler_bins = 0;
+    for (int doppler = -d_acq_params.doppler_max; doppler <= d_acq_params.doppler_max; doppler += d_acq_params.doppler_step)
+        {
+            d_num_doppler_bins++;
+        }
+
+    // Create the carrier Doppler wipeoff signals
+    d_grid_doppler_wipeoffs = std::vector<std::vector<gr_complex>>(d_num_doppler_bins, std::vector<gr_complex>(d_fft_size));
+    for (int doppler_index = 0; doppler_index < d_num_doppler_bins; doppler_index++)
+        {
+            int doppler = -d_acq_params.doppler_max + d_acq_params.doppler_step * doppler_index;
+            float phase_step_rad = static_cast<float>(TWO_PI) * static_cast<float>(doppler) / static_cast<float>(d_acq_params.fs_in);
+            std::array<float, 1> _phase{};
+            volk_gnsssdr_s32f_sincos_32fc(d_grid_doppler_wipeoffs[doppler_index].data(), -phase_step_rad, _phase.data(), d_fft_size);
+        }
+
+    /* CAF Filtering to resolve doppler ambiguity. Phase and quadrature must be processed
+     * separately before non-coherent integration */
+    if (d_CAF_window_hz > 0)
+        {
+            d_CAF_vector = std::vector<float>(d_num_doppler_bins);
+            d_CAF_vector_I = std::vector<float>(d_num_doppler_bins);
+            if (d_both_signal_components == true)
+                {
+                    d_CAF_vector_Q = std::vector<float>(d_num_doppler_bins);
+                }
+        }
 }
 
 
@@ -194,51 +221,6 @@ void galileo_e5a_noncoherentIQ_acquisition_caf_cc::set_local_code(std::complex<f
 
                     // Conjugate the local code
                     volk_32fc_conjugate_32fc(d_fft_code_Q_B.data(), d_fft_if->get_outbuf(), d_fft_size);
-                }
-        }
-}
-
-
-void galileo_e5a_noncoherentIQ_acquisition_caf_cc::init()
-{
-    d_gnss_synchro->Flag_valid_acquisition = false;
-    d_gnss_synchro->Flag_valid_symbol_output = false;
-    d_gnss_synchro->Flag_valid_pseudorange = false;
-    d_gnss_synchro->Flag_valid_word = false;
-
-    d_gnss_synchro->Acq_delay_samples = 0.0;
-    d_gnss_synchro->Acq_doppler_hz = 0.0;
-    d_gnss_synchro->Acq_doppler_step = 0U;
-    d_gnss_synchro->Acq_samplestamp_samples = 0ULL;
-    d_mag = 0.0;
-    d_input_power = 0.0;
-
-    // Count the number of bins
-    d_num_doppler_bins = 0;
-    for (int doppler = -d_acq_params.doppler_max; doppler <= d_acq_params.doppler_max; doppler += d_acq_params.doppler_step)
-        {
-            d_num_doppler_bins++;
-        }
-
-    // Create the carrier Doppler wipeoff signals
-    d_grid_doppler_wipeoffs = std::vector<std::vector<gr_complex>>(d_num_doppler_bins, std::vector<gr_complex>(d_fft_size));
-    for (int doppler_index = 0; doppler_index < d_num_doppler_bins; doppler_index++)
-        {
-            int doppler = -d_acq_params.doppler_max + d_acq_params.doppler_step * doppler_index;
-            float phase_step_rad = static_cast<float>(TWO_PI) * static_cast<float>(doppler) / static_cast<float>(d_acq_params.fs_in);
-            std::array<float, 1> _phase{};
-            volk_gnsssdr_s32f_sincos_32fc(d_grid_doppler_wipeoffs[doppler_index].data(), -phase_step_rad, _phase.data(), d_fft_size);
-        }
-
-    /* CAF Filtering to resolve doppler ambiguity. Phase and quadrature must be processed
-     * separately before non-coherent integration */
-    if (d_CAF_window_hz > 0)
-        {
-            d_CAF_vector = std::vector<float>(d_num_doppler_bins);
-            d_CAF_vector_I = std::vector<float>(d_num_doppler_bins);
-            if (d_both_signal_components == true)
-                {
-                    d_CAF_vector_Q = std::vector<float>(d_num_doppler_bins);
                 }
         }
 }

--- a/src/algorithms/acquisition/gnuradio_blocks/galileo_e5a_noncoherent_iq_acquisition_caf_cc.h
+++ b/src/algorithms/acquisition/gnuradio_blocks/galileo_e5a_noncoherent_iq_acquisition_caf_cc.h
@@ -86,11 +86,6 @@ public:
     }
 
     /*!
-     * \brief Initializes acquisition algorithm.
-     */
-    void init() override;
-
-    /*!
      * \brief Sets local code for PCPS acquisition algorithm.
      * \param code - Pointer to the PRN code.
      */
@@ -164,24 +159,6 @@ private:
 
     float estimate_input_power(gr_complex* in);
 
-    std::weak_ptr<ChannelFsm> d_channel_fsm;
-    std::unique_ptr<gnss_fft_complex_fwd> d_fft_if;
-    std::unique_ptr<gnss_fft_complex_rev> d_ifft;
-
-    std::vector<std::vector<gr_complex>> d_grid_doppler_wipeoffs;
-    std::vector<gr_complex> d_fft_code_I_A;
-    std::vector<gr_complex> d_fft_code_I_B;
-    std::vector<gr_complex> d_fft_code_Q_A;
-    std::vector<gr_complex> d_fft_code_Q_B;
-    std::vector<gr_complex> d_inbuffer;
-    std::vector<float> d_magnitudeIA;
-    std::vector<float> d_magnitudeIB;
-    std::vector<float> d_magnitudeQA;
-    std::vector<float> d_magnitudeQB;
-    std::vector<float> d_CAF_vector;
-    std::vector<float> d_CAF_vector_I;
-    std::vector<float> d_CAF_vector_Q;
-
     std::string d_satellite_str;
 
     const Acq_Conf d_acq_params;
@@ -210,6 +187,24 @@ private:
 
     bool d_active;
     const bool d_both_signal_components;
+
+    std::weak_ptr<ChannelFsm> d_channel_fsm;
+    std::unique_ptr<gnss_fft_complex_fwd> d_fft_if;
+    std::unique_ptr<gnss_fft_complex_rev> d_ifft;
+
+    std::vector<std::vector<gr_complex>> d_grid_doppler_wipeoffs;
+    std::vector<gr_complex> d_fft_code_I_A;
+    std::vector<gr_complex> d_fft_code_I_B;
+    std::vector<gr_complex> d_fft_code_Q_A;
+    std::vector<gr_complex> d_fft_code_Q_B;
+    std::vector<gr_complex> d_inbuffer;
+    std::vector<float> d_magnitudeIA;
+    std::vector<float> d_magnitudeIB;
+    std::vector<float> d_magnitudeQA;
+    std::vector<float> d_magnitudeQB;
+    std::vector<float> d_CAF_vector;
+    std::vector<float> d_CAF_vector_I;
+    std::vector<float> d_CAF_vector_Q;
 };
 
 

--- a/src/algorithms/acquisition/gnuradio_blocks/galileo_pcps_8ms_acquisition_cc.cc
+++ b/src/algorithms/acquisition/gnuradio_blocks/galileo_pcps_8ms_acquisition_cc.cc
@@ -54,15 +54,30 @@ galileo_pcps_8ms_acquisition_cc::galileo_pcps_8ms_acquisition_cc(const Acq_Conf 
       d_fft_size(conf.sampled_ms * conf.samples_per_ms),
       d_num_doppler_bins(0),
       d_code_phase(0),
-      d_active(false)
+      d_active(false),
+      d_fft_if(gnss_fft_fwd_make_unique(d_fft_size)),
+      d_ifft(gnss_fft_rev_make_unique(d_fft_size)),
+      d_fft_code_A(d_fft_size, lv_cmake(0.0F, 0.0F)),
+      d_fft_code_B(d_fft_size, lv_cmake(0.0F, 0.0F)),
+      d_magnitude(d_fft_size, 0.0F)
 {
     this->message_port_register_out(pmt::mp("events"));
 
-    d_fft_code_A = std::vector<gr_complex>(d_fft_size, lv_cmake(0.0F, 0.0F));
-    d_fft_code_B = std::vector<gr_complex>(d_fft_size, lv_cmake(0.0F, 0.0F));
-    d_magnitude = std::vector<float>(d_fft_size, 0.0F);
-    d_fft_if = gnss_fft_fwd_make_unique(d_fft_size);
-    d_ifft = gnss_fft_rev_make_unique(d_fft_size);
+    // Count the number of bins
+    for (auto doppler = -d_acq_params.doppler_max; doppler <= d_acq_params.doppler_max; doppler += d_acq_params.doppler_step)
+        {
+            d_num_doppler_bins++;
+        }
+
+    // Create the carrier Doppler wipeoff signals
+    d_grid_doppler_wipeoffs = std::vector<std::vector<gr_complex>>(d_num_doppler_bins, std::vector<gr_complex>(d_fft_size));
+    for (uint32_t doppler_index = 0; doppler_index < d_num_doppler_bins; doppler_index++)
+        {
+            int32_t doppler = -d_acq_params.doppler_max + d_acq_params.doppler_step * doppler_index;
+            float phase_step_rad = static_cast<float>(TWO_PI) * doppler / static_cast<float>(d_acq_params.fs_in);
+            std::array<float, 1> _phase{};
+            volk_gnsssdr_s32f_sincos_32fc(d_grid_doppler_wipeoffs[doppler_index].data(), -phase_step_rad, _phase.data(), d_fft_size);
+        }
 }
 
 
@@ -112,37 +127,6 @@ void galileo_pcps_8ms_acquisition_cc::set_local_code(std::complex<float> *code)
 
     // Conjugate the local code
     volk_32fc_conjugate_32fc(d_fft_code_B.data(), d_fft_if->get_outbuf(), d_fft_size);
-}
-
-
-void galileo_pcps_8ms_acquisition_cc::init()
-{
-    d_gnss_synchro->Flag_valid_acquisition = false;
-    d_gnss_synchro->Flag_valid_symbol_output = false;
-    d_gnss_synchro->Flag_valid_pseudorange = false;
-    d_gnss_synchro->Flag_valid_word = false;
-    d_gnss_synchro->Acq_doppler_step = 0U;
-    d_gnss_synchro->Acq_delay_samples = 0.0;
-    d_gnss_synchro->Acq_doppler_hz = 0.0;
-    d_gnss_synchro->Acq_samplestamp_samples = 0ULL;
-    d_mag = 0.0;
-    d_input_power = 0.0;
-
-    // Count the number of bins
-    d_num_doppler_bins = 0;
-    for (auto doppler = -d_acq_params.doppler_max; doppler <= d_acq_params.doppler_max; doppler += d_acq_params.doppler_step)
-        {
-            d_num_doppler_bins++;
-        }
-    // Create the carrier Doppler wipeoff signals
-    d_grid_doppler_wipeoffs = std::vector<std::vector<gr_complex>>(d_num_doppler_bins, std::vector<gr_complex>(d_fft_size));
-    for (uint32_t doppler_index = 0; doppler_index < d_num_doppler_bins; doppler_index++)
-        {
-            int32_t doppler = -d_acq_params.doppler_max + d_acq_params.doppler_step * doppler_index;
-            float phase_step_rad = static_cast<float>(TWO_PI) * doppler / static_cast<float>(d_acq_params.fs_in);
-            std::array<float, 1> _phase{};
-            volk_gnsssdr_s32f_sincos_32fc(d_grid_doppler_wipeoffs[doppler_index].data(), -phase_step_rad, _phase.data(), d_fft_size);
-        }
 }
 
 

--- a/src/algorithms/acquisition/gnuradio_blocks/galileo_pcps_8ms_acquisition_cc.h
+++ b/src/algorithms/acquisition/gnuradio_blocks/galileo_pcps_8ms_acquisition_cc.h
@@ -75,11 +75,6 @@ public:
     }
 
     /*!
-     * \brief Initializes acquisition algorithm.
-     */
-    void init() override;
-
-    /*!
      * \brief Sets local code for PCPS acquisition algorithm.
      * \param code - Pointer to the PRN code.
      */
@@ -145,15 +140,6 @@ private:
         int32_t doppler_shift,
         int32_t doppler_offset);
 
-    std::weak_ptr<ChannelFsm> d_channel_fsm;
-    std::unique_ptr<gnss_fft_complex_fwd> d_fft_if;
-    std::unique_ptr<gnss_fft_complex_rev> d_ifft;
-
-    std::vector<std::vector<gr_complex>> d_grid_doppler_wipeoffs;
-    std::vector<gr_complex> d_fft_code_A;
-    std::vector<gr_complex> d_fft_code_B;
-    std::vector<float> d_magnitude;
-
     std::string d_satellite_str;
     const Acq_Conf d_acq_params;
     std::ofstream d_dump_file;
@@ -174,6 +160,15 @@ private:
     uint32_t d_code_phase;
 
     bool d_active;
+
+    std::weak_ptr<ChannelFsm> d_channel_fsm;
+    std::unique_ptr<gnss_fft_complex_fwd> d_fft_if;
+    std::unique_ptr<gnss_fft_complex_rev> d_ifft;
+
+    std::vector<std::vector<gr_complex>> d_grid_doppler_wipeoffs;
+    std::vector<gr_complex> d_fft_code_A;
+    std::vector<gr_complex> d_fft_code_B;
+    std::vector<float> d_magnitude;
 };
 
 

--- a/src/algorithms/acquisition/gnuradio_blocks/pcps_acquisition.cc
+++ b/src/algorithms/acquisition/gnuradio_blocks/pcps_acquisition.cc
@@ -87,7 +87,15 @@ pcps_acquisition::pcps_acquisition(const Acq_Conf& conf_)
       d_cshort(conf_.it_size != sizeof(gr_complex)),
       d_step_two(false),
       d_use_CFAR_algorithm_flag(conf_.use_CFAR_algorithm_flag),
-      d_dump(conf_.dump)
+      d_dump(conf_.dump),
+      d_magnitude_grid(d_num_doppler_bins, volk_gnsssdr::vector<float>(d_fft_size)),
+      d_tmp_buffer(d_fft_size),
+      d_input_signal(d_fft_size),
+      d_grid_doppler_wipeoffs(d_num_doppler_bins, volk_gnsssdr::vector<std::complex<float>>(d_fft_size)),
+      d_fft_codes(d_fft_size),
+      d_data_buffer(d_consumed_samples),
+      d_fft_if(gnss_fft_fwd_make_unique(d_fft_size)),
+      d_ifft(gnss_fft_rev_make_unique(d_fft_size))
 {
     this->message_port_register_out(pmt::mp("events"));
 
@@ -109,20 +117,22 @@ pcps_acquisition::pcps_acquisition(const Acq_Conf& conf_)
     //  d_acq_parameters.max_dwells = 1;  // Activation of d_acq_parameters.bit_transition_flag invalidates the value of d_acq_parameters.max_dwells
     // }
 
-    d_tmp_buffer = volk_gnsssdr::vector<float>(d_fft_size);
-    d_fft_codes = volk_gnsssdr::vector<std::complex<float>>(d_fft_size);
-    d_input_signal = volk_gnsssdr::vector<std::complex<float>>(d_fft_size);
-    d_fft_if = gnss_fft_fwd_make_unique(d_fft_size);
-    d_ifft = gnss_fft_rev_make_unique(d_fft_size);
-
-    d_grid = arma::fmat();
-    d_narrow_grid = arma::fmat();
-
-    d_data_buffer = volk_gnsssdr::vector<std::complex<float>>(d_consumed_samples);
     if (d_cshort)
         {
             d_data_buffer_sc = volk_gnsssdr::vector<lv_16sc_t>(d_consumed_samples);
         }
+
+    if (d_acq_parameters.make_2_steps && (d_grid_doppler_wipeoffs_step_two.empty()))
+        {
+            d_grid_doppler_wipeoffs_step_two = volk_gnsssdr::vector<volk_gnsssdr::vector<std::complex<float>>>(d_num_doppler_bins_step2, volk_gnsssdr::vector<std::complex<float>>(d_fft_size));
+        }
+
+    for (uint32_t doppler_index = 0; doppler_index < d_num_doppler_bins; doppler_index++)
+        {
+            std::fill(d_magnitude_grid[doppler_index].begin(), d_magnitude_grid[doppler_index].end(), 0.0);
+        }
+
+    update_grid_doppler_wipeoffs();
 
     if (d_dump)
         {
@@ -154,6 +164,10 @@ pcps_acquisition::pcps_acquisition(const Acq_Conf& conf_)
                     std::cerr << "GNSS-SDR cannot create dump file for the Acquisition block. Wrong permissions?\n";
                     d_dump = false;
                 }
+
+            const uint32_t effective_fft_size = (d_acq_parameters.bit_transition_flag ? (d_fft_size / 2) : d_fft_size);
+            d_grid = arma::fmat(effective_fft_size, d_num_doppler_bins, arma::fill::zeros);
+            d_narrow_grid = arma::fmat(effective_fft_size, d_num_doppler_bins_step2, arma::fill::zeros);
         }
 }
 
@@ -235,51 +249,6 @@ void pcps_acquisition::update_local_carrier(own::span<gr_complex> carrier_vector
         }
     std::array<float, 1> _phase{};
     volk_gnsssdr_s32f_sincos_32fc(carrier_vector.data(), -phase_step_rad, _phase.data(), carrier_vector.size());
-}
-
-
-void pcps_acquisition::init()
-{
-    d_gnss_synchro->Flag_valid_acquisition = false;
-    d_gnss_synchro->Flag_valid_symbol_output = false;
-    d_gnss_synchro->Flag_valid_pseudorange = false;
-    d_gnss_synchro->Flag_valid_word = false;
-    d_gnss_synchro->Acq_doppler_step = 0U;
-    d_gnss_synchro->Acq_delay_samples = 0.0;
-    d_gnss_synchro->Acq_doppler_hz = 0.0;
-    d_gnss_synchro->Acq_samplestamp_samples = 0ULL;
-    d_mag = 0.0;
-    d_input_power = 0.0;
-
-    // Create the carrier Doppler wipeoff signals
-    if (d_grid_doppler_wipeoffs.empty())
-        {
-            d_grid_doppler_wipeoffs = volk_gnsssdr::vector<volk_gnsssdr::vector<std::complex<float>>>(d_num_doppler_bins, volk_gnsssdr::vector<std::complex<float>>(d_fft_size));
-        }
-    if (d_acq_parameters.make_2_steps && (d_grid_doppler_wipeoffs_step_two.empty()))
-        {
-            d_grid_doppler_wipeoffs_step_two = volk_gnsssdr::vector<volk_gnsssdr::vector<std::complex<float>>>(d_num_doppler_bins_step2, volk_gnsssdr::vector<std::complex<float>>(d_fft_size));
-        }
-
-    if (d_magnitude_grid.empty())
-        {
-            d_magnitude_grid = volk_gnsssdr::vector<volk_gnsssdr::vector<float>>(d_num_doppler_bins, volk_gnsssdr::vector<float>(d_fft_size));
-        }
-
-    for (uint32_t doppler_index = 0; doppler_index < d_num_doppler_bins; doppler_index++)
-        {
-            std::fill(d_magnitude_grid[doppler_index].begin(), d_magnitude_grid[doppler_index].end(), 0.0);
-        }
-
-    update_grid_doppler_wipeoffs();
-    d_worker_active = false;
-
-    if (d_dump)
-        {
-            const uint32_t effective_fft_size = (d_acq_parameters.bit_transition_flag ? (d_fft_size / 2) : d_fft_size);
-            d_grid = arma::fmat(effective_fft_size, d_num_doppler_bins, arma::fill::zeros);
-            d_narrow_grid = arma::fmat(effective_fft_size, d_num_doppler_bins_step2, arma::fill::zeros);
-        }
 }
 
 

--- a/src/algorithms/acquisition/gnuradio_blocks/pcps_acquisition.h
+++ b/src/algorithms/acquisition/gnuradio_blocks/pcps_acquisition.h
@@ -96,11 +96,6 @@ public:
     ~pcps_acquisition() override = default;
 
     /*!
-     * \brief Initializes acquisition algorithm and reserves memory.
-     */
-    void init() override;
-
-    /*!
      * \brief Set acquisition/tracking common Gnss_Synchro object pointer
      * to exchange synchronization data between acquisition and tracking blocks.
      * \param p_gnss_synchro Satellite information shared by the processing blocks.
@@ -199,19 +194,6 @@ private:
     float first_vs_second_peak_statistic(uint32_t& indext, int32_t& doppler, uint32_t num_doppler_bins, int32_t doppler_max, int32_t doppler_step);
     float max_to_input_power_statistic(uint32_t& indext, int32_t& doppler, uint32_t num_doppler_bins, int32_t doppler_max, int32_t doppler_step);
 
-    volk_gnsssdr::vector<volk_gnsssdr::vector<float>> d_magnitude_grid;
-    volk_gnsssdr::vector<float> d_tmp_buffer;
-    volk_gnsssdr::vector<std::complex<float>> d_input_signal;
-    volk_gnsssdr::vector<volk_gnsssdr::vector<std::complex<float>>> d_grid_doppler_wipeoffs;
-    volk_gnsssdr::vector<volk_gnsssdr::vector<std::complex<float>>> d_grid_doppler_wipeoffs_step_two;
-    volk_gnsssdr::vector<std::complex<float>> d_fft_codes;
-    volk_gnsssdr::vector<std::complex<float>> d_data_buffer;
-    volk_gnsssdr::vector<lv_16sc_t> d_data_buffer_sc;
-
-    std::unique_ptr<gnss_fft_complex_fwd> d_fft_if;
-    std::unique_ptr<gnss_fft_complex_rev> d_ifft;
-    std::weak_ptr<ChannelFsm> d_channel_fsm;
-
     const Acq_Conf d_acq_parameters;
     Gnss_Synchro* d_gnss_synchro;
     arma::fmat d_grid;
@@ -251,6 +233,19 @@ private:
     bool d_step_two;
     const bool d_use_CFAR_algorithm_flag;
     bool d_dump;
+
+    volk_gnsssdr::vector<volk_gnsssdr::vector<float>> d_magnitude_grid;
+    volk_gnsssdr::vector<float> d_tmp_buffer;
+    volk_gnsssdr::vector<std::complex<float>> d_input_signal;
+    volk_gnsssdr::vector<volk_gnsssdr::vector<std::complex<float>>> d_grid_doppler_wipeoffs;
+    volk_gnsssdr::vector<volk_gnsssdr::vector<std::complex<float>>> d_grid_doppler_wipeoffs_step_two;
+    volk_gnsssdr::vector<std::complex<float>> d_fft_codes;
+    volk_gnsssdr::vector<std::complex<float>> d_data_buffer;
+    volk_gnsssdr::vector<lv_16sc_t> d_data_buffer_sc;
+
+    std::unique_ptr<gnss_fft_complex_fwd> d_fft_if;
+    std::unique_ptr<gnss_fft_complex_rev> d_ifft;
+    std::weak_ptr<ChannelFsm> d_channel_fsm;
 };
 
 

--- a/src/algorithms/acquisition/gnuradio_blocks/pcps_acquisition_fine_doppler_cc.cc
+++ b/src/algorithms/acquisition/gnuradio_blocks/pcps_acquisition_fine_doppler_cc.cc
@@ -62,16 +62,16 @@ pcps_acquisition_fine_doppler_cc::pcps_acquisition_fine_doppler_cc(const Acq_Con
       d_channel(0),
       d_dump_channel(0),
       d_active(false),
-      d_dump(conf_.dump)
+      d_dump(conf_.dump),
+      d_fft_if(gnss_fft_fwd_make_unique(d_fft_size)),
+      d_ifft(gnss_fft_rev_make_unique(d_fft_size)),
+      d_grid_data(d_num_doppler_points, volk_gnsssdr::vector<float>(d_fft_size)),
+      d_fft_codes(d_fft_size),
+      d_10_ms_buffer(50 * d_fft_size),
+      d_magnitude(d_fft_size)
 {
     this->message_port_register_out(pmt::mp("events"));
 
-    d_fft_codes = volk_gnsssdr::vector<gr_complex>(d_fft_size);
-    d_magnitude = volk_gnsssdr::vector<float>(d_fft_size);
-    d_10_ms_buffer = volk_gnsssdr::vector<gr_complex>(50 * d_fft_size);
-    d_fft_if = gnss_fft_fwd_make_unique(d_fft_size);
-    d_ifft = gnss_fft_rev_make_unique(d_fft_size);
-    d_grid_data = volk_gnsssdr::vector<volk_gnsssdr::vector<float>>(d_num_doppler_points, volk_gnsssdr::vector<float>(d_fft_size));
     update_carrier_wipeoff();
 
     // this implementation can only produce dumps in channel 0
@@ -134,20 +134,6 @@ void pcps_acquisition_fine_doppler_cc::set_local_code(std::complex<float> *code)
     d_fft_if->execute();  // We need the FFT of local code
     // Conjugate the local code
     volk_32fc_conjugate_32fc(d_fft_codes.data(), d_fft_if->get_outbuf(), d_fft_size);
-}
-
-
-void pcps_acquisition_fine_doppler_cc::init()
-{
-    d_gnss_synchro->Flag_valid_acquisition = false;
-    d_gnss_synchro->Flag_valid_symbol_output = false;
-    d_gnss_synchro->Flag_valid_pseudorange = false;
-    d_gnss_synchro->Flag_valid_word = false;
-    d_gnss_synchro->Acq_doppler_step = 0U;
-    d_gnss_synchro->Acq_delay_samples = 0.0;
-    d_gnss_synchro->Acq_doppler_hz = 0.0;
-    d_gnss_synchro->Acq_samplestamp_samples = 0ULL;
-    d_state = 0;
 }
 
 

--- a/src/algorithms/acquisition/gnuradio_blocks/pcps_acquisition_fine_doppler_cc.h
+++ b/src/algorithms/acquisition/gnuradio_blocks/pcps_acquisition_fine_doppler_cc.h
@@ -98,11 +98,6 @@ public:
     }
 
     /*!
-     * \brief Initializes acquisition algorithm.
-     */
-    void init() override;
-
-    /*!
      * \brief Sets local code for PCPS acquisition algorithm.
      * \param code - Pointer to the PRN code.
      */
@@ -180,16 +175,6 @@ private:
     void update_carrier_wipeoff();
     bool start() override;
 
-    std::weak_ptr<ChannelFsm> d_channel_fsm;
-    std::unique_ptr<gnss_fft_complex_fwd> d_fft_if;
-    std::unique_ptr<gnss_fft_complex_rev> d_ifft;
-
-    volk_gnsssdr::vector<volk_gnsssdr::vector<std::complex<float>>> d_grid_doppler_wipeoffs;
-    volk_gnsssdr::vector<volk_gnsssdr::vector<float>> d_grid_data;
-    volk_gnsssdr::vector<gr_complex> d_fft_codes;
-    volk_gnsssdr::vector<gr_complex> d_10_ms_buffer;
-    volk_gnsssdr::vector<float> d_magnitude;
-
     arma::fmat grid_;
 
     std::string d_satellite_str;
@@ -217,6 +202,16 @@ private:
 
     bool d_active;
     bool d_dump;
+
+    std::weak_ptr<ChannelFsm> d_channel_fsm;
+    std::unique_ptr<gnss_fft_complex_fwd> d_fft_if;
+    std::unique_ptr<gnss_fft_complex_rev> d_ifft;
+
+    volk_gnsssdr::vector<volk_gnsssdr::vector<std::complex<float>>> d_grid_doppler_wipeoffs;
+    volk_gnsssdr::vector<volk_gnsssdr::vector<float>> d_grid_data;
+    volk_gnsssdr::vector<gr_complex> d_fft_codes;
+    volk_gnsssdr::vector<gr_complex> d_10_ms_buffer;
+    volk_gnsssdr::vector<float> d_magnitude;
 };
 
 

--- a/src/algorithms/acquisition/gnuradio_blocks/pcps_acquisition_fpga.cc
+++ b/src/algorithms/acquisition/gnuradio_blocks/pcps_acquisition_fpga.cc
@@ -167,6 +167,9 @@ void pcps_acquisition_fpga::set_active(bool active)
     d_active = active;
     d_input_power = 0.0;
     d_mag = 0.0;
+    d_gnss_synchro->Acq_delay_samples = 0.0;
+    d_gnss_synchro->Acq_doppler_hz = 0.0;
+    d_gnss_synchro->Acq_samplestamp_samples = 0;
 
     DLOG(INFO) << "Channel: " << d_channel
                << " , doing acquisition of satellite: " << d_gnss_synchro->System << " " << d_gnss_synchro->PRN

--- a/src/algorithms/acquisition/gnuradio_blocks/pcps_acquisition_fpga.cc
+++ b/src/algorithms/acquisition/gnuradio_blocks/pcps_acquisition_fpga.cc
@@ -65,26 +65,13 @@ pcps_acquisition_fpga::pcps_acquisition_fpga(Acq_Conf_Fpga *conf_, uint32_t acq_
         acq_buff_num,
         downsampling_filter_specs,
         max_FFT_size);
+    d_acquisition_fpga->init(d_acq_parameters->code_length, d_acq_parameters->fft_size,
+        d_acq_parameters->resampled_fs, d_acq_parameters->downsampling_filter_num, d_acq_parameters->excludelimit, d_acq_parameters->all_fft_codes);
 }
 
 void pcps_acquisition_fpga::set_local_code()
 {
     d_acquisition_fpga->set_local_code(d_gnss_synchro->PRN);
-}
-
-void pcps_acquisition_fpga::init()
-{
-    d_acquisition_fpga->init(d_acq_parameters->code_length, d_acq_parameters->fft_size,
-        d_acq_parameters->resampled_fs, d_acq_parameters->downsampling_filter_num, d_acq_parameters->excludelimit, d_acq_parameters->all_fft_codes);
-    d_gnss_synchro->Flag_valid_acquisition = false;
-    d_gnss_synchro->Flag_valid_symbol_output = false;
-    d_gnss_synchro->Flag_valid_pseudorange = false;
-    d_gnss_synchro->Flag_valid_word = false;
-    d_gnss_synchro->Acq_delay_samples = 0.0;
-    d_gnss_synchro->Acq_doppler_hz = 0.0;
-    d_gnss_synchro->Acq_samplestamp_samples = 0;
-    d_mag = 0.0;
-    d_input_power = 0.0;
 }
 
 

--- a/src/algorithms/acquisition/gnuradio_blocks/pcps_acquisition_fpga.h
+++ b/src/algorithms/acquisition/gnuradio_blocks/pcps_acquisition_fpga.h
@@ -82,11 +82,6 @@ public:
     }
 
     /*!
-     * \brief Initializes acquisition algorithm.
-     */
-    void init();
-
-    /*!
      * \brief Sets local code for PCPS acquisition algorithm.
      */
     void set_local_code();

--- a/src/algorithms/acquisition/gnuradio_blocks/pcps_assisted_acquisition_cc.cc
+++ b/src/algorithms/acquisition/gnuradio_blocks/pcps_assisted_acquisition_cc.cc
@@ -64,14 +64,12 @@ pcps_assisted_acquisition_cc::pcps_assisted_acquisition_cc(const Acq_Conf &conf)
       d_state(0),
       d_well_count(0),
       d_active(false),
-      d_disable_assist(false)
+      d_disable_assist(false),
+      d_fft_if(gnss_fft_fwd_make_unique(d_fft_size)),
+      d_ifft(gnss_fft_rev_make_unique(d_fft_size)),
+      d_fft_codes(d_fft_size)
 {
     this->message_port_register_out(pmt::mp("events"));
-
-    d_fft_codes = std::vector<gr_complex>(d_fft_size);
-
-    d_fft_if = gnss_fft_fwd_make_unique(d_fft_size);
-    d_ifft = gnss_fft_rev_make_unique(d_fft_size);
 }
 
 
@@ -98,22 +96,6 @@ pcps_assisted_acquisition_cc::~pcps_assisted_acquisition_cc()
 void pcps_assisted_acquisition_cc::set_local_code(std::complex<float> *code)
 {
     std::copy(code, code + d_fft_size, d_fft_if->get_inbuf());
-}
-
-
-void pcps_assisted_acquisition_cc::init()
-{
-    d_gnss_synchro->Flag_valid_acquisition = false;
-    d_gnss_synchro->Flag_valid_symbol_output = false;
-    d_gnss_synchro->Flag_valid_pseudorange = false;
-    d_gnss_synchro->Flag_valid_word = false;
-    d_gnss_synchro->Acq_doppler_step = 0U;
-    d_gnss_synchro->Acq_delay_samples = 0.0;
-    d_gnss_synchro->Acq_doppler_hz = 0.0;
-    d_gnss_synchro->Acq_samplestamp_samples = 0ULL;
-    d_input_power = 0.0;
-    d_state = 0;
-
     d_fft_if->execute();  // We need the FFT of local code
 
     // Conjugate the local code

--- a/src/algorithms/acquisition/gnuradio_blocks/pcps_assisted_acquisition_cc.h
+++ b/src/algorithms/acquisition/gnuradio_blocks/pcps_assisted_acquisition_cc.h
@@ -92,11 +92,6 @@ public:
     }
 
     /*!
-     * \brief Initializes acquisition algorithm.
-     */
-    void init() override;
-
-    /*!
      * \brief Sets local code for PCPS acquisition algorithm.
      * \param code - Pointer to the PRN code.
      */
@@ -169,14 +164,6 @@ private:
     void reset_grid();
     void redefine_grid();
 
-    std::weak_ptr<ChannelFsm> d_channel_fsm;
-    std::unique_ptr<gnss_fft_complex_fwd> d_fft_if;
-    std::unique_ptr<gnss_fft_complex_rev> d_ifft;
-
-    std::vector<std::vector<std::complex<float>>> d_grid_doppler_wipeoffs;
-    std::vector<std::vector<float>> d_grid_data;
-    std::vector<gr_complex> d_fft_codes;
-
     std::string d_satellite_str;
     const Acq_Conf d_acq_params;
 
@@ -203,6 +190,14 @@ private:
 
     bool d_active;
     bool d_disable_assist;
+
+    std::weak_ptr<ChannelFsm> d_channel_fsm;
+    std::unique_ptr<gnss_fft_complex_fwd> d_fft_if;
+    std::unique_ptr<gnss_fft_complex_rev> d_ifft;
+
+    std::vector<std::vector<std::complex<float>>> d_grid_doppler_wipeoffs;
+    std::vector<std::vector<float>> d_grid_data;
+    std::vector<gr_complex> d_fft_codes;
 };
 
 

--- a/src/algorithms/acquisition/gnuradio_blocks/pcps_cccwsr_acquisition_cc.cc
+++ b/src/algorithms/acquisition/gnuradio_blocks/pcps_cccwsr_acquisition_cc.cc
@@ -63,20 +63,34 @@ pcps_cccwsr_acquisition_cc::pcps_cccwsr_acquisition_cc(const Acq_Conf &conf)
       d_num_doppler_bins(0),
       d_code_phase(0),
       d_channel(0),
-      d_active(false)
+      d_active(false),
+      d_fft_if(gnss_fft_fwd_make_unique(d_fft_size)),
+      d_ifft(gnss_fft_rev_make_unique(d_fft_size)),
+      d_fft_code_data(d_fft_size),
+      d_fft_code_pilot(d_fft_size),
+      d_data_correlation(d_fft_size),
+      d_pilot_correlation(d_fft_size),
+      d_correlation_plus(d_fft_size),
+      d_correlation_minus(d_fft_size),
+      d_magnitude(d_fft_size)
 {
     this->message_port_register_out(pmt::mp("events"));
 
-    d_fft_code_data = std::vector<gr_complex>(d_fft_size);
-    d_fft_code_pilot = std::vector<gr_complex>(d_fft_size);
-    d_data_correlation = std::vector<gr_complex>(d_fft_size);
-    d_pilot_correlation = std::vector<gr_complex>(d_fft_size);
-    d_correlation_plus = std::vector<gr_complex>(d_fft_size);
-    d_correlation_minus = std::vector<gr_complex>(d_fft_size);
-    d_magnitude = std::vector<float>(d_fft_size);
+    // Count the number of bins
+    for (auto doppler = -d_acq_params.doppler_max; doppler <= d_acq_params.doppler_max; doppler += d_acq_params.doppler_step)
+        {
+            d_num_doppler_bins++;
+        }
 
-    d_fft_if = gnss_fft_fwd_make_unique(d_fft_size);
-    d_ifft = gnss_fft_rev_make_unique(d_fft_size);
+    // Create the carrier Doppler wipeoff signals
+    d_grid_doppler_wipeoffs = std::vector<std::vector<gr_complex>>(d_num_doppler_bins, std::vector<gr_complex>(d_fft_size));
+    for (uint32_t doppler_index = 0; doppler_index < d_num_doppler_bins; doppler_index++)
+        {
+            int32_t doppler = -d_acq_params.doppler_max + d_acq_params.doppler_step * doppler_index;
+            float phase_step_rad = static_cast<float>(TWO_PI) * doppler / static_cast<float>(d_fs_in);
+            std::array<float, 1> _phase{};
+            volk_gnsssdr_s32f_sincos_32fc(d_grid_doppler_wipeoffs[doppler_index].data(), -phase_step_rad, _phase.data(), d_fft_size);
+        }
 }
 
 
@@ -118,38 +132,6 @@ void pcps_cccwsr_acquisition_cc::set_local_code(std::complex<float> *code_data,
 
     // Conjugate the local code,
     volk_32fc_conjugate_32fc(d_fft_code_pilot.data(), d_fft_if->get_outbuf(), d_fft_size);
-}
-
-
-void pcps_cccwsr_acquisition_cc::init()
-{
-    d_gnss_synchro->Flag_valid_acquisition = false;
-    d_gnss_synchro->Flag_valid_symbol_output = false;
-    d_gnss_synchro->Flag_valid_pseudorange = false;
-    d_gnss_synchro->Flag_valid_word = false;
-    d_gnss_synchro->Acq_doppler_step = 0U;
-    d_gnss_synchro->Acq_delay_samples = 0.0;
-    d_gnss_synchro->Acq_doppler_hz = 0.0;
-    d_gnss_synchro->Acq_samplestamp_samples = 0ULL;
-    d_mag = 0.0;
-    d_input_power = 0.0;
-
-    // Count the number of bins
-    d_num_doppler_bins = 0;
-    for (auto doppler = -d_acq_params.doppler_max; doppler <= d_acq_params.doppler_max; doppler += d_acq_params.doppler_step)
-        {
-            d_num_doppler_bins++;
-        }
-
-    // Create the carrier Doppler wipeoff signals
-    d_grid_doppler_wipeoffs = std::vector<std::vector<gr_complex>>(d_num_doppler_bins, std::vector<gr_complex>(d_fft_size));
-    for (uint32_t doppler_index = 0; doppler_index < d_num_doppler_bins; doppler_index++)
-        {
-            int32_t doppler = -d_acq_params.doppler_max + d_acq_params.doppler_step * doppler_index;
-            float phase_step_rad = static_cast<float>(TWO_PI) * doppler / static_cast<float>(d_fs_in);
-            std::array<float, 1> _phase{};
-            volk_gnsssdr_s32f_sincos_32fc(d_grid_doppler_wipeoffs[doppler_index].data(), -phase_step_rad, _phase.data(), d_fft_size);
-        }
 }
 
 

--- a/src/algorithms/acquisition/gnuradio_blocks/pcps_cccwsr_acquisition_cc.h
+++ b/src/algorithms/acquisition/gnuradio_blocks/pcps_cccwsr_acquisition_cc.h
@@ -79,11 +79,6 @@ public:
     }
 
     /*!
-     * \brief Initializes acquisition algorithm.
-     */
-    void init() override;
-
-    /*!
      * \brief Sets local code for CCCWSR acquisition algorithm.
      * \param data_code - Pointer to the data PRN code.
      * \param pilot_code - Pointer to the pilot PRN code.
@@ -147,20 +142,6 @@ private:
 
     void calculate_magnitudes(gr_complex* fft_begin, int32_t doppler_shift, int32_t doppler_offset);
 
-    std::weak_ptr<ChannelFsm> d_channel_fsm;
-
-    std::unique_ptr<gnss_fft_complex_fwd> d_fft_if;
-    std::unique_ptr<gnss_fft_complex_rev> d_ifft;
-
-    std::vector<std::vector<gr_complex>> d_grid_doppler_wipeoffs;
-    std::vector<gr_complex> d_fft_code_data;
-    std::vector<gr_complex> d_fft_code_pilot;
-    std::vector<gr_complex> d_data_correlation;
-    std::vector<gr_complex> d_pilot_correlation;
-    std::vector<gr_complex> d_correlation_plus;
-    std::vector<gr_complex> d_correlation_minus;
-    std::vector<float> d_magnitude;
-
     std::ofstream d_dump_file;
     std::string d_satellite_str;
     const Acq_Conf d_acq_params;
@@ -184,6 +165,20 @@ private:
     uint32_t d_channel;
 
     bool d_active;
+
+    std::weak_ptr<ChannelFsm> d_channel_fsm;
+
+    std::unique_ptr<gnss_fft_complex_fwd> d_fft_if;
+    std::unique_ptr<gnss_fft_complex_rev> d_ifft;
+
+    std::vector<std::vector<gr_complex>> d_grid_doppler_wipeoffs;
+    std::vector<gr_complex> d_fft_code_data;
+    std::vector<gr_complex> d_fft_code_pilot;
+    std::vector<gr_complex> d_data_correlation;
+    std::vector<gr_complex> d_pilot_correlation;
+    std::vector<gr_complex> d_correlation_plus;
+    std::vector<gr_complex> d_correlation_minus;
+    std::vector<float> d_magnitude;
 };
 
 

--- a/src/algorithms/acquisition/gnuradio_blocks/pcps_opencl_acquisition_cc.cc
+++ b/src/algorithms/acquisition/gnuradio_blocks/pcps_opencl_acquisition_cc.cc
@@ -79,14 +79,13 @@ pcps_opencl_acquisition_cc::pcps_opencl_acquisition_cc(const Acq_Conf &conf, uin
       d_num_doppler_bins(0),
       d_in_dwell_count(0),
       d_active(false),
-      d_core_working(false)
+      d_core_working(false),
+      d_in_buffer(d_max_dwells, std::vector<gr_complex>(d_fft_size)),
+      d_magnitude(d_fft_size),
+      d_fft_codes(d_fft_size_pow2),
+      d_zero_vector(d_fft_size_pow2 - d_fft_size, 0.0)
 {
     this->message_port_register_out(pmt::mp("events"));
-
-    d_in_buffer = std::vector<std::vector<gr_complex>>(d_max_dwells, std::vector<gr_complex>(d_fft_size));
-    d_magnitude = std::vector<float>(d_fft_size);
-    d_fft_codes = std::vector<gr_complex>(d_fft_size_pow2);
-    d_zero_vector = std::vector<gr_complex>(d_fft_size_pow2 - d_fft_size, 0.0);
 
     d_opencl = init_opencl_environment("math_kernel.cl");
 
@@ -97,6 +96,44 @@ pcps_opencl_acquisition_cc::pcps_opencl_acquisition_cc(const Acq_Conf &conf, uin
 
             // Inverse FFT
             d_ifft = gnss_fft_rev_make_unique(d_fft_size);
+        }
+
+    // Count the number of bins
+    for (int doppler = -d_acq_params.doppler_max; doppler <= d_acq_params.doppler_max; doppler += d_acq_params.doppler_step)
+        {
+            d_num_doppler_bins++;
+        }
+
+    // Create the carrier Doppler wipeoff signals
+    d_grid_doppler_wipeoffs = std::vector<std::vector<gr_complex>>(d_num_doppler_bins, std::vector<gr_complex>(d_fft_size));
+    if (d_opencl == 0)
+        {
+            d_cl_buffer_grid_doppler_wipeoffs = new cl::Buffer *[d_num_doppler_bins];
+        }
+
+    for (uint32_t doppler_index = 0; doppler_index < d_num_doppler_bins; doppler_index++)
+        {
+            int doppler = -d_acq_params.doppler_max + d_acq_params.doppler_step * doppler_index;
+            float phase_step_rad = static_cast<float>(TWO_PI) * doppler / static_cast<float>(d_acq_params.fs_in);
+            std::array<float, 1> _phase{};
+            volk_gnsssdr_s32f_sincos_32fc(d_grid_doppler_wipeoffs[doppler_index].data(), -phase_step_rad, _phase.data(), d_fft_size);
+
+            if (d_opencl == 0)
+                {
+                    d_cl_buffer_grid_doppler_wipeoffs[doppler_index] =
+                        new cl::Buffer(d_cl_context, CL_MEM_READ_WRITE, sizeof(gr_complex) * d_fft_size);
+
+                    d_cl_queue->enqueueWriteBuffer(*(d_cl_buffer_grid_doppler_wipeoffs[doppler_index]),
+                        CL_TRUE, 0, sizeof(gr_complex) * d_fft_size,
+                        d_grid_doppler_wipeoffs[doppler_index].data());
+                }
+        }
+
+    // zero padding in buffer_1 (FFT input)
+    if (d_opencl == 0)
+        {
+            d_cl_queue->enqueueWriteBuffer(*d_cl_buffer_1, CL_TRUE, sizeof(gr_complex) * d_fft_size,
+                sizeof(gr_complex) * (d_fft_size_pow2 - d_fft_size), d_zero_vector.data());
         }
 }
 
@@ -223,60 +260,6 @@ int pcps_opencl_acquisition_cc::init_opencl_environment(const std::string &kerne
         }
 
     return 0;
-}
-
-
-void pcps_opencl_acquisition_cc::init()
-{
-    d_gnss_synchro->Flag_valid_acquisition = false;
-    d_gnss_synchro->Flag_valid_symbol_output = false;
-    d_gnss_synchro->Flag_valid_pseudorange = false;
-    d_gnss_synchro->Flag_valid_word = false;
-    d_gnss_synchro->Acq_doppler_step = 0U;
-    d_gnss_synchro->Acq_delay_samples = 0.0;
-    d_gnss_synchro->Acq_doppler_hz = 0.0;
-    d_gnss_synchro->Acq_samplestamp_samples = 0ULL;
-    d_mag = 0.0;
-    d_input_power = 0.0;
-
-    // Count the number of bins
-    d_num_doppler_bins = 0;
-    for (int doppler = -d_acq_params.doppler_max; doppler <= d_acq_params.doppler_max; doppler += d_acq_params.doppler_step)
-        {
-            d_num_doppler_bins++;
-        }
-
-    // Create the carrier Doppler wipeoff signals
-    d_grid_doppler_wipeoffs = std::vector<std::vector<gr_complex>>(d_num_doppler_bins, std::vector<gr_complex>(d_fft_size));
-    if (d_opencl == 0)
-        {
-            d_cl_buffer_grid_doppler_wipeoffs = new cl::Buffer *[d_num_doppler_bins];
-        }
-
-    for (uint32_t doppler_index = 0; doppler_index < d_num_doppler_bins; doppler_index++)
-        {
-            int doppler = -d_acq_params.doppler_max + d_acq_params.doppler_step * doppler_index;
-            float phase_step_rad = static_cast<float>(TWO_PI) * doppler / static_cast<float>(d_acq_params.fs_in);
-            std::array<float, 1> _phase{};
-            volk_gnsssdr_s32f_sincos_32fc(d_grid_doppler_wipeoffs[doppler_index].data(), -phase_step_rad, _phase.data(), d_fft_size);
-
-            if (d_opencl == 0)
-                {
-                    d_cl_buffer_grid_doppler_wipeoffs[doppler_index] =
-                        new cl::Buffer(d_cl_context, CL_MEM_READ_WRITE, sizeof(gr_complex) * d_fft_size);
-
-                    d_cl_queue->enqueueWriteBuffer(*(d_cl_buffer_grid_doppler_wipeoffs[doppler_index]),
-                        CL_TRUE, 0, sizeof(gr_complex) * d_fft_size,
-                        d_grid_doppler_wipeoffs[doppler_index].data());
-                }
-        }
-
-    // zero padding in buffer_1 (FFT input)
-    if (d_opencl == 0)
-        {
-            d_cl_queue->enqueueWriteBuffer(*d_cl_buffer_1, CL_TRUE, sizeof(gr_complex) * d_fft_size,
-                sizeof(gr_complex) * (d_fft_size_pow2 - d_fft_size), d_zero_vector.data());
-        }
 }
 
 
@@ -492,7 +475,7 @@ void pcps_opencl_acquisition_cc::acquisition_core_opencl()
 
             // In the previous operation, we store the result in the first d_fft_size positions
             // of d_cl_buffer_1. The rest d_fft_size_pow2-d_fft_size already have zeros
-            // (zero-padding is made in init() for optimization purposes).
+            // (zero-padding is made in constructor for optimization purposes).
             clFFT_ExecuteInterleaved((*d_cl_queue)(), d_cl_fft_plan, d_cl_fft_batch_size,
                 clFFT_Forward, (*d_cl_buffer_1)(), (*d_cl_buffer_2)(),
                 0, nullptr, nullptr);

--- a/src/algorithms/acquisition/gnuradio_blocks/pcps_opencl_acquisition_cc.h
+++ b/src/algorithms/acquisition/gnuradio_blocks/pcps_opencl_acquisition_cc.h
@@ -99,11 +99,6 @@ public:
     }
 
     /*!
-     * \brief Initializes acquisition algorithm.
-     */
-    void init() override;
-
-    /*!
      * \brief Sets local code for PCPS acquisition algorithm.
      * \param code - Pointer to the PRN code.
      */
@@ -196,18 +191,6 @@ private:
     clFFT_Plan d_cl_fft_plan;
     cl_int d_cl_fft_batch_size;
 
-    std::weak_ptr<ChannelFsm> d_channel_fsm;
-
-    std::unique_ptr<gnss_fft_complex_fwd> d_fft_if;
-    std::unique_ptr<gnss_fft_complex_rev> d_ifft;
-
-    std::vector<std::vector<gr_complex>> d_grid_doppler_wipeoffs;
-    std::vector<std::vector<gr_complex>> d_in_buffer;
-    std::vector<gr_complex> d_fft_codes;
-    std::vector<gr_complex> d_zero_vector;
-    std::vector<uint64_t> d_sample_counter_buffer;
-    std::vector<float> d_magnitude;
-
     std::string d_satellite_str;
     const Acq_Conf d_acq_params;
 
@@ -238,6 +221,18 @@ private:
 
     bool d_active;
     bool d_core_working;
+
+    std::weak_ptr<ChannelFsm> d_channel_fsm;
+
+    std::unique_ptr<gnss_fft_complex_fwd> d_fft_if;
+    std::unique_ptr<gnss_fft_complex_rev> d_ifft;
+
+    std::vector<std::vector<gr_complex>> d_grid_doppler_wipeoffs;
+    std::vector<std::vector<gr_complex>> d_in_buffer;
+    std::vector<gr_complex> d_fft_codes;
+    std::vector<gr_complex> d_zero_vector;
+    std::vector<uint64_t> d_sample_counter_buffer;
+    std::vector<float> d_magnitude;
 };
 
 

--- a/src/algorithms/acquisition/gnuradio_blocks/pcps_quicksync_acquisition_cc.cc
+++ b/src/algorithms/acquisition/gnuradio_blocks/pcps_quicksync_acquisition_cc.cc
@@ -62,25 +62,38 @@ pcps_quicksync_acquisition_cc::pcps_quicksync_acquisition_cc(
       d_fft_size(d_samples_per_code / d_folding_factor),
       d_num_doppler_bins(0),
       d_code_phase(0),
-      d_active(false)
+      d_active(false),
+      d_fft_if(gnss_fft_fwd_make_unique(d_fft_size)),
+      d_ifft(gnss_fft_rev_make_unique(d_fft_size)),
+      d_code(d_samples_per_code, lv_cmake(0.0F, 0.0F)),
+      d_fft_codes(d_fft_size),
+      d_signal_folded(d_fft_size),
+      d_code_folded(d_fft_size, lv_cmake(0.0F, 0.0F)),
+      d_magnitude(d_samples_per_code * d_folding_factor),
+      d_corr_output_f(d_folding_factor),
+      d_magnitude_folded(d_fft_size),
+      d_possible_delay(d_folding_factor)
 {
     this->message_port_register_out(pmt::mp("events"));
 
-    d_fft_codes = std::vector<gr_complex>(d_fft_size);
-    d_magnitude = std::vector<float>(d_samples_per_code * d_folding_factor);
-    d_magnitude_folded = std::vector<float>(d_fft_size);
-    d_possible_delay = std::vector<uint32_t>(d_folding_factor);
-    d_corr_output_f = std::vector<float>(d_folding_factor);
-
     // Create the d_code vector, which would store the values of the code in its
     // original form to perform later correlation in time domain
-    d_code = std::vector<gr_complex>(d_samples_per_code, lv_cmake(0.0F, 0.0F));
 
-    d_fft_if = gnss_fft_fwd_make_unique(d_fft_size);
-    d_ifft = gnss_fft_rev_make_unique(d_fft_size);
+    // Count the number of bins
+    for (auto doppler = -d_acq_params.doppler_max; doppler <= d_acq_params.doppler_max; doppler += d_acq_params.doppler_step)
+        {
+            d_num_doppler_bins++;
+        }
 
-    d_code_folded = std::vector<gr_complex>(d_fft_size, lv_cmake(0.0F, 0.0F));
-    d_signal_folded = std::vector<gr_complex>(d_fft_size);
+    // Create the carrier Doppler wipeoff signals
+    d_grid_doppler_wipeoffs = std::vector<std::vector<gr_complex>>(d_num_doppler_bins, std::vector<gr_complex>(d_samples_per_code * d_folding_factor));
+    for (uint32_t doppler_index = 0; doppler_index < d_num_doppler_bins; doppler_index++)
+        {
+            int32_t doppler = -d_acq_params.doppler_max + d_acq_params.doppler_step * doppler_index;
+            float phase_step_rad = static_cast<float>(TWO_PI) * doppler / static_cast<float>(d_acq_params.fs_in);
+            std::array<float, 1> _phase{};
+            volk_gnsssdr_s32f_sincos_32fc(d_grid_doppler_wipeoffs[doppler_index].data(), -phase_step_rad, _phase.data(), d_samples_per_code * d_folding_factor);
+        }
 }
 
 
@@ -126,38 +139,6 @@ void pcps_quicksync_acquisition_cc::set_local_code(std::complex<float>* code)
 
     // Conjugate the local code
     volk_32fc_conjugate_32fc(d_fft_codes.data(), d_fft_if->get_outbuf(), d_fft_size);
-}
-
-
-void pcps_quicksync_acquisition_cc::init()
-{
-    d_gnss_synchro->Flag_valid_acquisition = false;
-    d_gnss_synchro->Flag_valid_symbol_output = false;
-    d_gnss_synchro->Flag_valid_pseudorange = false;
-    d_gnss_synchro->Flag_valid_word = false;
-    d_gnss_synchro->Acq_delay_samples = 0.0;
-    d_gnss_synchro->Acq_doppler_hz = 0.0;
-    d_gnss_synchro->Acq_samplestamp_samples = 0ULL;
-    d_gnss_synchro->Acq_doppler_step = 0U;
-    d_mag = 0.0;
-    d_input_power = 0.0;
-
-    // Count the number of bins
-    d_num_doppler_bins = 0;
-    for (auto doppler = -d_acq_params.doppler_max; doppler <= d_acq_params.doppler_max; doppler += d_acq_params.doppler_step)
-        {
-            d_num_doppler_bins++;
-        }
-
-    // Create the carrier Doppler wipeoff signals
-    d_grid_doppler_wipeoffs = std::vector<std::vector<gr_complex>>(d_num_doppler_bins, std::vector<gr_complex>(d_samples_per_code * d_folding_factor));
-    for (uint32_t doppler_index = 0; doppler_index < d_num_doppler_bins; doppler_index++)
-        {
-            int32_t doppler = -d_acq_params.doppler_max + d_acq_params.doppler_step * doppler_index;
-            float phase_step_rad = static_cast<float>(TWO_PI) * doppler / static_cast<float>(d_acq_params.fs_in);
-            std::array<float, 1> _phase{};
-            volk_gnsssdr_s32f_sincos_32fc(d_grid_doppler_wipeoffs[doppler_index].data(), -phase_step_rad, _phase.data(), d_samples_per_code * d_folding_factor);
-        }
 }
 
 

--- a/src/algorithms/acquisition/gnuradio_blocks/pcps_quicksync_acquisition_cc.h
+++ b/src/algorithms/acquisition/gnuradio_blocks/pcps_quicksync_acquisition_cc.h
@@ -98,11 +98,6 @@ public:
     }
 
     /*!
-     * \brief Initializes acquisition algorithm.
-     */
-    void init() override;
-
-    /*!
      * \brief Sets local code for PCPS acquisition algorithm.
      * \param code - Pointer to the PRN code.
      */
@@ -167,21 +162,6 @@ private:
 
     void calculate_magnitudes(gr_complex* fft_begin, int32_t doppler_shift, int32_t doppler_offset);
 
-    std::weak_ptr<ChannelFsm> d_channel_fsm;
-
-    std::unique_ptr<gnss_fft_complex_fwd> d_fft_if;
-    std::unique_ptr<gnss_fft_complex_rev> d_ifft;
-
-    std::vector<std::vector<gr_complex>> d_grid_doppler_wipeoffs;
-    std::vector<gr_complex> d_code;
-    std::vector<gr_complex> d_fft_codes;
-    std::vector<gr_complex> d_signal_folded;
-    std::vector<gr_complex> d_code_folded;
-    std::vector<float> d_magnitude;
-    std::vector<float> d_corr_output_f;
-    std::vector<float> d_magnitude_folded;
-    std::vector<uint32_t> d_possible_delay;
-
     std::string d_satellite_str;
     const Acq_Conf d_acq_params;
 
@@ -208,6 +188,21 @@ private:
     uint32_t d_code_phase;
 
     bool d_active;
+
+    std::weak_ptr<ChannelFsm> d_channel_fsm;
+
+    std::unique_ptr<gnss_fft_complex_fwd> d_fft_if;
+    std::unique_ptr<gnss_fft_complex_rev> d_ifft;
+
+    std::vector<std::vector<gr_complex>> d_grid_doppler_wipeoffs;
+    std::vector<gr_complex> d_code;
+    std::vector<gr_complex> d_fft_codes;
+    std::vector<gr_complex> d_signal_folded;
+    std::vector<gr_complex> d_code_folded;
+    std::vector<float> d_magnitude;
+    std::vector<float> d_corr_output_f;
+    std::vector<float> d_magnitude_folded;
+    std::vector<uint32_t> d_possible_delay;
 };
 
 

--- a/src/algorithms/acquisition/gnuradio_blocks/pcps_tong_acquisition_cc.cc
+++ b/src/algorithms/acquisition/gnuradio_blocks/pcps_tong_acquisition_cc.cc
@@ -87,15 +87,30 @@ pcps_tong_acquisition_cc::pcps_tong_acquisition_cc(
       d_fft_size(conf.sampled_ms * conf.samples_per_ms),
       d_num_doppler_bins(0),
       d_code_phase(0),
-      d_active(false)
+      d_active(false),
+      d_fft_if(gnss_fft_fwd_make_unique(d_fft_size)),
+      d_ifft(gnss_fft_rev_make_unique(d_fft_size)),
+      d_fft_codes(d_fft_size),
+      d_magnitude(d_fft_size)
 {
     this->message_port_register_out(pmt::mp("events"));
 
-    d_fft_codes = std::vector<gr_complex>(d_fft_size);
-    d_magnitude = std::vector<float>(d_fft_size);
+    // Count the number of bins
+    for (auto doppler = -d_acq_params.doppler_max; doppler <= d_acq_params.doppler_max; doppler += d_acq_params.doppler_step)
+        {
+            d_num_doppler_bins++;
+        }
 
-    d_fft_if = gnss_fft_fwd_make_unique(d_fft_size);
-    d_ifft = gnss_fft_rev_make_unique(d_fft_size);
+    // Create the carrier Doppler wipeoff signals and allocate data grid.
+    d_grid_doppler_wipeoffs = std::vector<std::vector<gr_complex>>(d_num_doppler_bins, std::vector<gr_complex>(d_fft_size));
+    d_grid_data = std::vector<std::vector<float>>(d_num_doppler_bins, std::vector<float>(d_fft_size, 0.0));
+    for (uint32_t doppler_index = 0; doppler_index < d_num_doppler_bins; doppler_index++)
+        {
+            int32_t doppler = -d_acq_params.doppler_max + d_acq_params.doppler_step * doppler_index;
+            float phase_step_rad = static_cast<float>(TWO_PI) * doppler / static_cast<float>(d_acq_params.fs_in);
+            std::array<float, 1> _phase{};
+            volk_gnsssdr_s32f_sincos_32fc(d_grid_doppler_wipeoffs[doppler_index].data(), -phase_step_rad, _phase.data(), d_fft_size);
+        }
 }
 
 
@@ -127,39 +142,6 @@ void pcps_tong_acquisition_cc::set_local_code(std::complex<float> *code)
 
     // Conjugate the local code
     volk_32fc_conjugate_32fc(d_fft_codes.data(), d_fft_if->get_outbuf(), d_fft_size);
-}
-
-
-void pcps_tong_acquisition_cc::init()
-{
-    d_gnss_synchro->Flag_valid_acquisition = false;
-    d_gnss_synchro->Flag_valid_symbol_output = false;
-    d_gnss_synchro->Flag_valid_pseudorange = false;
-    d_gnss_synchro->Flag_valid_word = false;
-    d_gnss_synchro->Acq_doppler_step = 0U;
-    d_gnss_synchro->Acq_delay_samples = 0.0;
-    d_gnss_synchro->Acq_doppler_hz = 0.0;
-    d_gnss_synchro->Acq_samplestamp_samples = 0ULL;
-    d_mag = 0.0;
-    d_input_power = 0.0;
-
-    // Count the number of bins
-    d_num_doppler_bins = 0;
-    for (auto doppler = -d_acq_params.doppler_max; doppler <= d_acq_params.doppler_max; doppler += d_acq_params.doppler_step)
-        {
-            d_num_doppler_bins++;
-        }
-
-    // Create the carrier Doppler wipeoff signals and allocate data grid.
-    d_grid_doppler_wipeoffs = std::vector<std::vector<gr_complex>>(d_num_doppler_bins, std::vector<gr_complex>(d_fft_size));
-    d_grid_data = std::vector<std::vector<float>>(d_num_doppler_bins, std::vector<float>(d_fft_size, 0.0));
-    for (uint32_t doppler_index = 0; doppler_index < d_num_doppler_bins; doppler_index++)
-        {
-            int32_t doppler = -d_acq_params.doppler_max + d_acq_params.doppler_step * doppler_index;
-            float phase_step_rad = static_cast<float>(TWO_PI) * doppler / static_cast<float>(d_acq_params.fs_in);
-            std::array<float, 1> _phase{};
-            volk_gnsssdr_s32f_sincos_32fc(d_grid_doppler_wipeoffs[doppler_index].data(), -phase_step_rad, _phase.data(), d_fft_size);
-        }
 }
 
 

--- a/src/algorithms/acquisition/gnuradio_blocks/pcps_tong_acquisition_cc.h
+++ b/src/algorithms/acquisition/gnuradio_blocks/pcps_tong_acquisition_cc.h
@@ -97,11 +97,6 @@ public:
     }
 
     /*!
-     * \brief Initializes acquisition algorithm.
-     */
-    void init() override;
-
-    /*!
      * \brief Sets local code for TONG acquisition algorithm.
      * \param code - Pointer to the PRN code.
      */
@@ -172,15 +167,6 @@ private:
 
     void calculate_magnitudes(gr_complex* fft_begin, int32_t doppler_shift, int32_t doppler_offset);
 
-    std::weak_ptr<ChannelFsm> d_channel_fsm;
-    std::unique_ptr<gnss_fft_complex_fwd> d_fft_if;
-    std::unique_ptr<gnss_fft_complex_rev> d_ifft;
-
-    std::vector<std::vector<gr_complex>> d_grid_doppler_wipeoffs;
-    std::vector<std::vector<float>> d_grid_data;
-    std::vector<gr_complex> d_fft_codes;
-    std::vector<float> d_magnitude;
-
     std::string d_satellite_str;
     const Acq_Conf d_acq_params;
 
@@ -206,6 +192,15 @@ private:
     uint32_t d_code_phase;
 
     bool d_active;
+
+    std::weak_ptr<ChannelFsm> d_channel_fsm;
+    std::unique_ptr<gnss_fft_complex_fwd> d_fft_if;
+    std::unique_ptr<gnss_fft_complex_rev> d_ifft;
+
+    std::vector<std::vector<gr_complex>> d_grid_doppler_wipeoffs;
+    std::vector<std::vector<float>> d_grid_data;
+    std::vector<gr_complex> d_fft_codes;
+    std::vector<float> d_magnitude;
 };
 
 

--- a/src/algorithms/channel/adapters/channel.cc
+++ b/src/algorithms/channel/adapters/channel.cc
@@ -19,7 +19,6 @@
 #include "acquisition_interface.h"
 #include "channel_fsm.h"
 #include "configuration_interface.h"
-#include "gnss_sdr_flags.h"
 #include "telemetry_decoder_interface.h"
 #include "tracking_interface.h"
 #include <stdexcept>  // for std::invalid_argument
@@ -82,8 +81,6 @@ Channel::Channel(const ConfigurationInterface* configuration,
         }
 
     acq_->set_threshold(threshold);
-
-    acq_->init();
 
     channel_fsm_->set_acquisition(acq_);
     channel_fsm_->set_tracking(trk_);

--- a/src/core/interfaces/acquisition_interface.h
+++ b/src/core/interfaces/acquisition_interface.h
@@ -55,7 +55,6 @@ public:
     virtual void set_channel_fsm(std::weak_ptr<ChannelFsm> channel_fsm) = 0;
     virtual void set_threshold(float threshold) = 0;
     virtual void set_doppler_center(int /*doppler_center*/) {}
-    virtual void init() = 0;
     virtual void set_local_code() = 0;
     virtual signed int mag() = 0;
     virtual void reset() = 0;

--- a/tests/unit-tests/signal-processing-blocks/acquisition/acq_performance_test.cc
+++ b/tests/unit-tests/signal-processing-blocks/acquisition/acq_performance_test.cc
@@ -854,7 +854,6 @@ int AcquisitionPerformanceTest::run_receiver()
     acquisition->set_gnss_synchro(&gnss_synchro);
     acquisition->set_channel(0);
     acquisition->set_threshold(config->property("Acquisition.threshold", 0.0));
-    acquisition->init();
     acquisition->set_local_code();
     acquisition->reset();
 

--- a/tests/unit-tests/signal-processing-blocks/acquisition/acq_performance_test.cc
+++ b/tests/unit-tests/signal-processing-blocks/acquisition/acq_performance_test.cc
@@ -856,10 +856,8 @@ int AcquisitionPerformanceTest::run_receiver()
     acquisition->set_threshold(config->property("Acquisition.threshold", 0.0));
     acquisition->set_local_code();
     acquisition->reset();
-
     acquisition->connect(top_block);
 
-    acquisition->reset();
     top_block->connect(file_source, 0, gr_interleaved_char_to_complex, 0);
     top_block->connect(gr_interleaved_char_to_complex, 0, skiphead, 0);
     top_block->connect(skiphead, 0, valve, 0);

--- a/tests/unit-tests/signal-processing-blocks/acquisition/beidou_b1i_pcps_acquisition_test.cc
+++ b/tests/unit-tests/signal-processing-blocks/acquisition/beidou_b1i_pcps_acquisition_test.cc
@@ -336,7 +336,6 @@ TEST_F(BeidouB1iPcpsAcquisitionTest, ValidationOfResults)
     }) << "Failure connecting the blocks of acquisition test.";
 
     acquisition->set_local_code();
-    acquisition->init();
     acquisition->reset();
 
     EXPECT_NO_THROW({

--- a/tests/unit-tests/signal-processing-blocks/acquisition/beidou_b3i_pcps_acquisition_test.cc
+++ b/tests/unit-tests/signal-processing-blocks/acquisition/beidou_b3i_pcps_acquisition_test.cc
@@ -335,7 +335,6 @@ TEST_F(BeidouB3iPcpsAcquisitionTest, ValidationOfResults)
 
     acquisition->set_local_code();
     acquisition->reset();
-    acquisition->init();
 
     EXPECT_NO_THROW({
         start = std::chrono::system_clock::now();

--- a/tests/unit-tests/signal-processing-blocks/acquisition/galileo_e1_pcps_8ms_ambiguous_acquisition_gsoc2013_test.cc
+++ b/tests/unit-tests/signal-processing-blocks/acquisition/galileo_e1_pcps_8ms_ambiguous_acquisition_gsoc2013_test.cc
@@ -506,8 +506,6 @@ TEST_F(GalileoE1Pcps8msAmbiguousAcquisitionGSoC2013Test, ValidationOfResults)
         acquisition->connect(top_block);
     }) << "Failure connecting acquisition to the top_block.";
 
-    acquisition->init();
-
     ASSERT_NO_THROW({
         std::shared_ptr<GNSSBlockInterface> signal_generator = std::make_shared<SignalGenerator>(config.get(), "SignalSource", 0, 1, queue.get());
         std::shared_ptr<GNSSBlockInterface> filter = std::make_shared<FirFilter>(config.get(), "InputFilter", 1, 1);
@@ -584,8 +582,6 @@ TEST_F(GalileoE1Pcps8msAmbiguousAcquisitionGSoC2013Test, ValidationOfResultsProb
     ASSERT_NO_THROW({
         acquisition->connect(top_block);
     }) << "Failure connecting acquisition to the top_block.";
-
-    acquisition->init();
 
     ASSERT_NO_THROW({
         std::shared_ptr<GNSSBlockInterface> signal_generator = std::make_shared<SignalGenerator>(config.get(), "SignalSource", 0, 1, queue.get());

--- a/tests/unit-tests/signal-processing-blocks/acquisition/galileo_e1_pcps_ambiguous_acquisition_gsoc2013_test.cc
+++ b/tests/unit-tests/signal-processing-blocks/acquisition/galileo_e1_pcps_ambiguous_acquisition_gsoc2013_test.cc
@@ -488,8 +488,6 @@ TEST_F(GalileoE1PcpsAmbiguousAcquisitionGSoC2013Test, ValidationOfResults)
         acquisition->connect(top_block);
     }) << "Failure connecting acquisition to the top_block.";
 
-    acquisition->init();
-
     ASSERT_NO_THROW({
         std::shared_ptr<GNSSBlockInterface> signal_generator = std::make_shared<SignalGenerator>(config.get(), "SignalSource", 0, 1, queue.get());
         std::shared_ptr<GNSSBlockInterface> filter = std::make_shared<FirFilter>(config.get(), "InputFilter", 1, 1);
@@ -559,8 +557,6 @@ TEST_F(GalileoE1PcpsAmbiguousAcquisitionGSoC2013Test, ValidationOfResultsProbabi
     ASSERT_NO_THROW({
         acquisition->connect(top_block);
     }) << "Failure connecting acquisition to the top_block.";
-
-    acquisition->init();
 
     ASSERT_NO_THROW({
         std::shared_ptr<GNSSBlockInterface> signal_generator = std::make_shared<SignalGenerator>(config.get(), "SignalSource", 0, 1, queue.get());

--- a/tests/unit-tests/signal-processing-blocks/acquisition/galileo_e1_pcps_ambiguous_acquisition_gsoc_test.cc
+++ b/tests/unit-tests/signal-processing-blocks/acquisition/galileo_e1_pcps_ambiguous_acquisition_gsoc_test.cc
@@ -292,7 +292,6 @@ TEST_F(GalileoE1PcpsAmbiguousAcquisitionGSoCTest, ValidationOfResults)
     ASSERT_NO_THROW({
         start_queue();
         acquisition->set_local_code();
-        acquisition->init();
         acquisition->reset();
     }) << "Failure starting acquisition";
 

--- a/tests/unit-tests/signal-processing-blocks/acquisition/galileo_e1_pcps_ambiguous_acquisition_test.cc
+++ b/tests/unit-tests/signal-processing-blocks/acquisition/galileo_e1_pcps_ambiguous_acquisition_test.cc
@@ -350,7 +350,6 @@ TEST_F(GalileoE1PcpsAmbiguousAcquisitionTest, ValidationOfResults)
     }) << "Failure connecting the blocks of acquisition test.";
 
     acquisition->set_local_code();
-    acquisition->init();
     acquisition->reset();
 
     EXPECT_NO_THROW({

--- a/tests/unit-tests/signal-processing-blocks/acquisition/galileo_e1_pcps_ambiguous_acquisition_test_fpga.cc
+++ b/tests/unit-tests/signal-processing-blocks/acquisition/galileo_e1_pcps_ambiguous_acquisition_test_fpga.cc
@@ -343,7 +343,6 @@ bool GalileoE1PcpsAmbiguousAcquisitionTestFpga::acquire_signal()
     channel_fsm_->Event_clear_test_result();
 
     acquisition->stop_acquisition();  // reset the whole system including the sample counters
-    acquisition->init();
     acquisition->set_local_code();
 
     args.skip_used_samples = 0;

--- a/tests/unit-tests/signal-processing-blocks/acquisition/galileo_e1_pcps_cccwsr_ambiguous_acquisition_gsoc2013_test.cc
+++ b/tests/unit-tests/signal-processing-blocks/acquisition/galileo_e1_pcps_cccwsr_ambiguous_acquisition_gsoc2013_test.cc
@@ -495,7 +495,6 @@ TEST_F(GalileoE1PcpsCccwsrAmbiguousAcquisitionTest, ValidationOfResults)
         acquisition->connect(top_block);
     }) << "Failure connecting acquisition to the top_block.";
 
-    acquisition->init();
     acquisition->reset();
 
     ASSERT_NO_THROW({
@@ -578,7 +577,6 @@ TEST_F(GalileoE1PcpsCccwsrAmbiguousAcquisitionTest, ValidationOfResultsProbabili
         acquisition->connect(top_block);
     }) << "Failure connecting acquisition to the top_block.";
 
-    acquisition->init();
     acquisition->reset();
 
     ASSERT_NO_THROW({
@@ -608,7 +606,6 @@ TEST_F(GalileoE1PcpsCccwsrAmbiguousAcquisitionTest, ValidationOfResultsProbabili
                 }
 
             acquisition->set_gnss_synchro(&gnss_synchro);
-            acquisition->init();
             acquisition->reset();
             acquisition->set_local_code();
             start_queue();

--- a/tests/unit-tests/signal-processing-blocks/acquisition/galileo_e1_pcps_quicksync_ambiguous_acquisition_gsoc2014_test.cc
+++ b/tests/unit-tests/signal-processing-blocks/acquisition/galileo_e1_pcps_quicksync_ambiguous_acquisition_gsoc2014_test.cc
@@ -646,7 +646,6 @@ TEST_F(GalileoE1PcpsQuickSyncAmbiguousAcquisitionGSoC2014Test, ValidationOfResul
         acquisition->connect(top_block);
     }) << "Failure connecting acquisition to the top_block.";
 
-    acquisition->init();
     acquisition->reset();
 
     ASSERT_NO_THROW({
@@ -728,7 +727,6 @@ TEST_F(GalileoE1PcpsQuickSyncAmbiguousAcquisitionGSoC2014Test, ValidationOfResul
         acquisition->connect(top_block);
     }) << "Failure connecting acquisition to the top_block.";
 
-    acquisition->init();
     acquisition->reset();
 
     ASSERT_NO_THROW({
@@ -806,8 +804,6 @@ TEST_F(GalileoE1PcpsQuickSyncAmbiguousAcquisitionGSoC2014Test, ValidationOfResul
     ASSERT_NO_THROW({
         acquisition->connect(top_block);
     }) << "Failure connecting acquisition to the top_block.";
-
-    acquisition->init();
 
     ASSERT_NO_THROW({
         std::shared_ptr<GNSSBlockInterface> signal_generator = std::make_shared<SignalGenerator>(config.get(), "SignalSource", 0, 1, queue.get());

--- a/tests/unit-tests/signal-processing-blocks/acquisition/galileo_e1_pcps_tong_ambiguous_acquisition_gsoc2013_test.cc
+++ b/tests/unit-tests/signal-processing-blocks/acquisition/galileo_e1_pcps_tong_ambiguous_acquisition_gsoc2013_test.cc
@@ -494,7 +494,6 @@ TEST_F(GalileoE1PcpsTongAmbiguousAcquisitionGSoC2013Test, ValidationOfResults)
     }) << "Failure connecting acquisition to the top_block.";
 
     acquisition->reset();
-    acquisition->init();
 
     ASSERT_NO_THROW({
         std::shared_ptr<GNSSBlockInterface> signal_generator = std::make_shared<SignalGenerator>(config.get(), "SignalSource", 0, 1, queue.get());
@@ -572,8 +571,6 @@ TEST_F(GalileoE1PcpsTongAmbiguousAcquisitionGSoC2013Test, ValidationOfResultsPro
     ASSERT_NO_THROW({
         acquisition->connect(top_block);
     }) << "Failure connecting acquisition to the top_block.";
-
-    acquisition->init();
 
     ASSERT_NO_THROW({
         std::shared_ptr<GNSSBlockInterface> signal_generator = std::make_shared<SignalGenerator>(config.get(), "SignalSource", 0, 1, queue.get());

--- a/tests/unit-tests/signal-processing-blocks/acquisition/galileo_e5a_pcps_acquisition_gsoc2014_gensource_test.cc
+++ b/tests/unit-tests/signal-processing-blocks/acquisition/galileo_e5a_pcps_acquisition_gsoc2014_gensource_test.cc
@@ -606,7 +606,6 @@ TEST_F(GalileoE5aPcpsAcquisitionGSoC2014GensourceTest, ValidationOfSIM)
     }) << "Failure connecting the blocks of acquisition test.";
 
     acquisition->reset();
-    acquisition->init();
 
     // i = 0 --> satellite in acquisition is visible
     // i = 1 --> satellite in acquisition is not visible

--- a/tests/unit-tests/signal-processing-blocks/acquisition/galileo_e5b_pcps_acquisition_test.cc
+++ b/tests/unit-tests/signal-processing-blocks/acquisition/galileo_e5b_pcps_acquisition_test.cc
@@ -392,7 +392,6 @@ TEST_F(GalileoE5bPcpsAcquisitionTest, ValidationOfResults)
     }) << "Failure connecting the blocks of acquisition test.";
 
     acquisition->reset();
-    acquisition->init();
 
     // i = 0 --> satellite in acquisition is visible
     // i = 1 --> satellite in acquisition is not visible

--- a/tests/unit-tests/signal-processing-blocks/acquisition/galileo_e6_pcps_acquisition_test.cc
+++ b/tests/unit-tests/signal-processing-blocks/acquisition/galileo_e6_pcps_acquisition_test.cc
@@ -387,7 +387,6 @@ TEST_F(GalileoE6PcpsAcquisitionTest, ValidationOfResults)
     }) << "Failure connecting the blocks of acquisition test.";
 
     acquisition->reset();
-    acquisition->init();
 
     // i = 0 --> satellite in acquisition is visible
     // i = 1 --> satellite in acquisition is not visible

--- a/tests/unit-tests/signal-processing-blocks/acquisition/glonass_l1_ca_pcps_acquisition_gsoc2017_test.cc
+++ b/tests/unit-tests/signal-processing-blocks/acquisition/glonass_l1_ca_pcps_acquisition_gsoc2017_test.cc
@@ -496,8 +496,6 @@ TEST_F(GlonassL1CaPcpsAcquisitionGSoC2017Test, ValidationOfResults)
         top_block->msg_connect(acquisition->get_right_block(), pmt::mp("events"), msg_rx, pmt::mp("events"));
     }) << "Failure connecting acquisition to the top_block.";
 
-    acquisition->init();
-
     ASSERT_NO_THROW({
         std::shared_ptr<SignalGenerator> signal_generator = std::make_shared<SignalGenerator>(config.get(), "SignalSource", 0, 1, queue.get());
         std::shared_ptr<FreqXlatingFirFilter> filter = std::make_shared<FreqXlatingFirFilter>(config.get(), "InputFilter", 1, 1);
@@ -569,8 +567,6 @@ TEST_F(GlonassL1CaPcpsAcquisitionGSoC2017Test, ValidationOfResultsProbabilities)
         acquisition->connect(top_block);
         top_block->msg_connect(acquisition->get_right_block(), pmt::mp("events"), msg_rx, pmt::mp("events"));
     }) << "Failure connecting acquisition to the top_block.";
-
-    acquisition->init();
 
     ASSERT_NO_THROW({
         std::shared_ptr<SignalGenerator> signal_generator = std::make_shared<SignalGenerator>(config.get(), "SignalSource", 0, 1, queue.get());

--- a/tests/unit-tests/signal-processing-blocks/acquisition/glonass_l1_ca_pcps_acquisition_test.cc
+++ b/tests/unit-tests/signal-processing-blocks/acquisition/glonass_l1_ca_pcps_acquisition_test.cc
@@ -244,7 +244,6 @@ TEST_F(GlonassL1CaPcpsAcquisitionTest, ValidationOfResults)
 
     acquisition->set_local_code();
     acquisition->reset();
-    acquisition->init();
 
     ASSERT_NO_THROW({
         std::string path = std::string(TEST_PATH);

--- a/tests/unit-tests/signal-processing-blocks/acquisition/glonass_l2_ca_pcps_acquisition_test.cc
+++ b/tests/unit-tests/signal-processing-blocks/acquisition/glonass_l2_ca_pcps_acquisition_test.cc
@@ -498,8 +498,6 @@ TEST_F(GlonassL2CaPcpsAcquisitionTest, ValidationOfResults)
         top_block->msg_connect(acquisition->get_right_block(), pmt::mp("events"), msg_rx, pmt::mp("events"));
     }) << "Failure connecting acquisition to the top_block.";
 
-    acquisition->init();
-
     ASSERT_NO_THROW({
         std::shared_ptr<GNSSBlockInterface> signal_generator = std::make_shared<SignalGenerator>(config.get(), "SignalSource", 0, 1, queue.get());
         std::shared_ptr<GNSSBlockInterface> filter = std::make_shared<FirFilter>(config.get(), "InputFilter", 1, 1);
@@ -575,8 +573,6 @@ TEST_F(GlonassL2CaPcpsAcquisitionTest, ValidationOfResultsProbabilities)
         acquisition->connect(top_block);
         top_block->msg_connect(acquisition->get_right_block(), pmt::mp("events"), msg_rx, pmt::mp("events"));
     }) << "Failure connecting acquisition to the top_block.";
-
-    acquisition->init();
 
     ASSERT_NO_THROW({
         std::shared_ptr<GNSSBlockInterface> signal_generator = std::make_shared<SignalGenerator>(config.get(), "SignalSource", 0, 1, queue.get());

--- a/tests/unit-tests/signal-processing-blocks/acquisition/gps_l1_ca_pcps_acquisition_gsoc2013_test.cc
+++ b/tests/unit-tests/signal-processing-blocks/acquisition/gps_l1_ca_pcps_acquisition_gsoc2013_test.cc
@@ -488,8 +488,6 @@ TEST_F(GpsL1CaPcpsAcquisitionGSoC2013Test, ValidationOfResults)
         top_block->msg_connect(acquisition->get_right_block(), pmt::mp("events"), msg_rx, pmt::mp("events"));
     }) << "Failure connecting acquisition to the top_block.";
 
-    acquisition->init();
-
     ASSERT_NO_THROW({
         std::shared_ptr<GNSSBlockInterface> signal_generator = std::make_shared<SignalGenerator>(config.get(), "SignalSource", 0, 1, queue.get());
         std::shared_ptr<GNSSBlockInterface> filter = std::make_shared<FirFilter>(config.get(), "InputFilter", 1, 1);
@@ -561,8 +559,6 @@ TEST_F(GpsL1CaPcpsAcquisitionGSoC2013Test, ValidationOfResultsProbabilities)
         acquisition->connect(top_block);
         top_block->msg_connect(acquisition->get_right_block(), pmt::mp("events"), msg_rx, pmt::mp("events"));
     }) << "Failure connecting acquisition to the top_block.";
-
-    acquisition->init();
 
     ASSERT_NO_THROW({
         std::shared_ptr<GNSSBlockInterface> signal_generator = std::make_shared<SignalGenerator>(config.get(), "SignalSource", 0, 1, queue.get());

--- a/tests/unit-tests/signal-processing-blocks/acquisition/gps_l1_ca_pcps_acquisition_test.cc
+++ b/tests/unit-tests/signal-processing-blocks/acquisition/gps_l1_ca_pcps_acquisition_test.cc
@@ -347,7 +347,6 @@ TEST_F(GpsL1CaPcpsAcquisitionTest /*unused*/, ValidationOfResults /*unused*/)
     }) << "Failure connecting the blocks of acquisition test.";
 
     acquisition->set_local_code();
-    acquisition->init();
     acquisition->reset();
 
     EXPECT_NO_THROW({

--- a/tests/unit-tests/signal-processing-blocks/acquisition/gps_l1_ca_pcps_acquisition_test_fpga.cc
+++ b/tests/unit-tests/signal-processing-blocks/acquisition/gps_l1_ca_pcps_acquisition_test_fpga.cc
@@ -342,7 +342,6 @@ bool GpsL1CaPcpsAcquisitionTestFpga::acquire_signal()
     channel_fsm_->Event_clear_test_result();
 
     acquisition->stop_acquisition();  // reset the whole system including the sample counters
-    acquisition->init();
     acquisition->set_local_code();
 
     args.skip_used_samples = 0;

--- a/tests/unit-tests/signal-processing-blocks/acquisition/gps_l1_ca_pcps_opencl_acquisition_gsoc2013_test.cc
+++ b/tests/unit-tests/signal-processing-blocks/acquisition/gps_l1_ca_pcps_opencl_acquisition_gsoc2013_test.cc
@@ -490,8 +490,6 @@ TEST_F(GpsL1CaPcpsOpenClAcquisitionGSoC2013Test, ValidationOfResults)
         acquisition->connect(top_block);
     }) << "Failure connecting acquisition to the top_block.";
 
-    acquisition->init();
-
     if (!acquisition->opencl_ready())
         {
             std::cout << "OpenCL Platform is not ready.\n";
@@ -570,7 +568,6 @@ TEST_F(GpsL1CaPcpsOpenClAcquisitionGSoC2013Test, ValidationOfResultsProbabilitie
         acquisition->connect(top_block);
     }) << "Failure connecting acquisition to the top_block.";
 
-    acquisition->init();
     if (!acquisition->opencl_ready())
         {
             std::cout << "OpenCL Platform is not ready.\n";

--- a/tests/unit-tests/signal-processing-blocks/acquisition/gps_l1_ca_pcps_quicksync_acquisition_gsoc2014_test.cc
+++ b/tests/unit-tests/signal-processing-blocks/acquisition/gps_l1_ca_pcps_quicksync_acquisition_gsoc2014_test.cc
@@ -618,7 +618,6 @@ TEST_F(GpsL1CaPcpsQuickSyncAcquisitionGSoC2014Test, ValidationOfResults)
         acquisition->connect(top_block);
     }) << "Failure connecting acquisition to the top_block.";
 
-    acquisition->init();
     acquisition->reset();
 
     ASSERT_NO_THROW({
@@ -702,7 +701,6 @@ TEST_F(GpsL1CaPcpsQuickSyncAcquisitionGSoC2014Test, ValidationOfResultsWithNoise
         acquisition->connect(top_block);
     }) << "Failure connecting acquisition to the top_block.";
 
-    acquisition->init();
     acquisition->reset();
 
     ASSERT_NO_THROW({
@@ -779,7 +777,6 @@ TEST_F(GpsL1CaPcpsQuickSyncAcquisitionGSoC2014Test, ValidationOfResultsProbabili
         acquisition->connect(top_block);
     }) << "Failure connecting acquisition to the top_block.";
 
-    acquisition->init();
     acquisition->reset();
 
     ASSERT_NO_THROW({

--- a/tests/unit-tests/signal-processing-blocks/acquisition/gps_l1_ca_pcps_tong_acquisition_gsoc2013_test.cc
+++ b/tests/unit-tests/signal-processing-blocks/acquisition/gps_l1_ca_pcps_tong_acquisition_gsoc2013_test.cc
@@ -487,8 +487,6 @@ TEST_F(GpsL1CaPcpsTongAcquisitionGSoC2013Test, ValidationOfResults)
         acquisition->connect(top_block);
     }) << "Failure connecting acquisition to the top_block.";
 
-    acquisition->init();
-
     ASSERT_NO_THROW({
         std::shared_ptr<GNSSBlockInterface> signal_generator = std::make_shared<SignalGenerator>(config.get(), "SignalSource", 0, 1, queue.get());
         std::shared_ptr<GNSSBlockInterface> filter = std::make_shared<FirFilter>(config.get(), "InputFilter", 1, 1);
@@ -565,8 +563,6 @@ TEST_F(GpsL1CaPcpsTongAcquisitionGSoC2013Test, ValidationOfResultsProbabilities)
     ASSERT_NO_THROW({
         acquisition->connect(top_block);
     }) << "Failure connecting acquisition to the top_block.";
-
-    acquisition->init();
 
     ASSERT_NO_THROW({
         std::shared_ptr<GNSSBlockInterface> signal_generator = std::make_shared<SignalGenerator>(config.get(), "SignalSource", 0, 1, queue.get());

--- a/tests/unit-tests/signal-processing-blocks/acquisition/gps_l2_m_pcps_acquisition_test.cc
+++ b/tests/unit-tests/signal-processing-blocks/acquisition/gps_l2_m_pcps_acquisition_test.cc
@@ -355,7 +355,6 @@ TEST_F(GpsL2MPcpsAcquisitionTest, ValidationOfResults)
 
     ASSERT_NO_THROW({
         acquisition->set_local_code();
-        acquisition->init();
         acquisition->reset();
     }) << "Failure set_state and init acquisition test";
 

--- a/tests/unit-tests/signal-processing-blocks/observables/hybrid_observables_test.cc
+++ b/tests/unit-tests/signal-processing-blocks/observables/hybrid_observables_test.cc
@@ -547,7 +547,6 @@ bool HybridObservablesTest::acquire_signal()
 #else
     acquisition->set_threshold(config->property("Acquisition.threshold", absl::GetFlag(FLAGS_external_signal_acquisition_threshold)));
 #endif
-    acquisition->init();
     acquisition->set_local_code();
     acquisition->reset();
     acquisition->connect(top_block_acq);
@@ -692,7 +691,6 @@ bool HybridObservablesTest::acquire_signal()
         {
             tmp_gnss_synchro.PRN = PRN;
             acquisition->set_gnss_synchro(&tmp_gnss_synchro);
-            acquisition->init();
             acquisition->set_local_code();
             acquisition->reset();
             msg_rx->rx_message = 0;

--- a/tests/unit-tests/signal-processing-blocks/observables/hybrid_observables_test_fpga.cc
+++ b/tests/unit-tests/signal-processing-blocks/observables/hybrid_observables_test_fpga.cc
@@ -755,7 +755,6 @@ bool HybridObservablesTestFpga::acquire_signal()
             channel_fsm_->Event_clear_test_result();
 
             acquisition->stop_acquisition();  // reset the whole system including the sample counters
-            acquisition->init();
             acquisition->set_local_code();
 
             if ((implementation == "GPS_L1_CA_DLL_PLL_Tracking_FPGA") or (implementation == "Galileo_E1_DLL_PLL_VEML_Tracking_FPGA"))

--- a/tests/unit-tests/signal-processing-blocks/tracking/tracking_pull-in_test.cc
+++ b/tests/unit-tests/signal-processing-blocks/tracking/tracking_pull-in_test.cc
@@ -540,7 +540,6 @@ bool TrackingPullInTest::acquire_signal(int SV_ID)
 #else
     acquisition->set_threshold(config->property("Acquisition.threshold", absl::GetFlag(FLAGS_external_signal_acquisition_threshold)));
 #endif
-    acquisition->init();
     acquisition->set_local_code();
     acquisition->reset();
     acquisition->connect(top_block_acq);
@@ -688,7 +687,6 @@ bool TrackingPullInTest::acquire_signal(int SV_ID)
         {
             tmp_gnss_synchro.PRN = PRN;
             acquisition->set_gnss_synchro(&tmp_gnss_synchro);
-            acquisition->init();
             acquisition->set_local_code();
             acquisition->reset();
             msg_rx->rx_message = 0;

--- a/tests/unit-tests/signal-processing-blocks/tracking/tracking_pull-in_test_fpga.cc
+++ b/tests/unit-tests/signal-processing-blocks/tracking/tracking_pull-in_test_fpga.cc
@@ -755,7 +755,6 @@ bool TrackingPullInTestFpga::acquire_signal(int SV_ID)
             channel_fsm_->Event_clear_test_result();
 
             acquisition->stop_acquisition();  // reset the whole system including the sample counters
-            acquisition->init();
             acquisition->set_local_code();
 
             if ((implementation == "GPS_L1_CA_DLL_PLL_Tracking_FPGA") or (implementation == "Galileo_E1_DLL_PLL_VEML_Tracking_FPGA"))

--- a/utils/front-end-cal/main.cc
+++ b/utils/front-end-cal/main.cc
@@ -531,7 +531,6 @@ int main(int argc, char** argv)
                 {
                     gnss_synchro.PRN = PRN;
                     acquisition->set_gnss_synchro(&gnss_synchro);
-                    acquisition->init();
                     acquisition->set_local_code();
                     acquisition->reset();
                     stop = false;


### PR DESCRIPTION
The `init` function is called in the `Channel` constructor right after the construction of the acquisition classes, and now that the doppler member variables are set at the acquisition construction and are `const`, there is no longer the risk that they get changed before `init` is call, which means we can move the work done in `init` to the acquisition classes constructors.