### PR TITLE
Cleanup rinex printer

### DIFF
--- a/src/algorithms/PVT/gnuradio_blocks/rtklib_pvt_gs.cc
+++ b/src/algorithms/PVT/gnuradio_blocks/rtklib_pvt_gs.cc
@@ -412,8 +412,7 @@ rtklib_pvt_gs::rtklib_pvt_gs(uint32_t nchannels,
     // initialize RINEX printer
     if (d_rinex_output_enabled)
         {
-            d_rp = std::make_unique<Rinex_Printer>(d_rinex_version, conf_.rinex_output_path, conf_.rinex_name);
-            d_rp->set_pre_2009_file(conf_.pre_2009_file);
+            d_rp = std::make_unique<Rinex_Printer>(d_rinex_version, conf_.rinex_output_path, conf_.rinex_name, conf_.pre_2009_file);
         }
     else
         {

--- a/src/algorithms/PVT/libs/rinex_printer.cc
+++ b/src/algorithms/PVT/libs/rinex_printer.cc
@@ -1204,9 +1204,9 @@ std::string get_leap_second_line(const Beidou_Dnav_Utc_Model& utc_model)
     return get_leap_second_line(utc_model.DeltaT_LS, utc_model.DeltaT_LSF, utc_model.WN_LSF, utc_model.DN);
 }
 
-void add_svclk_to_line(const boost::posix_time::ptime& p_utc_time, bool log_seconds, std::string& line)
+void add_svclk_to_line(const boost::posix_time::ptime& utc_time, bool log_seconds, std::string& line)
 {
-    const std::string timestring = boost::posix_time::to_iso_string(p_utc_time);
+    const std::string timestring = boost::posix_time::to_iso_string(utc_time);
     const std::string year(timestring, 0, 4);
     const std::string month(timestring, 4, 2);
     const std::string day(timestring, 6, 2);
@@ -1233,8 +1233,18 @@ void add_svclk_to_line(const boost::posix_time::ptime& p_utc_time, bool log_seco
         }
 }
 
-void add_seconds_to_line(double seconds, std::string& line)
+std::string get_obs_epoch_record_lines(const boost::posix_time::ptime& utc_time, double seconds)
 {
+    // -------- EPOCH record
+    std::string line = std::string(1, '>');
+
+    // double utc_t = nav_msg.utc_time(nav_msg.sv_clock_correction(obs_time));
+    // const double gps_t = eph.sv_clock_correction(obs_time);
+
+    line += std::string(1, '>');
+
+    add_svclk_to_line(utc_time, false, line);
+
     // Add extra 0 if seconds are < 10
     if (seconds < 10)
         {
@@ -1242,6 +1252,11 @@ void add_seconds_to_line(double seconds, std::string& line)
         }
     line += asString(seconds, 7);
     line += std::string(2, ' ');
+
+    // Epoch flag 0: OK     1: power failure between previous and current epoch   <1: Special event
+    line += std::string(1, '0');
+
+    return line;
 }
 
 std::string get_nav_sv_epoch_svclk_line(const boost::posix_time::ptime& p_utc_time, const std::string& sys_char, uint32_t prn, double value0, double value1, double value2)
@@ -5126,19 +5141,8 @@ void Rinex_Printer::log_rinex_obs(std::fstream& out, const Gps_Ephemeris& gps_ep
 
 void Rinex_Printer::log_rinex_obs(std::fstream& out, const Gps_CNAV_Ephemeris& gps_eph, const Glonass_Gnav_Ephemeris& /*glonass_gnav_eph*/, double gps_obs_time, const std::map<int32_t, Gnss_Synchro>& observables) const
 {
-    std::string line;
-
     // -------- EPOCH record
-
-    // double utc_t = nav_msg.utc_time(nav_msg.sv_clock_correction(obs_time));
-    // const double gps_t = eph.sv_clock_correction(obs_time);
-    line += std::string(1, '>');
-
-    add_svclk_to_line(Rinex_Printer::compute_GPS_time(gps_eph, gps_obs_time), false, line);
-    add_seconds_to_line(fmod(gps_obs_time, 60), line);
-
-    // Epoch flag 0: OK     1: power failure between previous and current epoch   <1: Special event
-    line += std::string(1, '0');
+    std::string line = get_obs_epoch_record_lines(Rinex_Printer::compute_GPS_time(gps_eph, gps_obs_time), fmod(gps_obs_time, 60));
 
     // Number of satellites observed in current epoch
     // Get maps with observations
@@ -5345,18 +5349,7 @@ void Rinex_Printer::log_rinex_obs(std::fstream& out, const Gps_CNAV_Ephemeris& g
 
 void Rinex_Printer::log_rinex_obs(std::fstream& out, const Galileo_Ephemeris& galileo_eph, const Glonass_Gnav_Ephemeris& /*glonass_gnav_eph*/, double galileo_obs_time, const std::map<int32_t, Gnss_Synchro>& observables) const
 {
-    std::string line;
-
-    // double utc_t = nav_msg.utc_time(nav_msg.sv_clock_correction(obs_time));
-    // const double gps_t = eph.sv_clock_correction(obs_time);
-
-    line += std::string(1, '>');
-
-    add_svclk_to_line(Rinex_Printer::compute_Galileo_time(galileo_eph, galileo_obs_time), false, line);
-    add_seconds_to_line(fmod(galileo_obs_time, 60), line);
-
-    // Epoch flag 0: OK     1: power failure between previous and current epoch   <1: Special event
-    line += std::string(1, '0');
+    std::string line = get_obs_epoch_record_lines(Rinex_Printer::compute_Galileo_time(galileo_eph, galileo_obs_time), fmod(galileo_obs_time, 60));
 
     // Number of satellites observed in current epoch
 
@@ -5794,18 +5787,7 @@ void Rinex_Printer::log_rinex_obs(std::fstream& out, const Gps_Ephemeris& eph, d
 void Rinex_Printer::log_rinex_obs(std::fstream& out, const Gps_CNAV_Ephemeris& eph, double obs_time, const std::map<int32_t, Gnss_Synchro>& observables) const
 {
     // RINEX observations timestamps are GPS timestamps.
-    std::string line;
-
-    // double utc_t = nav_msg.utc_time(nav_msg.sv_clock_correction(obs_time));
-    // const double gps_t = eph.sv_clock_correction(obs_time);
-
-    line += std::string(1, '>');
-
-    add_svclk_to_line(Rinex_Printer::compute_GPS_time(eph, obs_time), false, line);
-    add_seconds_to_line(fmod(obs_time, 60), line);
-
-    // Epoch flag 0: OK     1: power failure between previous and current epoch   <1: Special event
-    line += std::string(1, '0');
+    std::string line = get_obs_epoch_record_lines(Rinex_Printer::compute_GPS_time(eph, obs_time), fmod(obs_time, 60));
 
     // Number of satellites observed in current epoch
     const int32_t numSatellitesObserved = observables.size();
@@ -5887,17 +5869,7 @@ void Rinex_Printer::log_rinex_obs(std::fstream& out, const Gps_CNAV_Ephemeris& e
 void Rinex_Printer::log_rinex_obs(std::fstream& out, const Gps_Ephemeris& eph, const Gps_CNAV_Ephemeris& /*eph_cnav*/, double obs_time, const std::map<int32_t, Gnss_Synchro>& observables, bool triple_band) const
 {
     // RINEX observations timestamps are GPS timestamps.
-    std::string line;
-
-    // double utc_t = nav_msg.utc_time(nav_msg.sv_clock_correction(obs_time));
-    // const double gps_t = eph.sv_clock_correction(obs_time);
-    line += std::string(1, '>');
-
-    add_svclk_to_line(Rinex_Printer::compute_GPS_time(eph, obs_time), false, line);
-    add_seconds_to_line(fmod(obs_time, 60), line);
-
-    // Epoch flag 0: OK     1: power failure between previous and current epoch   <1: Special event
-    line += std::string(1, '0');
+    std::string line = get_obs_epoch_record_lines(Rinex_Printer::compute_GPS_time(eph, obs_time), fmod(obs_time, 60));
 
     // Number of satellites observed in current epoch
 
@@ -6081,17 +6053,7 @@ void Rinex_Printer::log_rinex_obs(std::fstream& out, const Galileo_Ephemeris& ep
 {
     // RINEX observations timestamps are Galileo timestamps.
     // See https://gage.upc.edu/sites/default/files/gLAB/HTML/Observation_Rinex_v3.01.html
-    std::string line;
-
-    // double utc_t = nav_msg.utc_time(nav_msg.sv_clock_correction(obs_time));
-    // const double gps_t = eph.sv_clock_correction(obs_time);
-    line += std::string(1, '>');
-
-    add_svclk_to_line(Rinex_Printer::compute_Galileo_time(eph, obs_time), false, line);
-    add_seconds_to_line(fmod(obs_time, 60), line);
-
-    // Epoch flag 0: OK     1: power failure between previous and current epoch   <1: Special event
-    line += std::string(1, '0');
+    std::string line = get_obs_epoch_record_lines(Rinex_Printer::compute_Galileo_time(eph, obs_time), fmod(obs_time, 60));
 
     // Number of satellites observed in current epoch
 
@@ -6281,18 +6243,7 @@ void Rinex_Printer::log_rinex_obs(std::fstream& out, const Galileo_Ephemeris& ep
 
 void Rinex_Printer::log_rinex_obs(std::fstream& out, const Gps_Ephemeris& gps_eph, const Galileo_Ephemeris& /*galileo_eph*/, double gps_obs_time, const std::map<int32_t, Gnss_Synchro>& observables) const
 {
-    std::string line;
-
-    // double utc_t = nav_msg.utc_time(nav_msg.sv_clock_correction(obs_time));
-    // double gps_t = eph.sv_clock_correction(obs_time);
-
-    line += std::string(1, '>');
-
-    add_svclk_to_line(Rinex_Printer::compute_GPS_time(gps_eph, gps_obs_time), false, line);
-    add_seconds_to_line(fmod(gps_obs_time, 60), line);
-
-    // Epoch flag 0: OK     1: power failure between previous and current epoch   <1: Special event
-    line += std::string(1, '0');
+    std::string line = get_obs_epoch_record_lines(Rinex_Printer::compute_GPS_time(gps_eph, gps_obs_time), fmod(gps_obs_time, 60));
 
     // Number of satellites observed in current epoch
 
@@ -6529,18 +6480,7 @@ void Rinex_Printer::log_rinex_obs(std::fstream& out, const Gps_Ephemeris& gps_ep
 
 void Rinex_Printer::log_rinex_obs(std::fstream& out, const Gps_CNAV_Ephemeris& eph, const Galileo_Ephemeris& /*galileo_eph*/, double gps_obs_time, const std::map<int32_t, Gnss_Synchro>& observables) const
 {
-    std::string line;
-
-    // double utc_t = nav_msg.utc_time(nav_msg.sv_clock_correction(obs_time));
-    // double gps_t = eph.sv_clock_correction(obs_time);
-
-    line += std::string(1, '>');
-
-    add_svclk_to_line(Rinex_Printer::compute_GPS_time(eph, gps_obs_time), false, line);
-    add_seconds_to_line(fmod(gps_obs_time, 60), line);
-
-    // Epoch flag 0: OK     1: power failure between previous and current epoch   <1: Special event
-    line += std::string(1, '0');
+    std::string line = get_obs_epoch_record_lines(Rinex_Printer::compute_GPS_time(eph, gps_obs_time), fmod(gps_obs_time, 60));
 
     // Number of satellites observed in current epoch
 
@@ -6794,18 +6734,7 @@ void Rinex_Printer::log_rinex_obs(std::fstream& out, const Gps_CNAV_Ephemeris& e
 
 void Rinex_Printer::log_rinex_obs(std::fstream& out, const Gps_Ephemeris& gps_eph, const Gps_CNAV_Ephemeris& /*gps_cnav_eph*/, const Galileo_Ephemeris& /*galileo_eph*/, double gps_obs_time, const std::map<int32_t, Gnss_Synchro>& observables, bool triple_band) const
 {
-    std::string line;
-
-    // double utc_t = nav_msg.utc_time(nav_msg.sv_clock_correction(obs_time));
-    // double gps_t = eph.sv_clock_correction(obs_time);
-
-    line += std::string(1, '>');
-
-    add_svclk_to_line(Rinex_Printer::compute_GPS_time(gps_eph, gps_obs_time), false, line);
-    add_seconds_to_line(fmod(gps_obs_time, 60), line);
-
-    // Epoch flag 0: OK     1: power failure between previous and current epoch   <1: Special event
-    line += std::string(1, '0');
+    std::string line = get_obs_epoch_record_lines(Rinex_Printer::compute_GPS_time(gps_eph, gps_obs_time), fmod(gps_obs_time, 60));
 
     // Number of satellites observed in current epoch
 
@@ -7086,18 +7015,7 @@ void Rinex_Printer::log_rinex_obs(std::fstream& out, const Gps_Ephemeris& gps_ep
 
 void Rinex_Printer::log_rinex_obs(std::fstream& out, const Beidou_Dnav_Ephemeris& eph, double obs_time, const std::map<int32_t, Gnss_Synchro>& observables, const std::string& bds_bands) const
 {
-    std::string line;
-
-    // double utc_t = nav_msg.utc_time(nav_msg.sv_clock_correction(obs_time));
-    // double gps_t = eph.sv_clock_correction(obs_time);
-
-    line += std::string(1, '>');
-
-    add_svclk_to_line(Rinex_Printer::compute_BDS_time(eph, obs_time), false, line);
-    add_seconds_to_line(fmod(obs_time, 60), line);
-
-    // Epoch flag 0: OK     1: power failure between previous and current epoch   <1: Special event
-    line += std::string(1, '0');
+    std::string line = get_obs_epoch_record_lines(Rinex_Printer::compute_BDS_time(eph, obs_time), fmod(obs_time, 60));
 
     // Number of satellites observed in current epoch
 

--- a/src/algorithms/PVT/libs/rinex_printer.cc
+++ b/src/algorithms/PVT/libs/rinex_printer.cc
@@ -1233,6 +1233,17 @@ void add_svclk_to_line(const boost::posix_time::ptime& p_utc_time, bool log_seco
         }
 }
 
+void add_seconds_to_line(double seconds, std::string& line)
+{
+    // Add extra 0 if seconds are < 10
+    if (seconds < 10)
+        {
+            line += std::string(1, '0');
+        }
+    line += asString(seconds, 7);
+    line += std::string(2, ' ');
+}
+
 std::string get_nav_sv_epoch_svclk_line(const boost::posix_time::ptime& p_utc_time, const std::string& sys_char, uint32_t prn, double value0, double value1, double value2)
 {
     std::string line;
@@ -5124,15 +5135,8 @@ void Rinex_Printer::log_rinex_obs(std::fstream& out, const Gps_CNAV_Ephemeris& g
     line += std::string(1, '>');
 
     add_svclk_to_line(Rinex_Printer::compute_GPS_time(gps_eph, gps_obs_time), false, line);
+    add_seconds_to_line(fmod(gps_obs_time, 60), line);
 
-    double seconds = fmod(gps_obs_time, 60);
-    // Add extra 0 if seconds are < 10
-    if (seconds < 10)
-        {
-            line += std::string(1, '0');
-        }
-    line += asString(seconds, 7);
-    line += std::string(2, ' ');
     // Epoch flag 0: OK     1: power failure between previous and current epoch   <1: Special event
     line += std::string(1, '0');
 
@@ -5349,15 +5353,8 @@ void Rinex_Printer::log_rinex_obs(std::fstream& out, const Galileo_Ephemeris& ga
     line += std::string(1, '>');
 
     add_svclk_to_line(Rinex_Printer::compute_Galileo_time(galileo_eph, galileo_obs_time), false, line);
+    add_seconds_to_line(fmod(galileo_obs_time, 60), line);
 
-    const double seconds = fmod(galileo_obs_time, 60);
-    // Add extra 0 if seconds are < 10
-    if (seconds < 10)
-        {
-            line += std::string(1, '0');
-        }
-    line += asString(seconds, 7);
-    line += std::string(2, ' ');
     // Epoch flag 0: OK     1: power failure between previous and current epoch   <1: Special event
     line += std::string(1, '0');
 
@@ -5805,15 +5802,8 @@ void Rinex_Printer::log_rinex_obs(std::fstream& out, const Gps_CNAV_Ephemeris& e
     line += std::string(1, '>');
 
     add_svclk_to_line(Rinex_Printer::compute_GPS_time(eph, obs_time), false, line);
+    add_seconds_to_line(fmod(obs_time, 60), line);
 
-    const double seconds = fmod(obs_time, 60);
-    // Add extra 0 if seconds are < 10
-    if (seconds < 10)
-        {
-            line += std::string(1, '0');
-        }
-    line += asString(seconds, 7);
-    line += std::string(2, ' ');
     // Epoch flag 0: OK     1: power failure between previous and current epoch   <1: Special event
     line += std::string(1, '0');
 
@@ -5904,15 +5894,8 @@ void Rinex_Printer::log_rinex_obs(std::fstream& out, const Gps_Ephemeris& eph, c
     line += std::string(1, '>');
 
     add_svclk_to_line(Rinex_Printer::compute_GPS_time(eph, obs_time), false, line);
+    add_seconds_to_line(fmod(obs_time, 60), line);
 
-    const double seconds = fmod(obs_time, 60);
-    // Add extra 0 if seconds are < 10
-    if (seconds < 10)
-        {
-            line += std::string(1, '0');
-        }
-    line += asString(seconds, 7);
-    line += std::string(2, ' ');
     // Epoch flag 0: OK     1: power failure between previous and current epoch   <1: Special event
     line += std::string(1, '0');
 
@@ -6105,15 +6088,8 @@ void Rinex_Printer::log_rinex_obs(std::fstream& out, const Galileo_Ephemeris& ep
     line += std::string(1, '>');
 
     add_svclk_to_line(Rinex_Printer::compute_Galileo_time(eph, obs_time), false, line);
+    add_seconds_to_line(fmod(obs_time, 60), line);
 
-    const double seconds = fmod(obs_time, 60);
-    // Add extra 0 if seconds are < 10
-    if (seconds < 10)
-        {
-            line += std::string(1, '0');
-        }
-    line += asString(seconds, 7);
-    line += std::string(2, ' ');
     // Epoch flag 0: OK     1: power failure between previous and current epoch   <1: Special event
     line += std::string(1, '0');
 
@@ -6313,15 +6289,8 @@ void Rinex_Printer::log_rinex_obs(std::fstream& out, const Gps_Ephemeris& gps_ep
     line += std::string(1, '>');
 
     add_svclk_to_line(Rinex_Printer::compute_GPS_time(gps_eph, gps_obs_time), false, line);
+    add_seconds_to_line(fmod(gps_obs_time, 60), line);
 
-    const double seconds = fmod(gps_obs_time, 60);
-    // Add extra 0 if seconds are < 10
-    if (seconds < 10)
-        {
-            line += std::string(1, '0');
-        }
-    line += asString(seconds, 7);
-    line += std::string(2, ' ');
     // Epoch flag 0: OK     1: power failure between previous and current epoch   <1: Special event
     line += std::string(1, '0');
 
@@ -6568,15 +6537,8 @@ void Rinex_Printer::log_rinex_obs(std::fstream& out, const Gps_CNAV_Ephemeris& e
     line += std::string(1, '>');
 
     add_svclk_to_line(Rinex_Printer::compute_GPS_time(eph, gps_obs_time), false, line);
+    add_seconds_to_line(fmod(gps_obs_time, 60), line);
 
-    const double seconds = fmod(gps_obs_time, 60);
-    // Add extra 0 if seconds are < 10
-    if (seconds < 10)
-        {
-            line += std::string(1, '0');
-        }
-    line += asString(seconds, 7);
-    line += std::string(2, ' ');
     // Epoch flag 0: OK     1: power failure between previous and current epoch   <1: Special event
     line += std::string(1, '0');
 
@@ -6840,15 +6802,8 @@ void Rinex_Printer::log_rinex_obs(std::fstream& out, const Gps_Ephemeris& gps_ep
     line += std::string(1, '>');
 
     add_svclk_to_line(Rinex_Printer::compute_GPS_time(gps_eph, gps_obs_time), false, line);
+    add_seconds_to_line(fmod(gps_obs_time, 60), line);
 
-    const double seconds = fmod(gps_obs_time, 60);
-    // Add extra 0 if seconds are < 10
-    if (seconds < 10)
-        {
-            line += std::string(1, '0');
-        }
-    line += asString(seconds, 7);
-    line += std::string(2, ' ');
     // Epoch flag 0: OK     1: power failure between previous and current epoch   <1: Special event
     line += std::string(1, '0');
 
@@ -7139,15 +7094,8 @@ void Rinex_Printer::log_rinex_obs(std::fstream& out, const Beidou_Dnav_Ephemeris
     line += std::string(1, '>');
 
     add_svclk_to_line(Rinex_Printer::compute_BDS_time(eph, obs_time), false, line);
+    add_seconds_to_line(fmod(obs_time, 60), line);
 
-    const double seconds = fmod(obs_time, 60);
-    // Add extra 0 if seconds are < 10
-    if (seconds < 10)
-        {
-            line += std::string(1, '0');
-        }
-    line += asString(seconds, 7);
-    line += std::string(2, ' ');
     // Epoch flag 0: OK     1: power failure between previous and current epoch   <1: Special event
     line += std::string(1, '0');
 

--- a/src/algorithms/PVT/libs/rinex_printer.cc
+++ b/src/algorithms/PVT/libs/rinex_printer.cc
@@ -1205,28 +1205,16 @@ std::string get_leap_second_line(const Beidou_Dnav_Utc_Model& utc_model)
     return get_leap_second_line(utc_model.DeltaT_LS, utc_model.DeltaT_LSF, utc_model.WN_LSF, utc_model.DN);
 }
 
-
-std::string get_nav_sv_epoch_svclk_line(const boost::posix_time::ptime& p_utc_time, const std::string& sys_char, uint32_t prn, double value0, double value1, double value2)
+void add_svclk_to_line(const boost::posix_time::ptime& p_utc_time, bool log_seconds, std::string& line)
 {
-    std::string line;
-
     const std::string timestring = boost::posix_time::to_iso_string(p_utc_time);
+    const std::string year(timestring, 0, 4);
     const std::string month(timestring, 4, 2);
     const std::string day(timestring, 6, 2);
     const std::string hour(timestring, 9, 2);
     const std::string minutes(timestring, 11, 2);
     const std::string seconds(timestring, 13, 2);
 
-    if (!sys_char.empty())
-        {
-            line += sys_char;
-        }
-    if (prn < 10)
-        {
-            line += std::string("0");
-        }
-    line += std::to_string(prn);
-    const std::string year(timestring, 0, 4);
     line += std::string(1, ' ');
     line += year;
     line += std::string(1, ' ');
@@ -1238,8 +1226,31 @@ std::string get_nav_sv_epoch_svclk_line(const boost::posix_time::ptime& p_utc_ti
     line += std::string(1, ' ');
     line += minutes;
     line += std::string(1, ' ');
-    line += seconds;
-    line += std::string(1, ' ');
+
+    if (log_seconds)
+        {
+            line += seconds;
+            line += std::string(1, ' ');
+        }
+}
+
+std::string get_nav_sv_epoch_svclk_line(const boost::posix_time::ptime& p_utc_time, const std::string& sys_char, uint32_t prn, double value0, double value1, double value2)
+{
+    std::string line;
+
+    if (!sys_char.empty())
+        {
+            line += sys_char;
+        }
+    if (prn < 10)
+        {
+            line += std::string("0");
+        }
+
+    line += std::to_string(prn);
+
+    add_svclk_to_line(p_utc_time, true, line);
+
     line += doub2for(value0, 18, 2);
     line += std::string(1, ' ');
     line += doub2for(value1, 18, 2);
@@ -2201,8 +2212,7 @@ void Rinex_Printer::log_rinex_nav_bds_dnav(uint32_t signal_enabled_flags, const 
 {
     const Signal_Enabled_Flags flags(signal_enabled_flags);
 
-    if (flags.check_any_enabled(BDS_B1) ||
-        flags.check_any_enabled(BDS_B3))
+    if (flags.check_any_enabled(BDS_B1) || flags.check_any_enabled(BDS_B3))
         {
             log_rinex_nav(navBdsFile, new_bds_eph);
         }
@@ -4636,25 +4646,16 @@ void Rinex_Printer::log_rinex_obs(std::fstream& out, const Glonass_Gnav_Ephemeri
             // Epoch flag 0: OK     1: power failure between previous and current epoch   <1: Special event
             line += std::string(1, '0');
             // Number of satellites observed in current epoch
-            int32_t numSatellitesObserved = 0;
-            std::map<int32_t, Gnss_Synchro>::const_iterator observables_iter;
-            for (observables_iter = observables.cbegin();
-                observables_iter != observables.cend();
-                observables_iter++)
-                {
-                    numSatellitesObserved++;
-                }
+            const int32_t numSatellitesObserved = observables.size();
             line += rightJustify(std::to_string(numSatellitesObserved), 3);
-            for (observables_iter = observables.cbegin();
-                observables_iter != observables.cend();
-                observables_iter++)
+            for (const auto& observables_iter : observables)
                 {
                     line += satelliteSystem.at("GLONASS");
-                    if (static_cast<int32_t>(observables_iter->second.PRN) < 10)
+                    if (static_cast<int32_t>(observables_iter.second.PRN) < 10)
                         {
                             line += std::string(1, '0');
                         }
-                    line += std::to_string(static_cast<int32_t>(observables_iter->second.PRN));
+                    line += std::to_string(static_cast<int32_t>(observables_iter.second.PRN));
                 }
             // Receiver clock offset (optional)
             // line += rightJustify(asString(clockOffset, 12), 15);
@@ -4662,16 +4663,14 @@ void Rinex_Printer::log_rinex_obs(std::fstream& out, const Glonass_Gnav_Ephemeri
             lengthCheck(line);
             out << line << '\n';
 
-            for (observables_iter = observables.cbegin();
-                observables_iter != observables.cend();
-                observables_iter++)
+            for (const auto& observables_iter : observables)
                 {
                     std::string lineObs;
                     lineObs.clear();
                     line.clear();
                     // GLONASS L1 PSEUDORANGE
                     line += std::string(2, ' ');
-                    lineObs += rightJustify(asString(observables_iter->second.Pseudorange_m, 3), 14);
+                    lineObs += rightJustify(asString(observables_iter.second.Pseudorange_m, 3), 14);
 
                     // Loss of lock indicator (LLI)
                     int32_t lli = 0;  // Include in the observation!!
@@ -4685,10 +4684,10 @@ void Rinex_Printer::log_rinex_obs(std::fstream& out, const Glonass_Gnav_Ephemeri
                     //    }
 
                     // Signal Strength Indicator (SSI)
-                    const int32_t ssi = Rinex_Printer::signalStrength(observables_iter->second.CN0_dB_hz);
+                    const int32_t ssi = Rinex_Printer::signalStrength(observables_iter.second.CN0_dB_hz);
                     lineObs += rightJustify(asString<int32_t>(ssi), 1);
                     // GLONASS L1 CA PHASE
-                    lineObs += rightJustify(asString(observables_iter->second.Carrier_phase_rads / TWO_PI, 3), 14);
+                    lineObs += rightJustify(asString(observables_iter.second.Carrier_phase_rads / TWO_PI, 3), 14);
                     if (lli == 0)
                         {
                             lineObs += std::string(1, ' ');
@@ -4699,7 +4698,7 @@ void Rinex_Printer::log_rinex_obs(std::fstream& out, const Glonass_Gnav_Ephemeri
                     //    }
                     lineObs += rightJustify(asString<int32_t>(ssi), 1);
                     // GLONASS L1 CA DOPPLER
-                    lineObs += rightJustify(asString(observables_iter->second.Carrier_Doppler_hz, 3), 14);
+                    lineObs += rightJustify(asString(observables_iter.second.Carrier_Doppler_hz, 3), 14);
                     if (lli == 0)
                         {
                             lineObs += std::string(1, ' ');
@@ -4710,7 +4709,7 @@ void Rinex_Printer::log_rinex_obs(std::fstream& out, const Glonass_Gnav_Ephemeri
                     //    }
                     lineObs += rightJustify(asString<int32_t>(ssi), 1);
                     // GLONASS L1 SIGNAL STRENGTH
-                    lineObs += rightJustify(asString(observables_iter->second.CN0_dB_hz, 3), 14);
+                    lineObs += rightJustify(asString(observables_iter.second.CN0_dB_hz, 3), 14);
                     if (lineObs.size() < 80)
                         {
                             lineObs += std::string(80 - lineObs.size(), ' ');
@@ -4746,14 +4745,7 @@ void Rinex_Printer::log_rinex_obs(std::fstream& out, const Glonass_Gnav_Ephemeri
             line += std::string(1, '0');
 
             // Number of satellites observed in current epoch
-            int32_t numSatellitesObserved = 0;
-            std::map<int32_t, Gnss_Synchro>::const_iterator observables_iter;
-            for (observables_iter = observables.cbegin();
-                observables_iter != observables.cend();
-                observables_iter++)
-                {
-                    numSatellitesObserved++;
-                }
+            const int32_t numSatellitesObserved = observables.size();
             line += rightJustify(std::to_string(numSatellitesObserved), 3);
 
             // Receiver clock offset (optional)
@@ -4763,20 +4755,18 @@ void Rinex_Printer::log_rinex_obs(std::fstream& out, const Glonass_Gnav_Ephemeri
             lengthCheck(line);
             out << line << '\n';
 
-            for (observables_iter = observables.cbegin();
-                observables_iter != observables.cend();
-                observables_iter++)
+            for (const auto& observables_iter : observables)
                 {
                     std::string lineObs;
                     lineObs.clear();
                     lineObs += satelliteSystem.at("GLONASS");
-                    if (static_cast<int32_t>(observables_iter->second.PRN) < 10)
+                    if (static_cast<int32_t>(observables_iter.second.PRN) < 10)
                         {
                             lineObs += std::string(1, '0');
                         }
-                    lineObs += std::to_string(static_cast<int32_t>(observables_iter->second.PRN));
+                    lineObs += std::to_string(static_cast<int32_t>(observables_iter.second.PRN));
                     // lineObs += std::string(2, ' ');
-                    lineObs += rightJustify(asString(observables_iter->second.Pseudorange_m, 3), 14);
+                    lineObs += rightJustify(asString(observables_iter.second.Pseudorange_m, 3), 14);
 
                     // Loss of lock indicator (LLI)
                     int32_t lli = 0;  // Include in the observation!!
@@ -4790,11 +4780,11 @@ void Rinex_Printer::log_rinex_obs(std::fstream& out, const Glonass_Gnav_Ephemeri
                     //    }
 
                     // Signal Strength Indicator (SSI)
-                    const int32_t ssi = Rinex_Printer::signalStrength(observables_iter->second.CN0_dB_hz);
+                    const int32_t ssi = Rinex_Printer::signalStrength(observables_iter.second.CN0_dB_hz);
                     lineObs += rightJustify(asString<int32_t>(ssi), 1);
 
                     // GLONASS L1 CA PHASE
-                    lineObs += rightJustify(asString(observables_iter->second.Carrier_phase_rads / TWO_PI, 3), 14);
+                    lineObs += rightJustify(asString(observables_iter.second.Carrier_phase_rads / TWO_PI, 3), 14);
                     if (lli == 0)
                         {
                             lineObs += std::string(1, ' ');
@@ -4806,7 +4796,7 @@ void Rinex_Printer::log_rinex_obs(std::fstream& out, const Glonass_Gnav_Ephemeri
                     lineObs += rightJustify(asString<int32_t>(ssi), 1);
 
                     // GLONASS L1 CA DOPPLER
-                    lineObs += rightJustify(asString(observables_iter->second.Carrier_Doppler_hz, 3), 14);
+                    lineObs += rightJustify(asString(observables_iter.second.Carrier_Doppler_hz, 3), 14);
                     if (lli == 0)
                         {
                             lineObs += std::string(1, ' ');
@@ -4819,7 +4809,7 @@ void Rinex_Printer::log_rinex_obs(std::fstream& out, const Glonass_Gnav_Ephemeri
                     lineObs += rightJustify(asString<int32_t>(ssi), 1);
 
                     // GLONASS L1 SIGNAL STRENGTH
-                    lineObs += rightJustify(asString(observables_iter->second.CN0_dB_hz, 3), 14);
+                    lineObs += rightJustify(asString(observables_iter.second.CN0_dB_hz, 3), 14);
 
                     if (lineObs.size() < 80)
                         {
@@ -4924,37 +4914,32 @@ void Rinex_Printer::log_rinex_obs(std::fstream& out, const Gps_Ephemeris& gps_ep
     std::map<int32_t, Gnss_Synchro> observablesG1C;
     std::map<int32_t, Gnss_Synchro> observablesR1C;
     std::map<int32_t, Gnss_Synchro> observablesR2C;
-    std::map<int32_t, Gnss_Synchro>::const_iterator observables_iter;
 
-    for (observables_iter = observables.cbegin();
-        observables_iter != observables.cend();
-        observables_iter++)
+    for (const auto& observables_iter : observables)
         {
-            const std::string system_(&observables_iter->second.System, 1);
-            const std::string sig_(observables_iter->second.Signal);
+            const std::string system_(&observables_iter.second.System, 1);
+            const std::string sig_(observables_iter.second.Signal);
             if ((system_ == "R") && (sig_ == "1G"))
                 {
-                    observablesR1C.insert(std::pair<int32_t, Gnss_Synchro>(observables_iter->first, observables_iter->second));
+                    observablesR1C.insert(std::pair<int32_t, Gnss_Synchro>(observables_iter.first, observables_iter.second));
                 }
             if ((system_ == "R") && (sig_ == "2G"))
                 {
-                    observablesR2C.insert(std::pair<int32_t, Gnss_Synchro>(observables_iter->first, observables_iter->second));
+                    observablesR2C.insert(std::pair<int32_t, Gnss_Synchro>(observables_iter.first, observables_iter.second));
                 }
             if ((system_ == "G") && (sig_ == "1C"))
                 {
-                    observablesG1C.insert(std::pair<int32_t, Gnss_Synchro>(observables_iter->first, observables_iter->second));
+                    observablesG1C.insert(std::pair<int32_t, Gnss_Synchro>(observables_iter.first, observables_iter.second));
                 }
         }
 
     std::multimap<uint32_t, Gnss_Synchro> total_glo_map;
     std::set<uint32_t> available_glo_prns;
     std::set<uint32_t>::iterator it;
-    for (observables_iter = observablesR1C.cbegin();
-        observables_iter != observablesR1C.cend();
-        observables_iter++)
+    for (const auto& observables_iter : observablesR1C)
         {
-            const uint32_t prn_ = observables_iter->second.PRN;
-            total_glo_map.insert(std::pair<uint32_t, Gnss_Synchro>(prn_, observables_iter->second));
+            const uint32_t prn_ = observables_iter.second.PRN;
+            total_glo_map.insert(std::pair<uint32_t, Gnss_Synchro>(prn_, observables_iter.second));
             it = available_glo_prns.find(prn_);
             if (it == available_glo_prns.end())
                 {
@@ -4962,12 +4947,10 @@ void Rinex_Printer::log_rinex_obs(std::fstream& out, const Gps_Ephemeris& gps_ep
                 }
         }
 
-    for (observables_iter = observablesR2C.cbegin();
-        observables_iter != observablesR2C.cend();
-        observables_iter++)
+    for (const auto& observables_iter : observablesR2C)
         {
-            const uint32_t prn_ = observables_iter->second.PRN;
-            total_glo_map.insert(std::pair<uint32_t, Gnss_Synchro>(prn_, observables_iter->second));
+            const uint32_t prn_ = observables_iter.second.PRN;
+            total_glo_map.insert(std::pair<uint32_t, Gnss_Synchro>(prn_, observables_iter.second));
             it = available_glo_prns.find(prn_);
             if (it == available_glo_prns.end())
                 {
@@ -4982,40 +4965,34 @@ void Rinex_Printer::log_rinex_obs(std::fstream& out, const Gps_Ephemeris& gps_ep
     if (d_version == 2)
         {
             // Add list of GPS satellites
-            for (observables_iter = observablesG1C.cbegin();
-                observables_iter != observablesG1C.cend();
-                observables_iter++)
+            for (const auto& observables_iter : observablesG1C)
                 {
                     line += satelliteSystem.at("GPS");
-                    if (static_cast<int32_t>(observables_iter->second.PRN) < 10)
+                    if (static_cast<int32_t>(observables_iter.second.PRN) < 10)
                         {
                             line += std::string(1, '0');
                         }
-                    line += std::to_string(static_cast<int32_t>(observables_iter->second.PRN));
+                    line += std::to_string(static_cast<int32_t>(observables_iter.second.PRN));
                 }
             // Add list of GLONASS L1 satellites
-            for (observables_iter = observablesR1C.cbegin();
-                observables_iter != observablesR1C.cend();
-                observables_iter++)
+            for (const auto& observables_iter : observablesR1C)
                 {
                     line += satelliteSystem.at("GLONASS");
-                    if (static_cast<int32_t>(observables_iter->second.PRN) < 10)
+                    if (static_cast<int32_t>(observables_iter.second.PRN) < 10)
                         {
                             line += std::string(1, '0');
                         }
-                    line += std::to_string(static_cast<int32_t>(observables_iter->second.PRN));
+                    line += std::to_string(static_cast<int32_t>(observables_iter.second.PRN));
                 }
             // Add list of GLONASS L2 satellites
-            for (observables_iter = observablesR2C.cbegin();
-                observables_iter != observablesR2C.cend();
-                observables_iter++)
+            for (const auto& observables_iter : observablesR2C)
                 {
                     line += satelliteSystem.at("GLONASS");
-                    if (static_cast<int32_t>(observables_iter->second.PRN) < 10)
+                    if (static_cast<int32_t>(observables_iter.second.PRN) < 10)
                         {
                             line += std::string(1, '0');
                         }
-                    line += std::to_string(static_cast<int32_t>(observables_iter->second.PRN));
+                    line += std::to_string(static_cast<int32_t>(observables_iter.second.PRN));
                 }
         }
     line += std::string(80 - line.size(), ' ');
@@ -5025,13 +5002,11 @@ void Rinex_Printer::log_rinex_obs(std::fstream& out, const Gps_Ephemeris& gps_ep
     // -------- OBSERVATION record
     std::string s;
     std::string lineObs;
-    for (observables_iter = observablesG1C.cbegin();
-        observables_iter != observablesG1C.cend();
-        observables_iter++)
+    for (const auto& observables_iter : observablesG1C)
         {
             lineObs.clear();
 
-            s.assign(1, observables_iter->second.System);
+            s.assign(1, observables_iter.second.System);
             if (d_version == 3)
                 {
                     // Specify system only if in version 3
@@ -5043,15 +5018,15 @@ void Rinex_Printer::log_rinex_obs(std::fstream& out, const Gps_Ephemeris& gps_ep
                         {
                             line += satelliteSystem.at("GLONASS");
                         }
-                    if (static_cast<int32_t>(observables_iter->second.PRN) < 10)
+                    if (static_cast<int32_t>(observables_iter.second.PRN) < 10)
                         {
                             lineObs += std::string(1, '0');
                         }
-                    lineObs += std::to_string(static_cast<int32_t>(observables_iter->second.PRN));
+                    lineObs += std::to_string(static_cast<int32_t>(observables_iter.second.PRN));
                 }
 
             // Pseudorange Measurements
-            lineObs += rightJustify(asString(observables_iter->second.Pseudorange_m, 3), 14);
+            lineObs += rightJustify(asString(observables_iter.second.Pseudorange_m, 3), 14);
 
             // Loss of lock indicator (LLI)
             int32_t lli = 0;  // Include in the observation!!
@@ -5065,11 +5040,11 @@ void Rinex_Printer::log_rinex_obs(std::fstream& out, const Gps_Ephemeris& gps_ep
             //    }
 
             // Signal Strength Indicator (SSI)
-            const int32_t ssi = Rinex_Printer::signalStrength(observables_iter->second.CN0_dB_hz);
+            const int32_t ssi = Rinex_Printer::signalStrength(observables_iter.second.CN0_dB_hz);
             lineObs += rightJustify(asString<int32_t>(ssi), 1);
 
             // PHASE
-            lineObs += rightJustify(asString(observables_iter->second.Carrier_phase_rads / TWO_PI, 3), 14);
+            lineObs += rightJustify(asString(observables_iter.second.Carrier_phase_rads / TWO_PI, 3), 14);
             if (lli == 0)
                 {
                     lineObs += std::string(1, ' ');
@@ -5081,7 +5056,7 @@ void Rinex_Printer::log_rinex_obs(std::fstream& out, const Gps_Ephemeris& gps_ep
             lineObs += rightJustify(asString<int32_t>(ssi), 1);
 
             // DOPPLER
-            lineObs += rightJustify(asString(observables_iter->second.Carrier_Doppler_hz, 3), 14);
+            lineObs += rightJustify(asString(observables_iter.second.Carrier_Doppler_hz, 3), 14);
             if (lli == 0)
                 {
                     lineObs += std::string(1, ' ');
@@ -5093,7 +5068,7 @@ void Rinex_Printer::log_rinex_obs(std::fstream& out, const Gps_Ephemeris& gps_ep
             lineObs += rightJustify(asString<int32_t>(ssi), 1);
 
             // SIGNAL STRENGTH
-            lineObs += rightJustify(asString(observables_iter->second.CN0_dB_hz, 3), 14);
+            lineObs += rightJustify(asString(observables_iter.second.CN0_dB_hz, 3), 14);
 
             if (lineObs.size() < 80)
                 {
@@ -5102,22 +5077,19 @@ void Rinex_Printer::log_rinex_obs(std::fstream& out, const Gps_Ephemeris& gps_ep
             out << lineObs << '\n';
         }
 
-    std::pair<std::multimap<uint32_t, Gnss_Synchro>::iterator, std::multimap<uint32_t, Gnss_Synchro>::iterator> ret;
-    for (it = available_glo_prns.cbegin();
-        it != available_glo_prns.cend();
-        it++)
+    for (const auto& available_glo_prn : available_glo_prns)
         {
             lineObs.clear();
             if (d_version == 3)
                 {
                     lineObs += satelliteSystem.at("GLONASS");
-                    if (static_cast<int32_t>(*it) < 10)
+                    if (static_cast<int32_t>(available_glo_prn) < 10)
                         {
                             lineObs += std::string(1, '0');
                         }
-                    lineObs += std::to_string(static_cast<int32_t>(*it));
+                    lineObs += std::to_string(static_cast<int32_t>(available_glo_prn));
                 }
-            ret = total_glo_map.equal_range(*it);
+            const auto ret = total_glo_map.equal_range(available_glo_prn);
             for (auto iter = ret.first; iter != ret.second; ++iter)
                 {
                     /// \todo Need to account for pseudorange correction for glonass
@@ -5184,32 +5156,14 @@ void Rinex_Printer::log_rinex_obs(std::fstream& out, const Gps_CNAV_Ephemeris& g
     std::string line;
 
     // -------- EPOCH record
-    const boost::posix_time::ptime p_gps_time = Rinex_Printer::compute_GPS_time(gps_eph, gps_obs_time);
-    const std::string timestring = boost::posix_time::to_iso_string(p_gps_time);
+
     // double utc_t = nav_msg.utc_time(nav_msg.sv_clock_correction(obs_time));
     // const double gps_t = eph.sv_clock_correction(obs_time);
-    const double gps_t = gps_obs_time;
-
-    const std::string month(timestring, 4, 2);
-    const std::string day(timestring, 6, 2);
-    const std::string hour(timestring, 9, 2);
-    const std::string minutes(timestring, 11, 2);
-
-    const std::string year(timestring, 0, 4);
     line += std::string(1, '>');
-    line += std::string(1, ' ');
-    line += year;
-    line += std::string(1, ' ');
-    line += month;
-    line += std::string(1, ' ');
-    line += day;
-    line += std::string(1, ' ');
-    line += hour;
-    line += std::string(1, ' ');
-    line += minutes;
 
-    line += std::string(1, ' ');
-    double seconds = fmod(gps_t, 60);
+    add_svclk_to_line(Rinex_Printer::compute_GPS_time(gps_eph, gps_obs_time), false, line);
+
+    double seconds = fmod(gps_obs_time, 60);
     // Add extra 0 if seconds are < 10
     if (seconds < 10)
         {
@@ -5225,37 +5179,32 @@ void Rinex_Printer::log_rinex_obs(std::fstream& out, const Gps_CNAV_Ephemeris& g
     std::map<int32_t, Gnss_Synchro> observablesG2S;
     std::map<int32_t, Gnss_Synchro> observablesR1C;
     std::map<int32_t, Gnss_Synchro> observablesR2C;
-    std::map<int32_t, Gnss_Synchro>::const_iterator observables_iter;
 
-    for (observables_iter = observables.cbegin();
-        observables_iter != observables.cend();
-        observables_iter++)
+    for (const auto& observables_iter : observables)
         {
-            const std::string system_(&observables_iter->second.System, 1);
-            const std::string sig_(observables_iter->second.Signal);
+            const std::string system_(&observables_iter.second.System, 1);
+            const std::string sig_(observables_iter.second.Signal);
             if ((system_ == "R") && (sig_ == "1G"))
                 {
-                    observablesR1C.insert(std::pair<int32_t, Gnss_Synchro>(observables_iter->first, observables_iter->second));
+                    observablesR1C.insert(std::pair<int32_t, Gnss_Synchro>(observables_iter.first, observables_iter.second));
                 }
             if ((system_ == "R") && (sig_ == "2G"))
                 {
-                    observablesR2C.insert(std::pair<int32_t, Gnss_Synchro>(observables_iter->first, observables_iter->second));
+                    observablesR2C.insert(std::pair<int32_t, Gnss_Synchro>(observables_iter.first, observables_iter.second));
                 }
             if ((system_ == "G") && (sig_ == "2S"))
                 {
-                    observablesG2S.insert(std::pair<int32_t, Gnss_Synchro>(observables_iter->first, observables_iter->second));
+                    observablesG2S.insert(std::pair<int32_t, Gnss_Synchro>(observables_iter.first, observables_iter.second));
                 }
         }
 
     std::multimap<uint32_t, Gnss_Synchro> total_glo_map;
     std::set<uint32_t> available_glo_prns;
     std::set<uint32_t>::iterator it;
-    for (observables_iter = observablesR1C.cbegin();
-        observables_iter != observablesR1C.cend();
-        observables_iter++)
+    for (const auto& observables_iter : observablesR1C)
         {
-            const uint32_t prn_ = observables_iter->second.PRN;
-            total_glo_map.insert(std::pair<uint32_t, Gnss_Synchro>(prn_, observables_iter->second));
+            const uint32_t prn_ = observables_iter.second.PRN;
+            total_glo_map.insert(std::pair<uint32_t, Gnss_Synchro>(prn_, observables_iter.second));
             it = available_glo_prns.find(prn_);
             if (it == available_glo_prns.end())
                 {
@@ -5263,12 +5212,10 @@ void Rinex_Printer::log_rinex_obs(std::fstream& out, const Gps_CNAV_Ephemeris& g
                 }
         }
 
-    for (observables_iter = observablesR2C.cbegin();
-        observables_iter != observablesR2C.cend();
-        observables_iter++)
+    for (const auto& observables_iter : observablesR2C)
         {
-            const uint32_t prn_ = observables_iter->second.PRN;
-            total_glo_map.insert(std::pair<uint32_t, Gnss_Synchro>(prn_, observables_iter->second));
+            const uint32_t prn_ = observables_iter.second.PRN;
+            total_glo_map.insert(std::pair<uint32_t, Gnss_Synchro>(prn_, observables_iter.second));
             it = available_glo_prns.find(prn_);
             if (it == available_glo_prns.end())
                 {
@@ -5288,13 +5235,11 @@ void Rinex_Printer::log_rinex_obs(std::fstream& out, const Gps_CNAV_Ephemeris& g
     // -------- OBSERVATION record
     std::string s;
     std::string lineObs;
-    for (observables_iter = observablesG2S.cbegin();
-        observables_iter != observablesG2S.cend();
-        observables_iter++)
+    for (const auto& observables_iter : observablesG2S)
         {
             lineObs.clear();
 
-            s.assign(1, observables_iter->second.System);
+            s.assign(1, observables_iter.second.System);
             // Specify system only if in version 3
             if (s == "G")
                 {
@@ -5304,14 +5249,14 @@ void Rinex_Printer::log_rinex_obs(std::fstream& out, const Gps_CNAV_Ephemeris& g
                 {
                     line += satelliteSystem.at("GLONASS");
                 }
-            if (static_cast<int32_t>(observables_iter->second.PRN) < 10)
+            if (static_cast<int32_t>(observables_iter.second.PRN) < 10)
                 {
                     lineObs += std::string(1, '0');
                 }
-            lineObs += std::to_string(static_cast<int32_t>(observables_iter->second.PRN));
+            lineObs += std::to_string(static_cast<int32_t>(observables_iter.second.PRN));
 
             // Pseudorange Measurements
-            lineObs += rightJustify(asString(observables_iter->second.Pseudorange_m, 3), 14);
+            lineObs += rightJustify(asString(observables_iter.second.Pseudorange_m, 3), 14);
 
             // Loss of lock indicator (LLI)
             int32_t lli = 0;  // Include in the observation!!
@@ -5325,11 +5270,11 @@ void Rinex_Printer::log_rinex_obs(std::fstream& out, const Gps_CNAV_Ephemeris& g
             //    }
 
             // Signal Strength Indicator (SSI)
-            const int32_t ssi = Rinex_Printer::signalStrength(observables_iter->second.CN0_dB_hz);
+            const int32_t ssi = Rinex_Printer::signalStrength(observables_iter.second.CN0_dB_hz);
             lineObs += rightJustify(asString<int32_t>(ssi), 1);
 
             // PHASE
-            lineObs += rightJustify(asString(observables_iter->second.Carrier_phase_rads / TWO_PI, 3), 14);
+            lineObs += rightJustify(asString(observables_iter.second.Carrier_phase_rads / TWO_PI, 3), 14);
             if (lli == 0)
                 {
                     lineObs += std::string(1, ' ');
@@ -5341,7 +5286,7 @@ void Rinex_Printer::log_rinex_obs(std::fstream& out, const Gps_CNAV_Ephemeris& g
             lineObs += rightJustify(asString<int32_t>(ssi), 1);
 
             // DOPPLER
-            lineObs += rightJustify(asString(observables_iter->second.Carrier_Doppler_hz, 3), 14);
+            lineObs += rightJustify(asString(observables_iter.second.Carrier_Doppler_hz, 3), 14);
             if (lli == 0)
                 {
                     lineObs += std::string(1, ' ');
@@ -5353,7 +5298,7 @@ void Rinex_Printer::log_rinex_obs(std::fstream& out, const Gps_CNAV_Ephemeris& g
             lineObs += rightJustify(asString<int32_t>(ssi), 1);
 
             // SIGNAL STRENGTH
-            lineObs += rightJustify(asString(observables_iter->second.CN0_dB_hz, 3), 14);
+            lineObs += rightJustify(asString(observables_iter.second.CN0_dB_hz, 3), 14);
 
             if (lineObs.size() < 80)
                 {
@@ -5363,19 +5308,17 @@ void Rinex_Printer::log_rinex_obs(std::fstream& out, const Gps_CNAV_Ephemeris& g
         }
 
     std::pair<std::multimap<uint32_t, Gnss_Synchro>::iterator, std::multimap<uint32_t, Gnss_Synchro>::iterator> ret;
-    for (it = available_glo_prns.cbegin();
-        it != available_glo_prns.cend();
-        it++)
+    for (const auto& prn : available_glo_prns)
         {
             lineObs.clear();
             lineObs += satelliteSystem.at("GLONASS");
-            if (static_cast<int32_t>(*it) < 10)
+            if (static_cast<int32_t>(prn) < 10)
                 {
                     lineObs += std::string(1, '0');
                 }
-            lineObs += std::to_string(static_cast<int32_t>(*it));
+            lineObs += std::to_string(static_cast<int32_t>(prn));
 
-            ret = total_glo_map.equal_range(*it);
+            ret = total_glo_map.equal_range(prn);
             for (auto iter = ret.first; iter != ret.second; ++iter)
                 {
                     /// \todo Need to account for pseudorange correction for glonass
@@ -5441,32 +5384,14 @@ void Rinex_Printer::log_rinex_obs(std::fstream& out, const Galileo_Ephemeris& ga
         }  // avoid warning, not needed
     std::string line;
 
-    const boost::posix_time::ptime p_galileo_time = Rinex_Printer::compute_Galileo_time(galileo_eph, galileo_obs_time);
-    const std::string timestring = boost::posix_time::to_iso_string(p_galileo_time);
     // double utc_t = nav_msg.utc_time(nav_msg.sv_clock_correction(obs_time));
     // const double gps_t = eph.sv_clock_correction(obs_time);
-    const double galileo_t = galileo_obs_time;
 
-    const std::string month(timestring, 4, 2);
-    const std::string day(timestring, 6, 2);
-    const std::string hour(timestring, 9, 2);
-    const std::string minutes(timestring, 11, 2);
-
-    const std::string year(timestring, 0, 4);
     line += std::string(1, '>');
-    line += std::string(1, ' ');
-    line += year;
-    line += std::string(1, ' ');
-    line += month;
-    line += std::string(1, ' ');
-    line += day;
-    line += std::string(1, ' ');
-    line += hour;
-    line += std::string(1, ' ');
-    line += minutes;
 
-    line += std::string(1, ' ');
-    const double seconds = fmod(galileo_t, 60);
+    add_svclk_to_line(Rinex_Printer::compute_Galileo_time(galileo_eph, galileo_obs_time), false, line);
+
+    const double seconds = fmod(galileo_obs_time, 60);
     // Add extra 0 if seconds are < 10
     if (seconds < 10)
         {
@@ -5483,49 +5408,43 @@ void Rinex_Printer::log_rinex_obs(std::fstream& out, const Galileo_Ephemeris& ga
     std::map<int32_t, Gnss_Synchro> observablesE1B;
     std::map<int32_t, Gnss_Synchro> observablesR1C;
     std::map<int32_t, Gnss_Synchro> observablesR2C;
-    std::map<int32_t, Gnss_Synchro>::const_iterator observables_iter;
 
-    for (observables_iter = observables.cbegin();
-        observables_iter != observables.cend();
-        observables_iter++)
+    for (const auto& observables_iter : observables)
         {
-            const std::string system_(&observables_iter->second.System, 1);
-            const std::string sig_(observables_iter->second.Signal);
+            const std::string system_(&observables_iter.second.System, 1);
+            const std::string sig_(observables_iter.second.Signal);
             if ((system_ == "R") && (sig_ == "1G"))
                 {
-                    observablesR1C.insert(std::pair<int32_t, Gnss_Synchro>(observables_iter->first, observables_iter->second));
+                    observablesR1C.insert(std::pair<int32_t, Gnss_Synchro>(observables_iter.first, observables_iter.second));
                 }
             if ((system_ == "R") && (sig_ == "2G"))
                 {
-                    observablesR2C.insert(std::pair<int32_t, Gnss_Synchro>(observables_iter->first, observables_iter->second));
+                    observablesR2C.insert(std::pair<int32_t, Gnss_Synchro>(observables_iter.first, observables_iter.second));
                 }
             if ((system_ == "E") && (sig_ == "1B"))
                 {
-                    observablesE1B.insert(std::pair<int32_t, Gnss_Synchro>(observables_iter->first, observables_iter->second));
+                    observablesE1B.insert(std::pair<int32_t, Gnss_Synchro>(observables_iter.first, observables_iter.second));
                 }
         }
 
     std::multimap<uint32_t, Gnss_Synchro> total_glo_map;
     std::set<uint32_t> available_glo_prns;
     std::set<uint32_t>::iterator it;
-    for (observables_iter = observablesR1C.cbegin();
-        observables_iter != observablesR1C.cend();
-        observables_iter++)
+    for (const auto& observables_iter : observablesR1C)
         {
-            const uint32_t prn_ = observables_iter->second.PRN;
-            total_glo_map.insert(std::pair<uint32_t, Gnss_Synchro>(prn_, observables_iter->second));
+            const uint32_t prn_ = observables_iter.second.PRN;
+            total_glo_map.insert(std::pair<uint32_t, Gnss_Synchro>(prn_, observables_iter.second));
             it = available_glo_prns.find(prn_);
             if (it == available_glo_prns.end())
                 {
                     available_glo_prns.insert(prn_);
                 }
         }
-    for (observables_iter = observablesR2C.cbegin();
-        observables_iter != observablesR2C.cend();
-        observables_iter++)
+
+    for (const auto& observables_iter : observablesR2C)
         {
-            const uint32_t prn_ = observables_iter->second.PRN;
-            total_glo_map.insert(std::pair<uint32_t, Gnss_Synchro>(prn_, observables_iter->second));
+            const uint32_t prn_ = observables_iter.second.PRN;
+            total_glo_map.insert(std::pair<uint32_t, Gnss_Synchro>(prn_, observables_iter.second));
             it = available_glo_prns.find(prn_);
             if (it == available_glo_prns.end())
                 {
@@ -5547,13 +5466,11 @@ void Rinex_Printer::log_rinex_obs(std::fstream& out, const Galileo_Ephemeris& ga
 
     std::string s;
     std::string lineObs;
-    for (observables_iter = observablesE1B.cbegin();
-        observables_iter != observablesE1B.cend();
-        observables_iter++)
+    for (const auto& observables_iter : observablesE1B)
         {
             lineObs.clear();
 
-            s.assign(1, observables_iter->second.System);
+            s.assign(1, observables_iter.second.System);
             if (s == "E")
                 {
                     lineObs += satelliteSystem.at("Galileo");
@@ -5562,12 +5479,12 @@ void Rinex_Printer::log_rinex_obs(std::fstream& out, const Galileo_Ephemeris& ga
                 {
                     line += satelliteSystem.at("GLONASS");
                 }
-            if (static_cast<int32_t>(observables_iter->second.PRN) < 10)
+            if (static_cast<int32_t>(observables_iter.second.PRN) < 10)
                 {
                     lineObs += std::string(1, '0');
                 }
-            lineObs += std::to_string(static_cast<int32_t>(observables_iter->second.PRN));
-            lineObs += rightJustify(asString(observables_iter->second.Pseudorange_m, 3), 14);
+            lineObs += std::to_string(static_cast<int32_t>(observables_iter.second.PRN));
+            lineObs += rightJustify(asString(observables_iter.second.Pseudorange_m, 3), 14);
 
             // Loss of lock indicator (LLI)
             int32_t lli = 0;  // Include in the observation!!
@@ -5581,11 +5498,11 @@ void Rinex_Printer::log_rinex_obs(std::fstream& out, const Galileo_Ephemeris& ga
             //    }
 
             // Signal Strength Indicator (SSI)
-            const int32_t ssi = Rinex_Printer::signalStrength(observables_iter->second.CN0_dB_hz);
+            const int32_t ssi = Rinex_Printer::signalStrength(observables_iter.second.CN0_dB_hz);
             lineObs += rightJustify(asString<int32_t>(ssi), 1);
 
             // PHASE
-            lineObs += rightJustify(asString(observables_iter->second.Carrier_phase_rads / TWO_PI, 3), 14);
+            lineObs += rightJustify(asString(observables_iter.second.Carrier_phase_rads / TWO_PI, 3), 14);
             if (lli == 0)
                 {
                     lineObs += std::string(1, ' ');
@@ -5597,7 +5514,7 @@ void Rinex_Printer::log_rinex_obs(std::fstream& out, const Galileo_Ephemeris& ga
             lineObs += rightJustify(asString<int32_t>(ssi), 1);
 
             // DOPPLER
-            lineObs += rightJustify(asString(observables_iter->second.Carrier_Doppler_hz, 3), 14);
+            lineObs += rightJustify(asString(observables_iter.second.Carrier_Doppler_hz, 3), 14);
             if (lli == 0)
                 {
                     lineObs += std::string(1, ' ');
@@ -5609,7 +5526,7 @@ void Rinex_Printer::log_rinex_obs(std::fstream& out, const Galileo_Ephemeris& ga
             lineObs += rightJustify(asString<int32_t>(ssi), 1);
 
             // SIGNAL STRENGTH
-            lineObs += rightJustify(asString(observables_iter->second.CN0_dB_hz, 3), 14);
+            lineObs += rightJustify(asString(observables_iter.second.CN0_dB_hz, 3), 14);
 
             if (lineObs.size() < 80)
                 {
@@ -5619,18 +5536,16 @@ void Rinex_Printer::log_rinex_obs(std::fstream& out, const Galileo_Ephemeris& ga
         }
 
     std::pair<std::multimap<uint32_t, Gnss_Synchro>::iterator, std::multimap<uint32_t, Gnss_Synchro>::iterator> ret;
-    for (it = available_glo_prns.cbegin();
-        it != available_glo_prns.cend();
-        it++)
+    for (const auto& prn : available_glo_prns)
         {
             lineObs.clear();
             lineObs += satelliteSystem.at("Galileo");
-            if (static_cast<int32_t>(*it) < 10)
+            if (static_cast<int32_t>(prn) < 10)
                 {
                     lineObs += std::string(1, '0');
                 }
-            lineObs += std::to_string(static_cast<int32_t>(*it));
-            ret = total_glo_map.equal_range(*it);
+            lineObs += std::to_string(static_cast<int32_t>(prn));
+            ret = total_glo_map.equal_range(prn);
             for (auto iter = ret.first; iter != ret.second; ++iter)
                 {
                     lineObs += rightJustify(asString(iter->second.Pseudorange_m, 3), 14);
@@ -5744,25 +5659,16 @@ void Rinex_Printer::log_rinex_obs(std::fstream& out, const Gps_Ephemeris& eph, d
             // Epoch flag 0: OK     1: power failure between previous and current epoch   <1: Special event
             line += std::string(1, '0');
             // Number of satellites observed in current epoch
-            int32_t numSatellitesObserved = 0;
-            std::map<int32_t, Gnss_Synchro>::const_iterator observables_iter;
-            for (observables_iter = observables.cbegin();
-                observables_iter != observables.cend();
-                observables_iter++)
-                {
-                    numSatellitesObserved++;
-                }
+            const int32_t numSatellitesObserved = observables.size();
             line += rightJustify(std::to_string(numSatellitesObserved), 3);
-            for (observables_iter = observables.cbegin();
-                observables_iter != observables.cend();
-                observables_iter++)
+            for (const auto& observables_iter : observables)
                 {
                     line += satelliteSystem.at("GPS");
-                    if (static_cast<int32_t>(observables_iter->second.PRN) < 10)
+                    if (static_cast<int32_t>(observables_iter.second.PRN) < 10)
                         {
                             line += std::string(1, '0');
                         }
-                    line += std::to_string(static_cast<int32_t>(observables_iter->second.PRN));
+                    line += std::to_string(static_cast<int32_t>(observables_iter.second.PRN));
                 }
             // Receiver clock offset (optional)
             // line += rightJustify(asString(clockOffset, 12), 15);
@@ -5770,16 +5676,14 @@ void Rinex_Printer::log_rinex_obs(std::fstream& out, const Gps_Ephemeris& eph, d
             lengthCheck(line);
             out << line << '\n';
 
-            for (observables_iter = observables.cbegin();
-                observables_iter != observables.cend();
-                observables_iter++)
+            for (const auto& observables_iter : observables)
                 {
                     std::string lineObs;
                     lineObs.clear();
                     line.clear();
                     // GPS L1 PSEUDORANGE
                     line += std::string(2, ' ');
-                    lineObs += rightJustify(asString(observables_iter->second.Pseudorange_m, 3), 14);
+                    lineObs += rightJustify(asString(observables_iter.second.Pseudorange_m, 3), 14);
 
                     // Loss of lock indicator (LLI)
                     int32_t lli = 0;  // Include in the observation!!
@@ -5793,10 +5697,10 @@ void Rinex_Printer::log_rinex_obs(std::fstream& out, const Gps_Ephemeris& eph, d
                     //    }
 
                     // Signal Strength Indicator (SSI)
-                    const int32_t ssi = Rinex_Printer::signalStrength(observables_iter->second.CN0_dB_hz);
+                    const int32_t ssi = Rinex_Printer::signalStrength(observables_iter.second.CN0_dB_hz);
                     lineObs += rightJustify(asString<int32_t>(ssi), 1);
                     // GPS L1 CA PHASE
-                    lineObs += rightJustify(asString(observables_iter->second.Carrier_phase_rads / TWO_PI, 3), 14);
+                    lineObs += rightJustify(asString(observables_iter.second.Carrier_phase_rads / TWO_PI, 3), 14);
                     if (lli == 0)
                         {
                             lineObs += std::string(1, ' ');
@@ -5807,7 +5711,7 @@ void Rinex_Printer::log_rinex_obs(std::fstream& out, const Gps_Ephemeris& eph, d
                     //    }
                     lineObs += rightJustify(asString<int32_t>(ssi), 1);
                     // GPS L1 CA DOPPLER
-                    lineObs += rightJustify(asString(observables_iter->second.Carrier_Doppler_hz, 3), 14);
+                    lineObs += rightJustify(asString(observables_iter.second.Carrier_Doppler_hz, 3), 14);
                     if (lli == 0)
                         {
                             lineObs += std::string(1, ' ');
@@ -5818,7 +5722,7 @@ void Rinex_Printer::log_rinex_obs(std::fstream& out, const Gps_Ephemeris& eph, d
                     //   }
                     lineObs += rightJustify(asString<int32_t>(ssi), 1);
                     // GPS L1 SIGNAL STRENGTH
-                    lineObs += rightJustify(asString(observables_iter->second.CN0_dB_hz, 3), 14);
+                    lineObs += rightJustify(asString(observables_iter.second.CN0_dB_hz, 3), 14);
                     if (lineObs.size() < 80)
                         {
                             lineObs += std::string(80 - lineObs.size(), ' ');
@@ -5855,14 +5759,7 @@ void Rinex_Printer::log_rinex_obs(std::fstream& out, const Gps_Ephemeris& eph, d
             line += std::string(1, '0');
 
             // Number of satellites observed in current epoch
-            int32_t numSatellitesObserved = 0;
-            std::map<int32_t, Gnss_Synchro>::const_iterator observables_iter;
-            for (observables_iter = observables.cbegin();
-                observables_iter != observables.cend();
-                observables_iter++)
-                {
-                    numSatellitesObserved++;
-                }
+            const int32_t numSatellitesObserved = observables.size();
             line += rightJustify(std::to_string(numSatellitesObserved), 3);
 
             // Receiver clock offset (optional)
@@ -5872,20 +5769,18 @@ void Rinex_Printer::log_rinex_obs(std::fstream& out, const Gps_Ephemeris& eph, d
             lengthCheck(line);
             out << line << '\n';
 
-            for (observables_iter = observables.cbegin();
-                observables_iter != observables.cend();
-                observables_iter++)
+            for (const auto& observables_iter : observables)
                 {
                     std::string lineObs;
                     lineObs.clear();
                     lineObs += satelliteSystem.at("GPS");
-                    if (static_cast<int32_t>(observables_iter->second.PRN) < 10)
+                    if (static_cast<int32_t>(observables_iter.second.PRN) < 10)
                         {
                             lineObs += std::string(1, '0');
                         }
-                    lineObs += std::to_string(static_cast<int32_t>(observables_iter->second.PRN));
+                    lineObs += std::to_string(static_cast<int32_t>(observables_iter.second.PRN));
                     // lineObs += std::string(2, ' ');
-                    lineObs += rightJustify(asString(observables_iter->second.Pseudorange_m, 3), 14);
+                    lineObs += rightJustify(asString(observables_iter.second.Pseudorange_m, 3), 14);
 
                     // Loss of lock indicator (LLI)
                     int32_t lli = 0;  // Include in the observation!!
@@ -5899,11 +5794,11 @@ void Rinex_Printer::log_rinex_obs(std::fstream& out, const Gps_Ephemeris& eph, d
                     //    }
 
                     // Signal Strength Indicator (SSI)
-                    const int32_t ssi = Rinex_Printer::signalStrength(observables_iter->second.CN0_dB_hz);
+                    const int32_t ssi = Rinex_Printer::signalStrength(observables_iter.second.CN0_dB_hz);
                     lineObs += rightJustify(asString<int32_t>(ssi), 1);
 
                     // GPS L1 CA PHASE
-                    lineObs += rightJustify(asString(observables_iter->second.Carrier_phase_rads / TWO_PI, 3), 14);
+                    lineObs += rightJustify(asString(observables_iter.second.Carrier_phase_rads / TWO_PI, 3), 14);
                     if (lli == 0)
                         {
                             lineObs += std::string(1, ' ');
@@ -5915,7 +5810,7 @@ void Rinex_Printer::log_rinex_obs(std::fstream& out, const Gps_Ephemeris& eph, d
                     lineObs += rightJustify(asString<int32_t>(ssi), 1);
 
                     // GPS L1 CA DOPPLER
-                    lineObs += rightJustify(asString(observables_iter->second.Carrier_Doppler_hz, 3), 14);
+                    lineObs += rightJustify(asString(observables_iter.second.Carrier_Doppler_hz, 3), 14);
                     if (lli == 0)
                         {
                             lineObs += std::string(1, ' ');
@@ -5928,7 +5823,7 @@ void Rinex_Printer::log_rinex_obs(std::fstream& out, const Gps_Ephemeris& eph, d
                     lineObs += rightJustify(asString<int32_t>(ssi), 1);
 
                     // GPS L1 SIGNAL STRENGTH
-                    lineObs += rightJustify(asString(observables_iter->second.CN0_dB_hz, 3), 14);
+                    lineObs += rightJustify(asString(observables_iter.second.CN0_dB_hz, 3), 14);
 
                     if (lineObs.size() < 80)
                         {
@@ -5945,32 +5840,14 @@ void Rinex_Printer::log_rinex_obs(std::fstream& out, const Gps_CNAV_Ephemeris& e
     // RINEX observations timestamps are GPS timestamps.
     std::string line;
 
-    const boost::posix_time::ptime p_gps_time = Rinex_Printer::compute_GPS_time(eph, obs_time);
-    const std::string timestring = boost::posix_time::to_iso_string(p_gps_time);
     // double utc_t = nav_msg.utc_time(nav_msg.sv_clock_correction(obs_time));
     // const double gps_t = eph.sv_clock_correction(obs_time);
-    const double gps_t = obs_time;
 
-    const std::string month(timestring, 4, 2);
-    const std::string day(timestring, 6, 2);
-    const std::string hour(timestring, 9, 2);
-    const std::string minutes(timestring, 11, 2);
-
-    const std::string year(timestring, 0, 4);
     line += std::string(1, '>');
-    line += std::string(1, ' ');
-    line += year;
-    line += std::string(1, ' ');
-    line += month;
-    line += std::string(1, ' ');
-    line += day;
-    line += std::string(1, ' ');
-    line += hour;
-    line += std::string(1, ' ');
-    line += minutes;
 
-    line += std::string(1, ' ');
-    const double seconds = fmod(gps_t, 60);
+    add_svclk_to_line(Rinex_Printer::compute_GPS_time(eph, obs_time), false, line);
+
+    const double seconds = fmod(obs_time, 60);
     // Add extra 0 if seconds are < 10
     if (seconds < 10)
         {
@@ -5982,14 +5859,7 @@ void Rinex_Printer::log_rinex_obs(std::fstream& out, const Gps_CNAV_Ephemeris& e
     line += std::string(1, '0');
 
     // Number of satellites observed in current epoch
-    int32_t numSatellitesObserved = 0;
-    std::map<int32_t, Gnss_Synchro>::const_iterator observables_iter;
-    for (observables_iter = observables.cbegin();
-        observables_iter != observables.cend();
-        observables_iter++)
-        {
-            numSatellitesObserved++;
-        }
+    const int32_t numSatellitesObserved = observables.size();
     line += rightJustify(std::to_string(numSatellitesObserved), 3);
 
     // Receiver clock offset (optional)
@@ -5999,21 +5869,19 @@ void Rinex_Printer::log_rinex_obs(std::fstream& out, const Gps_CNAV_Ephemeris& e
     lengthCheck(line);
     out << line << '\n';
 
-    for (observables_iter = observables.cbegin();
-        observables_iter != observables.cend();
-        observables_iter++)
+    for (const auto& observables_iter : observables)
         {
             std::string lineObs;
             lineObs.clear();
             lineObs += satelliteSystem.at("GPS");
-            if (static_cast<int32_t>(observables_iter->second.PRN) < 10)
+            if (static_cast<int32_t>(observables_iter.second.PRN) < 10)
                 {
                     lineObs += std::string(1, '0');
                 }
-            lineObs += std::to_string(static_cast<int32_t>(observables_iter->second.PRN));
+            lineObs += std::to_string(static_cast<int32_t>(observables_iter.second.PRN));
             // lineObs += std::string(2, ' ');
             // GPS L2 PSEUDORANGE
-            lineObs += rightJustify(asString(observables_iter->second.Pseudorange_m, 3), 14);
+            lineObs += rightJustify(asString(observables_iter.second.Pseudorange_m, 3), 14);
 
             // Loss of lock indicator (LLI)
             int32_t lli = 0;  // Include in the observation!!
@@ -6027,11 +5895,11 @@ void Rinex_Printer::log_rinex_obs(std::fstream& out, const Gps_CNAV_Ephemeris& e
             //   }
 
             // Signal Strength Indicator (SSI)
-            const int32_t ssi = Rinex_Printer::signalStrength(observables_iter->second.CN0_dB_hz);
+            const int32_t ssi = Rinex_Printer::signalStrength(observables_iter.second.CN0_dB_hz);
             lineObs += rightJustify(asString<int32_t>(ssi), 1);
 
             // GPS L2 PHASE
-            lineObs += rightJustify(asString(observables_iter->second.Carrier_phase_rads / TWO_PI, 3), 14);
+            lineObs += rightJustify(asString(observables_iter.second.Carrier_phase_rads / TWO_PI, 3), 14);
             if (lli == 0)
                 {
                     lineObs += std::string(1, ' ');
@@ -6043,7 +5911,7 @@ void Rinex_Printer::log_rinex_obs(std::fstream& out, const Gps_CNAV_Ephemeris& e
             lineObs += rightJustify(asString<int32_t>(ssi), 1);
 
             // GPS L2 DOPPLER
-            lineObs += rightJustify(asString(observables_iter->second.Carrier_Doppler_hz, 3), 14);
+            lineObs += rightJustify(asString(observables_iter.second.Carrier_Doppler_hz, 3), 14);
             if (lli == 0)
                 {
                     lineObs += std::string(1, ' ');
@@ -6056,7 +5924,7 @@ void Rinex_Printer::log_rinex_obs(std::fstream& out, const Gps_CNAV_Ephemeris& e
             lineObs += rightJustify(asString<int32_t>(ssi), 1);
 
             // GPS L2 SIGNAL STRENGTH
-            lineObs += rightJustify(asString(observables_iter->second.CN0_dB_hz, 3), 14);
+            lineObs += rightJustify(asString(observables_iter.second.CN0_dB_hz, 3), 14);
 
             if (lineObs.size() < 80)
                 {
@@ -6075,32 +5943,13 @@ void Rinex_Printer::log_rinex_obs(std::fstream& out, const Gps_Ephemeris& eph, c
     // RINEX observations timestamps are GPS timestamps.
     std::string line;
 
-    const boost::posix_time::ptime p_gps_time = Rinex_Printer::compute_GPS_time(eph, obs_time);
-    const std::string timestring = boost::posix_time::to_iso_string(p_gps_time);
     // double utc_t = nav_msg.utc_time(nav_msg.sv_clock_correction(obs_time));
     // const double gps_t = eph.sv_clock_correction(obs_time);
-    const double gps_t = obs_time;
-
-    const std::string month(timestring, 4, 2);
-    const std::string day(timestring, 6, 2);
-    const std::string hour(timestring, 9, 2);
-    const std::string minutes(timestring, 11, 2);
-
-    const std::string year(timestring, 0, 4);
     line += std::string(1, '>');
-    line += std::string(1, ' ');
-    line += year;
-    line += std::string(1, ' ');
-    line += month;
-    line += std::string(1, ' ');
-    line += day;
-    line += std::string(1, ' ');
-    line += hour;
-    line += std::string(1, ' ');
-    line += minutes;
 
-    line += std::string(1, ' ');
-    const double seconds = fmod(gps_t, 60);
+    add_svclk_to_line(Rinex_Printer::compute_GPS_time(eph, obs_time), false, line);
+
+    const double seconds = fmod(obs_time, 60);
     // Add extra 0 if seconds are < 10
     if (seconds < 10)
         {
@@ -6117,72 +5966,65 @@ void Rinex_Printer::log_rinex_obs(std::fstream& out, const Gps_Ephemeris& eph, c
     std::map<int32_t, Gnss_Synchro> observablesL1;
     std::map<int32_t, Gnss_Synchro> observablesL2;
     std::map<int32_t, Gnss_Synchro> observablesL5;
-    std::map<int32_t, Gnss_Synchro>::const_iterator observables_iter;
 
     std::multimap<uint32_t, Gnss_Synchro> total_mmap;
     std::multimap<uint32_t, Gnss_Synchro>::iterator mmap_iter;
-    for (observables_iter = observables.cbegin();
-        observables_iter != observables.cend();
-        observables_iter++)
+    for (const auto& observables_iter : observables)
         {
-            const std::string system_(&observables_iter->second.System, 1);
-            const std::string sig_(observables_iter->second.Signal);
+            const std::string system_(&observables_iter.second.System, 1);
+            const std::string sig_(observables_iter.second.Signal);
             if ((system_ == "G") && (sig_ == "1C"))
                 {
-                    observablesL1.insert(std::pair<int32_t, Gnss_Synchro>(observables_iter->first, observables_iter->second));
-                    total_mmap.insert(std::pair<uint32_t, Gnss_Synchro>(observables_iter->second.PRN, observables_iter->second));
+                    observablesL1.insert(std::pair<int32_t, Gnss_Synchro>(observables_iter.first, observables_iter.second));
+                    total_mmap.insert(std::pair<uint32_t, Gnss_Synchro>(observables_iter.second.PRN, observables_iter.second));
                 }
             if ((system_ == "G") && (sig_ == "2S"))
                 {
-                    observablesL2.insert(std::pair<int32_t, Gnss_Synchro>(observables_iter->first, observables_iter->second));
-                    mmap_iter = total_mmap.find(observables_iter->second.PRN);
+                    observablesL2.insert(std::pair<int32_t, Gnss_Synchro>(observables_iter.first, observables_iter.second));
+                    mmap_iter = total_mmap.find(observables_iter.second.PRN);
                     if (mmap_iter == total_mmap.end())
                         {
                             Gnss_Synchro gs = Gnss_Synchro();
-                            total_mmap.insert(std::pair<uint32_t, Gnss_Synchro>(observables_iter->second.PRN, gs));
+                            total_mmap.insert(std::pair<uint32_t, Gnss_Synchro>(observables_iter.second.PRN, gs));
                         }
-                    total_mmap.insert(std::pair<uint32_t, Gnss_Synchro>(observables_iter->second.PRN, observables_iter->second));
+                    total_mmap.insert(std::pair<uint32_t, Gnss_Synchro>(observables_iter.second.PRN, observables_iter.second));
                 }
 
             if ((system_ == "G") && (sig_ == "L5"))
                 {
-                    observablesL5.insert(std::pair<int32_t, Gnss_Synchro>(observables_iter->first, observables_iter->second));
-                    mmap_iter = total_mmap.find(observables_iter->second.PRN);
+                    observablesL5.insert(std::pair<int32_t, Gnss_Synchro>(observables_iter.first, observables_iter.second));
+                    mmap_iter = total_mmap.find(observables_iter.second.PRN);
                     if (mmap_iter == total_mmap.end())
                         {
                             Gnss_Synchro gs = Gnss_Synchro();
-                            total_mmap.insert(std::pair<uint32_t, Gnss_Synchro>(observables_iter->second.PRN, gs));
+                            total_mmap.insert(std::pair<uint32_t, Gnss_Synchro>(observables_iter.second.PRN, gs));
                         }
-                    total_mmap.insert(std::pair<uint32_t, Gnss_Synchro>(observables_iter->second.PRN, observables_iter->second));
+                    total_mmap.insert(std::pair<uint32_t, Gnss_Synchro>(observables_iter.second.PRN, observables_iter.second));
                 }
         }
 
     // Fill with zeros satellites with L1 obs but not L2
     std::multimap<uint32_t, Gnss_Synchro> mmap_aux;
     mmap_aux = total_mmap;
-    for (mmap_iter = mmap_aux.begin();
-        mmap_iter != mmap_aux.end();
-        mmap_iter++)
+    for (const auto& mmap_iter : mmap_aux)
         {
-            if ((total_mmap.count(mmap_iter->second.PRN)) == 1 && (mmap_iter->second.PRN != 0))
+            if ((total_mmap.count(mmap_iter.second.PRN)) == 1 && (mmap_iter.second.PRN != 0))
                 {
                     Gnss_Synchro gs = Gnss_Synchro();
                     gs.System = 'G';
                     gs.Signal[0] = '2';
                     gs.Signal[1] = 'S';
                     gs.Signal[2] = '\0';
-                    gs.PRN = mmap_iter->second.PRN;
-                    total_mmap.insert(std::pair<uint32_t, Gnss_Synchro>(mmap_iter->second.PRN, gs));
+                    gs.PRN = mmap_iter.second.PRN;
+                    total_mmap.insert(std::pair<uint32_t, Gnss_Synchro>(mmap_iter.second.PRN, gs));
                 }
         }
 
     std::set<uint32_t> available_prns;
     std::set<uint32_t>::iterator it;
-    for (observables_iter = observablesL1.cbegin();
-        observables_iter != observablesL1.cend();
-        observables_iter++)
+    for (const auto& observables_iter : observablesL1)
         {
-            const uint32_t prn_ = observables_iter->second.PRN;
+            const uint32_t prn_ = observables_iter.second.PRN;
             it = available_prns.find(prn_);
             if (it == available_prns.end())
                 {
@@ -6190,11 +6032,9 @@ void Rinex_Printer::log_rinex_obs(std::fstream& out, const Gps_Ephemeris& eph, c
                 }
         }
 
-    for (observables_iter = observablesL2.cbegin();
-        observables_iter != observablesL2.cend();
-        observables_iter++)
+    for (const auto& observables_iter : observablesL2)
         {
-            const uint32_t prn_ = observables_iter->second.PRN;
+            const uint32_t prn_ = observables_iter.second.PRN;
             it = available_prns.find(prn_);
             if (it == available_prns.end())
                 {
@@ -6202,11 +6042,9 @@ void Rinex_Printer::log_rinex_obs(std::fstream& out, const Gps_Ephemeris& eph, c
                 }
         }
 
-    for (observables_iter = observablesL5.cbegin();
-        observables_iter != observablesL5.cend();
-        observables_iter++)
+    for (const auto& observables_iter : observablesL5)
         {
-            const uint32_t prn_ = observables_iter->second.PRN;
+            const uint32_t prn_ = observables_iter.second.PRN;
             it = available_prns.find(prn_);
             if (it == available_prns.end())
                 {
@@ -6223,19 +6061,16 @@ void Rinex_Printer::log_rinex_obs(std::fstream& out, const Gps_Ephemeris& eph, c
     out << line << '\n';
 
     std::string lineObs;
-    std::pair<std::multimap<uint32_t, Gnss_Synchro>::iterator, std::multimap<uint32_t, Gnss_Synchro>::iterator> ret;
-    for (it = available_prns.cbegin();
-        it != available_prns.cend();
-        it++)
+    for (const auto& available_prn : available_prns)
         {
             lineObs.clear();
             lineObs += satelliteSystem.at("GPS");
-            if (static_cast<int32_t>(*it) < 10)
+            if (static_cast<int32_t>(available_prn) < 10)
                 {
                     lineObs += std::string(1, '0');
                 }
-            lineObs += std::to_string(static_cast<int32_t>(*it));
-            ret = total_mmap.equal_range(*it);
+            lineObs += std::to_string(static_cast<int32_t>(available_prn));
+            const auto ret = total_mmap.equal_range(available_prn);
             bool have_l2 = false;
             for (auto iter = ret.first; iter != ret.second; ++iter)
                 {
@@ -6309,32 +6144,13 @@ void Rinex_Printer::log_rinex_obs(std::fstream& out, const Galileo_Ephemeris& ep
     // See https://gage.upc.edu/sites/default/files/gLAB/HTML/Observation_Rinex_v3.01.html
     std::string line;
 
-    const boost::posix_time::ptime p_galileo_time = Rinex_Printer::compute_Galileo_time(eph, obs_time);
-    const std::string timestring = boost::posix_time::to_iso_string(p_galileo_time);
     // double utc_t = nav_msg.utc_time(nav_msg.sv_clock_correction(obs_time));
     // const double gps_t = eph.sv_clock_correction(obs_time);
-    const double galileo_t = obs_time;
-
-    const std::string month(timestring, 4, 2);
-    const std::string day(timestring, 6, 2);
-    const std::string hour(timestring, 9, 2);
-    const std::string minutes(timestring, 11, 2);
-
-    const std::string year(timestring, 0, 4);
     line += std::string(1, '>');
-    line += std::string(1, ' ');
-    line += year;
-    line += std::string(1, ' ');
-    line += month;
-    line += std::string(1, ' ');
-    line += day;
-    line += std::string(1, ' ');
-    line += hour;
-    line += std::string(1, ' ');
-    line += minutes;
 
-    line += std::string(1, ' ');
-    const double seconds = fmod(galileo_t, 60);
+    add_svclk_to_line(Rinex_Printer::compute_Galileo_time(eph, obs_time), false, line);
+
+    const double seconds = fmod(obs_time, 60);
     // Add extra 0 if seconds are < 10
     if (seconds < 10)
         {
@@ -6352,29 +6168,26 @@ void Rinex_Printer::log_rinex_obs(std::fstream& out, const Galileo_Ephemeris& ep
     std::map<int32_t, Gnss_Synchro> observablesE5A;
     std::map<int32_t, Gnss_Synchro> observablesE5B;
     std::map<int32_t, Gnss_Synchro> observablesE6B;
-    std::map<int32_t, Gnss_Synchro>::const_iterator observables_iter;
 
-    for (observables_iter = observables.cbegin();
-        observables_iter != observables.cend();
-        observables_iter++)
+    for (const auto& observables_iter : observables)
         {
-            const std::string system_(&observables_iter->second.System, 1);
-            const std::string sig_(observables_iter->second.Signal);
+            const std::string system_(&observables_iter.second.System, 1);
+            const std::string sig_(observables_iter.second.Signal);
             if ((system_ == "E") && (sig_ == "1B"))
                 {
-                    observablesE1B.insert(std::pair<int32_t, Gnss_Synchro>(observables_iter->first, observables_iter->second));
+                    observablesE1B.insert(std::pair<int32_t, Gnss_Synchro>(observables_iter.first, observables_iter.second));
                 }
             if ((system_ == "E") && (sig_ == "5X"))
                 {
-                    observablesE5A.insert(std::pair<int32_t, Gnss_Synchro>(observables_iter->first, observables_iter->second));
+                    observablesE5A.insert(std::pair<int32_t, Gnss_Synchro>(observables_iter.first, observables_iter.second));
                 }
             if ((system_ == "E") && (sig_ == "7X"))
                 {
-                    observablesE5B.insert(std::pair<int32_t, Gnss_Synchro>(observables_iter->first, observables_iter->second));
+                    observablesE5B.insert(std::pair<int32_t, Gnss_Synchro>(observables_iter.first, observables_iter.second));
                 }
             if ((system_ == "E") && (sig_ == "E6"))
                 {
-                    observablesE6B.insert(std::pair<int32_t, Gnss_Synchro>(observables_iter->first, observables_iter->second));
+                    observablesE6B.insert(std::pair<int32_t, Gnss_Synchro>(observables_iter.first, observables_iter.second));
                 }
         }
     const std::size_t found_1B = galileo_bands.find("1B");
@@ -6387,12 +6200,10 @@ void Rinex_Printer::log_rinex_obs(std::fstream& out, const Galileo_Ephemeris& ep
     std::set<uint32_t>::iterator it;
     if (found_1B != std::string::npos)
         {
-            for (observables_iter = observablesE1B.cbegin();
-                observables_iter != observablesE1B.cend();
-                observables_iter++)
+            for (const auto& observables_iter : observablesE1B)
                 {
-                    const uint32_t prn_ = observables_iter->second.PRN;
-                    total_map.insert(std::pair<uint32_t, Gnss_Synchro>(prn_, observables_iter->second));
+                    const uint32_t prn_ = observables_iter.second.PRN;
+                    total_map.insert(std::pair<uint32_t, Gnss_Synchro>(prn_, observables_iter.second));
                     it = available_prns.find(prn_);
                     if (it == available_prns.end())
                         {
@@ -6402,11 +6213,9 @@ void Rinex_Printer::log_rinex_obs(std::fstream& out, const Galileo_Ephemeris& ep
         }
     if (found_E5a != std::string::npos)
         {
-            for (observables_iter = observablesE5A.cbegin();
-                observables_iter != observablesE5A.cend();
-                observables_iter++)
+            for (const auto& observables_iter : observablesE5A)
                 {
-                    const uint32_t prn_ = observables_iter->second.PRN;
+                    const uint32_t prn_ = observables_iter.second.PRN;
                     it = available_prns.find(prn_);
                     if (it == available_prns.end())
                         {
@@ -6422,16 +6231,14 @@ void Rinex_Printer::log_rinex_obs(std::fstream& out, const Galileo_Ephemeris& ep
                                     total_map.insert(std::pair<uint32_t, Gnss_Synchro>(prn_, gs));
                                 }
                         }
-                    total_map.insert(std::pair<uint32_t, Gnss_Synchro>(prn_, observables_iter->second));
+                    total_map.insert(std::pair<uint32_t, Gnss_Synchro>(prn_, observables_iter.second));
                 }
         }
     if (found_E5b != std::string::npos)
         {
-            for (observables_iter = observablesE5B.cbegin();
-                observables_iter != observablesE5B.cend();
-                observables_iter++)
+            for (const auto& observables_iter : observablesE5B)
                 {
-                    const uint32_t prn_ = observables_iter->second.PRN;
+                    const uint32_t prn_ = observables_iter.second.PRN;
                     it = available_prns.find(prn_);
                     if (it == available_prns.end())
                         {
@@ -6447,18 +6254,16 @@ void Rinex_Printer::log_rinex_obs(std::fstream& out, const Galileo_Ephemeris& ep
                                     total_map.insert(std::pair<uint32_t, Gnss_Synchro>(prn_, gs));
                                 }
                         }
-                    total_map.insert(std::pair<uint32_t, Gnss_Synchro>(prn_, observables_iter->second));
+                    total_map.insert(std::pair<uint32_t, Gnss_Synchro>(prn_, observables_iter.second));
                 }
         }
 
     if (found_E6b != std::string::npos)
         {
-            for (observables_iter = observablesE6B.cbegin();
-                observables_iter != observablesE6B.cend();
-                observables_iter++)
+            for (const auto& observables_iter : observablesE6B)
                 {
-                    const uint32_t prn_ = observables_iter->second.PRN;
-                    total_map.insert(std::pair<uint32_t, Gnss_Synchro>(prn_, observables_iter->second));
+                    const uint32_t prn_ = observables_iter.second.PRN;
+                    total_map.insert(std::pair<uint32_t, Gnss_Synchro>(prn_, observables_iter.second));
                     it = available_prns.find(prn_);
                     if (it == available_prns.end())
                         {
@@ -6476,19 +6281,16 @@ void Rinex_Printer::log_rinex_obs(std::fstream& out, const Galileo_Ephemeris& ep
     out << line << '\n';
 
     std::string lineObs;
-    std::pair<std::multimap<uint32_t, Gnss_Synchro>::iterator, std::multimap<uint32_t, Gnss_Synchro>::iterator> ret;
-    for (it = available_prns.cbegin();
-        it != available_prns.cend();
-        it++)
+    for (const auto& available_prn : available_prns)
         {
             lineObs.clear();
             lineObs += satelliteSystem.at("Galileo");
-            if (static_cast<int32_t>(*it) < 10)
+            if (static_cast<int32_t>(available_prn) < 10)
                 {
                     lineObs += std::string(1, '0');
                 }
-            lineObs += std::to_string(static_cast<int32_t>(*it));
-            ret = total_map.equal_range(*it);
+            lineObs += std::to_string(static_cast<int32_t>(available_prn));
+            const auto ret = total_map.equal_range(available_prn);
             for (auto iter = ret.first; iter != ret.second; ++iter)
                 {
                     lineObs += rightJustify(asString(iter->second.Pseudorange_m, 3), 14);
@@ -6552,32 +6354,14 @@ void Rinex_Printer::log_rinex_obs(std::fstream& out, const Gps_Ephemeris& gps_ep
         }  // avoid warning, not needed
     std::string line;
 
-    const boost::posix_time::ptime p_gps_time = Rinex_Printer::compute_GPS_time(gps_eph, gps_obs_time);
-    const std::string timestring = boost::posix_time::to_iso_string(p_gps_time);
     // double utc_t = nav_msg.utc_time(nav_msg.sv_clock_correction(obs_time));
     // double gps_t = eph.sv_clock_correction(obs_time);
-    const double gps_t = gps_obs_time;
 
-    const std::string month(timestring, 4, 2);
-    const std::string day(timestring, 6, 2);
-    const std::string hour(timestring, 9, 2);
-    const std::string minutes(timestring, 11, 2);
-
-    const std::string year(timestring, 0, 4);
     line += std::string(1, '>');
-    line += std::string(1, ' ');
-    line += year;
-    line += std::string(1, ' ');
-    line += month;
-    line += std::string(1, ' ');
-    line += day;
-    line += std::string(1, ' ');
-    line += hour;
-    line += std::string(1, ' ');
-    line += minutes;
 
-    line += std::string(1, ' ');
-    const double seconds = fmod(gps_t, 60);
+    add_svclk_to_line(Rinex_Printer::compute_GPS_time(gps_eph, gps_obs_time), false, line);
+
+    const double seconds = fmod(gps_obs_time, 60);
     // Add extra 0 if seconds are < 10
     if (seconds < 10)
         {
@@ -6596,45 +6380,40 @@ void Rinex_Printer::log_rinex_obs(std::fstream& out, const Gps_Ephemeris& gps_ep
     std::map<int32_t, Gnss_Synchro> observablesE5A;
     std::map<int32_t, Gnss_Synchro> observablesE5B;
     std::map<int32_t, Gnss_Synchro> observablesE6B;
-    std::map<int32_t, Gnss_Synchro>::const_iterator observables_iter;
 
-    for (observables_iter = observables.cbegin();
-        observables_iter != observables.cend();
-        observables_iter++)
+    for (const auto& observables_iter : observables)
         {
-            const std::string system_(&observables_iter->second.System, 1);
-            const std::string sig_(observables_iter->second.Signal);
+            const std::string system_(&observables_iter.second.System, 1);
+            const std::string sig_(observables_iter.second.Signal);
             if ((system_ == "E") && (sig_ == "1B"))
                 {
-                    observablesE1B.insert(std::pair<int32_t, Gnss_Synchro>(observables_iter->first, observables_iter->second));
+                    observablesE1B.insert(std::pair<int32_t, Gnss_Synchro>(observables_iter.first, observables_iter.second));
                 }
             if ((system_ == "E") && (sig_ == "5X"))
                 {
-                    observablesE5A.insert(std::pair<int32_t, Gnss_Synchro>(observables_iter->first, observables_iter->second));
+                    observablesE5A.insert(std::pair<int32_t, Gnss_Synchro>(observables_iter.first, observables_iter.second));
                 }
             if ((system_ == "E") && (sig_ == "7X"))
                 {
-                    observablesE5B.insert(std::pair<int32_t, Gnss_Synchro>(observables_iter->first, observables_iter->second));
+                    observablesE5B.insert(std::pair<int32_t, Gnss_Synchro>(observables_iter.first, observables_iter.second));
                 }
             if ((system_ == "E") && (sig_ == "E6"))
                 {
-                    observablesE6B.insert(std::pair<int32_t, Gnss_Synchro>(observables_iter->first, observables_iter->second));
+                    observablesE6B.insert(std::pair<int32_t, Gnss_Synchro>(observables_iter.first, observables_iter.second));
                 }
             if ((system_ == "G") && (sig_ == "1C"))
                 {
-                    observablesG1C.insert(std::pair<int32_t, Gnss_Synchro>(observables_iter->first, observables_iter->second));
+                    observablesG1C.insert(std::pair<int32_t, Gnss_Synchro>(observables_iter.first, observables_iter.second));
                 }
         }
 
     std::multimap<uint32_t, Gnss_Synchro> total_gal_map;
     std::set<uint32_t> available_gal_prns;
     std::set<uint32_t>::iterator it;
-    for (observables_iter = observablesE1B.cbegin();
-        observables_iter != observablesE1B.cend();
-        observables_iter++)
+    for (const auto& observables_iter : observablesE1B)
         {
-            const uint32_t prn_ = observables_iter->second.PRN;
-            total_gal_map.insert(std::pair<uint32_t, Gnss_Synchro>(prn_, observables_iter->second));
+            const uint32_t prn_ = observables_iter.second.PRN;
+            total_gal_map.insert(std::pair<uint32_t, Gnss_Synchro>(prn_, observables_iter.second));
             it = available_gal_prns.find(prn_);
             if (it == available_gal_prns.end())
                 {
@@ -6642,12 +6421,10 @@ void Rinex_Printer::log_rinex_obs(std::fstream& out, const Gps_Ephemeris& gps_ep
                 }
         }
 
-    for (observables_iter = observablesE5A.cbegin();
-        observables_iter != observablesE5A.cend();
-        observables_iter++)
+    for (const auto& observables_iter : observablesE5A)
         {
-            const uint32_t prn_ = observables_iter->second.PRN;
-            total_gal_map.insert(std::pair<uint32_t, Gnss_Synchro>(prn_, observables_iter->second));
+            const uint32_t prn_ = observables_iter.second.PRN;
+            total_gal_map.insert(std::pair<uint32_t, Gnss_Synchro>(prn_, observables_iter.second));
             it = available_gal_prns.find(prn_);
             if (it == available_gal_prns.end())
                 {
@@ -6655,12 +6432,10 @@ void Rinex_Printer::log_rinex_obs(std::fstream& out, const Gps_Ephemeris& gps_ep
                 }
         }
 
-    for (observables_iter = observablesE5B.cbegin();
-        observables_iter != observablesE5B.cend();
-        observables_iter++)
+    for (const auto& observables_iter : observablesE5B)
         {
-            const uint32_t prn_ = observables_iter->second.PRN;
-            total_gal_map.insert(std::pair<uint32_t, Gnss_Synchro>(prn_, observables_iter->second));
+            const uint32_t prn_ = observables_iter.second.PRN;
+            total_gal_map.insert(std::pair<uint32_t, Gnss_Synchro>(prn_, observables_iter.second));
             it = available_gal_prns.find(prn_);
             if (it == available_gal_prns.end())
                 {
@@ -6668,12 +6443,10 @@ void Rinex_Printer::log_rinex_obs(std::fstream& out, const Gps_Ephemeris& gps_ep
                 }
         }
 
-    for (observables_iter = observablesE6B.cbegin();
-        observables_iter != observablesE6B.cend();
-        observables_iter++)
+    for (const auto& observables_iter : observablesE6B)
         {
-            const uint32_t prn_ = observables_iter->second.PRN;
-            total_gal_map.insert(std::pair<uint32_t, Gnss_Synchro>(prn_, observables_iter->second));
+            const uint32_t prn_ = observables_iter.second.PRN;
+            total_gal_map.insert(std::pair<uint32_t, Gnss_Synchro>(prn_, observables_iter.second));
             it = available_gal_prns.find(prn_);
             if (it == available_gal_prns.end())
                 {
@@ -6696,13 +6469,11 @@ void Rinex_Printer::log_rinex_obs(std::fstream& out, const Gps_Ephemeris& gps_ep
     std::string s;
     std::string lineObs;
 
-    for (observables_iter = observablesG1C.cbegin();
-        observables_iter != observablesG1C.cend();
-        observables_iter++)
+    for (const auto& observables_iter : observablesG1C)
         {
             lineObs.clear();
 
-            s.assign(1, observables_iter->second.System);
+            s.assign(1, observables_iter.second.System);
             if (s == "G")
                 {
                     lineObs += satelliteSystem.at("GPS");
@@ -6711,12 +6482,12 @@ void Rinex_Printer::log_rinex_obs(std::fstream& out, const Gps_Ephemeris& gps_ep
                 {
                     lineObs += satelliteSystem.at("Galileo");
                 }
-            if (static_cast<int32_t>(observables_iter->second.PRN) < 10)
+            if (static_cast<int32_t>(observables_iter.second.PRN) < 10)
                 {
                     lineObs += std::string(1, '0');
                 }
-            lineObs += std::to_string(static_cast<int32_t>(observables_iter->second.PRN));
-            lineObs += rightJustify(asString(observables_iter->second.Pseudorange_m, 3), 14);
+            lineObs += std::to_string(static_cast<int32_t>(observables_iter.second.PRN));
+            lineObs += rightJustify(asString(observables_iter.second.Pseudorange_m, 3), 14);
 
             // Loss of lock indicator (LLI)
             int32_t lli = 0;  // Include in the observation!!
@@ -6730,11 +6501,11 @@ void Rinex_Printer::log_rinex_obs(std::fstream& out, const Gps_Ephemeris& gps_ep
             //    }
 
             // Signal Strength Indicator (SSI)
-            const int32_t ssi = Rinex_Printer::signalStrength(observables_iter->second.CN0_dB_hz);
+            const int32_t ssi = Rinex_Printer::signalStrength(observables_iter.second.CN0_dB_hz);
             lineObs += rightJustify(asString<int32_t>(ssi), 1);
 
             // PHASE
-            lineObs += rightJustify(asString(observables_iter->second.Carrier_phase_rads / TWO_PI, 3), 14);
+            lineObs += rightJustify(asString(observables_iter.second.Carrier_phase_rads / TWO_PI, 3), 14);
             if (lli == 0)
                 {
                     lineObs += std::string(1, ' ');
@@ -6746,7 +6517,7 @@ void Rinex_Printer::log_rinex_obs(std::fstream& out, const Gps_Ephemeris& gps_ep
             lineObs += rightJustify(asString<int32_t>(ssi), 1);
 
             // DOPPLER
-            lineObs += rightJustify(asString(observables_iter->second.Carrier_Doppler_hz, 3), 14);
+            lineObs += rightJustify(asString(observables_iter.second.Carrier_Doppler_hz, 3), 14);
             if (lli == 0)
                 {
                     lineObs += std::string(1, ' ');
@@ -6758,7 +6529,7 @@ void Rinex_Printer::log_rinex_obs(std::fstream& out, const Gps_Ephemeris& gps_ep
             lineObs += rightJustify(asString<int32_t>(ssi), 1);
 
             // SIGNAL STRENGTH
-            lineObs += rightJustify(asString(observables_iter->second.CN0_dB_hz, 3), 14);
+            lineObs += rightJustify(asString(observables_iter.second.CN0_dB_hz, 3), 14);
 
             if (lineObs.size() < 80)
                 {
@@ -6768,18 +6539,16 @@ void Rinex_Printer::log_rinex_obs(std::fstream& out, const Gps_Ephemeris& gps_ep
         }
 
     std::pair<std::multimap<uint32_t, Gnss_Synchro>::iterator, std::multimap<uint32_t, Gnss_Synchro>::iterator> ret;
-    for (it = available_gal_prns.cbegin();
-        it != available_gal_prns.cend();
-        it++)
+    for (const auto& prn : available_gal_prns)
         {
             lineObs.clear();
             lineObs += satelliteSystem.at("Galileo");
-            if (static_cast<int32_t>(*it) < 10)
+            if (static_cast<int32_t>(prn) < 10)
                 {
                     lineObs += std::string(1, '0');
                 }
-            lineObs += std::to_string(static_cast<int32_t>(*it));
-            ret = total_gal_map.equal_range(*it);
+            lineObs += std::to_string(static_cast<int32_t>(prn));
+            ret = total_gal_map.equal_range(prn);
             for (auto iter = ret.first; iter != ret.second; ++iter)
                 {
                     lineObs += rightJustify(asString(iter->second.Pseudorange_m, 3), 14);
@@ -6843,32 +6612,14 @@ void Rinex_Printer::log_rinex_obs(std::fstream& out, const Gps_CNAV_Ephemeris& e
         }  // avoid warning, not needed
     std::string line;
 
-    const boost::posix_time::ptime p_gps_time = Rinex_Printer::compute_GPS_time(eph, gps_obs_time);
-    const std::string timestring = boost::posix_time::to_iso_string(p_gps_time);
     // double utc_t = nav_msg.utc_time(nav_msg.sv_clock_correction(obs_time));
     // double gps_t = eph.sv_clock_correction(obs_time);
-    const double gps_t = gps_obs_time;
 
-    const std::string month(timestring, 4, 2);
-    const std::string day(timestring, 6, 2);
-    const std::string hour(timestring, 9, 2);
-    const std::string minutes(timestring, 11, 2);
-
-    const std::string year(timestring, 0, 4);
     line += std::string(1, '>');
-    line += std::string(1, ' ');
-    line += year;
-    line += std::string(1, ' ');
-    line += month;
-    line += std::string(1, ' ');
-    line += day;
-    line += std::string(1, ' ');
-    line += hour;
-    line += std::string(1, ' ');
-    line += minutes;
 
-    line += std::string(1, ' ');
-    const double seconds = fmod(gps_t, 60);
+    add_svclk_to_line(Rinex_Printer::compute_GPS_time(eph, gps_obs_time), false, line);
+
+    const double seconds = fmod(gps_obs_time, 60);
     // Add extra 0 if seconds are < 10
     if (seconds < 10)
         {
@@ -6888,37 +6639,34 @@ void Rinex_Printer::log_rinex_obs(std::fstream& out, const Gps_CNAV_Ephemeris& e
     std::map<int32_t, Gnss_Synchro> observablesE5A;
     std::map<int32_t, Gnss_Synchro> observablesE5B;
     std::map<int32_t, Gnss_Synchro> observablesE6B;
-    std::map<int32_t, Gnss_Synchro>::const_iterator observables_iter;
 
-    for (observables_iter = observables.cbegin();
-        observables_iter != observables.cend();
-        observables_iter++)
+    for (const auto& observables_iter : observables)
         {
-            const std::string system_(&observables_iter->second.System, 1);
-            const std::string sig_(observables_iter->second.Signal);
+            const std::string system_(&observables_iter.second.System, 1);
+            const std::string sig_(observables_iter.second.Signal);
             if ((system_ == "E") && (sig_ == "1B"))
                 {
-                    observablesE1B.insert(std::pair<int32_t, Gnss_Synchro>(observables_iter->first, observables_iter->second));
+                    observablesE1B.insert(std::pair<int32_t, Gnss_Synchro>(observables_iter.first, observables_iter.second));
                 }
             if ((system_ == "E") && (sig_ == "5X"))
                 {
-                    observablesE5A.insert(std::pair<int32_t, Gnss_Synchro>(observables_iter->first, observables_iter->second));
+                    observablesE5A.insert(std::pair<int32_t, Gnss_Synchro>(observables_iter.first, observables_iter.second));
                 }
             if ((system_ == "E") && (sig_ == "7X"))
                 {
-                    observablesE5B.insert(std::pair<int32_t, Gnss_Synchro>(observables_iter->first, observables_iter->second));
+                    observablesE5B.insert(std::pair<int32_t, Gnss_Synchro>(observables_iter.first, observables_iter.second));
                 }
             if ((system_ == "E") && (sig_ == "E6"))
                 {
-                    observablesE6B.insert(std::pair<int32_t, Gnss_Synchro>(observables_iter->first, observables_iter->second));
+                    observablesE6B.insert(std::pair<int32_t, Gnss_Synchro>(observables_iter.first, observables_iter.second));
                 }
             if ((system_ == "G") && (sig_ == "2S"))
                 {
-                    observablesG2S.insert(std::pair<int32_t, Gnss_Synchro>(observables_iter->first, observables_iter->second));
+                    observablesG2S.insert(std::pair<int32_t, Gnss_Synchro>(observables_iter.first, observables_iter.second));
                 }
             if ((system_ == "G") && (sig_ == "L5"))
                 {
-                    observablesGL5.insert(std::pair<int32_t, Gnss_Synchro>(observables_iter->first, observables_iter->second));
+                    observablesGL5.insert(std::pair<int32_t, Gnss_Synchro>(observables_iter.first, observables_iter.second));
                 }
         }
 
@@ -6927,12 +6675,10 @@ void Rinex_Printer::log_rinex_obs(std::fstream& out, const Gps_CNAV_Ephemeris& e
     std::set<uint32_t> available_gal_prns;
     std::set<uint32_t> available_gps_prns;
     std::set<uint32_t>::iterator it;
-    for (observables_iter = observablesE1B.cbegin();
-        observables_iter != observablesE1B.cend();
-        observables_iter++)
+    for (const auto& observables_iter : observablesE1B)
         {
-            const uint32_t prn_ = observables_iter->second.PRN;
-            total_gal_map.insert(std::pair<uint32_t, Gnss_Synchro>(prn_, observables_iter->second));
+            const uint32_t prn_ = observables_iter.second.PRN;
+            total_gal_map.insert(std::pair<uint32_t, Gnss_Synchro>(prn_, observables_iter.second));
             it = available_gal_prns.find(prn_);
             if (it == available_gal_prns.end())
                 {
@@ -6940,12 +6686,10 @@ void Rinex_Printer::log_rinex_obs(std::fstream& out, const Gps_CNAV_Ephemeris& e
                 }
         }
 
-    for (observables_iter = observablesE5A.cbegin();
-        observables_iter != observablesE5A.cend();
-        observables_iter++)
+    for (const auto& observables_iter : observablesE5A)
         {
-            const uint32_t prn_ = observables_iter->second.PRN;
-            total_gal_map.insert(std::pair<uint32_t, Gnss_Synchro>(prn_, observables_iter->second));
+            const uint32_t prn_ = observables_iter.second.PRN;
+            total_gal_map.insert(std::pair<uint32_t, Gnss_Synchro>(prn_, observables_iter.second));
             it = available_gal_prns.find(prn_);
             if (it == available_gal_prns.end())
                 {
@@ -6953,12 +6697,10 @@ void Rinex_Printer::log_rinex_obs(std::fstream& out, const Gps_CNAV_Ephemeris& e
                 }
         }
 
-    for (observables_iter = observablesE5B.cbegin();
-        observables_iter != observablesE5B.cend();
-        observables_iter++)
+    for (const auto& observables_iter : observablesE5B)
         {
-            const uint32_t prn_ = observables_iter->second.PRN;
-            total_gal_map.insert(std::pair<uint32_t, Gnss_Synchro>(prn_, observables_iter->second));
+            const uint32_t prn_ = observables_iter.second.PRN;
+            total_gal_map.insert(std::pair<uint32_t, Gnss_Synchro>(prn_, observables_iter.second));
             it = available_gal_prns.find(prn_);
             if (it == available_gal_prns.end())
                 {
@@ -6966,12 +6708,10 @@ void Rinex_Printer::log_rinex_obs(std::fstream& out, const Gps_CNAV_Ephemeris& e
                 }
         }
 
-    for (observables_iter = observablesE6B.cbegin();
-        observables_iter != observablesE6B.cend();
-        observables_iter++)
+    for (const auto& observables_iter : observablesE6B)
         {
-            const uint32_t prn_ = observables_iter->second.PRN;
-            total_gal_map.insert(std::pair<uint32_t, Gnss_Synchro>(prn_, observables_iter->second));
+            const uint32_t prn_ = observables_iter.second.PRN;
+            total_gal_map.insert(std::pair<uint32_t, Gnss_Synchro>(prn_, observables_iter.second));
             it = available_gal_prns.find(prn_);
             if (it == available_gal_prns.end())
                 {
@@ -6979,12 +6719,10 @@ void Rinex_Printer::log_rinex_obs(std::fstream& out, const Gps_CNAV_Ephemeris& e
                 }
         }
 
-    for (observables_iter = observablesG2S.cbegin();
-        observables_iter != observablesG2S.cend();
-        observables_iter++)
+    for (const auto& observables_iter : observablesG2S)
         {
-            const uint32_t prn_ = observables_iter->second.PRN;
-            total_gps_map.insert(std::pair<uint32_t, Gnss_Synchro>(prn_, observables_iter->second));
+            const uint32_t prn_ = observables_iter.second.PRN;
+            total_gps_map.insert(std::pair<uint32_t, Gnss_Synchro>(prn_, observables_iter.second));
             it = available_gps_prns.find(prn_);
             if (it == available_gps_prns.end())
                 {
@@ -6992,12 +6730,10 @@ void Rinex_Printer::log_rinex_obs(std::fstream& out, const Gps_CNAV_Ephemeris& e
                 }
         }
 
-    for (observables_iter = observablesGL5.cbegin();
-        observables_iter != observablesGL5.cend();
-        observables_iter++)
+    for (const auto& observables_iter : observablesGL5)
         {
-            const uint32_t prn_ = observables_iter->second.PRN;
-            total_gps_map.insert(std::pair<uint32_t, Gnss_Synchro>(prn_, observables_iter->second));
+            const uint32_t prn_ = observables_iter.second.PRN;
+            total_gps_map.insert(std::pair<uint32_t, Gnss_Synchro>(prn_, observables_iter.second));
             it = available_gps_prns.find(prn_);
             if (it == available_gps_prns.end())
                 {
@@ -7021,18 +6757,16 @@ void Rinex_Printer::log_rinex_obs(std::fstream& out, const Gps_CNAV_Ephemeris& e
     std::string lineObs;
 
     std::pair<std::multimap<uint32_t, Gnss_Synchro>::iterator, std::multimap<uint32_t, Gnss_Synchro>::iterator> ret;
-    for (it = available_gps_prns.cbegin();
-        it != available_gps_prns.cend();
-        it++)
+    for (const auto& prn : available_gps_prns)
         {
             lineObs.clear();
             lineObs += satelliteSystem.at("GPS");
-            if (static_cast<int32_t>(*it) < 10)
+            if (static_cast<int32_t>(prn) < 10)
                 {
                     lineObs += std::string(1, '0');
                 }
-            lineObs += std::to_string(static_cast<int32_t>(*it));
-            ret = total_gps_map.equal_range(*it);
+            lineObs += std::to_string(static_cast<int32_t>(prn));
+            ret = total_gps_map.equal_range(prn);
             for (auto iter = ret.first; iter != ret.second; ++iter)
                 {
                     lineObs += rightJustify(asString(iter->second.Pseudorange_m, 3), 14);
@@ -7083,18 +6817,16 @@ void Rinex_Printer::log_rinex_obs(std::fstream& out, const Gps_CNAV_Ephemeris& e
             out << lineObs << '\n';
         }
 
-    for (it = available_gal_prns.cbegin();
-        it != available_gal_prns.cend();
-        it++)
+    for (const auto& prn : available_gal_prns)
         {
             lineObs.clear();
             lineObs += satelliteSystem.at("Galileo");
-            if (static_cast<int32_t>(*it) < 10)
+            if (static_cast<int32_t>(prn) < 10)
                 {
                     lineObs += std::string(1, '0');
                 }
-            lineObs += std::to_string(static_cast<int32_t>(*it));
-            ret = total_gal_map.equal_range(*it);
+            lineObs += std::to_string(static_cast<int32_t>(prn));
+            ret = total_gal_map.equal_range(prn);
             for (auto iter = ret.first; iter != ret.second; ++iter)
                 {
                     lineObs += rightJustify(asString(iter->second.Pseudorange_m, 3), 14);
@@ -7158,32 +6890,14 @@ void Rinex_Printer::log_rinex_obs(std::fstream& out, const Gps_Ephemeris& gps_ep
         }  // avoid warning, not needed
     std::string line;
 
-    const boost::posix_time::ptime p_gps_time = Rinex_Printer::compute_GPS_time(gps_eph, gps_obs_time);
-    const std::string timestring = boost::posix_time::to_iso_string(p_gps_time);
     // double utc_t = nav_msg.utc_time(nav_msg.sv_clock_correction(obs_time));
     // double gps_t = eph.sv_clock_correction(obs_time);
-    const double gps_t = gps_obs_time;
 
-    const std::string month(timestring, 4, 2);
-    const std::string day(timestring, 6, 2);
-    const std::string hour(timestring, 9, 2);
-    const std::string minutes(timestring, 11, 2);
-
-    const std::string year(timestring, 0, 4);
     line += std::string(1, '>');
-    line += std::string(1, ' ');
-    line += year;
-    line += std::string(1, ' ');
-    line += month;
-    line += std::string(1, ' ');
-    line += day;
-    line += std::string(1, ' ');
-    line += hour;
-    line += std::string(1, ' ');
-    line += minutes;
 
-    line += std::string(1, ' ');
-    const double seconds = fmod(gps_t, 60);
+    add_svclk_to_line(Rinex_Printer::compute_GPS_time(gps_eph, gps_obs_time), false, line);
+
+    const double seconds = fmod(gps_obs_time, 60);
     // Add extra 0 if seconds are < 10
     if (seconds < 10)
         {
@@ -7204,41 +6918,38 @@ void Rinex_Printer::log_rinex_obs(std::fstream& out, const Gps_Ephemeris& gps_ep
     std::map<int32_t, Gnss_Synchro> observablesE5A;
     std::map<int32_t, Gnss_Synchro> observablesE5B;
     std::map<int32_t, Gnss_Synchro> observablesE6B;
-    std::map<int32_t, Gnss_Synchro>::const_iterator observables_iter;
 
-    for (observables_iter = observables.cbegin();
-        observables_iter != observables.cend();
-        observables_iter++)
+    for (const auto& observables_iter : observables)
         {
-            const std::string system_(&observables_iter->second.System, 1);
-            const std::string sig_(observables_iter->second.Signal);
+            const std::string system_(&observables_iter.second.System, 1);
+            const std::string sig_(observables_iter.second.Signal);
             if ((system_ == "E") && (sig_ == "1B"))
                 {
-                    observablesE1B.insert(std::pair<int32_t, Gnss_Synchro>(observables_iter->first, observables_iter->second));
+                    observablesE1B.insert(std::pair<int32_t, Gnss_Synchro>(observables_iter.first, observables_iter.second));
                 }
             if ((system_ == "E") && (sig_ == "5X"))
                 {
-                    observablesE5A.insert(std::pair<int32_t, Gnss_Synchro>(observables_iter->first, observables_iter->second));
+                    observablesE5A.insert(std::pair<int32_t, Gnss_Synchro>(observables_iter.first, observables_iter.second));
                 }
             if ((system_ == "E") && (sig_ == "7X"))
                 {
-                    observablesE5B.insert(std::pair<int32_t, Gnss_Synchro>(observables_iter->first, observables_iter->second));
+                    observablesE5B.insert(std::pair<int32_t, Gnss_Synchro>(observables_iter.first, observables_iter.second));
                 }
             if ((system_ == "E") && (sig_ == "E6"))
                 {
-                    observablesE6B.insert(std::pair<int32_t, Gnss_Synchro>(observables_iter->first, observables_iter->second));
+                    observablesE6B.insert(std::pair<int32_t, Gnss_Synchro>(observables_iter.first, observables_iter.second));
                 }
             if ((system_ == "G") && (sig_ == "2S"))
                 {
-                    observablesG2S.insert(std::pair<int32_t, Gnss_Synchro>(observables_iter->first, observables_iter->second));
+                    observablesG2S.insert(std::pair<int32_t, Gnss_Synchro>(observables_iter.first, observables_iter.second));
                 }
             if ((system_ == "G") && (sig_ == "L5"))
                 {
-                    observablesGL5.insert(std::pair<int32_t, Gnss_Synchro>(observables_iter->first, observables_iter->second));
+                    observablesGL5.insert(std::pair<int32_t, Gnss_Synchro>(observables_iter.first, observables_iter.second));
                 }
             if ((system_ == "G") && (sig_ == "1C"))
                 {
-                    observablesG1C.insert(std::pair<int32_t, Gnss_Synchro>(observables_iter->first, observables_iter->second));
+                    observablesG1C.insert(std::pair<int32_t, Gnss_Synchro>(observables_iter.first, observables_iter.second));
                 }
         }
 
@@ -7247,12 +6958,10 @@ void Rinex_Printer::log_rinex_obs(std::fstream& out, const Gps_Ephemeris& gps_ep
     std::set<uint32_t> available_gal_prns;
     std::set<uint32_t> available_gps_prns;
     std::set<uint32_t>::iterator it;
-    for (observables_iter = observablesE1B.cbegin();
-        observables_iter != observablesE1B.cend();
-        observables_iter++)
+    for (const auto& observables_iter : observablesE1B)
         {
-            const uint32_t prn_ = observables_iter->second.PRN;
-            total_gal_map.insert(std::pair<uint32_t, Gnss_Synchro>(prn_, observables_iter->second));
+            const uint32_t prn_ = observables_iter.second.PRN;
+            total_gal_map.insert(std::pair<uint32_t, Gnss_Synchro>(prn_, observables_iter.second));
             it = available_gal_prns.find(prn_);
             if (it == available_gal_prns.end())
                 {
@@ -7260,12 +6969,10 @@ void Rinex_Printer::log_rinex_obs(std::fstream& out, const Gps_Ephemeris& gps_ep
                 }
         }
 
-    for (observables_iter = observablesE5A.cbegin();
-        observables_iter != observablesE5A.cend();
-        observables_iter++)
+    for (const auto& observables_iter : observablesE5A)
         {
-            const uint32_t prn_ = observables_iter->second.PRN;
-            total_gal_map.insert(std::pair<uint32_t, Gnss_Synchro>(prn_, observables_iter->second));
+            const uint32_t prn_ = observables_iter.second.PRN;
+            total_gal_map.insert(std::pair<uint32_t, Gnss_Synchro>(prn_, observables_iter.second));
             it = available_gal_prns.find(prn_);
             if (it == available_gal_prns.end())
                 {
@@ -7273,12 +6980,10 @@ void Rinex_Printer::log_rinex_obs(std::fstream& out, const Gps_Ephemeris& gps_ep
                 }
         }
 
-    for (observables_iter = observablesE5B.cbegin();
-        observables_iter != observablesE5B.cend();
-        observables_iter++)
+    for (const auto& observables_iter : observablesE5B)
         {
-            const uint32_t prn_ = observables_iter->second.PRN;
-            total_gal_map.insert(std::pair<uint32_t, Gnss_Synchro>(prn_, observables_iter->second));
+            const uint32_t prn_ = observables_iter.second.PRN;
+            total_gal_map.insert(std::pair<uint32_t, Gnss_Synchro>(prn_, observables_iter.second));
             it = available_gal_prns.find(prn_);
             if (it == available_gal_prns.end())
                 {
@@ -7286,12 +6991,10 @@ void Rinex_Printer::log_rinex_obs(std::fstream& out, const Gps_Ephemeris& gps_ep
                 }
         }
 
-    for (observables_iter = observablesE6B.cbegin();
-        observables_iter != observablesE6B.cend();
-        observables_iter++)
+    for (const auto& observables_iter : observablesE6B)
         {
-            const uint32_t prn_ = observables_iter->second.PRN;
-            total_gal_map.insert(std::pair<uint32_t, Gnss_Synchro>(prn_, observables_iter->second));
+            const uint32_t prn_ = observables_iter.second.PRN;
+            total_gal_map.insert(std::pair<uint32_t, Gnss_Synchro>(prn_, observables_iter.second));
             it = available_gal_prns.find(prn_);
             if (it == available_gal_prns.end())
                 {
@@ -7299,12 +7002,10 @@ void Rinex_Printer::log_rinex_obs(std::fstream& out, const Gps_Ephemeris& gps_ep
                 }
         }
 
-    for (observables_iter = observablesG1C.cbegin();
-        observables_iter != observablesG1C.cend();
-        observables_iter++)
+    for (const auto& observables_iter : observablesG1C)
         {
-            const uint32_t prn_ = observables_iter->second.PRN;
-            total_gps_map.insert(std::pair<uint32_t, Gnss_Synchro>(prn_, observables_iter->second));
+            const uint32_t prn_ = observables_iter.second.PRN;
+            total_gps_map.insert(std::pair<uint32_t, Gnss_Synchro>(prn_, observables_iter.second));
             it = available_gps_prns.find(prn_);
             if (it == available_gps_prns.end())
                 {
@@ -7312,12 +7013,10 @@ void Rinex_Printer::log_rinex_obs(std::fstream& out, const Gps_Ephemeris& gps_ep
                 }
         }
 
-    for (observables_iter = observablesG2S.cbegin();
-        observables_iter != observablesG2S.cend();
-        observables_iter++)
+    for (const auto& observables_iter : observablesG2S)
         {
-            const uint32_t prn_ = observables_iter->second.PRN;
-            total_gps_map.insert(std::pair<uint32_t, Gnss_Synchro>(prn_, observables_iter->second));
+            const uint32_t prn_ = observables_iter.second.PRN;
+            total_gps_map.insert(std::pair<uint32_t, Gnss_Synchro>(prn_, observables_iter.second));
             it = available_gps_prns.find(prn_);
             if (it == available_gps_prns.end())
                 {
@@ -7325,12 +7024,10 @@ void Rinex_Printer::log_rinex_obs(std::fstream& out, const Gps_Ephemeris& gps_ep
                 }
         }
 
-    for (observables_iter = observablesGL5.cbegin();
-        observables_iter != observablesGL5.cend();
-        observables_iter++)
+    for (const auto& observables_iter : observablesGL5)
         {
-            const uint32_t prn_ = observables_iter->second.PRN;
-            total_gps_map.insert(std::pair<uint32_t, Gnss_Synchro>(prn_, observables_iter->second));
+            const uint32_t prn_ = observables_iter.second.PRN;
+            total_gps_map.insert(std::pair<uint32_t, Gnss_Synchro>(prn_, observables_iter.second));
             it = available_gps_prns.find(prn_);
             if (it == available_gps_prns.end())
                 {
@@ -7354,18 +7051,16 @@ void Rinex_Printer::log_rinex_obs(std::fstream& out, const Gps_Ephemeris& gps_ep
     std::string lineObs;
 
     std::pair<std::multimap<uint32_t, Gnss_Synchro>::iterator, std::multimap<uint32_t, Gnss_Synchro>::iterator> ret;
-    for (it = available_gps_prns.cbegin();
-        it != available_gps_prns.cend();
-        it++)
+    for (const auto& prn : available_gps_prns)
         {
             lineObs.clear();
             lineObs += satelliteSystem.at("GPS");
-            if (static_cast<int32_t>(*it) < 10)
+            if (static_cast<int32_t>(prn) < 10)
                 {
                     lineObs += std::string(1, '0');
                 }
-            lineObs += std::to_string(static_cast<int32_t>(*it));
-            ret = total_gps_map.equal_range(*it);
+            lineObs += std::to_string(static_cast<int32_t>(prn));
+            ret = total_gps_map.equal_range(prn);
             bool have_l2 = false;
             for (auto iter = ret.first; iter != ret.second; ++iter)
                 {
@@ -7427,18 +7122,16 @@ void Rinex_Printer::log_rinex_obs(std::fstream& out, const Gps_Ephemeris& gps_ep
             out << lineObs << '\n';
         }
 
-    for (it = available_gal_prns.cbegin();
-        it != available_gal_prns.cend();
-        it++)
+    for (const auto& prn : available_gal_prns)
         {
             lineObs.clear();
             lineObs += satelliteSystem.at("Galileo");
-            if (static_cast<int32_t>(*it) < 10)
+            if (static_cast<int32_t>(prn) < 10)
                 {
                     lineObs += std::string(1, '0');
                 }
-            lineObs += std::to_string(static_cast<int32_t>(*it));
-            ret = total_gal_map.equal_range(*it);
+            lineObs += std::to_string(static_cast<int32_t>(prn));
+            ret = total_gal_map.equal_range(prn);
             for (auto iter = ret.first; iter != ret.second; ++iter)
                 {
                     lineObs += rightJustify(asString(iter->second.Pseudorange_m, 3), 14);
@@ -7496,32 +7189,14 @@ void Rinex_Printer::log_rinex_obs(std::fstream& out, const Beidou_Dnav_Ephemeris
 {
     std::string line;
 
-    const boost::posix_time::ptime p_bds_time = Rinex_Printer::compute_BDS_time(eph, obs_time);
-    const std::string timestring = boost::posix_time::to_iso_string(p_bds_time);
     // double utc_t = nav_msg.utc_time(nav_msg.sv_clock_correction(obs_time));
     // double gps_t = eph.sv_clock_correction(obs_time);
-    const double bds_t = obs_time;
 
-    const std::string month(timestring, 4, 2);
-    const std::string day(timestring, 6, 2);
-    const std::string hour(timestring, 9, 2);
-    const std::string minutes(timestring, 11, 2);
-
-    const std::string year(timestring, 0, 4);
     line += std::string(1, '>');
-    line += std::string(1, ' ');
-    line += year;
-    line += std::string(1, ' ');
-    line += month;
-    line += std::string(1, ' ');
-    line += day;
-    line += std::string(1, ' ');
-    line += hour;
-    line += std::string(1, ' ');
-    line += minutes;
 
-    line += std::string(1, ' ');
-    const double seconds = fmod(bds_t, 60);
+    add_svclk_to_line(Rinex_Printer::compute_BDS_time(eph, obs_time), false, line);
+
+    const double seconds = fmod(obs_time, 60);
     // Add extra 0 if seconds are < 10
     if (seconds < 10)
         {
@@ -7538,21 +7213,18 @@ void Rinex_Printer::log_rinex_obs(std::fstream& out, const Beidou_Dnav_Ephemeris
     std::map<int32_t, Gnss_Synchro> observablesB1I;
     std::map<int32_t, Gnss_Synchro> observablesB3I;
 
-    std::map<int32_t, Gnss_Synchro>::const_iterator observables_iter;
 
-    for (observables_iter = observables.cbegin();
-        observables_iter != observables.cend();
-        observables_iter++)
+    for (const auto& observables_iter : observables)
         {
-            const std::string system_(&observables_iter->second.System, 1);
-            const std::string sig_(observables_iter->second.Signal);
+            const std::string system_(&observables_iter.second.System, 1);
+            const std::string sig_(observables_iter.second.Signal);
             if ((system_ == "C") && (sig_ == "B1"))
                 {
-                    observablesB1I.insert(std::pair<int32_t, Gnss_Synchro>(observables_iter->first, observables_iter->second));
+                    observablesB1I.insert(std::pair<int32_t, Gnss_Synchro>(observables_iter.first, observables_iter.second));
                 }
             if ((system_ == "C") && (sig_ == "B3"))
                 {
-                    observablesB3I.insert(std::pair<int32_t, Gnss_Synchro>(observables_iter->first, observables_iter->second));
+                    observablesB3I.insert(std::pair<int32_t, Gnss_Synchro>(observables_iter.first, observables_iter.second));
                 }
         }
     const std::size_t found_B1 = bds_bands.find("B1");
@@ -7563,12 +7235,10 @@ void Rinex_Printer::log_rinex_obs(std::fstream& out, const Beidou_Dnav_Ephemeris
     std::set<uint32_t>::iterator it;
     if (found_B1 != std::string::npos)
         {
-            for (observables_iter = observablesB1I.cbegin();
-                observables_iter != observablesB1I.cend();
-                observables_iter++)
+            for (const auto& observables_iter : observablesB1I)
                 {
-                    const uint32_t prn_ = observables_iter->second.PRN;
-                    total_map.insert(std::pair<uint32_t, Gnss_Synchro>(prn_, observables_iter->second));
+                    const uint32_t prn_ = observables_iter.second.PRN;
+                    total_map.insert(std::pair<uint32_t, Gnss_Synchro>(prn_, observables_iter.second));
                     it = available_prns.find(prn_);
                     if (it == available_prns.end())
                         {
@@ -7578,11 +7248,9 @@ void Rinex_Printer::log_rinex_obs(std::fstream& out, const Beidou_Dnav_Ephemeris
         }
     if (found_B3 != std::string::npos)
         {
-            for (observables_iter = observablesB3I.cbegin();
-                observables_iter != observablesB3I.cend();
-                observables_iter++)
+            for (const auto& observables_iter : observablesB3I)
                 {
-                    const uint32_t prn_ = observables_iter->second.PRN;
+                    const uint32_t prn_ = observables_iter.second.PRN;
                     it = available_prns.find(prn_);
                     if (it == available_prns.end())
                         {
@@ -7598,7 +7266,7 @@ void Rinex_Printer::log_rinex_obs(std::fstream& out, const Beidou_Dnav_Ephemeris
                                     total_map.insert(std::pair<uint32_t, Gnss_Synchro>(prn_, gs));
                                 }
                         }
-                    total_map.insert(std::pair<uint32_t, Gnss_Synchro>(prn_, observables_iter->second));
+                    total_map.insert(std::pair<uint32_t, Gnss_Synchro>(prn_, observables_iter.second));
                 }
         }
 
@@ -7611,19 +7279,16 @@ void Rinex_Printer::log_rinex_obs(std::fstream& out, const Beidou_Dnav_Ephemeris
     out << line << '\n';
 
     std::string lineObs;
-    std::pair<std::multimap<uint32_t, Gnss_Synchro>::iterator, std::multimap<uint32_t, Gnss_Synchro>::iterator> ret;
-    for (it = available_prns.cbegin();
-        it != available_prns.cend();
-        it++)
+    for (const auto& available_prn : available_prns)
         {
             lineObs.clear();
             lineObs += satelliteSystem.at("Beidou");
-            if (static_cast<int32_t>(*it) < 10)
+            if (static_cast<int32_t>(available_prn) < 10)
                 {
                     lineObs += std::string(1, '0');
                 }
-            lineObs += std::to_string(static_cast<int32_t>(*it));
-            ret = total_map.equal_range(*it);
+            lineObs += std::to_string(static_cast<int32_t>(available_prn));
+            const auto ret = total_map.equal_range(available_prn);
             for (auto iter = ret.first; iter != ret.second; ++iter)
                 {
                     lineObs += rightJustify(asString(iter->second.Pseudorange_m, 3), 14);

--- a/src/algorithms/PVT/libs/rinex_printer.cc
+++ b/src/algorithms/PVT/libs/rinex_printer.cc
@@ -23,7 +23,6 @@
 #include "galileo_ephemeris.h"
 #include "galileo_iono.h"
 #include "galileo_utc_model.h"
-#include "glonass_gnav_almanac.h"
 #include "glonass_gnav_ephemeris.h"
 #include "glonass_gnav_utc_model.h"
 #include "gnss_sdr_filesystem.h"
@@ -1734,7 +1733,7 @@ void Rinex_Printer::print_rinex_annotation(const Rtklib_Solver* pvt_solver,
                     rinex_obs_header(obsFile, gps_ephemeris_iter->second, glonass_gnav_ephemeris_iter->second, rx_time, signal);
                     if (d_version == 3)
                         {
-                            rinex_nav_header(navMixFile, pvt_solver->gps_iono, pvt_solver->gps_utc_model, gps_ephemeris_iter->second, pvt_solver->glonass_gnav_utc_model, pvt_solver->glonass_gnav_almanac);
+                            rinex_nav_header(navMixFile, pvt_solver->gps_iono, pvt_solver->gps_utc_model, gps_ephemeris_iter->second, pvt_solver->glonass_gnav_utc_model);
                             output_navfilename.push_back(navMixfilename);
                             log_rinex_nav(navMixFile, pvt_solver->gps_ephemeris_map, pvt_solver->glonass_gnav_ephemeris_map);
                         }
@@ -1752,7 +1751,7 @@ void Rinex_Printer::print_rinex_annotation(const Rtklib_Solver* pvt_solver,
                      has_gps_cnav_eph && has_glonass_eph)
                 {
                     rinex_obs_header(obsFile, gps_cnav_ephemeris_iter->second, glonass_gnav_ephemeris_iter->second, rx_time, signal);
-                    rinex_nav_header(navMixFile, pvt_solver->gps_cnav_iono, pvt_solver->gps_cnav_utc_model, pvt_solver->glonass_gnav_utc_model, pvt_solver->glonass_gnav_almanac);
+                    rinex_nav_header(navMixFile, pvt_solver->gps_cnav_iono, pvt_solver->gps_cnav_utc_model, pvt_solver->glonass_gnav_utc_model);
                     output_navfilename.push_back(navfilename);
                     log_rinex_nav(navMixFile, pvt_solver->gps_cnav_ephemeris_map, pvt_solver->glonass_gnav_ephemeris_map);
                 }
@@ -1760,7 +1759,7 @@ void Rinex_Printer::print_rinex_annotation(const Rtklib_Solver* pvt_solver,
                      has_galileo_eph && has_glonass_eph)
                 {
                     rinex_obs_header(obsFile, galileo_ephemeris_iter->second, glonass_gnav_ephemeris_iter->second, rx_time, signal, signal);
-                    rinex_nav_header(navMixFile, pvt_solver->galileo_iono, pvt_solver->galileo_utc_model, pvt_solver->glonass_gnav_utc_model, pvt_solver->glonass_gnav_almanac);
+                    rinex_nav_header(navMixFile, pvt_solver->galileo_iono, pvt_solver->galileo_utc_model, pvt_solver->glonass_gnav_utc_model);
                     output_navfilename.push_back(navMixfilename);
                     log_rinex_nav(navMixFile, pvt_solver->galileo_ephemeris_map, pvt_solver->glonass_gnav_ephemeris_map);
                 }
@@ -1896,11 +1895,11 @@ void Rinex_Printer::print_rinex_annotation(const Rtklib_Solver* pvt_solver,
                 {
                     if (has_glonass_eph)
                         {
-                            log_rinex_obs(obsFile, glonass_gnav_ephemeris_iter->second, rx_time, gnss_observables_map, signal);
+                            log_rinex_obs(obsFile, glonass_gnav_ephemeris_iter->second, rx_time, gnss_observables_map);
                         }
                     if (!d_rinex_header_updated && (pvt_solver->glonass_gnav_utc_model.d_tau_c != 0))
                         {
-                            update_nav_header(navGloFile, pvt_solver->glonass_gnav_utc_model, pvt_solver->glonass_gnav_almanac);
+                            update_nav_header(navGloFile, pvt_solver->glonass_gnav_utc_model);
                             d_rinex_header_updated = true;
                         }
                 }
@@ -1935,7 +1934,7 @@ void Rinex_Printer::print_rinex_annotation(const Rtklib_Solver* pvt_solver,
                     if (!d_rinex_header_updated && (pvt_solver->gps_utc_model.A0 != 0))
                         {
                             update_obs_header(obsFile, get_leap_second_line(pvt_solver->gps_utc_model, d_version));
-                            update_nav_header(navMixFile, pvt_solver->gps_iono, pvt_solver->gps_utc_model, gps_ephemeris_iter->second, pvt_solver->glonass_gnav_utc_model, pvt_solver->glonass_gnav_almanac);
+                            update_nav_header(navMixFile, pvt_solver->gps_iono, pvt_solver->gps_utc_model, gps_ephemeris_iter->second, pvt_solver->glonass_gnav_utc_model);
                             d_rinex_header_updated = true;  // do not write header anymore
                         }
                 }
@@ -1961,7 +1960,7 @@ void Rinex_Printer::print_rinex_annotation(const Rtklib_Solver* pvt_solver,
                     if (!d_rinex_header_updated && (pvt_solver->galileo_utc_model.A0 != 0))
                         {
                             update_obs_header(obsFile, get_leap_second_line(pvt_solver->galileo_utc_model));
-                            update_nav_header(navMixFile, pvt_solver->galileo_iono, pvt_solver->galileo_utc_model, pvt_solver->glonass_gnav_utc_model, pvt_solver->glonass_gnav_almanac);
+                            update_nav_header(navMixFile, pvt_solver->galileo_iono, pvt_solver->galileo_utc_model, pvt_solver->glonass_gnav_utc_model);
                             d_rinex_header_updated = true;  // do not write header anymore
                         }
                 }
@@ -1974,7 +1973,7 @@ void Rinex_Printer::print_rinex_annotation(const Rtklib_Solver* pvt_solver,
                     if (!d_rinex_header_updated && (pvt_solver->gps_cnav_utc_model.A0 != 0))
                         {
                             update_obs_header(obsFile, get_leap_second_line(pvt_solver->gps_cnav_utc_model));
-                            update_nav_header(navMixFile, pvt_solver->gps_cnav_iono, pvt_solver->gps_cnav_utc_model, pvt_solver->glonass_gnav_utc_model, pvt_solver->glonass_gnav_almanac);
+                            update_nav_header(navMixFile, pvt_solver->gps_cnav_iono, pvt_solver->gps_cnav_utc_model, pvt_solver->glonass_gnav_utc_model);
                             d_rinex_header_updated = true;  // do not write header anymore
                         }
                 }
@@ -2356,12 +2355,8 @@ void Rinex_Printer::rinex_nav_header(std::fstream& out, const Glonass_Gnav_Utc_M
 }
 
 
-void Rinex_Printer::rinex_nav_header(std::fstream& out, const Gps_Iono& gps_iono, const Gps_Utc_Model& gps_utc_model, const Gps_Ephemeris& eph, const Glonass_Gnav_Utc_Model& glonass_gnav_utc_model, const Glonass_Gnav_Almanac& glonass_gnav_almanac)
+void Rinex_Printer::rinex_nav_header(std::fstream& out, const Gps_Iono& gps_iono, const Gps_Utc_Model& gps_utc_model, const Gps_Ephemeris& eph, const Glonass_Gnav_Utc_Model& glonass_gnav_utc_model)
 {
-    if (glonass_gnav_almanac.i_satellite_freq_channel)
-        {
-        }  // Avoid compiler warning
-
     d_stringVersion = "3.02";
     d_version = 3;
 
@@ -2387,11 +2382,8 @@ void Rinex_Printer::rinex_nav_header(std::fstream& out, const Gps_Iono& gps_iono
 }
 
 
-void Rinex_Printer::rinex_nav_header(std::fstream& out, const Gps_CNAV_Iono& gps_iono, const Gps_CNAV_Utc_Model& gps_utc_model, const Glonass_Gnav_Utc_Model& glonass_gnav_utc_model, const Glonass_Gnav_Almanac& glonass_gnav_almanac)
+void Rinex_Printer::rinex_nav_header(std::fstream& out, const Gps_CNAV_Iono& gps_iono, const Gps_CNAV_Utc_Model& gps_utc_model, const Glonass_Gnav_Utc_Model& glonass_gnav_utc_model)
 {
-    if (glonass_gnav_almanac.i_satellite_freq_channel)
-        {
-        }  // Avoid compiler warning
     d_stringVersion = "3.02";
     d_version = 3;
 
@@ -2417,12 +2409,8 @@ void Rinex_Printer::rinex_nav_header(std::fstream& out, const Gps_CNAV_Iono& gps
 }
 
 
-void Rinex_Printer::rinex_nav_header(std::fstream& out, const Galileo_Iono& galileo_iono, const Galileo_Utc_Model& galileo_utc_model, const Glonass_Gnav_Utc_Model& glonass_gnav_utc_model, const Glonass_Gnav_Almanac& glonass_gnav_almanac) const
+void Rinex_Printer::rinex_nav_header(std::fstream& out, const Galileo_Iono& galileo_iono, const Galileo_Utc_Model& galileo_utc_model, const Glonass_Gnav_Utc_Model& glonass_gnav_utc_model) const
 {
-    if (glonass_gnav_almanac.i_satellite_freq_channel)
-        {
-        }  // Avoid compiler warning
-
     add_navigation_header_start(out, "M: MIXED", "GNSS", Rinex_Printer::getLocalTime(), d_stringVersion);
 
     // -------- Line ionospheric info 1
@@ -2937,11 +2925,8 @@ void Rinex_Printer::rinex_sbs_header(std::fstream& out) const
 }
 
 
-void Rinex_Printer::update_nav_header(std::fstream& out, const Glonass_Gnav_Utc_Model& glonass_gnav_utc_model, const Glonass_Gnav_Almanac& glonass_gnav_almanac) const
+void Rinex_Printer::update_nav_header(std::fstream& out, const Glonass_Gnav_Utc_Model& glonass_gnav_utc_model) const
 {
-    if (glonass_gnav_almanac.i_satellite_freq_channel)
-        {
-        }  // Avoid compiler warning
     std::vector<std::string> data;
 
     const int64_t pos = out.tellp();
@@ -3352,11 +3337,8 @@ void Rinex_Printer::update_nav_header(std::fstream& out, const Gps_Iono& gps_ion
 }
 
 
-void Rinex_Printer::update_nav_header(std::fstream& out, const Gps_Iono& gps_iono, const Gps_Utc_Model& gps_utc_model, const Gps_Ephemeris& eph, const Glonass_Gnav_Utc_Model& glonass_gnav_utc_model, const Glonass_Gnav_Almanac& glonass_gnav_almanac) const
+void Rinex_Printer::update_nav_header(std::fstream& out, const Gps_Iono& gps_iono, const Gps_Utc_Model& gps_utc_model, const Gps_Ephemeris& eph, const Glonass_Gnav_Utc_Model& glonass_gnav_utc_model) const
 {
-    if (glonass_gnav_almanac.i_satellite_freq_channel)
-        {
-        }  // Avoid compiler warning
     std::vector<std::string> data;
 
     const int64_t pos = out.tellp();
@@ -3413,11 +3395,8 @@ void Rinex_Printer::update_nav_header(std::fstream& out, const Gps_Iono& gps_ion
 }
 
 
-void Rinex_Printer::update_nav_header(std::fstream& out, const Gps_CNAV_Iono& gps_iono, const Gps_CNAV_Utc_Model& gps_utc_model, const Glonass_Gnav_Utc_Model& glonass_gnav_utc_model, const Glonass_Gnav_Almanac& glonass_gnav_almanac) const
+void Rinex_Printer::update_nav_header(std::fstream& out, const Gps_CNAV_Iono& gps_iono, const Gps_CNAV_Utc_Model& gps_utc_model, const Glonass_Gnav_Utc_Model& glonass_gnav_utc_model) const
 {
-    if (glonass_gnav_almanac.i_satellite_freq_channel)
-        {
-        }  // Avoid compiler warning
     std::vector<std::string> data;
 
     const int64_t pos = out.tellp();
@@ -3474,15 +3453,9 @@ void Rinex_Printer::update_nav_header(std::fstream& out, const Gps_CNAV_Iono& gp
 }
 
 
-void Rinex_Printer::update_nav_header(std::fstream& out, const Galileo_Iono& galileo_iono, const Galileo_Utc_Model& galileo_utc_model, const Glonass_Gnav_Utc_Model& glonass_gnav_utc_model, const Glonass_Gnav_Almanac& glonass_gnav_almanac) const
+void Rinex_Printer::update_nav_header(std::fstream& out, const Galileo_Iono& galileo_iono, const Galileo_Utc_Model& galileo_utc_model, const Glonass_Gnav_Utc_Model& glonass_gnav_utc_model) const
 {
-    if (glonass_gnav_almanac.i_satellite_freq_channel)
-        {
-        }  // Avoid compiler warning
-    // Avoid compiler warning, there is not time system correction between Galileo and GLONASS
-    if (galileo_utc_model.A_0G > 0.0)
-        {
-        }
+    // There is not time system correction between Galileo and GLONASS
     std::vector<std::string> data;
 
     const int64_t pos = out.tellp();
@@ -4584,16 +4557,11 @@ void Rinex_Printer::update_obs_header(std::fstream& out, const std::string& leap
 }
 
 
-void Rinex_Printer::log_rinex_obs(std::fstream& out, const Glonass_Gnav_Ephemeris& eph, double obs_time, const std::map<int32_t, Gnss_Synchro>& observables, const std::string& glonass_bands) const
+void Rinex_Printer::log_rinex_obs(std::fstream& out, const Glonass_Gnav_Ephemeris& eph, double obs_time, const std::map<int32_t, Gnss_Synchro>& observables) const
 {
     // RINEX observations timestamps are GPS timestamps.
     std::string line;
     double int_sec = 0;
-
-    // Avoid compiler warning
-    if (!glonass_bands.empty())
-        {
-        }
 
     const boost::posix_time::ptime p_glonass_time = Rinex_Printer::compute_UTC_time(eph, obs_time);
     const std::string timestring = boost::posix_time::to_iso_string(p_glonass_time);
@@ -4821,11 +4789,8 @@ void Rinex_Printer::log_rinex_obs(std::fstream& out, const Glonass_Gnav_Ephemeri
 }
 
 
-void Rinex_Printer::log_rinex_obs(std::fstream& out, const Gps_Ephemeris& gps_eph, const Glonass_Gnav_Ephemeris& glonass_gnav_eph, double gps_obs_time, const std::map<int32_t, Gnss_Synchro>& observables) const
+void Rinex_Printer::log_rinex_obs(std::fstream& out, const Gps_Ephemeris& gps_eph, const Glonass_Gnav_Ephemeris& /*glonass_gnav_eph*/, double gps_obs_time, const std::map<int32_t, Gnss_Synchro>& observables) const
 {
-    if (glonass_gnav_eph.d_m > 0.0)
-        {
-        }  // avoid warning, not needed
     std::string line;
 
     // -------- EPOCH record
@@ -5148,11 +5113,8 @@ void Rinex_Printer::log_rinex_obs(std::fstream& out, const Gps_Ephemeris& gps_ep
 }
 
 
-void Rinex_Printer::log_rinex_obs(std::fstream& out, const Gps_CNAV_Ephemeris& gps_eph, const Glonass_Gnav_Ephemeris& glonass_gnav_eph, double gps_obs_time, const std::map<int32_t, Gnss_Synchro>& observables) const
+void Rinex_Printer::log_rinex_obs(std::fstream& out, const Gps_CNAV_Ephemeris& gps_eph, const Glonass_Gnav_Ephemeris& /*glonass_gnav_eph*/, double gps_obs_time, const std::map<int32_t, Gnss_Synchro>& observables) const
 {
-    if (glonass_gnav_eph.d_m > 0.0)
-        {
-        }  // avoid warning, not needed
     std::string line;
 
     // -------- EPOCH record
@@ -5377,11 +5339,8 @@ void Rinex_Printer::log_rinex_obs(std::fstream& out, const Gps_CNAV_Ephemeris& g
 }
 
 
-void Rinex_Printer::log_rinex_obs(std::fstream& out, const Galileo_Ephemeris& galileo_eph, const Glonass_Gnav_Ephemeris& glonass_gnav_eph, double galileo_obs_time, const std::map<int32_t, Gnss_Synchro>& observables) const
+void Rinex_Printer::log_rinex_obs(std::fstream& out, const Galileo_Ephemeris& galileo_eph, const Glonass_Gnav_Ephemeris& /*glonass_gnav_eph*/, double galileo_obs_time, const std::map<int32_t, Gnss_Synchro>& observables) const
 {
-    if (glonass_gnav_eph.d_m > 0.0)
-        {
-        }  // avoid warning, not needed
     std::string line;
 
     // double utc_t = nav_msg.utc_time(nav_msg.sv_clock_correction(obs_time));
@@ -5935,11 +5894,8 @@ void Rinex_Printer::log_rinex_obs(std::fstream& out, const Gps_CNAV_Ephemeris& e
 }
 
 
-void Rinex_Printer::log_rinex_obs(std::fstream& out, const Gps_Ephemeris& eph, const Gps_CNAV_Ephemeris& eph_cnav, double obs_time, const std::map<int32_t, Gnss_Synchro>& observables, bool triple_band) const
+void Rinex_Printer::log_rinex_obs(std::fstream& out, const Gps_Ephemeris& eph, const Gps_CNAV_Ephemeris& /*eph_cnav*/, double obs_time, const std::map<int32_t, Gnss_Synchro>& observables, bool triple_band) const
 {
-    if (eph_cnav.i_0 > 0.0)
-        {
-        }  // avoid warning, not needed
     // RINEX observations timestamps are GPS timestamps.
     std::string line;
 
@@ -6347,11 +6303,8 @@ void Rinex_Printer::log_rinex_obs(std::fstream& out, const Galileo_Ephemeris& ep
 }
 
 
-void Rinex_Printer::log_rinex_obs(std::fstream& out, const Gps_Ephemeris& gps_eph, const Galileo_Ephemeris& galileo_eph, double gps_obs_time, const std::map<int32_t, Gnss_Synchro>& observables) const
+void Rinex_Printer::log_rinex_obs(std::fstream& out, const Gps_Ephemeris& gps_eph, const Galileo_Ephemeris& /*galileo_eph*/, double gps_obs_time, const std::map<int32_t, Gnss_Synchro>& observables) const
 {
-    if (galileo_eph.ecc > 0.0)
-        {
-        }  // avoid warning, not needed
     std::string line;
 
     // double utc_t = nav_msg.utc_time(nav_msg.sv_clock_correction(obs_time));
@@ -6605,11 +6558,8 @@ void Rinex_Printer::log_rinex_obs(std::fstream& out, const Gps_Ephemeris& gps_ep
 }
 
 
-void Rinex_Printer::log_rinex_obs(std::fstream& out, const Gps_CNAV_Ephemeris& eph, const Galileo_Ephemeris& galileo_eph, double gps_obs_time, const std::map<int32_t, Gnss_Synchro>& observables) const
+void Rinex_Printer::log_rinex_obs(std::fstream& out, const Gps_CNAV_Ephemeris& eph, const Galileo_Ephemeris& /*galileo_eph*/, double gps_obs_time, const std::map<int32_t, Gnss_Synchro>& observables) const
 {
-    if (galileo_eph.ecc > 0.0)
-        {
-        }  // avoid warning, not needed
     std::string line;
 
     // double utc_t = nav_msg.utc_time(nav_msg.sv_clock_correction(obs_time));
@@ -6880,14 +6830,8 @@ void Rinex_Printer::log_rinex_obs(std::fstream& out, const Gps_CNAV_Ephemeris& e
 }
 
 
-void Rinex_Printer::log_rinex_obs(std::fstream& out, const Gps_Ephemeris& gps_eph, const Gps_CNAV_Ephemeris& gps_cnav_eph, const Galileo_Ephemeris& galileo_eph, double gps_obs_time, const std::map<int32_t, Gnss_Synchro>& observables, bool triple_band) const
+void Rinex_Printer::log_rinex_obs(std::fstream& out, const Gps_Ephemeris& gps_eph, const Gps_CNAV_Ephemeris& /*gps_cnav_eph*/, const Galileo_Ephemeris& /*galileo_eph*/, double gps_obs_time, const std::map<int32_t, Gnss_Synchro>& observables, bool triple_band) const
 {
-    if (galileo_eph.ecc > 0.0)
-        {
-        }  // avoid warning, not needed
-    if (gps_cnav_eph.ecc > 0.0)
-        {
-        }  // avoid warning, not needed
     std::string line;
 
     // double utc_t = nav_msg.utc_time(nav_msg.sv_clock_correction(obs_time));

--- a/src/algorithms/PVT/libs/rinex_printer.cc
+++ b/src/algorithms/PVT/libs/rinex_printer.cc
@@ -1547,26 +1547,28 @@ void add_obs_glonass_code_phase_bias(std::fstream& out,
 
 Rinex_Printer::Rinex_Printer(int version,
     const std::string& base_path,
-    const std::string& base_name) : Rinex_Printer(base_name, getAndCreateBaseRinexPath(base_path), version)
+    const std::string& base_name,
+    bool pre_2009_file) : Rinex_Printer(base_name, getAndCreateBaseRinexPath(base_path), version, pre_2009_file)
 {
 }
 
 
 Rinex_Printer::Rinex_Printer(const std::string& base_name,
     const std::string& base_rinex_path,
-    int version) : observationType(getObservationTypes()),
-                   observationCode(getObservationCodes()),
-                   navfilename(getFilePath("RINEX_FILE_TYPE_GPS_NAV", base_name, base_rinex_path)),
-                   obsfilename(getFilePath("RINEX_FILE_TYPE_OBS", base_name, base_rinex_path)),
-                   sbsfilename(getFilePath("RINEX_FILE_TYPE_SBAS", base_name, base_rinex_path)),
-                   navGalfilename(getFilePath("RINEX_FILE_TYPE_GAL_NAV", base_name, base_rinex_path)),
-                   navGlofilename(getFilePath("RINEX_FILE_TYPE_GLO_NAV", base_name, base_rinex_path)),
-                   navBdsfilename(getFilePath("RINEX_FILE_TYPE_BDS_NAV", base_name, base_rinex_path)),
-                   navMixfilename(getFilePath("RINEX_FILE_TYPE_MIXED_NAV", base_name, base_rinex_path)),
-                   d_fake_cnav_iode(1),
-                   d_rinex_header_updated(false),
-                   d_rinex_header_written(false),
-                   d_pre_2009_file(false)
+    int version,
+    bool pre_2009_file) : observationType(getObservationTypes()),
+                          observationCode(getObservationCodes()),
+                          navfilename(getFilePath("RINEX_FILE_TYPE_GPS_NAV", base_name, base_rinex_path)),
+                          obsfilename(getFilePath("RINEX_FILE_TYPE_OBS", base_name, base_rinex_path)),
+                          sbsfilename(getFilePath("RINEX_FILE_TYPE_SBAS", base_name, base_rinex_path)),
+                          navGalfilename(getFilePath("RINEX_FILE_TYPE_GAL_NAV", base_name, base_rinex_path)),
+                          navGlofilename(getFilePath("RINEX_FILE_TYPE_GLO_NAV", base_name, base_rinex_path)),
+                          navBdsfilename(getFilePath("RINEX_FILE_TYPE_BDS_NAV", base_name, base_rinex_path)),
+                          navMixfilename(getFilePath("RINEX_FILE_TYPE_MIXED_NAV", base_name, base_rinex_path)),
+                          d_fake_cnav_iode(1),
+                          d_rinex_header_updated(false),
+                          d_rinex_header_written(false),
+                          d_pre_2009_file(pre_2009_file)
 
 {
     std::map<std::string, std::fstream&> fileMap = {
@@ -7514,12 +7516,6 @@ double Rinex_Printer::get_leap_second(const Glonass_Gnav_Ephemeris& eph, double 
         }
 
     return leap_second;
-}
-
-
-void Rinex_Printer::set_pre_2009_file(bool pre_2009_file)
-{
-    d_pre_2009_file = pre_2009_file;
 }
 
 

--- a/src/algorithms/PVT/libs/rinex_printer.cc
+++ b/src/algorithms/PVT/libs/rinex_printer.cc
@@ -4912,15 +4912,15 @@ void Rinex_Printer::log_rinex_obs(std::fstream& out, const Gps_Ephemeris& gps_ep
             const std::string sig_(observables_iter.second.Signal);
             if ((system_ == "R") && (sig_ == "1G"))
                 {
-                    observablesR1C.insert(std::pair<int32_t, Gnss_Synchro>(observables_iter.first, observables_iter.second));
+                    observablesR1C.insert(observables_iter);
                 }
             if ((system_ == "R") && (sig_ == "2G"))
                 {
-                    observablesR2C.insert(std::pair<int32_t, Gnss_Synchro>(observables_iter.first, observables_iter.second));
+                    observablesR2C.insert(observables_iter);
                 }
             if ((system_ == "G") && (sig_ == "1C"))
                 {
-                    observablesG1C.insert(std::pair<int32_t, Gnss_Synchro>(observables_iter.first, observables_iter.second));
+                    observablesG1C.insert(observables_iter);
                 }
         }
 
@@ -5156,15 +5156,15 @@ void Rinex_Printer::log_rinex_obs(std::fstream& out, const Gps_CNAV_Ephemeris& g
             const std::string sig_(observables_iter.second.Signal);
             if ((system_ == "R") && (sig_ == "1G"))
                 {
-                    observablesR1C.insert(std::pair<int32_t, Gnss_Synchro>(observables_iter.first, observables_iter.second));
+                    observablesR1C.insert(observables_iter);
                 }
             if ((system_ == "R") && (sig_ == "2G"))
                 {
-                    observablesR2C.insert(std::pair<int32_t, Gnss_Synchro>(observables_iter.first, observables_iter.second));
+                    observablesR2C.insert(observables_iter);
                 }
             if ((system_ == "G") && (sig_ == "2S"))
                 {
-                    observablesG2S.insert(std::pair<int32_t, Gnss_Synchro>(observables_iter.first, observables_iter.second));
+                    observablesG2S.insert(observables_iter);
                 }
         }
 
@@ -5364,15 +5364,15 @@ void Rinex_Printer::log_rinex_obs(std::fstream& out, const Galileo_Ephemeris& ga
             const std::string sig_(observables_iter.second.Signal);
             if ((system_ == "R") && (sig_ == "1G"))
                 {
-                    observablesR1C.insert(std::pair<int32_t, Gnss_Synchro>(observables_iter.first, observables_iter.second));
+                    observablesR1C.insert(observables_iter);
                 }
             if ((system_ == "R") && (sig_ == "2G"))
                 {
-                    observablesR2C.insert(std::pair<int32_t, Gnss_Synchro>(observables_iter.first, observables_iter.second));
+                    observablesR2C.insert(observables_iter);
                 }
             if ((system_ == "E") && (sig_ == "1B"))
                 {
-                    observablesE1B.insert(std::pair<int32_t, Gnss_Synchro>(observables_iter.first, observables_iter.second));
+                    observablesE1B.insert(observables_iter);
                 }
         }
 
@@ -5886,12 +5886,12 @@ void Rinex_Printer::log_rinex_obs(std::fstream& out, const Gps_Ephemeris& eph, c
             const std::string sig_(observables_iter.second.Signal);
             if ((system_ == "G") && (sig_ == "1C"))
                 {
-                    observablesL1.insert(std::pair<int32_t, Gnss_Synchro>(observables_iter.first, observables_iter.second));
+                    observablesL1.insert(observables_iter);
                     total_mmap.insert(std::pair<uint32_t, Gnss_Synchro>(observables_iter.second.PRN, observables_iter.second));
                 }
             if ((system_ == "G") && (sig_ == "2S"))
                 {
-                    observablesL2.insert(std::pair<int32_t, Gnss_Synchro>(observables_iter.first, observables_iter.second));
+                    observablesL2.insert(observables_iter);
                     mmap_iter = total_mmap.find(observables_iter.second.PRN);
                     if (mmap_iter == total_mmap.end())
                         {
@@ -5903,7 +5903,7 @@ void Rinex_Printer::log_rinex_obs(std::fstream& out, const Gps_Ephemeris& eph, c
 
             if ((system_ == "G") && (sig_ == "L5"))
                 {
-                    observablesL5.insert(std::pair<int32_t, Gnss_Synchro>(observables_iter.first, observables_iter.second));
+                    observablesL5.insert(observables_iter);
                     mmap_iter = total_mmap.find(observables_iter.second.PRN);
                     if (mmap_iter == total_mmap.end())
                         {
@@ -6069,19 +6069,19 @@ void Rinex_Printer::log_rinex_obs(std::fstream& out, const Galileo_Ephemeris& ep
             const std::string sig_(observables_iter.second.Signal);
             if ((system_ == "E") && (sig_ == "1B"))
                 {
-                    observablesE1B.insert(std::pair<int32_t, Gnss_Synchro>(observables_iter.first, observables_iter.second));
+                    observablesE1B.insert(observables_iter);
                 }
             if ((system_ == "E") && (sig_ == "5X"))
                 {
-                    observablesE5A.insert(std::pair<int32_t, Gnss_Synchro>(observables_iter.first, observables_iter.second));
+                    observablesE5A.insert(observables_iter);
                 }
             if ((system_ == "E") && (sig_ == "7X"))
                 {
-                    observablesE5B.insert(std::pair<int32_t, Gnss_Synchro>(observables_iter.first, observables_iter.second));
+                    observablesE5B.insert(observables_iter);
                 }
             if ((system_ == "E") && (sig_ == "E6"))
                 {
-                    observablesE6B.insert(std::pair<int32_t, Gnss_Synchro>(observables_iter.first, observables_iter.second));
+                    observablesE6B.insert(observables_iter);
                 }
         }
     const std::size_t found_1B = galileo_bands.find("1B");
@@ -6260,23 +6260,23 @@ void Rinex_Printer::log_rinex_obs(std::fstream& out, const Gps_Ephemeris& gps_ep
             const std::string sig_(observables_iter.second.Signal);
             if ((system_ == "E") && (sig_ == "1B"))
                 {
-                    observablesE1B.insert(std::pair<int32_t, Gnss_Synchro>(observables_iter.first, observables_iter.second));
+                    observablesE1B.insert(observables_iter);
                 }
             if ((system_ == "E") && (sig_ == "5X"))
                 {
-                    observablesE5A.insert(std::pair<int32_t, Gnss_Synchro>(observables_iter.first, observables_iter.second));
+                    observablesE5A.insert(observables_iter);
                 }
             if ((system_ == "E") && (sig_ == "7X"))
                 {
-                    observablesE5B.insert(std::pair<int32_t, Gnss_Synchro>(observables_iter.first, observables_iter.second));
+                    observablesE5B.insert(observables_iter);
                 }
             if ((system_ == "E") && (sig_ == "E6"))
                 {
-                    observablesE6B.insert(std::pair<int32_t, Gnss_Synchro>(observables_iter.first, observables_iter.second));
+                    observablesE6B.insert(observables_iter);
                 }
             if ((system_ == "G") && (sig_ == "1C"))
                 {
-                    observablesG1C.insert(std::pair<int32_t, Gnss_Synchro>(observables_iter.first, observables_iter.second));
+                    observablesG1C.insert(observables_iter);
                 }
         }
 
@@ -6498,27 +6498,27 @@ void Rinex_Printer::log_rinex_obs(std::fstream& out, const Gps_CNAV_Ephemeris& e
             const std::string sig_(observables_iter.second.Signal);
             if ((system_ == "E") && (sig_ == "1B"))
                 {
-                    observablesE1B.insert(std::pair<int32_t, Gnss_Synchro>(observables_iter.first, observables_iter.second));
+                    observablesE1B.insert(observables_iter);
                 }
             if ((system_ == "E") && (sig_ == "5X"))
                 {
-                    observablesE5A.insert(std::pair<int32_t, Gnss_Synchro>(observables_iter.first, observables_iter.second));
+                    observablesE5A.insert(observables_iter);
                 }
             if ((system_ == "E") && (sig_ == "7X"))
                 {
-                    observablesE5B.insert(std::pair<int32_t, Gnss_Synchro>(observables_iter.first, observables_iter.second));
+                    observablesE5B.insert(observables_iter);
                 }
             if ((system_ == "E") && (sig_ == "E6"))
                 {
-                    observablesE6B.insert(std::pair<int32_t, Gnss_Synchro>(observables_iter.first, observables_iter.second));
+                    observablesE6B.insert(observables_iter);
                 }
             if ((system_ == "G") && (sig_ == "2S"))
                 {
-                    observablesG2S.insert(std::pair<int32_t, Gnss_Synchro>(observables_iter.first, observables_iter.second));
+                    observablesG2S.insert(observables_iter);
                 }
             if ((system_ == "G") && (sig_ == "L5"))
                 {
-                    observablesGL5.insert(std::pair<int32_t, Gnss_Synchro>(observables_iter.first, observables_iter.second));
+                    observablesGL5.insert(observables_iter);
                 }
         }
 
@@ -6753,31 +6753,31 @@ void Rinex_Printer::log_rinex_obs(std::fstream& out, const Gps_Ephemeris& gps_ep
             const std::string sig_(observables_iter.second.Signal);
             if ((system_ == "E") && (sig_ == "1B"))
                 {
-                    observablesE1B.insert(std::pair<int32_t, Gnss_Synchro>(observables_iter.first, observables_iter.second));
+                    observablesE1B.insert(observables_iter);
                 }
             if ((system_ == "E") && (sig_ == "5X"))
                 {
-                    observablesE5A.insert(std::pair<int32_t, Gnss_Synchro>(observables_iter.first, observables_iter.second));
+                    observablesE5A.insert(observables_iter);
                 }
             if ((system_ == "E") && (sig_ == "7X"))
                 {
-                    observablesE5B.insert(std::pair<int32_t, Gnss_Synchro>(observables_iter.first, observables_iter.second));
+                    observablesE5B.insert(observables_iter);
                 }
             if ((system_ == "E") && (sig_ == "E6"))
                 {
-                    observablesE6B.insert(std::pair<int32_t, Gnss_Synchro>(observables_iter.first, observables_iter.second));
+                    observablesE6B.insert(observables_iter);
                 }
             if ((system_ == "G") && (sig_ == "2S"))
                 {
-                    observablesG2S.insert(std::pair<int32_t, Gnss_Synchro>(observables_iter.first, observables_iter.second));
+                    observablesG2S.insert(observables_iter);
                 }
             if ((system_ == "G") && (sig_ == "L5"))
                 {
-                    observablesGL5.insert(std::pair<int32_t, Gnss_Synchro>(observables_iter.first, observables_iter.second));
+                    observablesGL5.insert(observables_iter);
                 }
             if ((system_ == "G") && (sig_ == "1C"))
                 {
-                    observablesG1C.insert(std::pair<int32_t, Gnss_Synchro>(observables_iter.first, observables_iter.second));
+                    observablesG1C.insert(observables_iter);
                 }
         }
 
@@ -7030,11 +7030,11 @@ void Rinex_Printer::log_rinex_obs(std::fstream& out, const Beidou_Dnav_Ephemeris
             const std::string sig_(observables_iter.second.Signal);
             if ((system_ == "C") && (sig_ == "B1"))
                 {
-                    observablesB1I.insert(std::pair<int32_t, Gnss_Synchro>(observables_iter.first, observables_iter.second));
+                    observablesB1I.insert(observables_iter);
                 }
             if ((system_ == "C") && (sig_ == "B3"))
                 {
-                    observablesB3I.insert(std::pair<int32_t, Gnss_Synchro>(observables_iter.first, observables_iter.second));
+                    observablesB3I.insert(observables_iter);
                 }
         }
     const std::size_t found_B1 = bds_bands.find("B1");

--- a/src/algorithms/PVT/libs/rinex_printer.cc
+++ b/src/algorithms/PVT/libs/rinex_printer.cc
@@ -714,6 +714,16 @@ void lengthCheck(const std::string& line)
 }
 
 
+/*
+ * Generation of RINEX signal strength indicators
+ */
+int32_t signal_strength(double snr)
+{
+    auto ss = static_cast<int32_t>(std::min(std::max(static_cast<int32_t>(floor(snr / 6)), 1), 9));
+    return ss;
+}
+
+
 void override_stream_with_new_data(std::fstream& out, const std::string& filename, const std::vector<std::string>& data, int64_t seek_pos)
 {
     out.close();
@@ -1257,6 +1267,34 @@ std::string get_obs_epoch_record_lines(const boost::posix_time::ptime& utc_time,
     line += std::string(1, '0');
 
     return line;
+}
+
+void add_obs_sat_record_line(const Gnss_Synchro& synchro, std::string& line, bool padding = true)
+{
+    const int32_t ssi = signal_strength(synchro.CN0_dB_hz);
+
+    // PSEUDORANGE
+    line += rightJustify(asString(synchro.Pseudorange_m, 3), 14);
+    line += std::string(1, ' ');                      // Loss of lock indicator (LLI)
+    line += rightJustify(asString<int32_t>(ssi), 1);  // Signal Strength Indicator (SSI)
+
+    // PHASE
+    line += rightJustify(asString(synchro.Carrier_phase_rads / TWO_PI, 3), 14);
+    line += std::string(1, ' ');                      // Loss of lock indicator (LLI)
+    line += rightJustify(asString<int32_t>(ssi), 1);  // Signal Strength Indicator (SSI)
+
+    // DOPPLER
+    line += rightJustify(asString(synchro.Carrier_Doppler_hz, 3), 14);
+    line += std::string(1, ' ');                      // Loss of lock indicator (LLI)
+    line += rightJustify(asString<int32_t>(ssi), 1);  // Signal Strength Indicator (SSI)
+
+    // SIGNAL STRENGTH
+    line += rightJustify(asString(synchro.CN0_dB_hz, 3), 14);
+
+    if (padding && line.size() < 80)
+        {
+            line += std::string(80 - line.size(), ' ');
+        }
 }
 
 std::string get_nav_sv_epoch_svclk_line(const boost::posix_time::ptime& p_utc_time, const std::string& sys_char, uint32_t prn, double value0, double value1, double value2)
@@ -4662,54 +4700,7 @@ void Rinex_Printer::log_rinex_obs(std::fstream& out, const Glonass_Gnav_Ephemeri
             for (const auto& observables_iter : observables)
                 {
                     std::string lineObs;
-                    lineObs.clear();
-                    line.clear();
-                    // GLONASS L1 PSEUDORANGE
-                    line += std::string(2, ' ');
-                    lineObs += rightJustify(asString(observables_iter.second.Pseudorange_m, 3), 14);
-
-                    // Loss of lock indicator (LLI)
-                    int32_t lli = 0;  // Include in the observation!!
-                    if (lli == 0)
-                        {
-                            lineObs += std::string(1, ' ');
-                        }
-                    // else
-                    //    {
-                    //        lineObs += rightJustify(asString<int16_t>(lli), 1);
-                    //    }
-
-                    // Signal Strength Indicator (SSI)
-                    const int32_t ssi = Rinex_Printer::signalStrength(observables_iter.second.CN0_dB_hz);
-                    lineObs += rightJustify(asString<int32_t>(ssi), 1);
-                    // GLONASS L1 CA PHASE
-                    lineObs += rightJustify(asString(observables_iter.second.Carrier_phase_rads / TWO_PI, 3), 14);
-                    if (lli == 0)
-                        {
-                            lineObs += std::string(1, ' ');
-                        }
-                    // else
-                    //    {
-                    //        lineObs += rightJustify(asString<int16_t>(lli), 1);
-                    //    }
-                    lineObs += rightJustify(asString<int32_t>(ssi), 1);
-                    // GLONASS L1 CA DOPPLER
-                    lineObs += rightJustify(asString(observables_iter.second.Carrier_Doppler_hz, 3), 14);
-                    if (lli == 0)
-                        {
-                            lineObs += std::string(1, ' ');
-                        }
-                    // else
-                    //    {
-                    //        lineObs += rightJustify(asString<int16_t>(lli), 1);
-                    //    }
-                    lineObs += rightJustify(asString<int32_t>(ssi), 1);
-                    // GLONASS L1 SIGNAL STRENGTH
-                    lineObs += rightJustify(asString(observables_iter.second.CN0_dB_hz, 3), 14);
-                    if (lineObs.size() < 80)
-                        {
-                            lineObs += std::string(80 - lineObs.size(), ' ');
-                        }
+                    add_obs_sat_record_line(observables_iter.second, lineObs);
                     out << lineObs << '\n';
                 }
         }
@@ -4754,63 +4745,15 @@ void Rinex_Printer::log_rinex_obs(std::fstream& out, const Glonass_Gnav_Ephemeri
             for (const auto& observables_iter : observables)
                 {
                     std::string lineObs;
-                    lineObs.clear();
                     lineObs += satelliteSystem.at("GLONASS");
                     if (static_cast<int32_t>(observables_iter.second.PRN) < 10)
                         {
                             lineObs += std::string(1, '0');
                         }
                     lineObs += std::to_string(static_cast<int32_t>(observables_iter.second.PRN));
-                    // lineObs += std::string(2, ' ');
-                    lineObs += rightJustify(asString(observables_iter.second.Pseudorange_m, 3), 14);
 
-                    // Loss of lock indicator (LLI)
-                    int32_t lli = 0;  // Include in the observation!!
-                    if (lli == 0)
-                        {
-                            lineObs += std::string(1, ' ');
-                        }
-                    // else
-                    //    {
-                    //        lineObs += rightJustify(asString<int16_t>(lli), 1);
-                    //    }
+                    add_obs_sat_record_line(observables_iter.second, lineObs);
 
-                    // Signal Strength Indicator (SSI)
-                    const int32_t ssi = Rinex_Printer::signalStrength(observables_iter.second.CN0_dB_hz);
-                    lineObs += rightJustify(asString<int32_t>(ssi), 1);
-
-                    // GLONASS L1 CA PHASE
-                    lineObs += rightJustify(asString(observables_iter.second.Carrier_phase_rads / TWO_PI, 3), 14);
-                    if (lli == 0)
-                        {
-                            lineObs += std::string(1, ' ');
-                        }
-                    // else
-                    //    {
-                    //        lineObs += rightJustify(asString<int16_t>(lli), 1);
-                    //    }
-                    lineObs += rightJustify(asString<int32_t>(ssi), 1);
-
-                    // GLONASS L1 CA DOPPLER
-                    lineObs += rightJustify(asString(observables_iter.second.Carrier_Doppler_hz, 3), 14);
-                    if (lli == 0)
-                        {
-                            lineObs += std::string(1, ' ');
-                        }
-                    // else
-                    //    {
-                    //        lineObs += rightJustify(asString<int16_t>(lli), 1);
-                    //    }
-
-                    lineObs += rightJustify(asString<int32_t>(ssi), 1);
-
-                    // GLONASS L1 SIGNAL STRENGTH
-                    lineObs += rightJustify(asString(observables_iter.second.CN0_dB_hz, 3), 14);
-
-                    if (lineObs.size() < 80)
-                        {
-                            lineObs += std::string(80 - lineObs.size(), ' ');
-                        }
                     out << lineObs << '\n';
                 }
         }
@@ -5018,55 +4961,8 @@ void Rinex_Printer::log_rinex_obs(std::fstream& out, const Gps_Ephemeris& gps_ep
                     lineObs += std::to_string(static_cast<int32_t>(observables_iter.second.PRN));
                 }
 
-            // Pseudorange Measurements
-            lineObs += rightJustify(asString(observables_iter.second.Pseudorange_m, 3), 14);
+            add_obs_sat_record_line(observables_iter.second, lineObs);
 
-            // Loss of lock indicator (LLI)
-            int32_t lli = 0;  // Include in the observation!!
-            if (lli == 0)
-                {
-                    lineObs += std::string(1, ' ');
-                }
-            // else
-            //    {
-            //        lineObs += rightJustify(asString<int16_t>(lli), 1);
-            //    }
-
-            // Signal Strength Indicator (SSI)
-            const int32_t ssi = Rinex_Printer::signalStrength(observables_iter.second.CN0_dB_hz);
-            lineObs += rightJustify(asString<int32_t>(ssi), 1);
-
-            // PHASE
-            lineObs += rightJustify(asString(observables_iter.second.Carrier_phase_rads / TWO_PI, 3), 14);
-            if (lli == 0)
-                {
-                    lineObs += std::string(1, ' ');
-                }
-            // else
-            //    {
-            //        lineObs += rightJustify(asString<int16_t>(lli), 1);
-            //    }
-            lineObs += rightJustify(asString<int32_t>(ssi), 1);
-
-            // DOPPLER
-            lineObs += rightJustify(asString(observables_iter.second.Carrier_Doppler_hz, 3), 14);
-            if (lli == 0)
-                {
-                    lineObs += std::string(1, ' ');
-                }
-            // else
-            //    {
-            //        lineObs += rightJustify(asString<int16_t>(lli), 1);
-            //    }
-            lineObs += rightJustify(asString<int32_t>(ssi), 1);
-
-            // SIGNAL STRENGTH
-            lineObs += rightJustify(asString(observables_iter.second.CN0_dB_hz, 3), 14);
-
-            if (lineObs.size() < 80)
-                {
-                    lineObs += std::string(80 - lineObs.size(), ' ');
-                }
             out << lineObs << '\n';
         }
 
@@ -5087,49 +4983,7 @@ void Rinex_Printer::log_rinex_obs(std::fstream& out, const Gps_Ephemeris& gps_ep
                 {
                     /// \todo Need to account for pseudorange correction for glonass
                     // double leap_seconds = Rinex_Printer::get_leap_second(glonass_gnav_eph, gps_obs_time);
-                    lineObs += rightJustify(asString(iter->second.Pseudorange_m, 3), 14);
-
-                    // Loss of lock indicator (LLI)
-                    int32_t lli = 0;  // Include in the observation!!
-                    if (lli == 0)
-                        {
-                            lineObs += std::string(1, ' ');
-                        }
-                    // else
-                    //    {
-                    //        lineObs += rightJustify(asString<int16_t>(lli), 1);
-                    //    }
-
-                    // Signal Strength Indicator (SSI)
-                    const int32_t ssi = Rinex_Printer::signalStrength(iter->second.CN0_dB_hz);
-                    lineObs += rightJustify(asString<int32_t>(ssi), 1);
-
-                    // GLONASS CARRIER PHASE
-                    lineObs += rightJustify(asString(iter->second.Carrier_phase_rads / (TWO_PI), 3), 14);
-                    if (lli == 0)
-                        {
-                            lineObs += std::string(1, ' ');
-                        }
-                    // else
-                    //    {
-                    //        lineObs += rightJustify(asString<int16_t>(lli), 1);
-                    //    }
-                    lineObs += rightJustify(asString<int32_t>(ssi), 1);
-
-                    // GLONASS  DOPPLER
-                    lineObs += rightJustify(asString(iter->second.Carrier_Doppler_hz, 3), 14);
-                    if (lli == 0)
-                        {
-                            lineObs += std::string(1, ' ');
-                        }
-                    // else
-                    //    {
-                    //        lineObs += rightJustify(asString<int16_t>(lli), 1);
-                    //    }
-                    lineObs += rightJustify(asString<int32_t>(ssi), 1);
-
-                    // GLONASS SIGNAL STRENGTH
-                    lineObs += rightJustify(asString(iter->second.CN0_dB_hz, 3), 14);
+                    add_obs_sat_record_line(iter->second, lineObs, false);
                 }
 
             if (lineObs.size() < 80)
@@ -5227,55 +5081,8 @@ void Rinex_Printer::log_rinex_obs(std::fstream& out, const Gps_CNAV_Ephemeris& g
                 }
             lineObs += std::to_string(static_cast<int32_t>(observables_iter.second.PRN));
 
-            // Pseudorange Measurements
-            lineObs += rightJustify(asString(observables_iter.second.Pseudorange_m, 3), 14);
+            add_obs_sat_record_line(observables_iter.second, lineObs);
 
-            // Loss of lock indicator (LLI)
-            int32_t lli = 0;  // Include in the observation!!
-            if (lli == 0)
-                {
-                    lineObs += std::string(1, ' ');
-                }
-            // else
-            //    {
-            //        lineObs += rightJustify(asString<int16_t>(lli), 1);
-            //    }
-
-            // Signal Strength Indicator (SSI)
-            const int32_t ssi = Rinex_Printer::signalStrength(observables_iter.second.CN0_dB_hz);
-            lineObs += rightJustify(asString<int32_t>(ssi), 1);
-
-            // PHASE
-            lineObs += rightJustify(asString(observables_iter.second.Carrier_phase_rads / TWO_PI, 3), 14);
-            if (lli == 0)
-                {
-                    lineObs += std::string(1, ' ');
-                }
-            // else
-            //    {
-            //        lineObs += rightJustify(asString<int16_t>(lli), 1);
-            //    }
-            lineObs += rightJustify(asString<int32_t>(ssi), 1);
-
-            // DOPPLER
-            lineObs += rightJustify(asString(observables_iter.second.Carrier_Doppler_hz, 3), 14);
-            if (lli == 0)
-                {
-                    lineObs += std::string(1, ' ');
-                }
-            // else
-            //    {
-            //        lineObs += rightJustify(asString<int16_t>(lli), 1);
-            //    }
-            lineObs += rightJustify(asString<int32_t>(ssi), 1);
-
-            // SIGNAL STRENGTH
-            lineObs += rightJustify(asString(observables_iter.second.CN0_dB_hz, 3), 14);
-
-            if (lineObs.size() < 80)
-                {
-                    lineObs += std::string(80 - lineObs.size(), ' ');
-                }
             out << lineObs << '\n';
         }
 
@@ -5295,49 +5102,7 @@ void Rinex_Printer::log_rinex_obs(std::fstream& out, const Gps_CNAV_Ephemeris& g
                 {
                     /// \todo Need to account for pseudorange correction for glonass
                     // double leap_seconds = Rinex_Printer::get_leap_second(glonass_gnav_eph, gps_obs_time);
-                    lineObs += rightJustify(asString(iter->second.Pseudorange_m, 3), 14);
-
-                    // Loss of lock indicator (LLI)
-                    int32_t lli = 0;  // Include in the observation!!
-                    if (lli == 0)
-                        {
-                            lineObs += std::string(1, ' ');
-                        }
-                    // else
-                    //    {
-                    //        lineObs += rightJustify(asString<int16_t>(lli), 1);
-                    //    }
-
-                    // Signal Strength Indicator (SSI)
-                    const int32_t ssi = Rinex_Printer::signalStrength(iter->second.CN0_dB_hz);
-                    lineObs += rightJustify(asString<int32_t>(ssi), 1);
-
-                    // GLONASS CARRIER PHASE
-                    lineObs += rightJustify(asString(iter->second.Carrier_phase_rads / (TWO_PI), 3), 14);
-                    if (lli == 0)
-                        {
-                            lineObs += std::string(1, ' ');
-                        }
-                    // else
-                    //    {
-                    //        lineObs += rightJustify(asString<int16_t>(lli), 1);
-                    //    }
-                    lineObs += rightJustify(asString<int32_t>(ssi), 1);
-
-                    // GLONASS  DOPPLER
-                    lineObs += rightJustify(asString(iter->second.Carrier_Doppler_hz, 3), 14);
-                    if (lli == 0)
-                        {
-                            lineObs += std::string(1, ' ');
-                        }
-                    // else
-                    //    {
-                    //        lineObs += rightJustify(asString<int16_t>(lli), 1);
-                    //    }
-                    lineObs += rightJustify(asString<int32_t>(ssi), 1);
-
-                    // GLONASS SIGNAL STRENGTH
-                    lineObs += rightJustify(asString(iter->second.CN0_dB_hz, 3), 14);
+                    add_obs_sat_record_line(iter->second, lineObs, false);
                 }
 
             if (lineObs.size() < 80)
@@ -5435,54 +5200,9 @@ void Rinex_Printer::log_rinex_obs(std::fstream& out, const Galileo_Ephemeris& ga
                     lineObs += std::string(1, '0');
                 }
             lineObs += std::to_string(static_cast<int32_t>(observables_iter.second.PRN));
-            lineObs += rightJustify(asString(observables_iter.second.Pseudorange_m, 3), 14);
 
-            // Loss of lock indicator (LLI)
-            int32_t lli = 0;  // Include in the observation!!
-            if (lli == 0)
-                {
-                    lineObs += std::string(1, ' ');
-                }
-            // else
-            //    {
-            //        lineObs += rightJustify(asString<int16_t>(lli), 1);
-            //    }
+            add_obs_sat_record_line(observables_iter.second, lineObs);
 
-            // Signal Strength Indicator (SSI)
-            const int32_t ssi = Rinex_Printer::signalStrength(observables_iter.second.CN0_dB_hz);
-            lineObs += rightJustify(asString<int32_t>(ssi), 1);
-
-            // PHASE
-            lineObs += rightJustify(asString(observables_iter.second.Carrier_phase_rads / TWO_PI, 3), 14);
-            if (lli == 0)
-                {
-                    lineObs += std::string(1, ' ');
-                }
-            // else
-            //    {
-            //        lineObs += rightJustify(asString<int16_t>(lli), 1);
-            //    }
-            lineObs += rightJustify(asString<int32_t>(ssi), 1);
-
-            // DOPPLER
-            lineObs += rightJustify(asString(observables_iter.second.Carrier_Doppler_hz, 3), 14);
-            if (lli == 0)
-                {
-                    lineObs += std::string(1, ' ');
-                }
-            // else
-            //    {
-            //        lineObs += rightJustify(asString<int16_t>(lli), 1);
-            //    }
-            lineObs += rightJustify(asString<int32_t>(ssi), 1);
-
-            // SIGNAL STRENGTH
-            lineObs += rightJustify(asString(observables_iter.second.CN0_dB_hz, 3), 14);
-
-            if (lineObs.size() < 80)
-                {
-                    lineObs += std::string(80 - lineObs.size(), ' ');
-                }
             out << lineObs << '\n';
         }
 
@@ -5499,49 +5219,7 @@ void Rinex_Printer::log_rinex_obs(std::fstream& out, const Galileo_Ephemeris& ga
             ret = total_glo_map.equal_range(prn);
             for (auto iter = ret.first; iter != ret.second; ++iter)
                 {
-                    lineObs += rightJustify(asString(iter->second.Pseudorange_m, 3), 14);
-
-                    // Loss of lock indicator (LLI)
-                    int32_t lli = 0;  // Include in the observation!!
-                    if (lli == 0)
-                        {
-                            lineObs += std::string(1, ' ');
-                        }
-                    // else
-                    //    {
-                    //        lineObs += rightJustify(asString<int16_t>(lli), 1);
-                    //    }
-
-                    // Signal Strength Indicator (SSI)
-                    const int32_t ssi = Rinex_Printer::signalStrength(iter->second.CN0_dB_hz);
-                    lineObs += rightJustify(asString<int32_t>(ssi), 1);
-
-                    // GLONASS CARRIER PHASE
-                    lineObs += rightJustify(asString(iter->second.Carrier_phase_rads / (TWO_PI), 3), 14);
-                    if (lli == 0)
-                        {
-                            lineObs += std::string(1, ' ');
-                        }
-                    // else
-                    //    {
-                    //        lineObs += rightJustify(asString<int16_t>(lli), 1);
-                    //    }
-                    lineObs += rightJustify(asString<int32_t>(ssi), 1);
-
-                    // GLONASS  DOPPLER
-                    lineObs += rightJustify(asString(iter->second.Carrier_Doppler_hz, 3), 14);
-                    if (lli == 0)
-                        {
-                            lineObs += std::string(1, ' ');
-                        }
-                    // else
-                    //    {
-                    //        lineObs += rightJustify(asString<int16_t>(lli), 1);
-                    //   }
-                    lineObs += rightJustify(asString<int32_t>(ssi), 1);
-
-                    // GLONASS SIGNAL STRENGTH
-                    lineObs += rightJustify(asString(iter->second.CN0_dB_hz, 3), 14);
+                    add_obs_sat_record_line(iter->second, lineObs, false);
                 }
 
             if (lineObs.size() < 80)
@@ -5630,54 +5308,7 @@ void Rinex_Printer::log_rinex_obs(std::fstream& out, const Gps_Ephemeris& eph, d
             for (const auto& observables_iter : observables)
                 {
                     std::string lineObs;
-                    lineObs.clear();
-                    line.clear();
-                    // GPS L1 PSEUDORANGE
-                    line += std::string(2, ' ');
-                    lineObs += rightJustify(asString(observables_iter.second.Pseudorange_m, 3), 14);
-
-                    // Loss of lock indicator (LLI)
-                    int32_t lli = 0;  // Include in the observation!!
-                    if (lli == 0)
-                        {
-                            lineObs += std::string(1, ' ');
-                        }
-                    // else
-                    //    {
-                    //        lineObs += rightJustify(asString<int16_t>(lli), 1);
-                    //    }
-
-                    // Signal Strength Indicator (SSI)
-                    const int32_t ssi = Rinex_Printer::signalStrength(observables_iter.second.CN0_dB_hz);
-                    lineObs += rightJustify(asString<int32_t>(ssi), 1);
-                    // GPS L1 CA PHASE
-                    lineObs += rightJustify(asString(observables_iter.second.Carrier_phase_rads / TWO_PI, 3), 14);
-                    if (lli == 0)
-                        {
-                            lineObs += std::string(1, ' ');
-                        }
-                    // else
-                    //    {
-                    //        lineObs += rightJustify(asString<int16_t>(lli), 1);
-                    //    }
-                    lineObs += rightJustify(asString<int32_t>(ssi), 1);
-                    // GPS L1 CA DOPPLER
-                    lineObs += rightJustify(asString(observables_iter.second.Carrier_Doppler_hz, 3), 14);
-                    if (lli == 0)
-                        {
-                            lineObs += std::string(1, ' ');
-                        }
-                    // else
-                    //    {
-                    //       lineObs += rightJustify(asString<int16_t>(lli), 1);
-                    //   }
-                    lineObs += rightJustify(asString<int32_t>(ssi), 1);
-                    // GPS L1 SIGNAL STRENGTH
-                    lineObs += rightJustify(asString(observables_iter.second.CN0_dB_hz, 3), 14);
-                    if (lineObs.size() < 80)
-                        {
-                            lineObs += std::string(80 - lineObs.size(), ' ');
-                        }
+                    add_obs_sat_record_line(observables_iter.second, lineObs);
                     out << lineObs << '\n';
                 }
         }
@@ -5730,56 +5361,7 @@ void Rinex_Printer::log_rinex_obs(std::fstream& out, const Gps_Ephemeris& eph, d
                             lineObs += std::string(1, '0');
                         }
                     lineObs += std::to_string(static_cast<int32_t>(observables_iter.second.PRN));
-                    // lineObs += std::string(2, ' ');
-                    lineObs += rightJustify(asString(observables_iter.second.Pseudorange_m, 3), 14);
-
-                    // Loss of lock indicator (LLI)
-                    int32_t lli = 0;  // Include in the observation!!
-                    if (lli == 0)
-                        {
-                            lineObs += std::string(1, ' ');
-                        }
-                    // else
-                    //    {
-                    //        lineObs += rightJustify(asString<int16_t>(lli), 1);
-                    //    }
-
-                    // Signal Strength Indicator (SSI)
-                    const int32_t ssi = Rinex_Printer::signalStrength(observables_iter.second.CN0_dB_hz);
-                    lineObs += rightJustify(asString<int32_t>(ssi), 1);
-
-                    // GPS L1 CA PHASE
-                    lineObs += rightJustify(asString(observables_iter.second.Carrier_phase_rads / TWO_PI, 3), 14);
-                    if (lli == 0)
-                        {
-                            lineObs += std::string(1, ' ');
-                        }
-                    // else
-                    //    {
-                    //        lineObs += rightJustify(asString<int16_t>(lli), 1);
-                    //    }
-                    lineObs += rightJustify(asString<int32_t>(ssi), 1);
-
-                    // GPS L1 CA DOPPLER
-                    lineObs += rightJustify(asString(observables_iter.second.Carrier_Doppler_hz, 3), 14);
-                    if (lli == 0)
-                        {
-                            lineObs += std::string(1, ' ');
-                        }
-                    // else
-                    //    {
-                    //        lineObs += rightJustify(asString<int16_t>(lli), 1);
-                    //    }
-
-                    lineObs += rightJustify(asString<int32_t>(ssi), 1);
-
-                    // GPS L1 SIGNAL STRENGTH
-                    lineObs += rightJustify(asString(observables_iter.second.CN0_dB_hz, 3), 14);
-
-                    if (lineObs.size() < 80)
-                        {
-                            lineObs += std::string(80 - lineObs.size(), ' ');
-                        }
+                    add_obs_sat_record_line(observables_iter.second, lineObs);
                     out << lineObs << '\n';
                 }
         }
@@ -5812,57 +5394,7 @@ void Rinex_Printer::log_rinex_obs(std::fstream& out, const Gps_CNAV_Ephemeris& e
                     lineObs += std::string(1, '0');
                 }
             lineObs += std::to_string(static_cast<int32_t>(observables_iter.second.PRN));
-            // lineObs += std::string(2, ' ');
-            // GPS L2 PSEUDORANGE
-            lineObs += rightJustify(asString(observables_iter.second.Pseudorange_m, 3), 14);
-
-            // Loss of lock indicator (LLI)
-            int32_t lli = 0;  // Include in the observation!!
-            if (lli == 0)
-                {
-                    lineObs += std::string(1, ' ');
-                }
-            // else
-            //    {
-            //       lineObs += rightJustify(asString<int16_t>(lli), 1);
-            //   }
-
-            // Signal Strength Indicator (SSI)
-            const int32_t ssi = Rinex_Printer::signalStrength(observables_iter.second.CN0_dB_hz);
-            lineObs += rightJustify(asString<int32_t>(ssi), 1);
-
-            // GPS L2 PHASE
-            lineObs += rightJustify(asString(observables_iter.second.Carrier_phase_rads / TWO_PI, 3), 14);
-            if (lli == 0)
-                {
-                    lineObs += std::string(1, ' ');
-                }
-            // else
-            //    {
-            //        lineObs += rightJustify(asString<int16_t>(lli), 1);
-            //    }
-            lineObs += rightJustify(asString<int32_t>(ssi), 1);
-
-            // GPS L2 DOPPLER
-            lineObs += rightJustify(asString(observables_iter.second.Carrier_Doppler_hz, 3), 14);
-            if (lli == 0)
-                {
-                    lineObs += std::string(1, ' ');
-                }
-            // else
-            //    {
-            //        lineObs += rightJustify(asString<int16_t>(lli), 1);
-            //   }
-
-            lineObs += rightJustify(asString<int32_t>(ssi), 1);
-
-            // GPS L2 SIGNAL STRENGTH
-            lineObs += rightJustify(asString(observables_iter.second.CN0_dB_hz, 3), 14);
-
-            if (lineObs.size() < 80)
-                {
-                    lineObs += std::string(80 - lineObs.size(), ' ');
-                }
+            add_obs_sat_record_line(observables_iter.second, lineObs);
             out << lineObs << '\n';
         }
 }
@@ -5997,49 +5529,7 @@ void Rinex_Printer::log_rinex_obs(std::fstream& out, const Gps_Ephemeris& eph, c
                             lineObs += std::string(62, ' ');
                         }
 
-                    lineObs += rightJustify(asString(iter->second.Pseudorange_m, 3), 14);
-
-                    // Loss of lock indicator (LLI)
-                    int32_t lli = 0;  // Include in the observation!!
-                    if (lli == 0)
-                        {
-                            lineObs += std::string(1, ' ');
-                        }
-                    // else
-                    //   {
-                    //       lineObs += rightJustify(asString<int16_t>(lli), 1);
-                    //   }
-
-                    // Signal Strength Indicator (SSI)
-                    const int32_t ssi = Rinex_Printer::signalStrength(iter->second.CN0_dB_hz);
-                    lineObs += rightJustify(asString<int32_t>(ssi), 1);
-
-                    // GPS CARRIER PHASE
-                    lineObs += rightJustify(asString(iter->second.Carrier_phase_rads / (TWO_PI), 3), 14);
-                    if (lli == 0)
-                        {
-                            lineObs += std::string(1, ' ');
-                        }
-                    // else
-                    //    {
-                    //        lineObs += rightJustify(asString<int16_t>(lli), 1);
-                    //    }
-                    lineObs += rightJustify(asString<int32_t>(ssi), 1);
-
-                    // GPS  DOPPLER
-                    lineObs += rightJustify(asString(iter->second.Carrier_Doppler_hz, 3), 14);
-                    if (lli == 0)
-                        {
-                            lineObs += std::string(1, ' ');
-                        }
-                    // else
-                    //    {
-                    //        lineObs += rightJustify(asString<int16_t>(lli), 1);
-                    //    }
-                    lineObs += rightJustify(asString<int32_t>(ssi), 1);
-
-                    // GPS SIGNAL STRENGTH
-                    lineObs += rightJustify(asString(iter->second.CN0_dB_hz, 3), 14);
+                    add_obs_sat_record_line(iter->second, lineObs, false);
                 }
 
             if (lineObs.size() < 80)
@@ -6189,49 +5679,7 @@ void Rinex_Printer::log_rinex_obs(std::fstream& out, const Galileo_Ephemeris& ep
             const auto ret = total_map.equal_range(available_prn);
             for (auto iter = ret.first; iter != ret.second; ++iter)
                 {
-                    lineObs += rightJustify(asString(iter->second.Pseudorange_m, 3), 14);
-
-                    // Loss of lock indicator (LLI)
-                    int32_t lli = 0;  // Include in the observation!!
-                    if (lli == 0)
-                        {
-                            lineObs += std::string(1, ' ');
-                        }
-                    // else
-                    //    {
-                    //        lineObs += rightJustify(asString<int16_t>(lli), 1);
-                    //   }
-
-                    // Signal Strength Indicator (SSI)
-                    const int32_t ssi = Rinex_Printer::signalStrength(iter->second.CN0_dB_hz);
-                    lineObs += rightJustify(asString<int32_t>(ssi), 1);
-
-                    // Galileo CARRIER PHASE
-                    lineObs += rightJustify(asString(iter->second.Carrier_phase_rads / (TWO_PI), 3), 14);
-                    if (lli == 0)
-                        {
-                            lineObs += std::string(1, ' ');
-                        }
-                    // else
-                    //    {
-                    //        lineObs += rightJustify(asString<int16_t>(lli), 1);
-                    //    }
-                    lineObs += rightJustify(asString<int32_t>(ssi), 1);
-
-                    // Galileo  DOPPLER
-                    lineObs += rightJustify(asString(iter->second.Carrier_Doppler_hz, 3), 14);
-                    if (lli == 0)
-                        {
-                            lineObs += std::string(1, ' ');
-                        }
-                    // else
-                    //    {
-                    //       lineObs += rightJustify(asString<int16_t>(lli), 1);
-                    //    }
-                    lineObs += rightJustify(asString<int32_t>(ssi), 1);
-
-                    // Galileo SIGNAL STRENGTH
-                    lineObs += rightJustify(asString(iter->second.CN0_dB_hz, 3), 14);
+                    add_obs_sat_record_line(iter->second, lineObs, false);
                 }
 
             if (lineObs.size() < 80)
@@ -6362,54 +5810,7 @@ void Rinex_Printer::log_rinex_obs(std::fstream& out, const Gps_Ephemeris& gps_ep
                     lineObs += std::string(1, '0');
                 }
             lineObs += std::to_string(static_cast<int32_t>(observables_iter.second.PRN));
-            lineObs += rightJustify(asString(observables_iter.second.Pseudorange_m, 3), 14);
-
-            // Loss of lock indicator (LLI)
-            int32_t lli = 0;  // Include in the observation!!
-            if (lli == 0)
-                {
-                    lineObs += std::string(1, ' ');
-                }
-            // else
-            //    {
-            //       lineObs += rightJustify(asString<int16_t>(lli), 1);
-            //    }
-
-            // Signal Strength Indicator (SSI)
-            const int32_t ssi = Rinex_Printer::signalStrength(observables_iter.second.CN0_dB_hz);
-            lineObs += rightJustify(asString<int32_t>(ssi), 1);
-
-            // PHASE
-            lineObs += rightJustify(asString(observables_iter.second.Carrier_phase_rads / TWO_PI, 3), 14);
-            if (lli == 0)
-                {
-                    lineObs += std::string(1, ' ');
-                }
-            // else
-            //    {
-            //        lineObs += rightJustify(asString<int16_t>(lli), 1);
-            //   }
-            lineObs += rightJustify(asString<int32_t>(ssi), 1);
-
-            // DOPPLER
-            lineObs += rightJustify(asString(observables_iter.second.Carrier_Doppler_hz, 3), 14);
-            if (lli == 0)
-                {
-                    lineObs += std::string(1, ' ');
-                }
-            // else
-            //    {
-            //        lineObs += rightJustify(asString<int16_t>(lli), 1);
-            //    }
-            lineObs += rightJustify(asString<int32_t>(ssi), 1);
-
-            // SIGNAL STRENGTH
-            lineObs += rightJustify(asString(observables_iter.second.CN0_dB_hz, 3), 14);
-
-            if (lineObs.size() < 80)
-                {
-                    lineObs += std::string(80 - lineObs.size(), ' ');
-                }
+            add_obs_sat_record_line(observables_iter.second, lineObs);
             out << lineObs << '\n';
         }
 
@@ -6426,49 +5827,7 @@ void Rinex_Printer::log_rinex_obs(std::fstream& out, const Gps_Ephemeris& gps_ep
             ret = total_gal_map.equal_range(prn);
             for (auto iter = ret.first; iter != ret.second; ++iter)
                 {
-                    lineObs += rightJustify(asString(iter->second.Pseudorange_m, 3), 14);
-
-                    // Loss of lock indicator (LLI)
-                    int32_t lli = 0;  // Include in the observation!!
-                    if (lli == 0)
-                        {
-                            lineObs += std::string(1, ' ');
-                        }
-                    // else
-                    //    {
-                    //        lineObs += rightJustify(asString<int16_t>(lli), 1);
-                    //    }
-
-                    // Signal Strength Indicator (SSI)
-                    const int32_t ssi = Rinex_Printer::signalStrength(iter->second.CN0_dB_hz);
-                    lineObs += rightJustify(asString<int32_t>(ssi), 1);
-
-                    // Galileo CARRIER PHASE
-                    lineObs += rightJustify(asString(iter->second.Carrier_phase_rads / (TWO_PI), 3), 14);
-                    if (lli == 0)
-                        {
-                            lineObs += std::string(1, ' ');
-                        }
-                    // else
-                    //    {
-                    //        lineObs += rightJustify(asString<int16_t>(lli), 1);
-                    //    }
-                    lineObs += rightJustify(asString<int32_t>(ssi), 1);
-
-                    // Galileo  DOPPLER
-                    lineObs += rightJustify(asString(iter->second.Carrier_Doppler_hz, 3), 14);
-                    if (lli == 0)
-                        {
-                            lineObs += std::string(1, ' ');
-                        }
-                    // else
-                    //    {
-                    //        lineObs += rightJustify(asString<int16_t>(lli), 1);
-                    //    }
-                    lineObs += rightJustify(asString<int32_t>(ssi), 1);
-
-                    // Galileo SIGNAL STRENGTH
-                    lineObs += rightJustify(asString(iter->second.CN0_dB_hz, 3), 14);
+                    add_obs_sat_record_line(iter->second, lineObs, false);
                 }
 
             if (lineObs.size() < 80)
@@ -6623,49 +5982,12 @@ void Rinex_Printer::log_rinex_obs(std::fstream& out, const Gps_CNAV_Ephemeris& e
             ret = total_gps_map.equal_range(prn);
             for (auto iter = ret.first; iter != ret.second; ++iter)
                 {
-                    lineObs += rightJustify(asString(iter->second.Pseudorange_m, 3), 14);
+                    add_obs_sat_record_line(iter->second, lineObs, false);
+                }
 
-                    // Loss of lock indicator (LLI)
-                    int32_t lli = 0;  // Include in the observation!!
-                    if (lli == 0)
-                        {
-                            lineObs += std::string(1, ' ');
-                        }
-                    // else
-                    //    {
-                    //        lineObs += rightJustify(asString<int16_t>(lli), 1);
-                    //    }
-
-                    // Signal Strength Indicator (SSI)
-                    const int32_t ssi = Rinex_Printer::signalStrength(iter->second.CN0_dB_hz);
-                    lineObs += rightJustify(asString<int32_t>(ssi), 1);
-
-                    // CARRIER PHASE
-                    lineObs += rightJustify(asString(iter->second.Carrier_phase_rads / (TWO_PI), 3), 14);
-                    if (lli == 0)
-                        {
-                            lineObs += std::string(1, ' ');
-                        }
-                    // else
-                    //    {
-                    //        lineObs += rightJustify(asString<int16_t>(lli), 1);
-                    //    }
-                    lineObs += rightJustify(asString<int32_t>(ssi), 1);
-
-                    //  DOPPLER
-                    lineObs += rightJustify(asString(iter->second.Carrier_Doppler_hz, 3), 14);
-                    if (lli == 0)
-                        {
-                            lineObs += std::string(1, ' ');
-                        }
-                    // else
-                    //    {
-                    //        lineObs += rightJustify(asString<int16_t>(lli), 1);
-                    //    }
-                    lineObs += rightJustify(asString<int32_t>(ssi), 1);
-
-                    // SIGNAL STRENGTH
-                    lineObs += rightJustify(asString(iter->second.CN0_dB_hz, 3), 14);
+            if (lineObs.size() < 80)
+                {
+                    lineObs += std::string(80 - lineObs.size(), ' ');
                 }
 
             out << lineObs << '\n';
@@ -6683,52 +6005,14 @@ void Rinex_Printer::log_rinex_obs(std::fstream& out, const Gps_CNAV_Ephemeris& e
             ret = total_gal_map.equal_range(prn);
             for (auto iter = ret.first; iter != ret.second; ++iter)
                 {
-                    lineObs += rightJustify(asString(iter->second.Pseudorange_m, 3), 14);
-
-                    // Loss of lock indicator (LLI)
-                    int32_t lli = 0;  // Include in the observation!!
-                    if (lli == 0)
-                        {
-                            lineObs += std::string(1, ' ');
-                        }
-                    // else
-                    //    {
-                    //        lineObs += rightJustify(asString<int16_t>(lli), 1);
-                    //    }
-
-                    // Signal Strength Indicator (SSI)
-                    const int32_t ssi = Rinex_Printer::signalStrength(iter->second.CN0_dB_hz);
-                    lineObs += rightJustify(asString<int32_t>(ssi), 1);
-
-                    // Galileo CARRIER PHASE
-                    lineObs += rightJustify(asString(iter->second.Carrier_phase_rads / (TWO_PI), 3), 14);
-                    if (lli == 0)
-                        {
-                            lineObs += std::string(1, ' ');
-                        }
-                    // else
-                    //    {
-                    //        lineObs += rightJustify(asString<int16_t>(lli), 1);
-                    //    }
-                    lineObs += rightJustify(asString<int32_t>(ssi), 1);
-
-                    // Galileo  DOPPLER
-                    lineObs += rightJustify(asString(iter->second.Carrier_Doppler_hz, 3), 14);
-                    if (lli == 0)
-                        {
-                            lineObs += std::string(1, ' ');
-                        }
-                    // else
-                    //    {
-                    //        lineObs += rightJustify(asString<int16_t>(lli), 1);
-                    //    }
-                    lineObs += rightJustify(asString<int32_t>(ssi), 1);
-
-                    // Galileo SIGNAL STRENGTH
-                    lineObs += rightJustify(asString(iter->second.CN0_dB_hz, 3), 14);
+                    add_obs_sat_record_line(iter->second, lineObs, false);
                 }
 
-            // if (lineObs.size() < 80) lineObs += std::string(80 - lineObs.size(), ' ');
+            if (lineObs.size() < 80)
+                {
+                    lineObs += std::string(80 - lineObs.size(), ' ');
+                }
+
             out << lineObs << '\n';
         }
 }
@@ -6904,49 +6188,12 @@ void Rinex_Printer::log_rinex_obs(std::fstream& out, const Gps_Ephemeris& gps_ep
                             lineObs += std::string(62, ' ');
                         }
 
-                    lineObs += rightJustify(asString(iter->second.Pseudorange_m, 3), 14);
+                    add_obs_sat_record_line(iter->second, lineObs, false);
+                }
 
-                    // Loss of lock indicator (LLI)
-                    int32_t lli = 0;  // Include in the observation!!
-                    if (lli == 0)
-                        {
-                            lineObs += std::string(1, ' ');
-                        }
-                    // else
-                    //    {
-                    //        lineObs += rightJustify(asString<int16_t>(lli), 1);
-                    //    }
-
-                    // Signal Strength Indicator (SSI)
-                    const int32_t ssi = Rinex_Printer::signalStrength(iter->second.CN0_dB_hz);
-                    lineObs += rightJustify(asString<int32_t>(ssi), 1);
-
-                    // CARRIER PHASE
-                    lineObs += rightJustify(asString(iter->second.Carrier_phase_rads / (TWO_PI), 3), 14);
-                    if (lli == 0)
-                        {
-                            lineObs += std::string(1, ' ');
-                        }
-                    // else
-                    //    {
-                    //        lineObs += rightJustify(asString<int16_t>(lli), 1);
-                    //    }
-                    lineObs += rightJustify(asString<int32_t>(ssi), 1);
-
-                    //  DOPPLER
-                    lineObs += rightJustify(asString(iter->second.Carrier_Doppler_hz, 3), 14);
-                    if (lli == 0)
-                        {
-                            lineObs += std::string(1, ' ');
-                        }
-                    // else
-                    //    {
-                    //        lineObs += rightJustify(asString<int16_t>(lli), 1);
-                    //    }
-                    lineObs += rightJustify(asString<int32_t>(ssi), 1);
-
-                    // SIGNAL STRENGTH
-                    lineObs += rightJustify(asString(iter->second.CN0_dB_hz, 3), 14);
+            if (lineObs.size() < 80)
+                {
+                    lineObs += std::string(80 - lineObs.size(), ' ');
                 }
 
             out << lineObs << '\n';
@@ -6964,52 +6211,14 @@ void Rinex_Printer::log_rinex_obs(std::fstream& out, const Gps_Ephemeris& gps_ep
             ret = total_gal_map.equal_range(prn);
             for (auto iter = ret.first; iter != ret.second; ++iter)
                 {
-                    lineObs += rightJustify(asString(iter->second.Pseudorange_m, 3), 14);
-
-                    // Loss of lock indicator (LLI)
-                    int32_t lli = 0;  // Include in the observation!!
-                    if (lli == 0)
-                        {
-                            lineObs += std::string(1, ' ');
-                        }
-                    // else
-                    //    {
-                    //        lineObs += rightJustify(asString<int16_t>(lli), 1);
-                    //    }
-
-                    // Signal Strength Indicator (SSI)
-                    const int32_t ssi = Rinex_Printer::signalStrength(iter->second.CN0_dB_hz);
-                    lineObs += rightJustify(asString<int32_t>(ssi), 1);
-
-                    // Galileo CARRIER PHASE
-                    lineObs += rightJustify(asString(iter->second.Carrier_phase_rads / (TWO_PI), 3), 14);
-                    if (lli == 0)
-                        {
-                            lineObs += std::string(1, ' ');
-                        }
-                    // else
-                    //    {
-                    //        lineObs += rightJustify(asString<int16_t>(lli), 1);
-                    //    }
-                    lineObs += rightJustify(asString<int32_t>(ssi), 1);
-
-                    // Galileo  DOPPLER
-                    lineObs += rightJustify(asString(iter->second.Carrier_Doppler_hz, 3), 14);
-                    if (lli == 0)
-                        {
-                            lineObs += std::string(1, ' ');
-                        }
-                    // else
-                    //    {
-                    //        lineObs += rightJustify(asString<int16_t>(lli), 1);
-                    //    }
-                    lineObs += rightJustify(asString<int32_t>(ssi), 1);
-
-                    // Galileo SIGNAL STRENGTH
-                    lineObs += rightJustify(asString(iter->second.CN0_dB_hz, 3), 14);
+                    add_obs_sat_record_line(iter->second, lineObs, false);
                 }
 
-            // if (lineObs.size() < 80) lineObs += std::string(80 - lineObs.size(), ' ');
+            if (lineObs.size() < 80)
+                {
+                    lineObs += std::string(80 - lineObs.size(), ' ');
+                }
+
             out << lineObs << '\n';
         }
 }
@@ -7103,37 +6312,7 @@ void Rinex_Printer::log_rinex_obs(std::fstream& out, const Beidou_Dnav_Ephemeris
             const auto ret = total_map.equal_range(available_prn);
             for (auto iter = ret.first; iter != ret.second; ++iter)
                 {
-                    lineObs += rightJustify(asString(iter->second.Pseudorange_m, 3), 14);
-
-                    // Loss of lock indicator (LLI)
-                    int32_t lli = 0;  // Include in the observation!!
-                    if (lli == 0)
-                        {
-                            lineObs += std::string(1, ' ');
-                        }
-
-                    // Signal Strength Indicator (SSI)
-                    const int32_t ssi = Rinex_Printer::signalStrength(iter->second.CN0_dB_hz);
-                    lineObs += rightJustify(asString<int32_t>(ssi), 1);
-
-                    // CARRIER PHASE
-                    lineObs += rightJustify(asString(iter->second.Carrier_phase_rads / (TWO_PI), 3), 14);
-                    if (lli == 0)
-                        {
-                            lineObs += std::string(1, ' ');
-                        }
-                    lineObs += rightJustify(asString<int32_t>(ssi), 1);
-
-                    //  DOPPLER
-                    lineObs += rightJustify(asString(iter->second.Carrier_Doppler_hz, 3), 14);
-                    if (lli == 0)
-                        {
-                            lineObs += std::string(1, ' ');
-                        }
-                    lineObs += rightJustify(asString<int32_t>(ssi), 1);
-
-                    //  SIGNAL STRENGTH
-                    lineObs += rightJustify(asString(iter->second.CN0_dB_hz, 3), 14);
+                    add_obs_sat_record_line(iter->second, lineObs, false);
                 }
 
             if (lineObs.size() < 80)
@@ -7297,12 +6476,6 @@ void Rinex_Printer::to_date_time(int32_t gps_week, int32_t gps_tow, int& year, i
 //    out << line3.str() << '\n';
 // }
 
-
-int32_t Rinex_Printer::signalStrength(double snr) const
-{
-    auto ss = static_cast<int32_t>(std::min(std::max(static_cast<int32_t>(floor(snr / 6)), 1), 9));
-    return ss;
-}
 
 boost::posix_time::ptime Rinex_Printer::compute_UTC_time(const Gps_Navigation_Message& nav_msg) const
 {

--- a/src/algorithms/PVT/libs/rinex_printer.h
+++ b/src/algorithms/PVT/libs/rinex_printer.h
@@ -88,7 +88,8 @@ public:
      */
     explicit Rinex_Printer(int version = 0,
         const std::string& base_path = ".",
-        const std::string& base_name = "-");
+        const std::string& base_name = "-",
+        bool pre_2009_file = false);
 
     /*!
      * \brief Destructor. Removes created files if empty.
@@ -140,11 +141,6 @@ public:
         const std::map<int32_t, Beidou_Dnav_Ephemeris>& new_bds_eph);
 
     /*!
-     * \brief Set processing for signals older than 2009
-     */
-    void set_pre_2009_file(bool pre_2009_file);
-
-    /*!
      * \brief Returns true is the RINEX file headers are already written
      */
     inline bool is_rinex_header_written() const
@@ -173,7 +169,8 @@ private:
     // Not the best, but reorder params to select the correct constructor
     explicit Rinex_Printer(const std::string& base_name,
         const std::string& base_rinex_path,
-        int version);
+        int version,
+        bool pre_2009_file);
 
     /*
      * Generates the GPS Observation data header

--- a/src/algorithms/PVT/libs/rinex_printer.h
+++ b/src/algorithms/PVT/libs/rinex_printer.h
@@ -39,15 +39,12 @@
 #define GNSS_SDR_RINEX_PRINTER_H
 
 #include <boost/date_time/posix_time/posix_time.hpp>
-#include <cstdint>        // for int32_t
-#include <cstdlib>        // for strtol, strtod
-#include <fstream>        // for fstream
-#include <iomanip>        // for setprecision
-#include <map>            // for map
-#include <sstream>        // for stringstream
-#include <string>         // for string
-#include <unordered_map>  // for unordered_map
-#include <vector>         // for vector
+#include <cstdint>  // for int32_t
+#include <cstdlib>  // for strtol, strtod
+#include <fstream>  // for fstream
+#include <map>      // for map
+#include <string>   // for string
+#include <vector>   // for vector
 
 
 /** \addtogroup PVT
@@ -731,7 +728,7 @@ private:
     int d_version;  // RINEX version (2 for 2.10/2.11 and 3 for 3.01)
     bool d_rinex_header_updated;
     bool d_rinex_header_written;
-    bool d_pre_2009_file;
+    const bool d_pre_2009_file;
 };
 
 

--- a/src/algorithms/PVT/libs/rinex_printer.h
+++ b/src/algorithms/PVT/libs/rinex_printer.h
@@ -367,8 +367,7 @@ private:
     void log_rinex_obs(std::fstream& out,
         const Glonass_Gnav_Ephemeris& eph,
         double obs_time,
-        const std::map<int32_t, Gnss_Synchro>& observables,
-        const std::string& glonass_bands = "1C") const;
+        const std::map<int32_t, Gnss_Synchro>& observables) const;
 
     /*
      * Writes Mixed GPS L1 C/A - GLONASS observables into the RINEX file
@@ -460,8 +459,7 @@ private:
     void rinex_nav_header(std::fstream& out,
         const Galileo_Iono& galileo_iono,
         const Galileo_Utc_Model& galileo_utc_model,
-        const Glonass_Gnav_Utc_Model& glonass_gnav_utc_model,
-        const Glonass_Gnav_Almanac& glonass_gnav_almanac) const;
+        const Glonass_Gnav_Utc_Model& glonass_gnav_utc_model) const;
 
     /*
      * Generates the Mixed (GPS L1 C/A/GLONASS L1, L2) Navigation Data header
@@ -470,8 +468,7 @@ private:
         const Gps_Iono& gps_iono,
         const Gps_Utc_Model& gps_utc_model,
         const Gps_Ephemeris& eph,
-        const Glonass_Gnav_Utc_Model& glonass_gnav_utc_model,
-        const Glonass_Gnav_Almanac& glonass_gnav_almanac);
+        const Glonass_Gnav_Utc_Model& glonass_gnav_utc_model);
 
     /*
      * Generates the Mixed (GPS L2C C/A/GLONASS L1, L2) Navigation Data header
@@ -479,8 +476,7 @@ private:
     void rinex_nav_header(std::fstream& out,
         const Gps_CNAV_Iono& gps_iono,
         const Gps_CNAV_Utc_Model& gps_utc_model,
-        const Glonass_Gnav_Utc_Model& glonass_gnav_utc_model,
-        const Glonass_Gnav_Almanac& glonass_gnav_almanac);
+        const Glonass_Gnav_Utc_Model& glonass_gnav_utc_model);
 
     /*
      * Generates the BDS B1I or B3I Navigation Data header
@@ -678,27 +674,23 @@ private:
         const Galileo_Utc_Model& utc_model) const;
 
     void update_nav_header(std::fstream& out,
-        const Glonass_Gnav_Utc_Model& glonass_gnav_utc_model,
-        const Glonass_Gnav_Almanac& glonass_gnav_almanac) const;
+        const Glonass_Gnav_Utc_Model& glonass_gnav_utc_model) const;
 
     void update_nav_header(std::fstream& out,
         const Gps_Iono& gps_iono,
         const Gps_Utc_Model& gps_utc,
         const Gps_Ephemeris& eph,
-        const Glonass_Gnav_Utc_Model& glonass_gnav_utc_model,
-        const Glonass_Gnav_Almanac& glonass_gnav_almanac) const;
+        const Glonass_Gnav_Utc_Model& glonass_gnav_utc_model) const;
 
     void update_nav_header(std::fstream& out,
         const Gps_CNAV_Iono& gps_iono,
         const Gps_CNAV_Utc_Model& gps_utc_model,
-        const Glonass_Gnav_Utc_Model& glonass_gnav_utc_model,
-        const Glonass_Gnav_Almanac& glonass_gnav_almanac) const;
+        const Glonass_Gnav_Utc_Model& glonass_gnav_utc_model) const;
 
     void update_nav_header(std::fstream& out,
         const Galileo_Iono& galileo_iono,
         const Galileo_Utc_Model& galileo_utc_model,
-        const Glonass_Gnav_Utc_Model& glonass_gnav_utc_model,
-        const Glonass_Gnav_Almanac& glonass_gnav_almanac) const;
+        const Glonass_Gnav_Utc_Model& glonass_gnav_utc_model) const;
 
     void update_nav_header(std::fstream& out,
         const Beidou_Dnav_Utc_Model& utc_model,

--- a/src/algorithms/PVT/libs/rinex_printer.h
+++ b/src/algorithms/PVT/libs/rinex_printer.h
@@ -693,11 +693,6 @@ private:
     void update_obs_header(std::fstream& out, const std::string& leap_second_line) const;
 
     /*
-     * Generation of RINEX signal strength indicators
-     */
-    int signalStrength(double snr) const;
-
-    /*
      * Generates the data for the PGM / RUN BY / DATE line
      */
     std::string getLocalTime() const;


### PR DESCRIPTION
- Change iterator for loops to range-for loops
- Add function `add_svclk_to_line`, `get_obs_epoch_record_lines` and `add_obs_sat_record_line` to remove duplicated code
- Remove `if` that do nothing
- Pass `pre_2009_file` in constructor