### PR TITLE
Fix acquisition two steps

### DIFF
--- a/src/algorithms/acquisition/gnuradio_blocks/pcps_acquisition.cc
+++ b/src/algorithms/acquisition/gnuradio_blocks/pcps_acquisition.cc
@@ -132,6 +132,7 @@ pcps_acquisition::pcps_acquisition(const Acq_Conf& conf_)
       d_worker_active(false),
       d_num_noncoherent_integrations_counter(0),
       d_dump_number(0),
+      d_input_power(0),
       d_doppler_center_step_two(0),
       d_magnitude_grid(d_num_doppler_bins, volk_gnsssdr::vector<float>(d_fft_size)),
       d_tmp_buffer(d_fft_size),
@@ -309,7 +310,7 @@ void pcps_acquisition::log_acquisition(const AcquisitionResult& result) const
                << ", test statistics threshold " << get_threshold()
                << ", code phase " << d_gnss_synchro->Acq_delay_samples
                << ", doppler " << static_cast<double>(result.doppler)
-               << ", input signal power " << result.input_power
+               << ", input signal power " << d_input_power
                << ", Assist doppler_center " << d_doppler_center;
 }
 
@@ -383,7 +384,7 @@ void pcps_acquisition::dump_results(const AcquisitionResult& result)
             write_matlab_var<1>("acq_delay_samples", static_cast<float>(d_gnss_synchro->Acq_delay_samples), matfp, dims_1d);
             write_matlab_var<1>("test_statistic", result.test_statistics, matfp, dims_1d);
             write_matlab_var<1>("threshold", get_threshold(), matfp, dims_1d);
-            write_matlab_var<1>("input_power", result.input_power, matfp, dims_1d);
+            write_matlab_var<1>("input_power", d_input_power, matfp, dims_1d);
             write_matlab_var<1>("sample_counter", result.sample_count, matfp, dims_1d);
             write_matlab_var<1>("PRN", d_gnss_synchro->PRN, matfp, dims_1d);
             write_matlab_var<1>("num_dwells", static_cast<int32_t>(d_num_noncoherent_integrations_counter), matfp, dims_1d);
@@ -425,7 +426,7 @@ pcps_acquisition::AcquisitionResult pcps_acquisition::max_to_input_power_statist
     if (!d_step_two)
         {
             const auto index_opp = (index_doppler + d_num_doppler_bins / 2) % d_num_doppler_bins;
-            result.input_power = static_cast<float>(std::accumulate(d_magnitude_grid[index_opp].data(), d_magnitude_grid[index_opp].data() + d_effective_fft_size, static_cast<float>(0.0)) / d_effective_fft_size / 2.0 / d_num_noncoherent_integrations_counter);
+            d_input_power = static_cast<float>(std::accumulate(d_magnitude_grid[index_opp].data(), d_magnitude_grid[index_opp].data() + d_effective_fft_size, static_cast<float>(0.0)) / d_effective_fft_size / 2.0 / d_num_noncoherent_integrations_counter);
             result.doppler = -static_cast<int32_t>(doppler_max) + d_doppler_center + doppler_step * static_cast<int32_t>(index_doppler);
         }
     else
@@ -433,13 +434,13 @@ pcps_acquisition::AcquisitionResult pcps_acquisition::max_to_input_power_statist
             result.doppler = static_cast<int32_t>(d_doppler_center_step_two + (static_cast<float>(index_doppler) - static_cast<float>(floor(d_num_doppler_bins_step2 / 2.0))) * d_acq_parameters.doppler_step2);
         }
 
-    if (result.input_power < std::numeric_limits<float>::epsilon())
+    if (d_input_power < std::numeric_limits<float>::epsilon())
         {
             result.test_statistics = 0;
         }
     else
         {
-            result.test_statistics = grid_maximum / result.input_power;
+            result.test_statistics = grid_maximum / d_input_power;
         }
 
     return result;

