### PR TITLE
Remove set_threshold from acquisition

### DIFF
--- a/src/algorithms/acquisition/adapters/base_pcps_acquisition.cc
+++ b/src/algorithms/acquisition/adapters/base_pcps_acquisition.cc
@@ -110,12 +110,6 @@ void BasePcpsAcquisition::stop_acquisition()
 }
 
 
-void BasePcpsAcquisition::set_threshold(float threshold)
-{
-    acquisition_->set_threshold(threshold);
-}
-
-
 void BasePcpsAcquisition::set_doppler_center(int doppler_center)
 {
     acquisition_->set_doppler_center(doppler_center);

--- a/src/algorithms/acquisition/adapters/base_pcps_acquisition.h
+++ b/src/algorithms/acquisition/adapters/base_pcps_acquisition.h
@@ -94,15 +94,9 @@ public:
     }
 
     /*!
-     * \brief Set statistics threshold of PCPS algorithm
-     */
-    void set_threshold(float threshold) override;
-
-    /*!
      * \brief Set Doppler center for the grid search
      */
     void set_doppler_center(int doppler_center) override;
-
 
     /*!
      * \brief Returns the maximum peak of grid search

--- a/src/algorithms/acquisition/adapters/base_pcps_acquisition_custom.cc
+++ b/src/algorithms/acquisition/adapters/base_pcps_acquisition_custom.cc
@@ -36,9 +36,11 @@ Acq_Conf get_acq_conf(
     const ConfigurationInterface* configuration,
     const std::string& role,
     double chip_rate,
+    double code_length_chips,
     double opt_freq,
     uint32_t ms_per_code,
-    uint32_t max_sampled_ms)
+    uint32_t max_sampled_ms,
+    const ThresholdComputeInterface& threshold_compute)
 {
     Acq_Conf acq_parameters;
     acq_parameters.ms_per_code = ms_per_code;
@@ -73,10 +75,71 @@ Acq_Conf get_acq_conf(
             std::cout << "Too high coherent integration time. Changing to " << max_sampled_ms << "ms\n";
         }
 
+    acq_parameters.num_codes = acq_parameters.sampled_ms / ms_per_code;
+    acq_parameters.code_length = static_cast<unsigned int>(round(acq_parameters.fs_in / (chip_rate / code_length_chips)));
+    acq_parameters.vector_length = acq_parameters.code_length * acq_parameters.num_codes;
+    acq_parameters.threshold = threshold_compute.calculate_threshold(acq_parameters);
+
     return acq_parameters;
 }
 }  // namespace
 
+
+float ThresholdComputeBasic::calculate_threshold(const Acq_Conf& acq_parameters) const
+{
+    return acq_parameters.threshold;
+}
+
+float ThresholdComputeDoppler::calculate_threshold(const Acq_Conf& acq_parameters) const
+{
+    if (acq_parameters.pfa != 0)
+        {
+            // Calculate the threshold
+            unsigned int frequency_bins = 0;
+            for (int doppler = -acq_parameters.doppler_max; doppler <= acq_parameters.doppler_max; doppler += acq_parameters.doppler_step)
+                {
+                    frequency_bins++;
+                }
+
+            const auto ncells = acq_parameters.vector_length * frequency_bins;
+            const auto exponent = 1 / static_cast<double>(ncells);
+            const auto val = pow(1.0 - acq_parameters.pfa, exponent);
+            const auto lambda = static_cast<double>(acq_parameters.vector_length);
+            boost::math::exponential_distribution<double> mydist(lambda);
+            const auto threshold = static_cast<float>(quantile(mydist, val));
+
+            return threshold;
+        }
+
+    return acq_parameters.threshold;
+}
+
+ThresholdComputeQuickSync::ThresholdComputeQuickSync(uint32_t folding_factor) : folding_factor_(folding_factor)
+{
+}
+
+float ThresholdComputeQuickSync::calculate_threshold(const Acq_Conf& acq_parameters) const
+{
+    if (acq_parameters.pfa != 0)
+        {
+            // Calculate the threshold
+            unsigned int frequency_bins = 0;
+            for (int doppler = -acq_parameters.doppler_max; doppler <= acq_parameters.doppler_max; doppler += static_cast<int>(acq_parameters.doppler_step))
+                {
+                    frequency_bins++;
+                }
+
+            const auto ncells = (acq_parameters.code_length / folding_factor_) * frequency_bins;
+            const auto exponent = 1.0 / static_cast<double>(ncells);
+            const auto val = pow(1.0 - acq_parameters.pfa, exponent);
+            const auto lambda = static_cast<double>(acq_parameters.code_length) / static_cast<double>(folding_factor_);
+            boost::math::exponential_distribution<double> mydist(lambda);
+            const auto threshold = static_cast<float>(quantile(mydist, val));
+            return threshold;
+        }
+
+    return acq_parameters.threshold;
+}
 
 BasePcpsAcquisitionCustom::BasePcpsAcquisitionCustom(
     const ConfigurationInterface* configuration,
@@ -87,20 +150,16 @@ BasePcpsAcquisitionCustom::BasePcpsAcquisitionCustom(
     double code_length_chips,
     unsigned int ms_per_code,
     bool use_stream_to_vector,
-    bool compute_threshold_from_pfa,
+    const ThresholdComputeInterface& threshold_compute,
     uint32_t max_sampled_ms)
-    : acq_parameters_(get_acq_conf(configuration, role, chip_rate, 0, ms_per_code, max_sampled_ms)),
-      num_codes_(acq_parameters_.sampled_ms / ms_per_code),
-      code_length_(static_cast<unsigned int>(round(acq_parameters_.fs_in / (chip_rate / code_length_chips)))),
-      vector_length_(code_length_ * num_codes_),
+    : acq_parameters_(get_acq_conf(configuration, role, chip_rate, code_length_chips, 0, ms_per_code, max_sampled_ms, threshold_compute)),
       gnss_synchro_(nullptr),
       channel_(0),
-      code_(vector_length_),
+      code_(acq_parameters_.vector_length),
       role_(role),
       is_type_gr_complex_(acq_parameters_.item_type == "gr_complex"),
       item_size_(is_type_gr_complex_ ? sizeof(gr_complex) : 0),
-      use_stream_to_vector_(use_stream_to_vector),
-      compute_threshold_from_pfa_(compute_threshold_from_pfa)
+      use_stream_to_vector_(use_stream_to_vector)
 {
     DLOG(INFO) << "role " << role_;
 
@@ -108,7 +167,7 @@ BasePcpsAcquisitionCustom::BasePcpsAcquisitionCustom(
         {
             if (use_stream_to_vector_)
                 {
-                    stream_to_vector_ = gr::blocks::stream_to_vector::make(item_size_, vector_length_);
+                    stream_to_vector_ = gr::blocks::stream_to_vector::make(item_size_, acq_parameters_.vector_length);
                     DLOG(INFO) << "stream_to_vector(" << stream_to_vector_->unique_id() << ")";
                 }
         }
@@ -220,56 +279,20 @@ void BasePcpsAcquisitionCustom::stop_acquisition()
 }
 
 
-void BasePcpsAcquisitionCustom::set_threshold(float threshold)
-{
-    if (is_type_gr_complex_)
-        {
-            if (compute_threshold_from_pfa_ && acq_parameters_.pfa != 0)
-                {
-                    threshold = calculate_threshold(acq_parameters_.pfa);
-                    DLOG(INFO) << "Channel " << channel_ << " Threshold = " << threshold;
-                }
-
-            acquisition_cc_->set_threshold(threshold);
-        }
-}
-
-
 void BasePcpsAcquisitionCustom::set_local_code()
 {
     if (is_type_gr_complex())
         {
-            std::vector<std::complex<float>> code(code_length_);
+            const auto code_length = acq_parameters_.code_length;
+            std::vector<std::complex<float>> code(code_length);
             code_gen_complex_sampled(code, gnss_synchro_->PRN, acq_parameters_.fs_in);
 
-            own::span<gr_complex> code_span(code_.data(), vector_length_);
-            for (unsigned int i = 0; i < num_codes_; i++)
+            own::span<gr_complex> code_span(code_.data(), acq_parameters_.vector_length);
+            for (unsigned int i = 0; i < acq_parameters_.num_codes; i++)
                 {
-                    std::copy_n(code.data(), code_length_, code_span.subspan(i * code_length_, code_length_).data());
+                    std::copy_n(code.data(), code_length, code_span.subspan(i * code_length, code_length).data());
                 }
 
             acquisition_cc_->set_local_code(code_.data());
         }
-}
-
-
-float BasePcpsAcquisitionCustom::calculate_threshold(float pfa) const
-{
-    // Calculate the threshold
-    unsigned int frequency_bins = 0;
-    for (int doppler = -acq_parameters_.doppler_max; doppler <= acq_parameters_.doppler_max; doppler += acq_parameters_.doppler_step)
-        {
-            frequency_bins++;
-        }
-
-    DLOG(INFO) << "Channel " << channel_ << "  Pfa = " << pfa;
-
-    const auto ncells = vector_length_ * frequency_bins;
-    const auto exponent = 1 / static_cast<double>(ncells);
-    const auto val = pow(1.0 - pfa, exponent);
-    const auto lambda = static_cast<double>(vector_length_);
-    boost::math::exponential_distribution<double> mydist(lambda);
-    const auto threshold = static_cast<float>(quantile(mydist, val));
-
-    return threshold;
 }

--- a/src/algorithms/acquisition/adapters/base_pcps_acquisition_custom.h
+++ b/src/algorithms/acquisition/adapters/base_pcps_acquisition_custom.h
@@ -37,6 +37,35 @@
 
 class ConfigurationInterface;
 
+class ThresholdComputeInterface
+{
+public:
+    virtual float calculate_threshold(const Acq_Conf& acq_parameters) const = 0;
+};
+
+class ThresholdComputeBasic : public ThresholdComputeInterface
+{
+public:
+    float calculate_threshold(const Acq_Conf& acq_parameters) const override;
+};
+
+class ThresholdComputeDoppler : public ThresholdComputeInterface
+{
+public:
+    float calculate_threshold(const Acq_Conf& acq_parameters) const override;
+};
+
+class ThresholdComputeQuickSync : public ThresholdComputeInterface
+{
+public:
+    explicit ThresholdComputeQuickSync(uint32_t folding_factor);
+
+    float calculate_threshold(const Acq_Conf& acq_parameters) const override;
+
+private:
+    const uint32_t folding_factor_;
+};
+
 /*!
  * \brief This class adapts a PCPS acquisition block to an AcquisitionInterface
  */
@@ -51,7 +80,7 @@ public:
         double code_length_chips,
         unsigned int ms_per_code,
         bool use_stream_to_vector,
-        bool compute_threshold_from_pfa,
+        const ThresholdComputeInterface& threshold_compute,
         uint32_t max_sampled_ms = std::numeric_limits<uint32_t>::max());
 
     ~BasePcpsAcquisitionCustom() = default;
@@ -97,11 +126,6 @@ public:
      */
     void stop_acquisition() override;
 
-    /*!
-     * \brief Set statistics threshold of PCPS algorithm
-     */
-    void set_threshold(float threshold) override;
-
     void set_resampler_latency(uint32_t /*latency_samples*/) override {};
 
     /*!
@@ -114,17 +138,12 @@ protected:
     bool is_type_gr_complex() const { return is_type_gr_complex_; }
 
     const Acq_Conf acq_parameters_;
-    const unsigned int num_codes_;
-    const unsigned int code_length_;
-    const unsigned int vector_length_;
     acquisition_impl_interface_sptr acquisition_cc_;
     Gnss_Synchro* gnss_synchro_;
     unsigned int channel_;
     volk_gnsssdr::vector<std::complex<float>> code_;
 
 private:
-    virtual float calculate_threshold(float pfa) const;
-
     /*!
      * \brief Generate code
      */
@@ -135,7 +154,6 @@ private:
     const bool is_type_gr_complex_;
     const size_t item_size_;
     const bool use_stream_to_vector_;
-    const bool compute_threshold_from_pfa_;
 };
 
 

--- a/src/algorithms/acquisition/adapters/base_pcps_acquisition_fpga.cc
+++ b/src/algorithms/acquisition/adapters/base_pcps_acquisition_fpga.cc
@@ -157,15 +157,6 @@ void BasePcpsAcquisitionFpga::set_channel_fsm(std::weak_ptr<ChannelFsm> channel_
 }
 
 
-void BasePcpsAcquisitionFpga::set_threshold(float threshold)
-{
-    if (acquisition_fpga_)
-        {
-            acquisition_fpga_->set_threshold(threshold);
-        }
-}
-
-
 void BasePcpsAcquisitionFpga::set_doppler_center(int doppler_center)
 {
     if (acquisition_fpga_)

--- a/src/algorithms/acquisition/adapters/base_pcps_acquisition_fpga.h
+++ b/src/algorithms/acquisition/adapters/base_pcps_acquisition_fpga.h
@@ -70,7 +70,6 @@ public:
     void set_gnss_synchro(Gnss_Synchro* p_gnss_synchro) override;
     void set_channel(unsigned int channel) override;
     void set_channel_fsm(std::weak_ptr<ChannelFsm> channel_fsm) override;
-    void set_threshold(float threshold) override;
     void set_doppler_center(int doppler_center) override;
     void reset() override;
     void stop_acquisition() override;

--- a/src/algorithms/acquisition/adapters/galileo_e1_pcps_8ms_ambiguous_acquisition.cc
+++ b/src/algorithms/acquisition/adapters/galileo_e1_pcps_8ms_ambiguous_acquisition.cc
@@ -42,7 +42,7 @@ GalileoE1Pcps8msAmbiguousAcquisition::GalileoE1Pcps8msAmbiguousAcquisition(
           GALILEO_E1_B_CODE_LENGTH_CHIPS,
           GALILEO_E1_CODE_PERIOD_MS,
           true,
-          true),
+          ThresholdComputeDoppler()),
       cboc_(configuration->property(role + ".cboc", false))
 {
     if (is_type_gr_complex())

--- a/src/algorithms/acquisition/adapters/galileo_e1_pcps_cccwsr_ambiguous_acquisition.cc
+++ b/src/algorithms/acquisition/adapters/galileo_e1_pcps_cccwsr_ambiguous_acquisition.cc
@@ -42,8 +42,8 @@ GalileoE1PcpsCccwsrAmbiguousAcquisition::GalileoE1PcpsCccwsrAmbiguousAcquisition
           GALILEO_E1_B_CODE_LENGTH_CHIPS,
           GALILEO_E1_CODE_PERIOD_MS,
           true,
-          false),
-      code_pilot_(vector_length_),
+          ThresholdComputeBasic()),
+      code_pilot_(acq_parameters_.vector_length),
       cboc_(configuration->property(role + ".cboc", false))
 {
     if (is_type_gr_complex())

--- a/src/algorithms/acquisition/adapters/galileo_e1_pcps_quicksync_ambiguous_acquisition.cc
+++ b/src/algorithms/acquisition/adapters/galileo_e1_pcps_quicksync_ambiguous_acquisition.cc
@@ -43,11 +43,23 @@ uint32_t get_folding_factor(const ConfigurationInterface* configuration, const s
 }
 }  // namespace
 
+
 GalileoE1PcpsQuickSyncAmbiguousAcquisition::GalileoE1PcpsQuickSyncAmbiguousAcquisition(
     const ConfigurationInterface* configuration,
     const std::string& role,
     unsigned int in_streams,
     unsigned int out_streams)
+    : GalileoE1PcpsQuickSyncAmbiguousAcquisition(configuration, role, in_streams, out_streams, get_folding_factor(configuration, role))
+{
+}
+
+
+GalileoE1PcpsQuickSyncAmbiguousAcquisition::GalileoE1PcpsQuickSyncAmbiguousAcquisition(
+    const ConfigurationInterface* configuration,
+    const std::string& role,
+    unsigned int in_streams,
+    unsigned int out_streams,
+    uint32_t folding_factor)
     : BasePcpsAcquisitionCustom(
           configuration,
           role,
@@ -55,19 +67,16 @@ GalileoE1PcpsQuickSyncAmbiguousAcquisition::GalileoE1PcpsQuickSyncAmbiguousAcqui
           out_streams,
           GALILEO_E1_CODE_CHIP_RATE_CPS,
           GALILEO_E1_B_CODE_LENGTH_CHIPS,
-          GALILEO_E1_CODE_PERIOD_MS * get_folding_factor(configuration, role),
+          GALILEO_E1_CODE_PERIOD_MS * folding_factor,
           true,
-          true),
-      folding_factor_(get_folding_factor(configuration, role)),
+          ThresholdComputeQuickSync(folding_factor)),
       cboc_(configuration->property(role + ".cboc", false))
 {
     if (is_type_gr_complex())
         {
             // const auto samples_per_ms = static_cast<int>(round(code_length_ / acq_parameters_.sampled_ms));
             const unsigned int max_dwells = acq_parameters_.bit_transition_flag ? 2 : acq_parameters_.max_dwells;
-
-            acquisition_cc_ = pcps_quicksync_make_acquisition_cc(acq_parameters_, folding_factor_, vector_length_, max_dwells, code_length_);
-
+            acquisition_cc_ = pcps_quicksync_make_acquisition_cc(acq_parameters_, folding_factor, max_dwells);
             DLOG(INFO) << "acquisition_quicksync(" << acquisition_cc_->unique_id() << ")";
         }
 }
@@ -81,25 +90,4 @@ void GalileoE1PcpsQuickSyncAmbiguousAcquisition::code_gen_complex_sampled(own::s
     Signal_[2] = '\0';
 
     galileo_e1_code_gen_complex_sampled(dest, Signal_, cboc_, prn, sampling_freq, 0, false);
-}
-
-
-float GalileoE1PcpsQuickSyncAmbiguousAcquisition::calculate_threshold(float pfa) const
-{
-    unsigned int frequency_bins = 0;
-    for (int doppler = -acq_parameters_.doppler_max; doppler <= acq_parameters_.doppler_max; doppler += acq_parameters_.doppler_step)
-        {
-            frequency_bins++;
-        }
-
-    DLOG(INFO) << "Channel " << channel_ << "  Pfa = " << pfa;
-
-    unsigned int ncells = code_length_ / folding_factor_ * frequency_bins;
-    double exponent = 1.0 / static_cast<double>(ncells);
-    double val = pow(1.0 - pfa, exponent);
-    double lambda = static_cast<double>(code_length_) / static_cast<double>(folding_factor_);
-    boost::math::exponential_distribution<double> mydist(lambda);
-    auto threshold = static_cast<float>(quantile(mydist, val));
-
-    return threshold;
 }

--- a/src/algorithms/acquisition/adapters/galileo_e1_pcps_quicksync_ambiguous_acquisition.h
+++ b/src/algorithms/acquisition/adapters/galileo_e1_pcps_quicksync_ambiguous_acquisition.h
@@ -49,10 +49,15 @@ public:
     }
 
 private:
-    float calculate_threshold(float pfa) const override;
+    GalileoE1PcpsQuickSyncAmbiguousAcquisition(
+        const ConfigurationInterface* configuration,
+        const std::string& role,
+        unsigned int in_streams,
+        unsigned int out_streams,
+        uint32_t folding_factor);
+
     void code_gen_complex_sampled(own::span<std::complex<float>> dest, uint32_t prn, int32_t sampling_freq) override;
 
-    const unsigned int folding_factor_;
     const bool cboc_;
 };
 

--- a/src/algorithms/acquisition/adapters/galileo_e1_pcps_tong_ambiguous_acquisition.cc
+++ b/src/algorithms/acquisition/adapters/galileo_e1_pcps_tong_ambiguous_acquisition.cc
@@ -42,7 +42,7 @@ GalileoE1PcpsTongAmbiguousAcquisition::GalileoE1PcpsTongAmbiguousAcquisition(
           GALILEO_E1_B_CODE_LENGTH_CHIPS,
           GALILEO_E1_CODE_PERIOD_MS,
           true,
-          true),
+          ThresholdComputeDoppler()),
       cboc_(configuration->property(role + ".cboc", false))
 {
     if (is_type_gr_complex())

--- a/src/algorithms/acquisition/adapters/galileo_e5a_noncoherent_iq_acquisition_caf.cc
+++ b/src/algorithms/acquisition/adapters/galileo_e5a_noncoherent_iq_acquisition_caf.cc
@@ -79,11 +79,11 @@ GalileoE5aNoncoherentIQAcquisitionCaf::GalileoE5aNoncoherentIQAcquisitionCaf(
           GALILEO_E5A_CODE_LENGTH_CHIPS,
           GALILEO_E5A_CODE_PERIOD_MS,
           false,
-          true,
+          ThresholdComputeDoppler(),
           get_max_sampled_ms(configuration, role)),
       zero_padding_(get_zero_padding(configuration, role)),
       caf_window_hz_(configuration->property(role + ".CAF_window_hz", 0)),
-      codeQ_(vector_length_)
+      codeQ_(acq_parameters_.vector_length)
 {
     if (is_type_gr_complex())
         {
@@ -100,9 +100,12 @@ void GalileoE5aNoncoherentIQAcquisitionCaf::set_local_code()
 {
     if (is_type_gr_complex())
         {
+            const auto code_length = acq_parameters_.code_length;
+            const auto vector_length = acq_parameters_.vector_length;
+
             auto& codeI_ = code_;
-            std::vector<std::complex<float>> codeI(code_length_);
-            std::vector<std::complex<float>> codeQ(code_length_);
+            std::vector<std::complex<float>> codeI(code_length);
+            std::vector<std::complex<float>> codeQ(code_length);
 
             if (gnss_synchro_->Signal[0] == '5' && gnss_synchro_->Signal[1] == 'X')
                 {
@@ -119,26 +122,26 @@ void GalileoE5aNoncoherentIQAcquisitionCaf::set_local_code()
                 }
             // WARNING: 3ms are coherently integrated. Secondary sequence (1,1,1)
             // is generated, and modulated in the 'block'.
-            own::span<gr_complex> codeI_span(codeI_.data(), vector_length_);
-            own::span<gr_complex> codeQ_span(codeQ_.data(), vector_length_);
+            own::span<gr_complex> codeI_span(codeI_.data(), vector_length);
+            own::span<gr_complex> codeQ_span(codeQ_.data(), vector_length);
             if (zero_padding_ == 0)  // if no zero_padding
                 {
                     for (unsigned int i = 0; i < acq_parameters_.sampled_ms; i++)
                         {
-                            std::copy_n(codeI.data(), code_length_, codeI_span.subspan(i * code_length_, code_length_).data());
+                            std::copy_n(codeI.data(), code_length, codeI_span.subspan(i * code_length, code_length).data());
                             if (gnss_synchro_->Signal[0] == '5' && gnss_synchro_->Signal[1] == 'X')
                                 {
-                                    std::copy_n(codeQ.data(), code_length_, codeQ_span.subspan(i * code_length_, code_length_).data());
+                                    std::copy_n(codeQ.data(), code_length, codeQ_span.subspan(i * code_length, code_length).data());
                                 }
                         }
                 }
             else
                 {
                     // 1ms code + 1ms zero padding
-                    std::copy_n(codeI.data(), code_length_, codeI_.data());
+                    std::copy_n(codeI.data(), code_length, codeI_.data());
                     if (gnss_synchro_->Signal[0] == '5' && gnss_synchro_->Signal[1] == 'X')
                         {
-                            std::copy_n(codeQ.data(), code_length_, codeQ_.data());
+                            std::copy_n(codeQ.data(), code_length, codeQ_.data());
                         }
                 }
 

--- a/src/algorithms/acquisition/adapters/gps_l1_ca_pcps_acquisition_fine_doppler.cc
+++ b/src/algorithms/acquisition/adapters/gps_l1_ca_pcps_acquisition_fine_doppler.cc
@@ -44,15 +44,13 @@ GpsL1CaPcpsAcquisitionFineDoppler::GpsL1CaPcpsAcquisitionFineDoppler(
           GPS_L1_CA_CODE_LENGTH_CHIPS,
           GPS_L1_CA_CODE_PERIOD_MS,
           false,
-          false)
+          ThresholdComputeBasic())
 {
     if (is_type_gr_complex())
         {
             Acq_Conf acq_parameters = acq_parameters_;
-            acq_parameters.samples_per_ms = static_cast<float>(vector_length_);
-
+            acq_parameters.samples_per_ms = static_cast<float>(acq_parameters.vector_length);
             acquisition_cc_ = pcps_make_acquisition_fine_doppler_cc(acq_parameters);
-
             DLOG(INFO) << "acquisition(" << acquisition_cc_->unique_id() << ")";
         }
 }

--- a/src/algorithms/acquisition/adapters/gps_l1_ca_pcps_assisted_acquisition.cc
+++ b/src/algorithms/acquisition/adapters/gps_l1_ca_pcps_assisted_acquisition.cc
@@ -43,7 +43,7 @@ GpsL1CaPcpsAssistedAcquisition::GpsL1CaPcpsAssistedAcquisition(
           GPS_L1_CA_CODE_LENGTH_CHIPS,
           GPS_L1_CA_CODE_PERIOD_MS,
           false,
-          false)
+          ThresholdComputeBasic())
 {
     if (is_type_gr_complex())
         {

--- a/src/algorithms/acquisition/adapters/gps_l1_ca_pcps_opencl_acquisition.cc
+++ b/src/algorithms/acquisition/adapters/gps_l1_ca_pcps_opencl_acquisition.cc
@@ -45,17 +45,15 @@ GpsL1CaPcpsOpenClAcquisition::GpsL1CaPcpsOpenClAcquisition(
           GPS_L1_CA_CODE_LENGTH_CHIPS,
           GPS_L1_CA_CODE_PERIOD_MS,
           true,
-          true),
+          ThresholdComputeDoppler()),
       opencl_ready_(false)
 {
     if (is_type_gr_complex())
         {
             const unsigned int max_dwells = acq_parameters_.bit_transition_flag ? 2 : acq_parameters_.max_dwells;
             auto acquisition_cc = pcps_make_opencl_acquisition_cc(acq_parameters_, max_dwells);
-
             opencl_ready_ = acquisition_cc->opencl_ready();
             acquisition_cc_ = std::move(acquisition_cc);
-
             DLOG(INFO) << "acquisition(" << acquisition_cc_->unique_id() << ")";
         }
 }

--- a/src/algorithms/acquisition/adapters/gps_l1_ca_pcps_quicksync_acquisition.cc
+++ b/src/algorithms/acquisition/adapters/gps_l1_ca_pcps_quicksync_acquisition.cc
@@ -41,11 +41,23 @@ uint32_t get_folding_factor(const ConfigurationInterface* configuration, const s
 }
 }  // namespace
 
+
 GpsL1CaPcpsQuickSyncAcquisition::GpsL1CaPcpsQuickSyncAcquisition(
     const ConfigurationInterface* configuration,
     const std::string& role,
     unsigned int in_streams,
     unsigned int out_streams)
+    : GpsL1CaPcpsQuickSyncAcquisition(configuration, role, in_streams, out_streams, get_folding_factor(configuration, role))
+{
+}
+
+
+GpsL1CaPcpsQuickSyncAcquisition::GpsL1CaPcpsQuickSyncAcquisition(
+    const ConfigurationInterface* configuration,
+    const std::string& role,
+    unsigned int in_streams,
+    unsigned int out_streams,
+    uint32_t folding_factor)
     : BasePcpsAcquisitionCustom(
           configuration,
           role,
@@ -53,18 +65,15 @@ GpsL1CaPcpsQuickSyncAcquisition::GpsL1CaPcpsQuickSyncAcquisition(
           out_streams,
           GPS_L1_CA_CODE_RATE_CPS,
           GPS_L1_CA_CODE_LENGTH_CHIPS,
-          GPS_L1_CA_CODE_PERIOD_MS * get_folding_factor(configuration, role),
+          GPS_L1_CA_CODE_PERIOD_MS * folding_factor,
           true,
-          true),
-      folding_factor_(get_folding_factor(configuration, role))
+          ThresholdComputeQuickSync(folding_factor))
 {
     if (is_type_gr_complex())
         {
             // const int samples_per_ms = round(code_length_ / acq_parameters_.sampled_ms);
             const unsigned int max_dwells = acq_parameters_.bit_transition_flag ? 2 : acq_parameters_.max_dwells;
-
-            acquisition_cc_ = pcps_quicksync_make_acquisition_cc(acq_parameters_, folding_factor_, vector_length_, max_dwells, code_length_);
-
+            acquisition_cc_ = pcps_quicksync_make_acquisition_cc(acq_parameters_, folding_factor, max_dwells);
             DLOG(INFO) << "acquisition(" << acquisition_cc_->unique_id() << ")";
         }
 }
@@ -73,24 +82,4 @@ GpsL1CaPcpsQuickSyncAcquisition::GpsL1CaPcpsQuickSyncAcquisition(
 void GpsL1CaPcpsQuickSyncAcquisition::code_gen_complex_sampled(own::span<std::complex<float>> dest, uint32_t prn, int32_t sampling_freq)
 {
     gps_l1_ca_code_gen_complex_sampled(dest, prn, sampling_freq, 0);
-}
-
-
-float GpsL1CaPcpsQuickSyncAcquisition::calculate_threshold(float pfa) const
-{
-    // Calculate the threshold
-    unsigned int frequency_bins = 0;
-    for (int doppler = -acq_parameters_.doppler_max; doppler <= acq_parameters_.doppler_max; doppler += static_cast<int>(acq_parameters_.doppler_step))
-        {
-            frequency_bins++;
-        }
-    DLOG(INFO) << "Channel " << channel_ << "  Pfa = " << pfa;
-    unsigned int ncells = (code_length_ / folding_factor_) * frequency_bins;
-    double exponent = 1.0 / static_cast<double>(ncells);
-    double val = pow(1.0 - pfa, exponent);
-    double lambda = static_cast<double>(code_length_) / static_cast<double>(folding_factor_);
-    boost::math::exponential_distribution<double> mydist(lambda);
-    auto threshold = static_cast<float>(quantile(mydist, val));
-
-    return threshold;
 }

--- a/src/algorithms/acquisition/adapters/gps_l1_ca_pcps_quicksync_acquisition.h
+++ b/src/algorithms/acquisition/adapters/gps_l1_ca_pcps_quicksync_acquisition.h
@@ -50,10 +50,14 @@ public:
     }
 
 private:
-    float calculate_threshold(float pfa) const override;
-    void code_gen_complex_sampled(own::span<std::complex<float>> dest, uint32_t prn, int32_t sampling_freq) override;
+    GpsL1CaPcpsQuickSyncAcquisition(
+        const ConfigurationInterface* configuration,
+        const std::string& role,
+        unsigned int in_streams,
+        unsigned int out_streams,
+        uint32_t folding_factor);
 
-    const unsigned int folding_factor_;
+    void code_gen_complex_sampled(own::span<std::complex<float>> dest, uint32_t prn, int32_t sampling_freq) override;
 };
 
 

--- a/src/algorithms/acquisition/adapters/gps_l1_ca_pcps_tong_acquisition.cc
+++ b/src/algorithms/acquisition/adapters/gps_l1_ca_pcps_tong_acquisition.cc
@@ -42,16 +42,14 @@ GpsL1CaPcpsTongAcquisition::GpsL1CaPcpsTongAcquisition(
           GPS_L1_CA_CODE_LENGTH_CHIPS,
           GPS_L1_CA_CODE_PERIOD_MS,
           true,
-          true)
+          ThresholdComputeDoppler())
 {
     if (is_type_gr_complex())
         {
             const auto tong_init_val = configuration->property(role + ".tong_init_val", 1U);
             const auto tong_max_val = configuration->property(role + ".tong_max_val", 2U);
             const auto tong_max_dwells = configuration->property(role + ".tong_max_dwells", tong_max_val + 1U);
-
             acquisition_cc_ = pcps_tong_make_acquisition_cc(acq_parameters_, tong_init_val, tong_max_val, tong_max_dwells);
-
             DLOG(INFO) << "acquisition(" << acquisition_cc_->unique_id() << ")";
         }
 }

--- a/src/algorithms/acquisition/gnuradio_blocks/acquisition_impl_interface.h
+++ b/src/algorithms/acquisition/gnuradio_blocks/acquisition_impl_interface.h
@@ -57,7 +57,6 @@ public:
     virtual void set_gnss_synchro(Gnss_Synchro* gnss_synchro) = 0;
     virtual void set_channel(uint32_t channel_id) = 0;
     virtual void set_channel_fsm(std::weak_ptr<ChannelFsm> channel_fsm) = 0;
-    virtual void set_threshold(float threshold) = 0;
     virtual void set_local_code(std::complex<float>* /*code*/) {};
     virtual void set_local_code(std::complex<float>* /*code_data*/, std::complex<float>* /*code_pilot*/) {};
     virtual uint32_t mag() const = 0;

--- a/src/algorithms/acquisition/gnuradio_blocks/galileo_e5a_noncoherent_iq_acquisition_caf_cc.cc
+++ b/src/algorithms/acquisition/gnuradio_blocks/galileo_e5a_noncoherent_iq_acquisition_caf_cc.cc
@@ -60,7 +60,6 @@ galileo_e5a_noncoherentIQ_acquisition_caf_cc::galileo_e5a_noncoherentIQ_acquisit
       d_acq_params(conf),
       d_gnss_synchro(nullptr),
       d_sample_counter(0ULL),
-      d_threshold(0),
       d_mag(0),
       d_input_power(0.0),
       d_test_statistics(0),
@@ -112,7 +111,6 @@ galileo_e5a_noncoherentIQ_acquisition_caf_cc::galileo_e5a_noncoherentIQ_acquisit
         }
 
     // Count the number of bins