--- a/src/algorithms/acquisition/gnuradio_blocks/pcps_acquisition.cc
+++ b/src/algorithms/acquisition/gnuradio_blocks/pcps_acquisition.cc
@@ -602,7 +602,6 @@ void pcps_acquisition::update_synchro(const AcquisitionResult& result)
 
 void pcps_acquisition::handle_threshold_reached(AcquisitionResult& result)
 {
-    d_active = false;
     d_state = 0;
 
     if (d_acq_parameters.make_2_steps)
@@ -611,6 +610,7 @@ void pcps_acquisition::handle_threshold_reached(AcquisitionResult& result)
                 {
                     send_positive_acquisition(result);
                     result.positive_acq = true;
+                    d_active = false;
                 }
             else
                 {
@@ -625,6 +625,7 @@ void pcps_acquisition::handle_threshold_reached(AcquisitionResult& result)
         {
             send_positive_acquisition(result);
             result.positive_acq = true;
+            d_active = false;
         }
 }
 
@@ -762,16 +763,11 @@ int pcps_acquisition::general_work(int noutput_items __attribute__((unused)),
     if (!d_active or d_worker_active)
         {
             // do not consume samples while performing a non-coherent integration
-            bool consume_samples = ((!d_active) || (d_worker_active && (d_num_noncoherent_integrations_counter == d_acq_parameters.max_dwells)));
+            const bool consume_samples = ((!d_active) || (d_worker_active && (d_num_noncoherent_integrations_counter == d_acq_parameters.max_dwells)));
             if ((!d_acq_parameters.blocking_on_standby) && consume_samples)
                 {
                     d_sample_count += static_cast<uint64_t>(ninput_items[0]);
                     consume_each(ninput_items[0]);
-                }
-            if (d_step_two)
-                {
-                    d_state = 0;
-                    d_active = true;
                 }
             return 0;
         }

--- a/src/algorithms/acquisition/gnuradio_blocks/pcps_acquisition.h
+++ b/src/algorithms/acquisition/gnuradio_blocks/pcps_acquisition.h
@@ -168,7 +168,6 @@ private:
         int32_t doppler{0};
         uint32_t index_time{0};
         uint64_t sample_count{0};
-        float input_power{0};
         float test_statistics{0};
         bool positive_acq{false};
     };
@@ -228,6 +227,7 @@ private:
     // Only access these in acquisition_core and functions strictly called from acquisition_core
     uint32_t d_num_noncoherent_integrations_counter;
     int64_t d_dump_number;
+    float d_input_power;
     float d_doppler_center_step_two;
     volk_gnsssdr::vector<volk_gnsssdr::vector<float>> d_magnitude_grid;
     volk_gnsssdr::vector<float> d_tmp_buffer;

--- a/tests/unit-tests/signal-processing-blocks/acquisition/gps_l1_ca_pcps_acquisition_test.cc
+++ b/tests/unit-tests/signal-processing-blocks/acquisition/gps_l1_ca_pcps_acquisition_test.cc
@@ -372,3 +372,79 @@ TEST_F(GpsL1CaPcpsAcquisitionTest /*unused*/, ValidationOfResults /*unused*/)
             plot_grid();
         }
 }
+
+
+TEST_F(GpsL1CaPcpsAcquisitionTest /*unused*/, ValidationOfResultsMakeTwoStep /*unused*/)
+{
+    std::chrono::time_point<std::chrono::system_clock> start;
+    std::chrono::time_point<std::chrono::system_clock> end;
+    std::chrono::duration<double> elapsed_seconds(0.0);
+    top_block = gr::make_top_block("Acquisition test");
+
+    init();
+
+    config->set_property("Acquisition_1C.make_two_steps", "true");
+    config->set_property("Acquisition_1C.second_nbins", "5");
+    config->set_property("Acquisition_1C.second_doppler_step", "20");
+
+#if USE_GLOG_AND_GFLAGS
+    if (FLAGS_plot_acq_grid == true)
+#else
+    if (absl::GetFlag(FLAGS_plot_acq_grid) == true)
+#endif
+        {
+            std::string data_str = "./tmp-acq-gps1";
+            if (fs::exists(data_str))
+                {
+                    fs::remove_all(data_str);
+                }
+            fs::create_directory(data_str);
+        }
+
+    auto acquisition = gnss_make_shared<GpsL1CaPcpsAcquisition>(config.get(), "Acquisition_1C", 1, 0);
+    auto msg_rx = GpsL1CaPcpsAcquisitionTest_msg_rx_make();
+
+    ASSERT_NO_THROW({
+        acquisition->set_channel(1);
+    }) << "Failure setting channel.";
+
+    ASSERT_NO_THROW({
+        acquisition->set_gnss_synchro(&gnss_synchro);
+    }) << "Failure setting gnss_synchro.";
+
+    ASSERT_NO_THROW({
+        acquisition->connect(top_block);
+    }) << "Failure connecting acquisition to the top_block.";
+
+    ASSERT_NO_THROW({
+        std::string path = std::string(TEST_PATH);
+        std::string file = path + "signal_samples/GSoC_CTTC_capture_2012_07_26_4Msps_4ms.dat";
+        const char *file_name = file.c_str();
+        gr::blocks::file_source::sptr file_source = gr::blocks::file_source::make(sizeof(gr_complex), file_name, false);
+        top_block->connect(file_source, 0, acquisition->get_left_block(), 0);
+        top_block->msg_connect(acquisition->get_right_block(), pmt::mp("events"), msg_rx, pmt::mp("events"));
+    }) << "Failure connecting the blocks of acquisition test.";
+
+    acquisition->set_local_code();
+    acquisition->reset();
+
+    EXPECT_NO_THROW({
+        start = std::chrono::system_clock::now();
+        top_block->run();  // Start threads and wait
+        end = std::chrono::system_clock::now();
+        elapsed_seconds = end - start;
+    }) << "Failure running the top_block.";
+
+    uint64_t nsamples = gnss_synchro.Acq_samplestamp_samples;
+    std::cout << "Acquired " << nsamples << " samples in " << elapsed_seconds.count() * 1e6 << " microseconds\n";
+    ASSERT_EQ(1, msg_rx->rx_message) << "Acquisition failure. Expected message: 1=ACQ SUCCESS.";
+
+#if USE_GLOG_AND_GFLAGS
+    if (FLAGS_plot_acq_grid == true)
+#else
+    if (absl::GetFlag(FLAGS_plot_acq_grid) == true)
+#endif
+        {
+            plot_grid();
+        }
+}


### PR DESCRIPTION
Well I went a little bit too fast and didn't realize there wasn't any tests for `make_two_steps=true`.
The input power needs to stay in a member variable if we don't want to re-compute it on the second step, which I had not done.

I wanted to add a test, but I think we would need a test signal longer then 2ms to get an acquisition with `make_two_steps`.