-    d_num_doppler_bins = 0;
     for (int doppler = -d_acq_params.doppler_max; doppler <= d_acq_params.doppler_max; doppler += d_acq_params.doppler_step)
         {
             d_num_doppler_bins++;
@@ -326,8 +324,9 @@ int galileo_e5a_noncoherentIQ_acquisition_caf_cc::general_work(int noutput_items
 
                 DLOG(INFO) << "Channel: " << d_channel
                            << " , doing acquisition of satellite: " << d_gnss_synchro->System << " " << d_gnss_synchro->PRN
-                           << " ,sample stamp: " << d_sample_counter << ", threshold: "
-                           << d_threshold << ", doppler_max: " << d_acq_params.doppler_max
+                           << " , sample stamp: " << d_sample_counter
+                           << ", threshold: " << d_acq_params.threshold
+                           << ", doppler_max: " << d_acq_params.doppler_max
                            << ", doppler_step: " << d_acq_params.doppler_step;
 
                 // 1- Compute the input signal power estimation
@@ -634,7 +633,7 @@ int galileo_e5a_noncoherentIQ_acquisition_caf_cc::general_work(int noutput_items
 
                 if (d_well_count == d_acq_params.max_dwells)
                     {
-                        if (d_test_statistics > d_threshold)
+                        if (d_test_statistics > d_acq_params.threshold)
                             {
                                 d_state = 3;  // Positive acquisition
                             }
@@ -659,7 +658,7 @@ int galileo_e5a_noncoherentIQ_acquisition_caf_cc::general_work(int noutput_items
                 DLOG(INFO) << "satellite " << d_gnss_synchro->System << " " << d_gnss_synchro->PRN;
                 DLOG(INFO) << "sample_stamp " << d_sample_counter;
                 DLOG(INFO) << "test statistics value " << d_test_statistics;
-                DLOG(INFO) << "test statistics threshold " << d_threshold;
+                DLOG(INFO) << "test statistics threshold " << d_acq_params.threshold;
                 DLOG(INFO) << "code phase " << d_gnss_synchro->Acq_delay_samples;
                 DLOG(INFO) << "doppler " << d_gnss_synchro->Acq_doppler_hz;
                 DLOG(INFO) << "magnitude " << d_mag;
@@ -692,7 +691,7 @@ int galileo_e5a_noncoherentIQ_acquisition_caf_cc::general_work(int noutput_items
                 DLOG(INFO) << "satellite " << d_gnss_synchro->System << " " << d_gnss_synchro->PRN;
                 DLOG(INFO) << "sample_stamp " << d_sample_counter;
                 DLOG(INFO) << "test statistics value " << d_test_statistics;
-                DLOG(INFO) << "test statistics threshold " << d_threshold;
+                DLOG(INFO) << "test statistics threshold " << d_acq_params.threshold;
                 DLOG(INFO) << "code phase " << d_gnss_synchro->Acq_delay_samples;
                 DLOG(INFO) << "doppler " << d_gnss_synchro->Acq_doppler_hz;
                 DLOG(INFO) << "magnitude " << d_mag;

--- a/src/algorithms/acquisition/gnuradio_blocks/galileo_e5a_noncoherent_iq_acquisition_caf_cc.h
+++ b/src/algorithms/acquisition/gnuradio_blocks/galileo_e5a_noncoherent_iq_acquisition_caf_cc.h
@@ -124,16 +124,6 @@ public:
     }
 
     /*!
-     * \brief Set statistics threshold of PCPS algorithm.
-     * \param threshold - Threshold for signal detection (check \ref Navitec2012,
-     * Algorithm 1, for a definition of this threshold).
-     */
-    inline void set_threshold(float threshold) override
-    {
-        d_threshold = threshold;
-    }
-
-    /*!
      * \brief Parallel Code Phase Search Acquisition signal processing.
      */
     int general_work(int noutput_items, gr_vector_int& ninput_items,
@@ -168,7 +158,6 @@ private:
 
     uint64_t d_sample_counter;
 
-    float d_threshold;
     float d_mag;
     float d_input_power;
     float d_test_statistics;

--- a/src/algorithms/acquisition/gnuradio_blocks/galileo_pcps_8ms_acquisition_cc.cc
+++ b/src/algorithms/acquisition/gnuradio_blocks/galileo_pcps_8ms_acquisition_cc.cc
@@ -44,7 +44,6 @@ galileo_pcps_8ms_acquisition_cc::galileo_pcps_8ms_acquisition_cc(const Acq_Conf 
       d_acq_params(conf),
       d_gnss_synchro(nullptr),
       d_sample_counter(0ULL),
-      d_threshold(0),
       d_mag(0),
       d_input_power(0.0),
       d_test_statistics(0),
@@ -181,8 +180,9 @@ int galileo_pcps_8ms_acquisition_cc::general_work(int noutput_items,
 
                 DLOG(INFO) << "Channel: " << d_channel
                            << " , doing acquisition of satellite: " << d_gnss_synchro->System << " " << d_gnss_synchro->PRN
-                           << " ,sample stamp: " << d_sample_counter << ", threshold: "
-                           << d_threshold << ", doppler_max: " << d_acq_params.doppler_max
+                           << " , sample stamp: " << d_sample_counter
+                           << ", threshold: " << d_acq_params.threshold
+                           << ", doppler_max: " << d_acq_params.doppler_max
                            << ", doppler_step: " << d_acq_params.doppler_step;
 
                 // 1- Compute the input signal power estimation
@@ -276,7 +276,7 @@ int galileo_pcps_8ms_acquisition_cc::general_work(int noutput_items,
                 // d_test_statistics = 2 * d_fft_size * d_mag / d_input_power;
                 d_test_statistics = d_mag / d_input_power;
 
-                if (d_test_statistics > d_threshold)
+                if (d_test_statistics > d_acq_params.threshold)
                     {
                         d_state = 2;  // Positive acquisition
                     }
@@ -297,7 +297,7 @@ int galileo_pcps_8ms_acquisition_cc::general_work(int noutput_items,
                 DLOG(INFO) << "satellite " << d_gnss_synchro->System << " " << d_gnss_synchro->PRN;
                 DLOG(INFO) << "sample_stamp " << d_sample_counter;
                 DLOG(INFO) << "test statistics value " << d_test_statistics;
-                DLOG(INFO) << "test statistics threshold " << d_threshold;
+                DLOG(INFO) << "test statistics threshold " << d_acq_params.threshold;
                 DLOG(INFO) << "code phase " << d_gnss_synchro->Acq_delay_samples;
                 DLOG(INFO) << "doppler " << d_gnss_synchro->Acq_doppler_hz;
                 DLOG(INFO) << "magnitude " << d_mag;
@@ -332,7 +332,7 @@ int galileo_pcps_8ms_acquisition_cc::general_work(int noutput_items,
                 DLOG(INFO) << "satellite " << d_gnss_synchro->System << " " << d_gnss_synchro->PRN;
                 DLOG(INFO) << "sample_stamp " << d_sample_counter;
                 DLOG(INFO) << "test statistics value " << d_test_statistics;
-                DLOG(INFO) << "test statistics threshold " << d_threshold;
+                DLOG(INFO) << "test statistics threshold " << d_acq_params.threshold;
                 DLOG(INFO) << "code phase " << d_gnss_synchro->Acq_delay_samples;
                 DLOG(INFO) << "doppler " << d_gnss_synchro->Acq_doppler_hz;
                 DLOG(INFO) << "magnitude " << d_mag;

--- a/src/algorithms/acquisition/gnuradio_blocks/galileo_pcps_8ms_acquisition_cc.h
+++ b/src/algorithms/acquisition/gnuradio_blocks/galileo_pcps_8ms_acquisition_cc.h
@@ -113,16 +113,6 @@ public:
     }
 
     /*!
-     * \brief Set statistics threshold of PCPS algorithm.
-     * \param threshold - Threshold for signal detection (check \ref Navitec2012,
-     * Algorithm 1, for a definition of this threshold).
-     */
-    inline void set_threshold(float threshold) override
-    {
-        d_threshold = threshold;
-    }
-
-    /*!
      * \brief Parallel Code Phase Search Acquisition signal processing.
      */
     int general_work(int noutput_items, gr_vector_int& ninput_items,
@@ -148,7 +138,6 @@ private:
 
     uint64_t d_sample_counter;
 
-    float d_threshold;
     float d_mag;
     float d_input_power;
     float d_test_statistics;

--- a/src/algorithms/acquisition/gnuradio_blocks/pcps_acquisition.cc
+++ b/src/algorithms/acquisition/gnuradio_blocks/pcps_acquisition.cc
@@ -47,6 +47,16 @@
 #endif
 
 
+namespace
+{
+float compute_threshold(float pfa, uint32_t effective_fft_size, uint32_t num_doppler_bins, uint32_t max_dwells)
+{
+    const int num_bins = effective_fft_size * num_doppler_bins;
+    return static_cast<float>(2.0 * boost::math::gamma_p_inv(2.0 * max_dwells, std::pow(1.0 - pfa, 1.0 / static_cast<float>(num_bins))));
+}
+}  // namespace
+
+
 pcps_acquisition_sptr pcps_make_acquisition(const Acq_Conf& conf_)
 {
     return pcps_acquisition_sptr(new pcps_acquisition(conf_));
@@ -62,7 +72,6 @@ pcps_acquisition::pcps_acquisition(const Acq_Conf& conf_)
       d_dump_filename(conf_.dump_filename),
       d_dump_number(0LL),
       d_sample_counter(0ULL),
-      d_threshold(0.0),
       d_mag(0),
       d_input_power(0.0),
       d_doppler_center_step_two(0.0),
@@ -77,11 +86,14 @@ pcps_acquisition::pcps_acquisition(const Acq_Conf& conf_)
       d_num_noncoherent_integrations_counter(0U),
       d_consumed_samples(conf_.sampled_ms * conf_.samples_per_ms * (conf_.bit_transition_flag ? 2.0 : 1.0)),
       d_fft_size(conf_.sampled_ms == conf_.ms_per_code ? d_consumed_samples : d_consumed_samples * 2),
+      d_effective_fft_size(conf_.bit_transition_flag ? (d_fft_size / 2) : d_fft_size),
       d_num_doppler_bins(static_cast<uint32_t>(std::ceil(static_cast<double>(2 * d_doppler_max) / static_cast<double>(d_doppler_step)))),
       d_num_doppler_bins_step2(conf_.num_doppler_bins_step2),
       d_dump_channel(conf_.dump_channel),
       d_buffer_count(0U),
       d_resampler_latency_samples(conf_.resampler_latency_samples),
+      d_threshold(conf_.pfa > 0.0 ? compute_threshold(conf_.pfa, d_effective_fft_size, d_num_doppler_bins, conf_.bit_transition_flag ? 1 : conf_.max_dwells) : conf_.threshold),
+      d_threshold_step_two(conf_.pfa2 > 0.0 ? compute_threshold(conf_.pfa2, d_effective_fft_size, d_num_doppler_bins_step2, conf_.bit_transition_flag ? 1 : conf_.max_dwells) : conf_.threshold),
       d_active(false),
       d_worker_active(false),
       d_cshort(conf_.it_size != sizeof(gr_complex)),
@@ -165,9 +177,8 @@ pcps_acquisition::pcps_acquisition(const Acq_Conf& conf_)
                     d_dump = false;
                 }
 
-            const uint32_t effective_fft_size = (d_acq_parameters.bit_transition_flag ? (d_fft_size / 2) : d_fft_size);
-            d_grid = arma::fmat(effective_fft_size, d_num_doppler_bins, arma::fill::zeros);
-            d_narrow_grid = arma::fmat(effective_fft_size, d_num_doppler_bins_step2, arma::fill::zeros);
+            d_grid = arma::fmat(d_effective_fft_size, d_num_doppler_bins, arma::fill::zeros);
+            d_narrow_grid = arma::fmat(d_effective_fft_size, d_num_doppler_bins_step2, arma::fill::zeros);
         }
 }
 
@@ -280,7 +291,7 @@ void pcps_acquisition::send_positive_acquisition(float test_statistics)
                << ", satellite " << d_gnss_synchro->System << " " << d_gnss_synchro->PRN
                << ", sample_stamp " << d_sample_counter
                << ", test statistics value " << test_statistics
-               << ", test statistics threshold " << d_threshold
+               << ", test statistics threshold " << get_threshold()
                << ", code phase " << d_gnss_synchro->Acq_delay_samples
                << ", doppler " << d_gnss_synchro->Acq_doppler_hz
                << ", magnitude " << d_mag
@@ -316,7 +327,7 @@ void pcps_acquisition::send_negative_acquisition(float test_statistics)
                << ", satellite " << d_gnss_synchro->System << " " << d_gnss_synchro->PRN
                << ", sample_stamp " << d_sample_counter
                << ", test statistics value " << test_statistics
-               << ", test statistics threshold " << d_threshold
+               << ", test statistics threshold " << get_threshold()
                << ", code phase " << d_gnss_synchro->Acq_delay_samples
                << ", doppler " << d_gnss_synchro->Acq_doppler_hz
                << ", magnitude " << d_mag
@@ -326,7 +337,7 @@ void pcps_acquisition::send_negative_acquisition(float test_statistics)
 }
 
 
-void pcps_acquisition::dump_results(int32_t effective_fft_size, float test_statistics)
+void pcps_acquisition::dump_results(float test_statistics)
 {
     d_dump_number++;
     std::string filename = d_dump_filename;
@@ -351,7 +362,7 @@ void pcps_acquisition::dump_results(int32_t effective_fft_size, float test_stati
         }
     else
         {
-            std::array<size_t, 2> dims{static_cast<size_t>(effective_fft_size), static_cast<size_t>(d_num_doppler_bins)};
+            std::array<size_t, 2> dims{static_cast<size_t>(d_effective_fft_size), static_cast<size_t>(d_num_doppler_bins)};
             matvar_t* matvar = Mat_VarCreate("acq_grid", MAT_C_SINGLE, MAT_T_SINGLE, 2, dims.data(), d_grid.memptr(), 0);
             Mat_VarWrite(matfp, matvar, MAT_COMPRESSION_ZLIB);  // or MAT_COMPRESSION_NONE
             Mat_VarFree(matvar);
@@ -386,7 +397,8 @@ void pcps_acquisition::dump_results(int32_t effective_fft_size, float test_stati
             Mat_VarWrite(matfp, matvar, MAT_COMPRESSION_ZLIB);  // or MAT_COMPRESSION_NONE
             Mat_VarFree(matvar);
 
-            matvar = Mat_VarCreate("threshold", MAT_C_SINGLE, MAT_T_SINGLE, 1, dims.data(), &d_threshold, 0);
+            auto threshold = get_threshold();
+            matvar = Mat_VarCreate("threshold", MAT_C_SINGLE, MAT_T_SINGLE, 1, dims.data(), &threshold, 0);
             Mat_VarWrite(matfp, matvar, MAT_COMPRESSION_ZLIB);  // or MAT_COMPRESSION_NONE
             Mat_VarFree(matvar);
 
@@ -408,7 +420,7 @@ void pcps_acquisition::dump_results(int32_t effective_fft_size, float test_stati
 
             if (d_acq_parameters.make_2_steps)
                 {
-                    dims[0] = static_cast<size_t>(effective_fft_size);
+                    dims[0] = static_cast<size_t>(d_effective_fft_size);
                     dims[1] = static_cast<size_t>(d_num_doppler_bins_step2);
                     matvar = Mat_VarCreate("acq_grid_narrow", MAT_C_SINGLE, MAT_T_SINGLE, 2, dims.data(), d_narrow_grid.memptr(), 0);
                     Mat_VarWrite(matfp, matvar, MAT_COMPRESSION_ZLIB);  // or MAT_COMPRESSION_NONE
@@ -438,12 +450,11 @@ float pcps_acquisition::max_to_input_power_statistic(uint32_t& indext, int32_t& 
     uint32_t index_doppler = 0U;
     uint32_t tmp_intex_t = 0U;
     uint32_t index_time = 0U;
-    const int32_t effective_fft_size = (d_acq_parameters.bit_transition_flag ? d_fft_size / 2 : d_fft_size);
 
     // Find the correlation peak and the carrier frequency
     for (uint32_t i = 0; i < num_doppler_bins; i++)
         {
-            volk_gnsssdr_32f_index_max_32u(&tmp_intex_t, d_magnitude_grid[i].data(), effective_fft_size);
+            volk_gnsssdr_32f_index_max_32u(&tmp_intex_t, d_magnitude_grid[i].data(), d_effective_fft_size);
             if (d_magnitude_grid[i][tmp_intex_t] > grid_maximum)
                 {
                     grid_maximum = d_magnitude_grid[i][tmp_intex_t];
@@ -455,7 +466,7 @@ float pcps_acquisition::max_to_input_power_statistic(uint32_t& indext, int32_t& 
     if (!d_step_two)
         {
             const auto index_opp = (index_doppler + d_num_doppler_bins / 2) % d_num_doppler_bins;
-            d_input_power = static_cast<float>(std::accumulate(d_magnitude_grid[index_opp].data(), d_magnitude_grid[index_opp].data() + effective_fft_size, static_cast<float>(0.0)) / effective_fft_size / 2.0 / d_num_noncoherent_integrations_counter);
+            d_input_power = static_cast<float>(std::accumulate(d_magnitude_grid[index_opp].data(), d_magnitude_grid[index_opp].data() + d_effective_fft_size, static_cast<float>(0.0)) / d_effective_fft_size / 2.0 / d_num_noncoherent_integrations_counter);
             doppler = -static_cast<int32_t>(doppler_max) + d_doppler_center + doppler_step * static_cast<int32_t>(index_doppler);
         }
     else
@@ -538,7 +549,7 @@ float pcps_acquisition::first_vs_second_peak_statistic(uint32_t& indext, int32_t
     return firstPeak / secondPeak;
 }
 
-void pcps_acquisition::doppler_grid(const gr_complex* in, int32_t effective_fft_size)
+void pcps_acquisition::doppler_grid(const gr_complex* in)
 {
     const auto bin_count = d_step_two ? d_num_doppler_bins_step2 : d_num_doppler_bins;
     const auto& grid_doppler_wipeoffs = d_step_two ? d_grid_doppler_wipeoffs_step_two : d_grid_doppler_wipeoffs;
@@ -560,20 +571,20 @@ void pcps_acquisition::doppler_grid(const gr_complex* in, int32_t effective_fft_
             d_ifft->execute();
 
             // Compute squared magnitude (and accumulate in case of non-coherent integration)
-            const size_t offset = (d_acq_parameters.bit_transition_flag ? effective_fft_size : 0);
+            const size_t offset = (d_acq_parameters.bit_transition_flag ? d_effective_fft_size : 0);
             if (d_num_noncoherent_integrations_counter == 1)
                 {
-                    volk_32fc_magnitude_squared_32f(d_magnitude_grid[doppler_index].data(), d_ifft->get_outbuf() + offset, effective_fft_size);
+                    volk_32fc_magnitude_squared_32f(d_magnitude_grid[doppler_index].data(), d_ifft->get_outbuf() + offset, d_effective_fft_size);
                 }
             else
                 {
-                    volk_32fc_magnitude_squared_32f(d_tmp_buffer.data(), d_ifft->get_outbuf() + offset, effective_fft_size);
-                    volk_32f_x2_add_32f(d_magnitude_grid[doppler_index].data(), d_magnitude_grid[doppler_index].data(), d_tmp_buffer.data(), effective_fft_size);
+                    volk_32fc_magnitude_squared_32f(d_tmp_buffer.data(), d_ifft->get_outbuf() + offset, d_effective_fft_size);
+                    volk_32f_x2_add_32f(d_magnitude_grid[doppler_index].data(), d_magnitude_grid[doppler_index].data(), d_tmp_buffer.data(), d_effective_fft_size);
                 }
             // Record results to file if required
             if (d_dump and d_channel == d_dump_channel)
                 {
-                    std::copy(d_magnitude_grid[doppler_index].data(), d_magnitude_grid[doppler_index].data() + effective_fft_size, grid.colptr(doppler_index));
+                    std::copy(d_magnitude_grid[doppler_index].data(), d_magnitude_grid[doppler_index].data() + d_effective_fft_size, grid.colptr(doppler_index));
                 }
         }
 }
@@ -629,7 +640,6 @@ void pcps_acquisition::acquisition_core(uint64_t samp_count)
     // Initialize acquisition algorithm
     int32_t doppler = 0;
     uint32_t indext = 0U;
-    const int32_t effective_fft_size = (d_acq_parameters.bit_transition_flag ? d_fft_size / 2 : d_fft_size);
     if (d_cshort)
         {
             volk_gnsssdr_16ic_convert_32fc(d_data_buffer.data(), d_data_buffer_sc.data(), d_consumed_samples);
@@ -649,8 +659,9 @@ void pcps_acquisition::acquisition_core(uint64_t samp_count)
 
     DLOG(INFO) << "Channel: " << d_channel
                << " , doing acquisition of satellite: " << d_gnss_synchro->System << " " << d_gnss_synchro->PRN
-               << " , sample stamp: " << samp_count << ", threshold: "
-               << d_threshold << ", doppler_max: " << d_doppler_max
+               << " , sample stamp: " << samp_count
+               << ", threshold: " << get_threshold()
+               << ", doppler_max: " << d_doppler_max
                << ", doppler_step: " << d_doppler_step
                << ", use_CFAR_algorithm_flag: " << (d_use_CFAR_algorithm_flag ? "true" : "false");
 
@@ -660,7 +671,7 @@ void pcps_acquisition::acquisition_core(uint64_t samp_count)
         }
 
     // Doppler frequency grid loop
-    doppler_grid(in, effective_fft_size);
+    doppler_grid(in);
     const auto test_statistics = get_test_statistics(indext, doppler);
     update_synchro(indext, doppler, samp_count);
 
@@ -671,7 +682,7 @@ void pcps_acquisition::acquisition_core(uint64_t samp_count)
 
     if (!d_acq_parameters.bit_transition_flag)
         {
-            if (test_statistics > d_threshold)
+            if (test_statistics > get_threshold())
                 {
                     d_active = false;
                     if (d_acq_parameters.make_2_steps)
@@ -691,7 +702,6 @@ void pcps_acquisition::acquisition_core(uint64_t samp_count)
                                     d_positive_acq = 0;
                                     d_state = 0;
                                 }
-                            calculate_threshold();
                         }
                     else
                         {
@@ -713,18 +723,13 @@ void pcps_acquisition::acquisition_core(uint64_t samp_count)
                         }
                     d_state = 0;
                     d_active = false;
-                    const bool was_step_two = d_step_two;
                     d_step_two = false;
-                    if (was_step_two)
-                        {
-                            calculate_threshold();
-                        }
                 }
         }
     else
         {
             d_active = false;
-            if (test_statistics > d_threshold)
+            if (test_statistics > get_threshold())
                 {
                     if (d_acq_parameters.make_2_steps)
                         {
@@ -742,7 +747,6 @@ void pcps_acquisition::acquisition_core(uint64_t samp_count)
                                     d_num_noncoherent_integrations_counter = 0U;
                                     d_state = 0;
                                 }
-                            calculate_threshold();
                         }
                     else
                         {
@@ -753,12 +757,7 @@ void pcps_acquisition::acquisition_core(uint64_t samp_count)
             else
                 {
                     d_state = 0;  // Negative acquisition
-                    const bool was_step_two = d_step_two;
                     d_step_two = false;
-                    if (was_step_two)
-                        {
-                            calculate_threshold();
-                        }
                     send_negative_acquisition(test_statistics);
                 }
         }
@@ -769,7 +768,7 @@ void pcps_acquisition::acquisition_core(uint64_t samp_count)
             // Record results to file if required
             if (d_dump and d_channel == d_dump_channel)
                 {
-                    pcps_acquisition::dump_results(effective_fft_size, test_statistics);
+                    pcps_acquisition::dump_results(test_statistics);
                 }
             d_num_noncoherent_integrations_counter = 0U;
             d_positive_acq = 0;
@@ -782,26 +781,13 @@ bool pcps_acquisition::start()
 {
     gr::thread::scoped_lock lk(d_setlock);
     d_sample_counter = 0ULL;
-    calculate_threshold();
     return true;
 }
 
 
-void pcps_acquisition::calculate_threshold()
+float pcps_acquisition::get_threshold() const
 {
-    const float pfa = (d_step_two ? d_acq_parameters.pfa2 : d_acq_parameters.pfa);
-
-    if (pfa <= 0.0)
-        {
-            return;
-        }
-
-    const auto effective_fft_size = static_cast<int>(d_acq_parameters.bit_transition_flag ? (d_fft_size / 2) : d_fft_size);
-    const int num_doppler_bins = (d_step_two ? d_num_doppler_bins_step2 : d_num_doppler_bins);
-
-    const int num_bins = effective_fft_size * num_doppler_bins;
-
-    d_threshold = static_cast<float>(2.0 * boost::math::gamma_p_inv(2.0 * (d_acq_parameters.bit_transition_flag ? 1 : d_acq_parameters.max_dwells), std::pow(1.0 - pfa, 1.0 / static_cast<float>(num_bins))));
+    return d_step_two ? d_threshold_step_two : d_threshold;
 }
 
 

--- a/src/algorithms/acquisition/gnuradio_blocks/pcps_acquisition.h
+++ b/src/algorithms/acquisition/gnuradio_blocks/pcps_acquisition.h
@@ -151,17 +151,6 @@ public:
     }
 
     /*!
-     * \brief Set statistics threshold of PCPS algorithm.
-     * \param threshold - Threshold for signal detection (check \ref Navitec2012,
-     * Algorithm 1, for a definition of this threshold).
-     */
-    inline void set_threshold(float threshold) override
-    {
-        gr::thread::scoped_lock lock(d_setlock);  // require mutex with work function called by the scheduler
-        d_threshold = threshold;
-    }
-
-    /*!
      * \brief Set Doppler center frequency for the grid search. It will refresh the Doppler grid.
      * \param doppler_center - Frequency center of the search grid [Hz].
      */
@@ -181,16 +170,16 @@ private:
     void update_local_carrier(own::span<gr_complex> carrier_vector, float freq) const;
     void update_grid_doppler_wipeoffs();
     void update_grid_doppler_wipeoffs_step2();
-    void doppler_grid(const gr_complex* in, int32_t effective_fft_size);
+    void doppler_grid(const gr_complex* in);
     float get_test_statistics(uint32_t& indext, int32_t& doppler);
     void update_synchro(uint32_t indext, int32_t doppler, uint64_t samp_count);
     void acquisition_core(uint64_t samp_count);
     void send_negative_acquisition(float test_statistics);
     void send_positive_acquisition(float test_statistics);
-    void dump_results(int32_t effective_fft_size, float test_statistics);
+    void dump_results(float test_statistics);
     bool is_fdma();
     bool start() override;
-    void calculate_threshold();
+    float get_threshold() const;
     float first_vs_second_peak_statistic(uint32_t& indext, int32_t& doppler, uint32_t num_doppler_bins, int32_t doppler_max, int32_t doppler_step);
     float max_to_input_power_statistic(uint32_t& indext, int32_t& doppler, uint32_t num_doppler_bins, int32_t doppler_max, int32_t doppler_step);
 
@@ -205,7 +194,6 @@ private:
     int64_t d_dump_number;
     uint64_t d_sample_counter;
 
-    float d_threshold;
     float d_mag;
     float d_input_power;
     float d_doppler_center_step_two;
@@ -221,11 +209,15 @@ private:
     uint32_t d_num_noncoherent_integrations_counter;
     const uint32_t d_consumed_samples;
     const uint32_t d_fft_size;
+    const uint32_t d_effective_fft_size;
     const uint32_t d_num_doppler_bins;
     const uint32_t d_num_doppler_bins_step2;
     const uint32_t d_dump_channel;
     uint32_t d_buffer_count;
     uint32_t d_resampler_latency_samples;
+
+    const float d_threshold;
+    const float d_threshold_step_two;
 
     bool d_active;
     bool d_worker_active;

--- a/src/algorithms/acquisition/gnuradio_blocks/pcps_acquisition_fine_doppler_cc.cc
+++ b/src/algorithms/acquisition/gnuradio_blocks/pcps_acquisition_fine_doppler_cc.cc
@@ -36,8 +36,7 @@
 
 pcps_acquisition_fine_doppler_cc_sptr pcps_make_acquisition_fine_doppler_cc(const Acq_Conf &conf_)
 {
-    return pcps_acquisition_fine_doppler_cc_sptr(
-        new pcps_acquisition_fine_doppler_cc(conf_));
+    return pcps_acquisition_fine_doppler_cc_sptr(new pcps_acquisition_fine_doppler_cc(conf_));
 }
 
 
@@ -50,7 +49,6 @@ pcps_acquisition_fine_doppler_cc::pcps_acquisition_fine_doppler_cc(const Acq_Con
       d_gnss_synchro(nullptr),
       d_dump_number(0),
       d_sample_counter(0ULL),
-      d_threshold(0),
       d_test_statistics(0),
       d_positive_acq(0),
       d_state(0),
@@ -271,8 +269,9 @@ int pcps_acquisition_fine_doppler_cc::compute_and_accumulate_grid(gr_vector_cons
 
     DLOG(INFO) << "Channel: " << d_channel
                << " , doing acquisition of satellite: " << d_gnss_synchro->System << " " << d_gnss_synchro->PRN
-               << " ,sample stamp: " << d_sample_counter << ", threshold: "
-               << d_threshold << ", doppler_max: " << d_acq_params.doppler_max
+               << " , sample stamp: " << d_sample_counter
+               << ", threshold: " << d_acq_params.threshold
+               << ", doppler_max: " << d_acq_params.doppler_max
                << ", doppler_step: " << d_acq_params.doppler_step;
 
     // 2- Doppler frequency search loop
@@ -453,7 +452,7 @@ int pcps_acquisition_fine_doppler_cc::general_work(int noutput_items,
             break;
         case 2:  // Compute test statistics and decide
             d_test_statistics = compute_CAF();
-            if (d_test_statistics > d_threshold)
+            if (d_test_statistics > d_acq_params.threshold)
                 {
                     d_state = 3;  // perform fine doppler estimation
                 }
@@ -492,7 +491,7 @@ int pcps_acquisition_fine_doppler_cc::general_work(int noutput_items,
             DLOG(INFO) << "satellite " << d_gnss_synchro->System << " " << d_gnss_synchro->PRN;
             DLOG(INFO) << "sample_stamp " << d_sample_counter;
             DLOG(INFO) << "test statistics value " << d_test_statistics;
-            DLOG(INFO) << "test statistics threshold " << d_threshold;
+            DLOG(INFO) << "test statistics threshold " << d_acq_params.threshold;
             DLOG(INFO) << "code phase " << d_gnss_synchro->Acq_delay_samples;
             DLOG(INFO) << "doppler " << d_gnss_synchro->Acq_doppler_hz;
             d_positive_acq = 1;
@@ -525,7 +524,7 @@ int pcps_acquisition_fine_doppler_cc::general_work(int noutput_items,
             DLOG(INFO) << "satellite " << d_gnss_synchro->System << " " << d_gnss_synchro->PRN;
             DLOG(INFO) << "sample_stamp " << d_sample_counter;
             DLOG(INFO) << "test statistics value " << d_test_statistics;
-            DLOG(INFO) << "test statistics threshold " << d_threshold;
+            DLOG(INFO) << "test statistics threshold " << d_acq_params.threshold;
             DLOG(INFO) << "code phase " << d_gnss_synchro->Acq_delay_samples;
             DLOG(INFO) << "doppler " << d_gnss_synchro->Acq_doppler_hz;
             d_positive_acq = 0;
@@ -616,7 +615,8 @@ void pcps_acquisition_fine_doppler_cc::dump_results(int effective_fft_size)
             Mat_VarWrite(matfp, matvar, MAT_COMPRESSION_ZLIB);  // or MAT_COMPRESSION_NONE
             Mat_VarFree(matvar);
 
-            matvar = Mat_VarCreate("threshold", MAT_C_SINGLE, MAT_T_SINGLE, 1, dims.data(), &d_threshold, 0);
+            auto threshold = d_acq_params.threshold;
+            matvar = Mat_VarCreate("threshold", MAT_C_SINGLE, MAT_T_SINGLE, 1, dims.data(), &threshold, 0);
             Mat_VarWrite(matfp, matvar, MAT_COMPRESSION_ZLIB);  // or MAT_COMPRESSION_NONE
             Mat_VarFree(matvar);
             aux = 0.0;

--- a/src/algorithms/acquisition/gnuradio_blocks/pcps_acquisition_fine_doppler_cc.h
+++ b/src/algorithms/acquisition/gnuradio_blocks/pcps_acquisition_fine_doppler_cc.h
@@ -137,16 +137,6 @@ public:
     }
 
     /*!
-     * \brief Set statistics threshold of PCPS algorithm.
-     * \param threshold - Threshold for signal detection (check \ref Navitec2012,
-     * Algorithm 1, for a definition of this threshold).
-     */
-    inline void set_threshold(float threshold) override
-    {
-        d_threshold = threshold;
-    }
-
-    /*!
      * \brief Parallel Code Phase Search Acquisition signal processing.
      */
     int general_work(int noutput_items, gr_vector_int& ninput_items,
@@ -187,7 +177,6 @@ private:
     int64_t d_dump_number;
     uint64_t d_sample_counter;
 
-    float d_threshold;
     float d_test_statistics;
 
     int d_positive_acq;

--- a/src/algorithms/acquisition/gnuradio_blocks/pcps_acquisition_fpga.cc
+++ b/src/algorithms/acquisition/gnuradio_blocks/pcps_acquisition_fpga.cc
@@ -42,7 +42,7 @@ pcps_acquisition_fpga::pcps_acquisition_fpga(Acq_Conf_Fpga *conf_, uint32_t acq_
     : d_acq_parameters(conf_),
       d_gnss_synchro(nullptr),
       d_sample_counter(0ULL),
-      d_threshold(0.0),
+      d_threshold(conf_.threshold),
       d_mag(0),
       d_input_power(0.0),
       d_test_statistics(0.0),

--- a/src/algorithms/acquisition/gnuradio_blocks/pcps_acquisition_fpga.h
+++ b/src/algorithms/acquisition/gnuradio_blocks/pcps_acquisition_fpga.h
@@ -111,16 +111,6 @@ public:
     }
 
     /*!
-     * \brief Set statistics threshold of PCPS algorithm.
-     * \param threshold - Threshold for signal detection (check \ref Navitec2012,
-     * Algorithm 1, for a definition of this threshold).
-     */
-    inline void set_threshold(float threshold)
-    {
-        d_threshold = threshold;
-    }
-
-    /*!
      * \brief Set Doppler center frequency for the grid search. It will refresh the Doppler grid.
      * \param doppler_center - Frequency center of the search grid [Hz].
      */
@@ -154,7 +144,7 @@ private:
 
     uint64_t d_sample_counter;
 
-    float d_threshold;
+    const float d_threshold;
     float d_mag;
     float d_input_power;
     float d_test_statistics;

--- a/src/algorithms/acquisition/gnuradio_blocks/pcps_assisted_acquisition_cc.cc
+++ b/src/algorithms/acquisition/gnuradio_blocks/pcps_assisted_acquisition_cc.cc
@@ -51,7 +51,6 @@ pcps_assisted_acquisition_cc::pcps_assisted_acquisition_cc(const Acq_Conf &conf)
       d_acq_params(conf),
       d_gnss_synchro(nullptr),
       d_sample_counter(0ULL),
-      d_threshold(0),
       d_input_power(0.0),
       d_test_statistics(0),
       d_channel(0),
@@ -252,10 +251,10 @@ int32_t pcps_assisted_acquisition_cc::compute_and_accumulate_grid(gr_vector_cons
     const auto *in = reinterpret_cast<const gr_complex *>(input_items[0]);  // Get the input samples pointer
 
     DLOG(INFO) << "Channel: " << d_channel
-               << " , doing acquisition of satellite: " << d_gnss_synchro->System << " "
-               << d_gnss_synchro->PRN
-               << " ,sample stamp: " << d_sample_counter << ", threshold: "
-               << d_threshold << ", doppler_max: " << d_doppler_max
+               << " , doing acquisition of satellite: " << d_gnss_synchro->System << " " << d_gnss_synchro->PRN
+               << " , sample stamp: " << d_sample_counter
+               << ", threshold: " << d_acq_params.threshold
+               << ", doppler_max: " << d_doppler_max
                << ", doppler_step: " << d_acq_params.doppler_step;
 
     // 2- Doppler frequency search loop
@@ -341,7 +340,7 @@ int pcps_assisted_acquisition_cc::general_work(int noutput_items,
         case 3:  // Compute test statistics and decide
             d_input_power = estimate_input_power(input_items);
             d_test_statistics = search_maximum();
-            if (d_test_statistics > d_threshold)
+            if (d_test_statistics > d_acq_params.threshold)
                 {
                     d_state = 5;
                 }
@@ -373,7 +372,7 @@ int pcps_assisted_acquisition_cc::general_work(int noutput_items,
             DLOG(INFO) << "satellite " << d_gnss_synchro->System << " " << d_gnss_synchro->PRN;
             DLOG(INFO) << "sample_stamp " << d_sample_counter;
             DLOG(INFO) << "test statistics value " << d_test_statistics;
-            DLOG(INFO) << "test statistics threshold " << d_threshold;
+            DLOG(INFO) << "test statistics threshold " << d_acq_params.threshold;
             DLOG(INFO) << "code phase " << d_gnss_synchro->Acq_delay_samples;
             DLOG(INFO) << "doppler " << d_gnss_synchro->Acq_doppler_hz;
             DLOG(INFO) << "input signal power " << d_input_power;
@@ -399,7 +398,7 @@ int pcps_assisted_acquisition_cc::general_work(int noutput_items,
             DLOG(INFO) << "satellite " << d_gnss_synchro->System << " " << d_gnss_synchro->PRN;
             DLOG(INFO) << "sample_stamp " << d_sample_counter;
             DLOG(INFO) << "test statistics value " << d_test_statistics;
-            DLOG(INFO) << "test statistics threshold " << d_threshold;
+            DLOG(INFO) << "test statistics threshold " << d_acq_params.threshold;
             DLOG(INFO) << "code phase " << d_gnss_synchro->Acq_delay_samples;
             DLOG(INFO) << "doppler " << d_gnss_synchro->Acq_doppler_hz;
             DLOG(INFO) << "input signal power " << d_input_power;

--- a/src/algorithms/acquisition/gnuradio_blocks/pcps_assisted_acquisition_cc.h
+++ b/src/algorithms/acquisition/gnuradio_blocks/pcps_assisted_acquisition_cc.h
@@ -130,16 +130,6 @@ public:
     }
 
     /*!
-     * \brief Set statistics threshold of PCPS algorithm.
-     * \param threshold - Threshold for signal detection (check \ref Navitec2012,
-     * Algorithm 1, for a definition of this threshold).
-     */
-    inline void set_threshold(float threshold) override
-    {
-        d_threshold = threshold;
-    }
-
-    /*!
      * \brief Parallel Code Phase Search Acquisition signal processing.
      */
     int general_work(int noutput_items, gr_vector_int& ninput_items,
@@ -173,7 +163,6 @@ private:
 
     uint64_t d_sample_counter;
 
-    float d_threshold;
     float d_input_power;
     float d_test_statistics;
 

--- a/src/algorithms/acquisition/gnuradio_blocks/pcps_cccwsr_acquisition_cc.cc
+++ b/src/algorithms/acquisition/gnuradio_blocks/pcps_cccwsr_acquisition_cc.cc
@@ -52,7 +52,6 @@ pcps_cccwsr_acquisition_cc::pcps_cccwsr_acquisition_cc(const Acq_Conf &conf)
       d_gnss_synchro(nullptr),
       d_fs_in(conf.fs_in),
       d_sample_counter(0ULL),
-      d_threshold(0),
       d_mag(0),
       d_input_power(0.0),
       d_test_statistics(0),
@@ -184,8 +183,9 @@ int pcps_cccwsr_acquisition_cc::general_work(int noutput_items,
 
                 DLOG(INFO) << "Channel: " << d_channel
                            << " , doing acquisition of satellite: " << d_gnss_synchro->System << " " << d_gnss_synchro->PRN
-                           << " ,sample stamp: " << d_sample_counter << ", threshold: "
-                           << d_threshold << ", doppler_max: " << d_acq_params.doppler_max
+                           << " ,sample stamp: " << d_sample_counter
+                           << ", threshold: " << d_acq_params.threshold
+                           << ", doppler_max: " << d_acq_params.doppler_max
                            << ", doppler_step: " << d_acq_params.doppler_step;
 
                 // 1- Compute the input signal power estimation
@@ -292,7 +292,7 @@ int pcps_cccwsr_acquisition_cc::general_work(int noutput_items,
                 d_test_statistics = d_mag / d_input_power;
 
                 // 6- Declare positive or negative acquisition using a message port
-                if (d_test_statistics > d_threshold)
+                if (d_test_statistics > d_acq_params.threshold)
                     {
                         d_state = 2;  // Positive acquisition
                     }
@@ -313,7 +313,7 @@ int pcps_cccwsr_acquisition_cc::general_work(int noutput_items,
                 DLOG(INFO) << "satellite " << d_gnss_synchro->System << " " << d_gnss_synchro->PRN;
                 DLOG(INFO) << "sample_stamp " << d_sample_counter;
                 DLOG(INFO) << "test statistics value " << d_test_statistics;
-                DLOG(INFO) << "test statistics threshold " << d_threshold;
+                DLOG(INFO) << "test statistics threshold " << d_acq_params.threshold;
                 DLOG(INFO) << "code phase " << d_gnss_synchro->Acq_delay_samples;
                 DLOG(INFO) << "doppler " << d_gnss_synchro->Acq_doppler_hz;
                 DLOG(INFO) << "magnitude " << d_mag;
@@ -348,7 +348,7 @@ int pcps_cccwsr_acquisition_cc::general_work(int noutput_items,
                 DLOG(INFO) << "satellite " << d_gnss_synchro->System << " " << d_gnss_synchro->PRN;
                 DLOG(INFO) << "sample_stamp " << d_sample_counter;
                 DLOG(INFO) << "test statistics value " << d_test_statistics;
-                DLOG(INFO) << "test statistics threshold " << d_threshold;
+                DLOG(INFO) << "test statistics threshold " << d_acq_params.threshold;
                 DLOG(INFO) << "code phase " << d_gnss_synchro->Acq_delay_samples;
                 DLOG(INFO) << "doppler " << d_gnss_synchro->Acq_doppler_hz;
                 DLOG(INFO) << "magnitude " << d_mag;

--- a/src/algorithms/acquisition/gnuradio_blocks/pcps_cccwsr_acquisition_cc.h
+++ b/src/algorithms/acquisition/gnuradio_blocks/pcps_cccwsr_acquisition_cc.h
@@ -118,16 +118,6 @@ public:
     }
 
     /*!
-     * \brief Set statistics threshold of CCCWSR algorithm.
-     * \param threshold - Threshold for signal detection (check \ref Navitec2012,
-     * Algorithm 1, for a definition of this threshold).
-     */
-    inline void set_threshold(float threshold) override
-    {
-        d_threshold = threshold;
-    }
-
-    /*!
      * \brief Coherent Channel Combining With Sign Recovery Acquisition signal processing.
      */
     int general_work(int noutput_items, gr_vector_int& ninput_items,
@@ -151,7 +141,6 @@ private:
     int64_t d_fs_in;
     uint64_t d_sample_counter;
 
-    float d_threshold;
     float d_mag;
     float d_input_power;
     float d_test_statistics;

--- a/src/algorithms/acquisition/gnuradio_blocks/pcps_opencl_acquisition_cc.cc
+++ b/src/algorithms/acquisition/gnuradio_blocks/pcps_opencl_acquisition_cc.cc
@@ -315,8 +315,9 @@ void pcps_opencl_acquisition_cc::acquisition_core_volk()
 
     DLOG(INFO) << "Channel: " << d_channel
                << " , doing acquisition of satellite: " << d_gnss_synchro->System << " " << d_gnss_synchro->PRN
-               << " ,sample stamp: " << d_sample_counter << ", threshold: "
-               << d_threshold << ", doppler_max: " << d_acq_params.doppler_max
+               << " ,sample stamp: " << d_sample_counter
+               << ", threshold: " << d_acq_params.threshold
+               << ", doppler_max: " << d_acq_params.doppler_max
                << ", doppler_step: " << d_acq_params.doppler_step;
 
     // 1- Compute the input signal power estimation
@@ -394,7 +395,7 @@ void pcps_opencl_acquisition_cc::acquisition_core_volk()
 
     if (!d_acq_params.bit_transition_flag)
         {
-            if (d_test_statistics > d_threshold)
+            if (d_test_statistics > d_acq_params.threshold)
                 {
                     d_state = 2;  // Positive acquisition
                 }
@@ -407,7 +408,7 @@ void pcps_opencl_acquisition_cc::acquisition_core_volk()
         {
             if (d_well_count == d_max_dwells)  // d_max_dwells = 2
                 {
-                    if (d_test_statistics > d_threshold)
+                    if (d_test_statistics > d_acq_params.threshold)
                         {
                             d_state = 2;  // Positive acquisition
                         }
@@ -448,8 +449,9 @@ void pcps_opencl_acquisition_cc::acquisition_core_opencl()
 
     DLOG(INFO) << "Channel: " << d_channel
                << " , doing acquisition of satellite: " << d_gnss_synchro->System << " " << d_gnss_synchro->PRN
-               << " ,sample stamp: " << d_sample_counter << ", threshold: "
-               << d_threshold << ", doppler_max: " << d_acq_params.doppler_max
+               << " , sample stamp: " << d_sample_counter
+               << ", threshold: " << d_acq_params.threshold
+               << ", doppler_max: " << d_acq_params.doppler_max
                << ", doppler_step: " << d_acq_params.doppler_step;
 
     // 1- Compute the input signal power estimation
@@ -559,7 +561,7 @@ void pcps_opencl_acquisition_cc::acquisition_core_opencl()
 
     if (!d_acq_params.bit_transition_flag)
         {
-            if (d_test_statistics > d_threshold)
+            if (d_test_statistics > d_acq_params.threshold)
                 {
                     d_state = 2;  // Positive acquisition
                 }
@@ -572,7 +574,7 @@ void pcps_opencl_acquisition_cc::acquisition_core_opencl()
         {
             if (d_well_count == d_max_dwells)  // d_max_dwells = 2
                 {
-                    if (d_test_statistics > d_threshold)
+                    if (d_test_statistics > d_acq_params.threshold)
                         {
                             d_state = 2;  // Positive acquisition
                         }
@@ -678,7 +680,7 @@ int pcps_opencl_acquisition_cc::general_work(int noutput_items,
                 DLOG(INFO) << "satellite " << d_gnss_synchro->System << " " << d_gnss_synchro->PRN;
                 DLOG(INFO) << "sample_stamp " << d_sample_counter;
                 DLOG(INFO) << "test statistics value " << d_test_statistics;
-                DLOG(INFO) << "test statistics threshold " << d_threshold;
+                DLOG(INFO) << "test statistics threshold " << d_acq_params.threshold;
                 DLOG(INFO) << "code phase " << d_gnss_synchro->Acq_delay_samples;
                 DLOG(INFO) << "doppler " << d_gnss_synchro->Acq_doppler_hz;
                 DLOG(INFO) << "magnitude " << d_mag;
@@ -712,7 +714,7 @@ int pcps_opencl_acquisition_cc::general_work(int noutput_items,
                 DLOG(INFO) << "satellite " << d_gnss_synchro->System << " " << d_gnss_synchro->PRN;
                 DLOG(INFO) << "sample_stamp " << d_sample_counter;
                 DLOG(INFO) << "test statistics value " << d_test_statistics;
-                DLOG(INFO) << "test statistics threshold " << d_threshold;
+                DLOG(INFO) << "test statistics threshold " << d_acq_params.threshold;
                 DLOG(INFO) << "code phase " << d_gnss_synchro->Acq_delay_samples;
                 DLOG(INFO) << "doppler " << d_gnss_synchro->Acq_doppler_hz;
                 DLOG(INFO) << "magnitude " << d_mag;

--- a/src/algorithms/acquisition/gnuradio_blocks/pcps_opencl_acquisition_cc.h
+++ b/src/algorithms/acquisition/gnuradio_blocks/pcps_opencl_acquisition_cc.h
@@ -136,16 +136,6 @@ public:
         d_channel_fsm = channel_fsm;
     }
 
-    /*!
-     * \brief Set statistics threshold of PCPS algorithm.
-     * \param threshold - Threshold for signal detection (check \ref Navitec2012,
-     * Algorithm 1, for a definition of this threshold).
-     */
-    inline void set_threshold(float threshold) override
-    {
-        d_threshold = threshold;
-    }
-
     inline bool opencl_ready() const
     {
         bool ready = false;
@@ -202,7 +192,6 @@ private:
 
     int* d_max_doppler_indexs;
 
-    float d_threshold;
     float d_mag;
     float d_input_power;
     float d_test_statistics;

--- a/src/algorithms/acquisition/gnuradio_blocks/pcps_quicksync_acquisition_cc.cc
+++ b/src/algorithms/acquisition/gnuradio_blocks/pcps_quicksync_acquisition_cc.cc
@@ -31,29 +31,25 @@
 #endif
 
 
-pcps_quicksync_acquisition_cc_sptr pcps_quicksync_make_acquisition_cc(
-    const Acq_Conf& conf, uint32_t folding_factor, uint32_t vector_length, uint32_t max_dwells, int32_t samples_per_code)
+pcps_quicksync_acquisition_cc_sptr pcps_quicksync_make_acquisition_cc(const Acq_Conf& conf, uint32_t folding_factor, uint32_t max_dwells)
 {
-    return pcps_quicksync_acquisition_cc_sptr(
-        new pcps_quicksync_acquisition_cc(conf, folding_factor, vector_length, max_dwells, samples_per_code));
+    return pcps_quicksync_acquisition_cc_sptr(new pcps_quicksync_acquisition_cc(conf, folding_factor, max_dwells));
 }
 
 
-pcps_quicksync_acquisition_cc::pcps_quicksync_acquisition_cc(
-    const Acq_Conf& conf, uint32_t folding_factor, uint32_t vector_length, uint32_t max_dwells, int32_t samples_per_code)
+pcps_quicksync_acquisition_cc::pcps_quicksync_acquisition_cc(const Acq_Conf& conf, uint32_t folding_factor, uint32_t max_dwells)
     : acquisition_impl_interface("pcps_quicksync_acquisition_cc",
-          gr::io_signature::make(1, 1, static_cast<int>(sizeof(gr_complex) * vector_length)),
+          gr::io_signature::make(1, 1, static_cast<int>(sizeof(gr_complex) * conf.vector_length)),
           gr::io_signature::make(0, 1, sizeof(Gnss_Synchro))),
       d_acq_params(conf),
       d_gnss_synchro(nullptr),
       d_sample_counter(0ULL),
       d_noise_floor_power(0),
-      d_threshold(0),
       d_mag(0),
       d_input_power(0.0),
       d_test_statistics(0),
-      d_vector_length(vector_length),
-      d_samples_per_code(samples_per_code),
+      d_vector_length(conf.vector_length),
+      d_samples_per_code(conf.code_length),
       d_state(0),
       d_channel(0),
       d_folding_factor(folding_factor),
@@ -217,12 +213,12 @@ int pcps_quicksync_acquisition_cc::general_work(int noutput_items,
                 d_well_count++;
 
                 DLOG(INFO) << "Channel: " << d_channel
-                           << " , doing acquisition of satellite: "
-                           << d_gnss_synchro->System << " " << d_gnss_synchro->PRN
-                           << " ,algorithm: pcps_quicksync_acquisition"
-                           << " ,folding factor: " << d_folding_factor
-                           << " ,sample stamp: " << d_sample_counter << ", threshold: "
-                           << d_threshold << ", doppler_max: " << d_acq_params.doppler_max
+                           << " , doing acquisition of satellite: " << d_gnss_synchro->System << " " << d_gnss_synchro->PRN
+                           << " , algorithm: pcps_quicksync_acquisition"
+                           << " , folding factor: " << d_folding_factor
+                           << " , sample stamp: " << d_sample_counter
+                           << ", threshold: " << d_acq_params.threshold
+                           << ", doppler_max: " << d_acq_params.doppler_max
                            << ", doppler_step: " << d_acq_params.doppler_step << ", Signal Size: "
                            << d_samples_per_code * d_folding_factor;
 
@@ -364,7 +360,7 @@ int pcps_quicksync_acquisition_cc::general_work(int noutput_items,
 
                 if (!d_acq_params.bit_transition_flag)
                     {
-                        if (d_test_statistics > d_threshold)
+                        if (d_test_statistics > d_acq_params.threshold)
                             {
                                 d_state = 2;  // Positive acquisition
                             }
@@ -377,7 +373,7 @@ int pcps_quicksync_acquisition_cc::general_work(int noutput_items,
                     {
                         if (d_well_count == d_max_dwells)  // d_max_dwells = 2
                             {
-                                if (d_test_statistics > d_threshold)
+                                if (d_test_statistics > d_acq_params.threshold)
                                     {
                                         d_state = 2;  // Positive acquisition
                                     }
@@ -401,7 +397,7 @@ int pcps_quicksync_acquisition_cc::general_work(int noutput_items,
                 DLOG(INFO) << "satellite " << d_gnss_synchro->System << " " << d_gnss_synchro->PRN;
                 DLOG(INFO) << "sample_stamp " << d_sample_counter;
                 DLOG(INFO) << "test statistics value " << d_test_statistics;
-                DLOG(INFO) << "test statistics threshold " << d_threshold;
+                DLOG(INFO) << "test statistics threshold " << d_acq_params.threshold;
                 DLOG(INFO) << "folding factor " << d_folding_factor;
                 DLOG(INFO) << "possible delay correlation output";
                 for (int32_t i = 0; i < static_cast<int32_t>(d_folding_factor); i++)
@@ -444,7 +440,7 @@ int pcps_quicksync_acquisition_cc::general_work(int noutput_items,
                 DLOG(INFO) << "satellite " << d_gnss_synchro->System << " " << d_gnss_synchro->PRN;
                 DLOG(INFO) << "sample_stamp " << d_sample_counter;
                 DLOG(INFO) << "test statistics value " << d_test_statistics;
-                DLOG(INFO) << "test statistics threshold " << d_threshold;
+                DLOG(INFO) << "test statistics threshold " << d_acq_params.threshold;
                 DLOG(INFO) << "folding factor " << d_folding_factor;
                 DLOG(INFO) << "possible delay    corr output";
                 for (int32_t i = 0; i < static_cast<int32_t>(d_folding_factor); i++)

--- a/src/algorithms/acquisition/gnuradio_blocks/pcps_quicksync_acquisition_cc.h
+++ b/src/algorithms/acquisition/gnuradio_blocks/pcps_quicksync_acquisition_cc.h
@@ -61,8 +61,7 @@ class pcps_quicksync_acquisition_cc;
 
 using pcps_quicksync_acquisition_cc_sptr = gnss_shared_ptr<pcps_quicksync_acquisition_cc>;
 
-pcps_quicksync_acquisition_cc_sptr pcps_quicksync_make_acquisition_cc(
-    const Acq_Conf& conf, uint32_t folding_factor, uint32_t vector_length, uint32_t max_dwells, int32_t samples_per_code);
+pcps_quicksync_acquisition_cc_sptr pcps_quicksync_make_acquisition_cc(const Acq_Conf& conf, uint32_t folding_factor, uint32_t max_dwells);
 
 /*!
  * \brief This class implements a Parallel Code Phase Search Acquisition with
@@ -136,16 +135,6 @@ public:
     }
 
     /*!
-     * \brief Set statistics threshold of PCPS algorithm.
-     * \param threshold - Threshold for signal detection (check \ref Navitec2012,
-     * Algorithm 1, for a definition of this threshold).
-     */
-    inline void set_threshold(float threshold) override
-    {
-        d_threshold = threshold;
-    }
-
-    /*!
      * \brief Parallel Code Phase Search Acquisition signal processing.
      */
     int general_work(int noutput_items, gr_vector_int& ninput_items,
@@ -154,11 +143,9 @@ public:
 
 private:
     friend pcps_quicksync_acquisition_cc_sptr
-    pcps_quicksync_make_acquisition_cc(
-        const Acq_Conf& conf, uint32_t folding_factor, uint32_t vector_length, uint32_t max_dwells, int32_t samples_per_code);
+    pcps_quicksync_make_acquisition_cc(const Acq_Conf& conf, uint32_t folding_factor, uint32_t max_dwells);
 
-    explicit pcps_quicksync_acquisition_cc(
-        const Acq_Conf& conf, uint32_t folding_factor, uint32_t vector_length, uint32_t max_dwells, int32_t samples_per_code);
+    explicit pcps_quicksync_acquisition_cc(const Acq_Conf& conf, uint32_t folding_factor, uint32_t max_dwells);
 
     void calculate_magnitudes(gr_complex* fft_begin, int32_t doppler_shift, int32_t doppler_offset);
 
@@ -172,7 +159,6 @@ private:
     uint64_t d_sample_counter;
 
     float d_noise_floor_power;
-    float d_threshold;
     float d_mag;
     float d_input_power;
     float d_test_statistics;

--- a/src/algorithms/acquisition/gnuradio_blocks/pcps_tong_acquisition_cc.cc
+++ b/src/algorithms/acquisition/gnuradio_blocks/pcps_tong_acquisition_cc.cc
@@ -73,7 +73,6 @@ pcps_tong_acquisition_cc::pcps_tong_acquisition_cc(
       d_acq_params(conf),
       d_gnss_synchro(nullptr),
       d_sample_counter(0ULL),
-      d_threshold(0),
       d_mag(0),
       d_input_power(0.0),
       d_test_statistics(0),
@@ -202,8 +201,9 @@ int pcps_tong_acquisition_cc::general_work(int noutput_items,
 
                 DLOG(INFO) << "Channel: " << d_channel
                            << " , doing acquisition of satellite: " << d_gnss_synchro->System << " " << d_gnss_synchro->PRN
-                           << " ,sample stamp: " << d_sample_counter << ", threshold: "
-                           << d_threshold << ", doppler_max: " << d_acq_params.doppler_max
+                           << " , sample stamp: " << d_sample_counter
+                           << ", threshold: " << d_acq_params.threshold
+                           << ", doppler_max: " << d_acq_params.doppler_max
                            << ", doppler_step: " << d_acq_params.doppler_step;
 
                 // 1- Compute the input signal power estimation
@@ -276,7 +276,7 @@ int pcps_tong_acquisition_cc::general_work(int noutput_items,
                 // 5- Compute the test statistics and compare to the threshold
                 d_test_statistics = d_mag;
 
-                if (d_test_statistics > d_threshold * d_dwell_count)
+                if (d_test_statistics > d_acq_params.threshold * d_dwell_count)
                     {
                         d_tong_count++;
                         if (d_tong_count == d_tong_max_val)
@@ -309,7 +309,7 @@ int pcps_tong_acquisition_cc::general_work(int noutput_items,
                 DLOG(INFO) << "satellite " << d_gnss_synchro->System << " " << d_gnss_synchro->PRN;
                 DLOG(INFO) << "sample_stamp " << d_sample_counter;
                 DLOG(INFO) << "test statistics value " << d_test_statistics;
-                DLOG(INFO) << "test statistics threshold " << d_threshold;
+                DLOG(INFO) << "test statistics threshold " << d_acq_params.threshold;
                 DLOG(INFO) << "code phase " << d_gnss_synchro->Acq_delay_samples;
                 DLOG(INFO) << "doppler " << d_gnss_synchro->Acq_doppler_hz;
                 DLOG(INFO) << "magnitude " << d_mag;
@@ -344,7 +344,7 @@ int pcps_tong_acquisition_cc::general_work(int noutput_items,
                 DLOG(INFO) << "satellite " << d_gnss_synchro->System << " " << d_gnss_synchro->PRN;
                 DLOG(INFO) << "sample_stamp " << d_sample_counter;
                 DLOG(INFO) << "test statistics value " << d_test_statistics;
-                DLOG(INFO) << "test statistics threshold " << d_threshold;
+                DLOG(INFO) << "test statistics threshold " << d_acq_params.threshold;
                 DLOG(INFO) << "code phase " << d_gnss_synchro->Acq_delay_samples;
                 DLOG(INFO) << "doppler " << d_gnss_synchro->Acq_doppler_hz;
                 DLOG(INFO) << "magnitude " << d_mag;

--- a/src/algorithms/acquisition/gnuradio_blocks/pcps_tong_acquisition_cc.h
+++ b/src/algorithms/acquisition/gnuradio_blocks/pcps_tong_acquisition_cc.h
@@ -135,16 +135,6 @@ public:
     }
 
     /*!
-     * \brief Set statistics threshold of TONG algorithm.
-     * \param threshold - Threshold for signal detection (check \ref Navitec2012,
-     * Algorithm 1, for a definition of this threshold).
-     */
-    inline void set_threshold(float threshold) override
-    {
-        d_threshold = threshold;
-    }
-
-    /*!
      * \brief Parallel Code Phase Search Acquisition signal processing.
      */
     int general_work(int noutput_items, gr_vector_int& ninput_items,
@@ -176,7 +166,6 @@ private:
 
     uint64_t d_sample_counter;
 
-    float d_threshold;
     float d_mag;
     float d_input_power;
     float d_test_statistics;

--- a/src/algorithms/acquisition/libs/acq_conf.cc
+++ b/src/algorithms/acquisition/libs/acq_conf.cc
@@ -68,6 +68,7 @@ void Acq_Conf::SetFromConfiguration(const ConfigurationInterface *configuration,
     num_doppler_bins_step2 = configuration->property(role + ".second_nbins", num_doppler_bins_step2);
     doppler_step2 = configuration->property(role + ".second_doppler_step", doppler_step2);
     doppler_step = configuration->property(role + ".doppler_step", doppler_step);
+    threshold = configuration->property(role + ".threshold", threshold);
     pfa = configuration->property(role + ".pfa", pfa);
     if ((pfa < 0.0) or (pfa > 1.0))
         {

--- a/src/algorithms/acquisition/libs/acq_conf.h
+++ b/src/algorithms/acquisition/libs/acq_conf.h
@@ -48,6 +48,7 @@ public:
 
     float samples_per_ms{0.0};
     float doppler_step2{125.0};
+    float threshold{0.0};
     float pfa{0.0};
     float pfa2{0.0};
     float samples_per_code{0.0};
@@ -73,6 +74,11 @@ public:
     bool make_2_steps{false};
     bool use_automatic_resampler{false};
     bool enable_monitor_output{false};
+
+    // Not part of the configuration interface
+    uint32_t num_codes{0};
+    uint32_t code_length{0};
+    uint32_t vector_length{0};
 
 private:
     void SetDerivedParams();

--- a/src/algorithms/acquisition/libs/acq_conf_fpga.cc
+++ b/src/algorithms/acquisition/libs/acq_conf_fpga.cc
@@ -81,6 +81,7 @@ void Acq_Conf_Fpga::SetFromConfiguration(const ConfigurationInterface *configura
     doppler_step = configuration->property(role + ".doppler_step", doppler_step);
     make_2_steps = configuration->property(role + ".make_two_steps", make_2_steps);
     max_num_acqs = configuration->property(role + ".max_num_acqs", 2);
+    threshold = configuration->property(role + ".threshold", threshold);
 
     // reference for the FPGA FFT-IFFT attenuation factor
     total_block_exp = configuration->property(role + ".total_block_exp", blk_exp);

--- a/src/algorithms/acquisition/libs/acq_conf_fpga.h
+++ b/src/algorithms/acquisition/libs/acq_conf_fpga.h
@@ -49,6 +49,7 @@ public:
     double code_length_chips;
     float doppler_step{250.0};
     float doppler_step2{125.0};
+    float threshold{0.0};
 
     int64_t fs_in{4000000LL};
     int64_t resampled_fs{4000000LL};

--- a/src/algorithms/channel/adapters/channel.cc
+++ b/src/algorithms/channel/adapters/channel.cc
@@ -73,15 +73,6 @@ Channel::Channel(const ConfigurationInterface* configuration,
                 }
         }
 
-    // IMPORTANT: For future reference set_threshold needs to be called after doppler step is set (currently done at acquisition construction)
-    float threshold = configuration->property("Acquisition_" + signal_str + std::to_string(channel_) + ".threshold", static_cast<float>(0.0));
-    if (threshold == 0.0)
-        {
-            threshold = configuration->property("Acquisition_" + signal_str + ".threshold", static_cast<float>(0.0));
-        }
-
-    acq_->set_threshold(threshold);
-
     channel_fsm_->set_acquisition(acq_);
     channel_fsm_->set_tracking(trk_);
     channel_fsm_->set_telemetry(nav_);

--- a/src/core/interfaces/acquisition_interface.h
+++ b/src/core/interfaces/acquisition_interface.h
@@ -53,7 +53,6 @@ public:
     virtual void set_gnss_synchro(Gnss_Synchro* gnss_synchro) = 0;
     virtual void set_channel(unsigned int channel_id) = 0;
     virtual void set_channel_fsm(std::weak_ptr<ChannelFsm> channel_fsm) = 0;
-    virtual void set_threshold(float threshold) = 0;
     virtual void set_doppler_center(int /*doppler_center*/) {}
     virtual void set_local_code() = 0;
     virtual signed int mag() = 0;

--- a/tests/unit-tests/signal-processing-blocks/acquisition/acq_performance_test.cc
+++ b/tests/unit-tests/signal-processing-blocks/acquisition/acq_performance_test.cc
@@ -853,7 +853,6 @@ int AcquisitionPerformanceTest::run_receiver()
 
     acquisition->set_gnss_synchro(&gnss_synchro);
     acquisition->set_channel(0);
-    acquisition->set_threshold(config->property("Acquisition.threshold", 0.0));
     acquisition->set_local_code();
     acquisition->reset();
     acquisition->connect(top_block);

--- a/tests/unit-tests/signal-processing-blocks/acquisition/beidou_b1i_pcps_acquisition_test.cc
+++ b/tests/unit-tests/signal-processing-blocks/acquisition/beidou_b1i_pcps_acquisition_test.cc
@@ -319,10 +319,6 @@ TEST_F(BeidouB1iPcpsAcquisitionTest, ValidationOfResults)
     }) << "Failure setting gnss_synchro.";
 
     ASSERT_NO_THROW({
-        acquisition->set_threshold(0.0038);
-    }) << "Failure setting threshold.";
-
-    ASSERT_NO_THROW({
         acquisition->connect(top_block);
     }) << "Failure connecting acquisition to the top_block.";
 

--- a/tests/unit-tests/signal-processing-blocks/acquisition/beidou_b3i_pcps_acquisition_test.cc
+++ b/tests/unit-tests/signal-processing-blocks/acquisition/beidou_b3i_pcps_acquisition_test.cc
@@ -171,7 +171,7 @@ void BeidouB3iPcpsAcquisitionTest::init()
         }
     config->set_property("Acquisition_B3.dump_filename", "./tmp-acq-bds-b3i/acquisition");
     config->set_property("Acquisition_B3.dump_channel", "1");
-    config->set_property("Acquisition_B3.threshold", "0.00001");
+    config->set_property("Acquisition_B3.threshold", "0.0002");
     config->set_property("Acquisition_B3.doppler_max", std::to_string(doppler_max));
     config->set_property("Acquisition_B3.doppler_step", std::to_string(doppler_step));
     config->set_property("Acquisition_B3.repeat_satellite", "false");
@@ -315,10 +315,6 @@ TEST_F(BeidouB3iPcpsAcquisitionTest, ValidationOfResults)
     ASSERT_NO_THROW({
         acquisition->set_gnss_synchro(&gnss_synchro);
     }) << "Failure setting gnss_synchro.";
-
-    ASSERT_NO_THROW({
-        acquisition->set_threshold(0.0002);
-    }) << "Failure setting threshold.";
 
     ASSERT_NO_THROW({
         acquisition->connect(top_block);

--- a/tests/unit-tests/signal-processing-blocks/acquisition/galileo_e1_pcps_8ms_ambiguous_acquisition_gsoc2013_test.cc
+++ b/tests/unit-tests/signal-processing-blocks/acquisition/galileo_e1_pcps_8ms_ambiguous_acquisition_gsoc2013_test.cc
@@ -457,10 +457,6 @@ TEST_F(GalileoE1Pcps8msAmbiguousAcquisitionGSoC2013Test, ConnectAndRun)
     }) << "Failure setting gnss_synchro.";
 
     ASSERT_NO_THROW({
-        acquisition->set_threshold(config->property("Acquisition_1B.threshold", 0.0));
-    }) << "Failure setting threshold.";
-
-    ASSERT_NO_THROW({
         acquisition->connect(top_block);
         auto source = gr::analog::sig_source_c::make(fs_in, gr::analog::GR_SIN_WAVE, 1000, 1, gr_complex(0));
         auto valve = gnss_sdr_make_valve(sizeof(gr_complex), nsamples, queue.get());
@@ -497,10 +493,6 @@ TEST_F(GalileoE1Pcps8msAmbiguousAcquisitionGSoC2013Test, ValidationOfResults)
     ASSERT_NO_THROW({
         acquisition->set_gnss_synchro(&gnss_synchro);
     }) << "Failure setting gnss_synchro.";
-
-    ASSERT_NO_THROW({
-        acquisition->set_threshold(config->property("Acquisition_1B.threshold", 0.0));
-    }) << "Failure setting threshold.";
 
     ASSERT_NO_THROW({
         acquisition->connect(top_block);
@@ -574,10 +566,6 @@ TEST_F(GalileoE1Pcps8msAmbiguousAcquisitionGSoC2013Test, ValidationOfResultsProb
     ASSERT_NO_THROW({
         acquisition->set_gnss_synchro(&gnss_synchro);
     }) << "Failure setting gnss_synchro.";
-
-    ASSERT_NO_THROW({
-        acquisition->set_threshold(config->property("Acquisition_1B.threshold", 0.0));
-    }) << "Failure setting threshold.";
 
     ASSERT_NO_THROW({
         acquisition->connect(top_block);

--- a/tests/unit-tests/signal-processing-blocks/acquisition/galileo_e1_pcps_ambiguous_acquisition_gsoc_test.cc
+++ b/tests/unit-tests/signal-processing-blocks/acquisition/galileo_e1_pcps_ambiguous_acquisition_gsoc_test.cc
@@ -171,7 +171,7 @@ void GalileoE1PcpsAmbiguousAcquisitionGSoCTest::init()
     config->set_property("Acquisition_1B.item_type", "gr_complex");
     config->set_property("Acquisition_1B.coherent_integration_time_ms", "4");
     config->set_property("Acquisition_1B.dump", "false");
-    // config->set_property("Acquisition_1B.threshold", "2.5");
+    config->set_property("Acquisition_1B.threshold", "0.00001");
     config->set_property("Acquisition_1B.pfa", "0.001");
     config->set_property("Acquisition_1B.doppler_max", "10000");
     config->set_property("Acquisition_1B.doppler_step", "250");
@@ -270,10 +270,6 @@ TEST_F(GalileoE1PcpsAmbiguousAcquisitionGSoCTest, ValidationOfResults)
     ASSERT_NO_THROW({
         acquisition->set_gnss_synchro(&gnss_synchro);
     }) << "Failure setting gnss_synchro.";
-
-    ASSERT_NO_THROW({
-        acquisition->set_threshold(config->property("Acquisition_1B.threshold", 0.00001));
-    }) << "Failure setting threshold.";
 
     ASSERT_NO_THROW({
         acquisition->connect(top_block);

--- a/tests/unit-tests/signal-processing-blocks/acquisition/galileo_e1_pcps_ambiguous_acquisition_test.cc
+++ b/tests/unit-tests/signal-processing-blocks/acquisition/galileo_e1_pcps_ambiguous_acquisition_test.cc
@@ -174,7 +174,7 @@ void GalileoE1PcpsAmbiguousAcquisitionTest::init()
             config->set_property("Acquisition_1B.dump", "false");
         }
     config->set_property("Acquisition_1B.dump_filename", "./tmp-acq-gal1/acquisition");
-    // config->set_property("Acquisition_1B.threshold", "2.5");
+    config->set_property("Acquisition_1B.threshold", std::to_string(1e-9));
     config->set_property("Acquisition_1B.pfa", "0.001");
     config->set_property("Acquisition_1B.doppler_max", std::to_string(doppler_max));
     config->set_property("Acquisition_1B.doppler_step", std::to_string(doppler_step));
@@ -331,10 +331,6 @@ TEST_F(GalileoE1PcpsAmbiguousAcquisitionTest, ValidationOfResults)
     ASSERT_NO_THROW({
         acquisition->set_gnss_synchro(&gnss_synchro);
     }) << "Failure setting gnss_synchro.";
-
-    ASSERT_NO_THROW({
-        acquisition->set_threshold(config->property("Acquisition_1B.threshold", 1e-9));
-    }) << "Failure setting threshold.";
 
     ASSERT_NO_THROW({
         acquisition->connect(top_block);

--- a/tests/unit-tests/signal-processing-blocks/acquisition/galileo_e1_pcps_ambiguous_acquisition_test_fpga.cc
+++ b/tests/unit-tests/signal-processing-blocks/acquisition/galileo_e1_pcps_ambiguous_acquisition_test_fpga.cc
@@ -336,7 +336,6 @@ bool GalileoE1PcpsAmbiguousAcquisitionTestFpga::acquire_signal()
     acquisition->set_channel_fsm(channel_fsm_);
     acquisition->set_channel(1);
     acquisition->set_doppler_center(0);
-    acquisition->set_threshold(0.001);
 
     nsamples_to_transfer = static_cast<unsigned int>(std::round(static_cast<double>(BASEBAND_SAMPLING_FREQ) / (GALILEO_E1_CODE_CHIP_RATE_CPS / GALILEO_E1_B_CODE_LENGTH_CHIPS)));
 
@@ -395,7 +394,7 @@ void GalileoE1PcpsAmbiguousAcquisitionTestFpga::init()
 {
     config->set_property("GNSS-SDR.internal_fs_sps", "4000000");
     config->set_property("Acquisition.implementation", "Galileo_E1_PCPS_Ambiguous_Acquisition_FPGA");
-    config->set_property("Acquisition.threshold", "0.00001");
+    config->set_property("Acquisition.threshold", "0.001");
     config->set_property("Acquisition.doppler_max", std::to_string(doppler_max));
     config->set_property("Acquisition.doppler_step", std::to_string(doppler_step));
     config->set_property("Acquisition.repeat_satellite", "false");

--- a/tests/unit-tests/signal-processing-blocks/acquisition/galileo_e1_pcps_cccwsr_ambiguous_acquisition_gsoc2013_test.cc
+++ b/tests/unit-tests/signal-processing-blocks/acquisition/galileo_e1_pcps_cccwsr_ambiguous_acquisition_gsoc2013_test.cc
@@ -488,10 +488,6 @@ TEST_F(GalileoE1PcpsCccwsrAmbiguousAcquisitionTest, ValidationOfResults)
     }) << "Failure setting gnss_synchro.";
 
     ASSERT_NO_THROW({
-        acquisition->set_threshold(config->property("Acquisition_1B.threshold", 0.00001));
-    }) << "Failure setting threshold.";
-
-    ASSERT_NO_THROW({
         acquisition->connect(top_block);
     }) << "Failure connecting acquisition to the top_block.";
 
@@ -568,10 +564,6 @@ TEST_F(GalileoE1PcpsCccwsrAmbiguousAcquisitionTest, ValidationOfResultsProbabili
     ASSERT_NO_THROW({
         acquisition->set_gnss_synchro(&gnss_synchro);
     }) << "Failure setting gnss_synchro.";
-
-    ASSERT_NO_THROW({
-        acquisition->set_threshold(config->property("Acquisition_1B.threshold", 0.00215));
-    }) << "Failure setting threshold.";
 
     ASSERT_NO_THROW({
         acquisition->connect(top_block);

--- a/tests/unit-tests/signal-processing-blocks/acquisition/galileo_e1_pcps_quicksync_ambiguous_acquisition_gsoc2014_test.cc
+++ b/tests/unit-tests/signal-processing-blocks/acquisition/galileo_e1_pcps_quicksync_ambiguous_acquisition_gsoc2014_test.cc
@@ -477,7 +477,7 @@ void GalileoE1PcpsQuickSyncAmbiguousAcquisitionGSoC2014Test::config_3()
         std::to_string(integration_time_ms));
     config->set_property("Acquisition_1B.max_dwells", "1");
     config->set_property("Acquisition_1B.bit_transition_flag", "false");
-    config->set_property("Acquisition_1B.threshold", "0.2");
+    config->set_property("Acquisition_1B.threshold", "5");
     config->set_property("Acquisition_1B.doppler_max", "10000");
     config->set_property("Acquisition_1B.doppler_step", "50");
     config->set_property("Acquisition_1B.folding_factor", "4");
@@ -639,10 +639,6 @@ TEST_F(GalileoE1PcpsQuickSyncAmbiguousAcquisitionGSoC2014Test, ValidationOfResul
     }) << "Failure setting gnss_synchro.";
 
     ASSERT_NO_THROW({
-        acquisition->set_threshold(1);
-    }) << "Failure setting threshold.";
-
-    ASSERT_NO_THROW({
         acquisition->connect(top_block);
     }) << "Failure connecting acquisition to the top_block.";
 
@@ -720,10 +716,6 @@ TEST_F(GalileoE1PcpsQuickSyncAmbiguousAcquisitionGSoC2014Test, ValidationOfResul
     }) << "Failure setting gnss_synchro.";
 
     ASSERT_NO_THROW({
-        acquisition->set_threshold(5);
-    }) << "Failure setting threshold.";
-
-    ASSERT_NO_THROW({
         acquisition->connect(top_block);
     }) << "Failure connecting acquisition to the top_block.";
 
@@ -796,10 +788,6 @@ TEST_F(GalileoE1PcpsQuickSyncAmbiguousAcquisitionGSoC2014Test, ValidationOfResul
     ASSERT_NO_THROW({
         acquisition->set_gnss_synchro(&gnss_synchro);
     }) << "Failure setting gnss_synchro.";
-
-    ASSERT_NO_THROW({
-        acquisition->set_threshold(config->property("Acquisition_1B.threshold", 0.0));
-    }) << "Failure setting threshold.";
 
     ASSERT_NO_THROW({
         acquisition->connect(top_block);

--- a/tests/unit-tests/signal-processing-blocks/acquisition/galileo_e1_pcps_tong_ambiguous_acquisition_gsoc2013_test.cc
+++ b/tests/unit-tests/signal-processing-blocks/acquisition/galileo_e1_pcps_tong_ambiguous_acquisition_gsoc2013_test.cc
@@ -256,7 +256,7 @@ void GalileoE1PcpsTongAmbiguousAcquisitionGSoC2013Test::config_1()
         std::to_string(integration_time_ms));
     config->set_property("Acquisition_1B.tong_init_val", "1");
     config->set_property("Acquisition_1B.tong_max_val", "8");
-    config->set_property("Acquisition_1B.threshold", "0.3");
+    config->set_property("Acquisition_1B.threshold", "0.01");
     config->set_property("Acquisition_1B.doppler_max", "10000");
     config->set_property("Acquisition_1B.doppler_step", "100");
     config->set_property("Acquisition_1B.dump", "false");
@@ -486,10 +486,6 @@ TEST_F(GalileoE1PcpsTongAmbiguousAcquisitionGSoC2013Test, ValidationOfResults)
     }) << "Failure setting gnss_synchro.";
 
     ASSERT_NO_THROW({
-        acquisition->set_threshold(0.01);
-    }) << "Failure setting threshold.";
-
-    ASSERT_NO_THROW({
         acquisition->connect(top_block);
     }) << "Failure connecting acquisition to the top_block.";
 
@@ -563,10 +559,6 @@ TEST_F(GalileoE1PcpsTongAmbiguousAcquisitionGSoC2013Test, ValidationOfResultsPro
     ASSERT_NO_THROW({
         acquisition->set_gnss_synchro(&gnss_synchro);
     }) << "Failure setting gnss_synchro.";
-
-    ASSERT_NO_THROW({
-        acquisition->set_threshold(config->property("Acquisition_1B.threshold", 0.00028));
-    }) << "Failure setting threshold.";
 
     ASSERT_NO_THROW({
         acquisition->connect(top_block);

--- a/tests/unit-tests/signal-processing-blocks/acquisition/galileo_e5a_pcps_acquisition_gsoc2014_gensource_test.cc
+++ b/tests/unit-tests/signal-processing-blocks/acquisition/galileo_e5a_pcps_acquisition_gsoc2014_gensource_test.cc
@@ -272,7 +272,7 @@ void GalileoE5aPcpsAcquisitionGSoC2014GensourceTest::config_1()
     config->set_property("Acquisition_5X.CAF_window_hz", std::to_string(CAF_window_hz));
     config->set_property("Acquisition_5X.Zero_padding", std::to_string(Zero_padding));
     config->set_property("Acquisition_5X.pfa", "0.003");
-    //    config->set_property("Acquisition_5X.threshold", "0.01");
+    config->set_property("Acquisition_5X.threshold", "0.0001");
     config->set_property("Acquisition_5X.doppler_max", "10000");
     config->set_property("Acquisition_5X.doppler_step", "250");
     config->set_property("Acquisition_5X.bit_transition_flag", "false");
@@ -584,10 +584,6 @@ TEST_F(GalileoE5aPcpsAcquisitionGSoC2014GensourceTest, ValidationOfSIM)
     ASSERT_NO_THROW({
         acquisition->set_gnss_synchro(&gnss_synchro);
     }) << "Failure setting gnss_synchro.";
-
-    ASSERT_NO_THROW({
-        acquisition->set_threshold(config->property("Acquisition_5X.threshold", 0.0001));
-    }) << "Failure setting threshold.";
 
     ASSERT_NO_THROW({
         acquisition->connect(top_block);

--- a/tests/unit-tests/signal-processing-blocks/acquisition/galileo_e5b_pcps_acquisition_test.cc
+++ b/tests/unit-tests/signal-processing-blocks/acquisition/galileo_e5b_pcps_acquisition_test.cc
@@ -224,7 +224,7 @@ void GalileoE5bPcpsAcquisitionTest::init()
     config->set_property("Acquisition_7X.coherent_integration_time_ms", std::to_string(integration_time_ms));
     config->set_property("Acquisition_7X.dump", "false");
     config->set_property("Acquisition_7X.dump_filename", "./acquisition");
-    config->set_property("Acquisition_7X.threshold", "0.001");
+    config->set_property("Acquisition_7X.threshold", "0.0001");
     config->set_property("Acquisition_7X.doppler_max", "10000");
     config->set_property("Acquisition_7X.doppler_step", "250");
     config->set_property("Acquisition_7X.repeat_satellite", "false");
@@ -372,10 +372,6 @@ TEST_F(GalileoE5bPcpsAcquisitionTest, ValidationOfResults)
     ASSERT_NO_THROW({
         acquisition->set_gnss_synchro(&gnss_synchro);
     }) << "Failure setting gnss_synchro.";
-
-    ASSERT_NO_THROW({
-        acquisition->set_threshold(0.0001);
-    }) << "Failure setting threshold.";
 
     ASSERT_NO_THROW({
         acquisition->connect(top_block);

--- a/tests/unit-tests/signal-processing-blocks/acquisition/glonass_l1_ca_pcps_acquisition_test.cc
+++ b/tests/unit-tests/signal-processing-blocks/acquisition/glonass_l1_ca_pcps_acquisition_test.cc
@@ -164,7 +164,7 @@ void GlonassL1CaPcpsAcquisitionTest::init()
     config->set_property("Acquisition_1G.dump", "true");
     config->set_property("Acquisition_1G.dump_filename", "./acquisition");
     config->set_property("Acquisition_1G.implementation", "Glonass_L1_CA_PCPS_Acquisition");
-    config->set_property("Acquisition_1G.threshold", "0.001");
+    config->set_property("Acquisition_1G.threshold", "0.005");
     config->set_property("Acquisition_1G.doppler_max", "5000");
     config->set_property("Acquisition_1G.doppler_step", "500");
     config->set_property("Acquisition_1G.repeat_satellite", "false");
@@ -233,10 +233,6 @@ TEST_F(GlonassL1CaPcpsAcquisitionTest, ValidationOfResults)
     ASSERT_NO_THROW({
         acquisition->set_gnss_synchro(&gnss_synchro);
     }) << "Failure setting gnss_synchro.";
-
-    ASSERT_NO_THROW({
-        acquisition->set_threshold(0.005);
-    }) << "Failure setting threshold.";
 
     ASSERT_NO_THROW({
         acquisition->connect(top_block);

--- a/tests/unit-tests/signal-processing-blocks/acquisition/glonass_l2_ca_pcps_acquisition_test.cc
+++ b/tests/unit-tests/signal-processing-blocks/acquisition/glonass_l2_ca_pcps_acquisition_test.cc
@@ -259,7 +259,7 @@ void GlonassL2CaPcpsAcquisitionTest::config_1()
         std::to_string(integration_time_ms));
     config->set_property("Acquisition_2G.max_dwells", "1");
     config->set_property("Acquisition_2G.implementation", "GLONASS_L2_CA_PCPS_Acquisition");
-    config->set_property("Acquisition_2G.threshold", "0.8");
+    config->set_property("Acquisition_2G.threshold", "0.0005");
     config->set_property("Acquisition_2G.doppler_max", "10000");
     config->set_property("Acquisition_2G.doppler_step", "250");
     config->set_property("Acquisition_2G.bit_transition_flag", "false");
@@ -490,10 +490,6 @@ TEST_F(GlonassL2CaPcpsAcquisitionTest, ValidationOfResults)
     }) << "Failure setting gnss_synchro.";
 
     ASSERT_NO_THROW({
-        acquisition->set_threshold(0.0005);
-    }) << "Failure setting threshold.";
-
-    ASSERT_NO_THROW({
         acquisition->connect(top_block);
         top_block->msg_connect(acquisition->get_right_block(), pmt::mp("events"), msg_rx, pmt::mp("events"));
     }) << "Failure connecting acquisition to the top_block.";
@@ -564,10 +560,6 @@ TEST_F(GlonassL2CaPcpsAcquisitionTest, ValidationOfResultsProbabilities)
     ASSERT_NO_THROW({
         acquisition->set_gnss_synchro(&gnss_synchro);
     }) << "Failure setting gnss_synchro.";
-
-    ASSERT_NO_THROW({
-        acquisition->set_threshold(config->property("Acquisition_2G.threshold", 0.0));
-    }) << "Failure setting threshold.";
 
     ASSERT_NO_THROW({
         acquisition->connect(top_block);

--- a/tests/unit-tests/signal-processing-blocks/acquisition/gps_l1_ca_pcps_acquisition_test.cc
+++ b/tests/unit-tests/signal-processing-blocks/acquisition/gps_l1_ca_pcps_acquisition_test.cc
@@ -170,7 +170,7 @@ void GpsL1CaPcpsAcquisitionTest::init()
         }
     config->set_property("Acquisition_1C.dump_filename", "./tmp-acq-gps1/acquisition");
     config->set_property("Acquisition_1C.dump_channel", "1");
-    config->set_property("Acquisition_1C.threshold", "0.00001");
+    config->set_property("Acquisition_1C.threshold", "0.001");
     config->set_property("Acquisition_1C.doppler_max", std::to_string(doppler_max));
     config->set_property("Acquisition_1C.doppler_step", std::to_string(doppler_step));
     config->set_property("Acquisition_1C.repeat_satellite", "false");
@@ -328,10 +328,6 @@ TEST_F(GpsL1CaPcpsAcquisitionTest /*unused*/, ValidationOfResults /*unused*/)
     ASSERT_NO_THROW({
         acquisition->set_gnss_synchro(&gnss_synchro);
     }) << "Failure setting gnss_synchro.";
-
-    ASSERT_NO_THROW({
-        acquisition->set_threshold(0.001);
-    }) << "Failure setting threshold.";
 
     ASSERT_NO_THROW({
         acquisition->connect(top_block);

--- a/tests/unit-tests/signal-processing-blocks/acquisition/gps_l1_ca_pcps_acquisition_test_fpga.cc
+++ b/tests/unit-tests/signal-processing-blocks/acquisition/gps_l1_ca_pcps_acquisition_test_fpga.cc
@@ -335,7 +335,6 @@ bool GpsL1CaPcpsAcquisitionTestFpga::acquire_signal()
     acquisition->set_channel_fsm(channel_fsm_);
     acquisition->set_channel(1);
     acquisition->set_doppler_center(0);
-    acquisition->set_threshold(0.001);
 
     nsamples_to_transfer = static_cast<unsigned int>(std::round(static_cast<double>(BASEBAND_SAMPLING_FREQ) / (GPS_L1_CA_CODE_RATE_CPS / GPS_L1_CA_CODE_LENGTH_CHIPS)));
 
@@ -394,7 +393,7 @@ void GpsL1CaPcpsAcquisitionTestFpga::init()
 {
     config->set_property("GNSS-SDR.internal_fs_sps", "4000000");
     config->set_property("Acquisition.implementation", "GPS_L1_CA_PCPS_Acquisition_FPGA");
-    config->set_property("Acquisition.threshold", "0.00001");
+    config->set_property("Acquisition.threshold", "0.001");
     config->set_property("Acquisition.doppler_max", std::to_string(doppler_max));
     config->set_property("Acquisition.doppler_step", std::to_string(doppler_step));
     config->set_property("Acquisition.repeat_satellite", "false");

--- a/tests/unit-tests/signal-processing-blocks/acquisition/gps_l1_ca_pcps_opencl_acquisition_gsoc2013_test.cc
+++ b/tests/unit-tests/signal-processing-blocks/acquisition/gps_l1_ca_pcps_opencl_acquisition_gsoc2013_test.cc
@@ -483,10 +483,6 @@ TEST_F(GpsL1CaPcpsOpenClAcquisitionGSoC2013Test, ValidationOfResults)
     }) << "Failure setting gnss_synchro.";
 
     ASSERT_NO_THROW({
-        acquisition->set_threshold(config->property("Acquisition_1C.threshold", 0.0));
-    }) << "Failure setting threshold.";
-
-    ASSERT_NO_THROW({
         acquisition->connect(top_block);
     }) << "Failure connecting acquisition to the top_block.";
 
@@ -559,10 +555,6 @@ TEST_F(GpsL1CaPcpsOpenClAcquisitionGSoC2013Test, ValidationOfResultsProbabilitie
     ASSERT_NO_THROW({
         acquisition->set_gnss_synchro(&gnss_synchro);
     }) << "Failure setting gnss_synchro.";
-
-    ASSERT_NO_THROW({
-        acquisition->set_threshold(config->property("Acquisition_1C.threshold", 0.0));
-    }) << "Failure setting threshold.";
 
     ASSERT_NO_THROW({
         acquisition->connect(top_block);

--- a/tests/unit-tests/signal-processing-blocks/acquisition/gps_l1_ca_pcps_quicksync_acquisition_gsoc2014_test.cc
+++ b/tests/unit-tests/signal-processing-blocks/acquisition/gps_l1_ca_pcps_quicksync_acquisition_gsoc2014_test.cc
@@ -272,7 +272,7 @@ void GpsL1CaPcpsQuickSyncAcquisitionGSoC2014Test::config_1()
     config->set_property("Acquisition_1C.coherent_integration_time_ms",
         std::to_string(integration_time_ms));
     config->set_property("Acquisition_1C.max_dwells", "1");
-    config->set_property("Acquisition_1C.threshold", "250");
+    config->set_property("Acquisition_1C.threshold", "100");
     config->set_property("Acquisition_1C.doppler_max", "10000");
     config->set_property("Acquisition_1C.doppler_step", "250");
     config->set_property("Acquisition_1C.bit_transition_flag", "false");
@@ -611,10 +611,6 @@ TEST_F(GpsL1CaPcpsQuickSyncAcquisitionGSoC2014Test, ValidationOfResults)
     }) << "Failure setting gnss_synchro.";
 
     ASSERT_NO_THROW({
-        acquisition->set_threshold(100);
-    }) << "Failure setting threshold.";
-
-    ASSERT_NO_THROW({
         acquisition->connect(top_block);
     }) << "Failure connecting acquisition to the top_block.";
 
@@ -692,10 +688,6 @@ TEST_F(GpsL1CaPcpsQuickSyncAcquisitionGSoC2014Test, ValidationOfResultsWithNoise
     ASSERT_NO_THROW({
         acquisition->set_gnss_synchro(&gnss_synchro);
     }) << "Failure setting gnss_synchro.";
-
-    ASSERT_NO_THROW({
-        acquisition->set_threshold(100);
-    }) << "Failure setting threshold.";
 
     ASSERT_NO_THROW({
         acquisition->connect(top_block);

--- a/tests/unit-tests/signal-processing-blocks/acquisition/gps_l1_ca_pcps_tong_acquisition_gsoc2013_test.cc
+++ b/tests/unit-tests/signal-processing-blocks/acquisition/gps_l1_ca_pcps_tong_acquisition_gsoc2013_test.cc
@@ -480,10 +480,6 @@ TEST_F(GpsL1CaPcpsTongAcquisitionGSoC2013Test, ValidationOfResults)
     }) << "Failure setting gnss_synchro.";
 
     ASSERT_NO_THROW({
-        acquisition->set_threshold(config->property("Acquisition_1C.threshold", 0.0));
-    }) << "Failure setting threshold.";
-
-    ASSERT_NO_THROW({
         acquisition->connect(top_block);
     }) << "Failure connecting acquisition to the top_block.";
 
@@ -555,10 +551,6 @@ TEST_F(GpsL1CaPcpsTongAcquisitionGSoC2013Test, ValidationOfResultsProbabilities)
     ASSERT_NO_THROW({
         acquisition->set_gnss_synchro(&gnss_synchro);
     }) << "Failure setting gnss_synchro.";
-
-    ASSERT_NO_THROW({
-        acquisition->set_threshold(config->property("Acquisition_1C.threshold", 0.0));
-    }) << "Failure setting threshold.";
 
     ASSERT_NO_THROW({
         acquisition->connect(top_block);

--- a/tests/unit-tests/signal-processing-blocks/acquisition/gps_l2_m_pcps_acquisition_test.cc
+++ b/tests/unit-tests/signal-processing-blocks/acquisition/gps_l2_m_pcps_acquisition_test.cc
@@ -329,10 +329,6 @@ TEST_F(GpsL2MPcpsAcquisitionTest, ValidationOfResults)
     }) << "Failure setting gnss_synchro.";
 
     ASSERT_NO_THROW({
-        acquisition->set_threshold(0.001);
-    }) << "Failure setting threshold.";
-
-    ASSERT_NO_THROW({
         acquisition->connect(top_block);
     }) << "Failure connecting acquisition to the top_block.";
 

--- a/tests/unit-tests/signal-processing-blocks/observables/hybrid_observables_test.cc
+++ b/tests/unit-tests/signal-processing-blocks/observables/hybrid_observables_test.cc
@@ -540,13 +540,14 @@ bool HybridObservablesTest::acquire_signal()
             throw(std::exception());
         }
 
+#if USE_GLOG_AND_GFLAGS
+    config->set_property("Acquisition.threshold", FLAGS_external_signal_acquisition_threshold);
+#else
+    config->set_property("Acquisition.threshold", absl::GetFlag(FLAGS_external_signal_acquisition_threshold));
+#endif
+
     acquisition->set_gnss_synchro(&tmp_gnss_synchro);
     acquisition->set_channel(0);
-#if USE_GLOG_AND_GFLAGS
-    acquisition->set_threshold(config->property("Acquisition.threshold", FLAGS_external_signal_acquisition_threshold));
-#else
-    acquisition->set_threshold(config->property("Acquisition.threshold", absl::GetFlag(FLAGS_external_signal_acquisition_threshold)));
-#endif
     acquisition->set_local_code();
     acquisition->reset();
     acquisition->connect(top_block_acq);

--- a/tests/unit-tests/signal-processing-blocks/observables/hybrid_observables_test_fpga.cc
+++ b/tests/unit-tests/signal-processing-blocks/observables/hybrid_observables_test_fpga.cc
@@ -699,13 +699,8 @@ bool HybridObservablesTestFpga::acquire_signal()
     acquisition->set_gnss_synchro(&tmp_gnss_synchro);
     acquisition->set_channel_fsm(channel_fsm_);
     acquisition->set_channel(0);
-#if USE_GLOG_AND_GFLAGS
     acquisition->set_doppler_center(0);
-    acquisition->set_threshold(config->property("Acquisition.threshold", FLAGS_external_signal_acquisition_threshold));
-#else
-    acquisition->set_doppler_center(0);
-    acquisition->set_threshold(config->property("Acquisition.threshold", absl::GetFlag(FLAGS_external_signal_acquisition_threshold)));
-#endif
+
     std::chrono::time_point<std::chrono::system_clock> start, end;
     std::chrono::duration<double> elapsed_seconds;
     start = std::chrono::system_clock::now();
@@ -903,6 +898,12 @@ void HybridObservablesTestFpga::configure_receiver(
 
     gnss_synchro_master.Channel_ID = 0;
     config->set_property("GNSS-SDR.internal_fs_sps", std::to_string(baseband_sampling_freq));
+
+#if USE_GLOG_AND_GFLAGS
+    config->set_property("Acquisition.threshold", FLAGS_external_signal_acquisition_threshold);
+#else
+    config->set_property("Acquisition.threshold", absl::GetFlag(FLAGS_external_signal_acquisition_threshold));
+#endif
 
     std::string System_and_Signal;
     if (implementation == "GPS_L1_CA_DLL_PLL_Tracking_FPGA")

--- a/tests/unit-tests/signal-processing-blocks/tracking/tracking_pull-in_test.cc
+++ b/tests/unit-tests/signal-processing-blocks/tracking/tracking_pull-in_test.cc
@@ -324,6 +324,12 @@ void TrackingPullInTest::configure_receiver(
     gnss_synchro.Channel_ID = 0;
     config->set_property("GNSS-SDR.internal_fs_sps", std::to_string(baseband_sampling_freq));
 
+#if USE_GLOG_AND_GFLAGS
+    config->set_property("Acquisition.threshold", FLAGS_external_signal_acquisition_threshold);
+#else
+    config->set_property("Acquisition.threshold", absl::GetFlag(FLAGS_external_signal_acquisition_threshold));
+#endif
+
     std::string System_and_Signal;
     if (implementation == "GPS_L1_CA_DLL_PLL_Tracking")
         {
@@ -535,11 +541,6 @@ bool TrackingPullInTest::acquire_signal(int SV_ID)
 
     acquisition->set_gnss_synchro(&tmp_gnss_synchro);
     acquisition->set_channel(0);
-#if USE_GLOG_AND_GFLAGS
-    acquisition->set_threshold(config->property("Acquisition.threshold", FLAGS_external_signal_acquisition_threshold));
-#else
-    acquisition->set_threshold(config->property("Acquisition.threshold", absl::GetFlag(FLAGS_external_signal_acquisition_threshold)));
-#endif
     acquisition->set_local_code();
     acquisition->reset();
     acquisition->connect(top_block_acq);

--- a/tests/unit-tests/signal-processing-blocks/tracking/tracking_pull-in_test_fpga.cc
+++ b/tests/unit-tests/signal-processing-blocks/tracking/tracking_pull-in_test_fpga.cc
@@ -535,6 +535,12 @@ void TrackingPullInTestFpga::configure_receiver(
     gnss_synchro.Channel_ID = 0;
     config->set_property("GNSS-SDR.internal_fs_sps", std::to_string(baseband_sampling_freq));
 
+#if USE_GLOG_AND_GFLAGS
+    config->set_property("Acquisition.threshold", FLAGS_external_signal_acquisition_threshold);
+#else
+    config->set_property("Acquisition.threshold", absl::GetFlag(FLAGS_external_signal_acquisition_threshold));
+#endif
+
     std::string System_and_Signal;
     if (implementation == "GPS_L1_CA_DLL_PLL_Tracking_FPGA")
         {
@@ -695,13 +701,7 @@ bool TrackingPullInTestFpga::acquire_signal(int SV_ID)
     acquisition->set_gnss_synchro(&tmp_gnss_synchro);
     acquisition->set_channel_fsm(channel_fsm_);
     acquisition->set_channel(0);
-#if USE_GLOG_AND_GFLAGS
     acquisition->set_doppler_center(0);
-    acquisition->set_threshold(config->property("Acquisition.threshold", FLAGS_external_signal_acquisition_threshold));
-#else
-    acquisition->set_doppler_center(0);
-    acquisition->set_threshold(config->property("Acquisition.threshold", absl::GetFlag(FLAGS_external_signal_acquisition_threshold)));
-#endif
     std::chrono::time_point<std::chrono::system_clock> start, end;
     std::chrono::duration<double> elapsed_seconds;
     start = std::chrono::system_clock::now();

--- a/utils/front-end-cal/main.cc
+++ b/utils/front-end-cal/main.cc
@@ -474,12 +474,12 @@ int main(int argc, char** argv)
             int64_t fs_in_ = configuration->property("GNSS-SDR.internal_fs_sps", 2048000);
             configuration->set_property("Acquisition.max_dwells", "10");
             configuration->set_property("Acquisition.doppler_max", "10000");
+            configuration->set_property("Acquisition.threshold", "2.0");
 
             auto acquisition = std::make_shared<GpsL1CaPcpsAcquisitionFineDoppler>(configuration.get(), "Acquisition", 1, 1);
 
             acquisition->set_channel(1);
             acquisition->set_gnss_synchro(&gnss_synchro);
-            acquisition->set_threshold(configuration->property("Acquisition.threshold", 2.0));
 
             gr::block_sptr source;
             source = gr::blocks::file_source::make(sizeof(gr_complex), "tmp_capture.dat");


### PR DESCRIPTION
I moved the `threshold` computation at construction and removed the `set_threshold` functions.
