### PR TITLE
Cleanup RINEX file management

### DIFF
--- a/src/algorithms/PVT/gnuradio_blocks/rtklib_pvt_gs.cc
+++ b/src/algorithms/PVT/gnuradio_blocks/rtklib_pvt_gs.cc
@@ -412,7 +412,7 @@ rtklib_pvt_gs::rtklib_pvt_gs(uint32_t nchannels,
     // initialize RINEX printer
     if (d_rinex_output_enabled)
         {
-            d_rp = std::make_unique<Rinex_Printer>(d_rinex_version, conf_.rinex_output_path, conf_.rinex_name, conf_.pre_2009_file);
+            d_rp = std::make_unique<Rinex_Printer>(d_signal_enabled_flags, d_rinex_version, conf_.rinex_output_path, conf_.rinex_name, conf_.pre_2009_file);
         }
     else
         {
@@ -1217,24 +1217,11 @@ void rtklib_pvt_gs::msg_handler_telemetry(const pmt::pmt_t& msg)
                     // update/insert new ephemeris record to the global ephemeris map
                     if (d_rinex_output_enabled && d_rp->is_rinex_header_written())  // The header is already written, we can now log the navigation message data
                         {
-                            bool new_annotation = false;
-                            if (d_internal_pvt_solver->gps_ephemeris_map.find(gps_eph->PRN) == d_internal_pvt_solver->gps_ephemeris_map.cend())
+                            const auto eph_it = d_internal_pvt_solver->gps_ephemeris_map.find(gps_eph->PRN);
+
+                            if (eph_it == d_internal_pvt_solver->gps_ephemeris_map.cend() || eph_it->second.toe != gps_eph->toe)
                                 {
-                                    new_annotation = true;
-                                }
-                            else
-                                {
-                                    if (d_internal_pvt_solver->gps_ephemeris_map[gps_eph->PRN].toe != gps_eph->toe)
-                                        {
-                                            new_annotation = true;
-                                        }
-                                }
-                            if (new_annotation == true)
-                                {
-                                    // New record!
-                                    std::map<int32_t, Gps_Ephemeris> new_eph;
-                                    new_eph[gps_eph->PRN] = *gps_eph;
-                                    d_rp->log_rinex_nav_gps_nav(d_signal_enabled_flags, new_eph);
+                                    d_rp->log_rinex_nav_gps_nav({{gps_eph->PRN, *gps_eph}});  // New record!
                                 }
                         }
                     d_internal_pvt_solver->gps_ephemeris_map[gps_eph->PRN] = *gps_eph;
@@ -1285,24 +1272,11 @@ void rtklib_pvt_gs::msg_handler_telemetry(const pmt::pmt_t& msg)
                     // update/insert new ephemeris record to the global ephemeris map
                     if (d_rinex_output_enabled && d_rp->is_rinex_header_written())  // The header is already written, we can now log the navigation message data
                         {
-                            bool new_annotation = false;
-                            if (d_internal_pvt_solver->gps_cnav_ephemeris_map.find(gps_cnav_ephemeris->PRN) == d_internal_pvt_solver->gps_cnav_ephemeris_map.cend())
+                            const auto eph_it = d_internal_pvt_solver->gps_cnav_ephemeris_map.find(gps_cnav_ephemeris->PRN);
+
+                            if (eph_it == d_internal_pvt_solver->gps_cnav_ephemeris_map.cend() || eph_it->second.toe1 != gps_cnav_ephemeris->toe1)
                                 {
-                                    new_annotation = true;
-                                }
-                            else
-                                {
-                                    if (d_internal_pvt_solver->gps_cnav_ephemeris_map[gps_cnav_ephemeris->PRN].toe1 != gps_cnav_ephemeris->toe1)
-                                        {
-                                            new_annotation = true;
-                                        }
-                                }
-                            if (new_annotation == true)
-                                {
-                                    // New record!
-                                    std::map<int32_t, Gps_CNAV_Ephemeris> new_cnav_eph;
-                                    new_cnav_eph[gps_cnav_ephemeris->PRN] = *gps_cnav_ephemeris;
-                                    d_rp->log_rinex_nav_gps_cnav(d_signal_enabled_flags, new_cnav_eph);
+                                    d_rp->log_rinex_nav_gps_cnav({{gps_cnav_ephemeris->PRN, *gps_cnav_ephemeris}});  // New record!
                                 }
                         }
                     d_internal_pvt_solver->gps_cnav_ephemeris_map[gps_cnav_ephemeris->PRN] = *gps_cnav_ephemeris;
@@ -1377,28 +1351,11 @@ void rtklib_pvt_gs::msg_handler_telemetry(const pmt::pmt_t& msg)
                     // update/insert new ephemeris record to the global ephemeris map
                     if (d_rinex_output_enabled && d_rp->is_rinex_header_written())  // The header is already written, we can now log the navigation message data
                         {
-                            bool new_annotation = false;
-                            if (d_internal_pvt_solver->galileo_ephemeris_map.find(galileo_eph->PRN) == d_internal_pvt_solver->galileo_ephemeris_map.cend())
+                            const auto eph_it = d_internal_pvt_solver->galileo_ephemeris_map.find(galileo_eph->PRN);
+
+                            if ((eph_it == d_internal_pvt_solver->galileo_ephemeris_map.cend() || eph_it->second.toe != galileo_eph->toe) && galileo_eph->WN != 0 && galileo_eph->PRN <= 36)
                                 {
-                                    new_annotation = true;
-                                }
-                            else
-                                {
-                                    if (d_internal_pvt_solver->galileo_ephemeris_map[galileo_eph->PRN].toe != galileo_eph->toe)
-                                        {
-                                            new_annotation = true;
-                                        }
-                                }
-                            if (galileo_eph->WN == 0 || galileo_eph->PRN > 36)
-                                {
-                                    new_annotation = false;
-                                }
-                            if (new_annotation == true)
-                                {
-                                    // New record!
-                                    std::map<int32_t, Galileo_Ephemeris> new_gal_eph;
-                                    new_gal_eph[galileo_eph->PRN] = *galileo_eph;
-                                    d_rp->log_rinex_nav_gal_nav(d_signal_enabled_flags, new_gal_eph);
+                                    d_rp->log_rinex_nav_gal_nav({{galileo_eph->PRN, *galileo_eph}});  // New record!
                                 }
                         }
                     d_internal_pvt_solver->galileo_ephemeris_map[galileo_eph->PRN] = *galileo_eph;
@@ -1504,24 +1461,11 @@ void rtklib_pvt_gs::msg_handler_telemetry(const pmt::pmt_t& msg)
                     // update/insert new ephemeris record to the global ephemeris map
                     if (d_rinex_output_enabled && d_rp->is_rinex_header_written())  // The header is already written, we can now log the navigation message data
                         {
-                            bool new_annotation = false;
-                            if (d_internal_pvt_solver->glonass_gnav_ephemeris_map.find(glonass_gnav_eph->PRN) == d_internal_pvt_solver->glonass_gnav_ephemeris_map.cend())
+                            const auto eph_it = d_internal_pvt_solver->glonass_gnav_ephemeris_map.find(glonass_gnav_eph->PRN);
+
+                            if (eph_it == d_internal_pvt_solver->glonass_gnav_ephemeris_map.cend() || eph_it->second.d_t_b != glonass_gnav_eph->d_t_b)
                                 {
-                                    new_annotation = true;
-                                }
-                            else
-                                {
-                                    if (d_internal_pvt_solver->glonass_gnav_ephemeris_map[glonass_gnav_eph->PRN].d_t_b != glonass_gnav_eph->d_t_b)
-                                        {
-                                            new_annotation = true;
-                                        }
-                                }
-                            if (new_annotation == true)
-                                {
-                                    // New record!
-                                    std::map<int32_t, Glonass_Gnav_Ephemeris> new_glo_eph;
-                                    new_glo_eph[glonass_gnav_eph->PRN] = *glonass_gnav_eph;
-                                    d_rp->log_rinex_nav_glo_gnav(d_signal_enabled_flags, new_glo_eph);
+                                    d_rp->log_rinex_nav_glo_gnav({{glonass_gnav_eph->PRN, *glonass_gnav_eph}});  // New record!
                                 }
                         }
                     d_internal_pvt_solver->glonass_gnav_ephemeris_map[glonass_gnav_eph->PRN] = *glonass_gnav_eph;
@@ -1567,24 +1511,11 @@ void rtklib_pvt_gs::msg_handler_telemetry(const pmt::pmt_t& msg)
                     // update/insert new ephemeris record to the global ephemeris map
                     if (d_rinex_output_enabled && d_rp->is_rinex_header_written())  // The header is already written, we can now log the navigation message data
                         {
-                            bool new_annotation = false;
-                            if (d_internal_pvt_solver->beidou_dnav_ephemeris_map.find(bds_dnav_eph->PRN) == d_internal_pvt_solver->beidou_dnav_ephemeris_map.cend())
+                            const auto eph_it = d_internal_pvt_solver->beidou_dnav_ephemeris_map.find(bds_dnav_eph->PRN);
+
+                            if (eph_it == d_internal_pvt_solver->beidou_dnav_ephemeris_map.cend() || eph_it->second.toc != bds_dnav_eph->toc)
                                 {
-                                    new_annotation = true;
-                                }
-                            else
-                                {
-                                    if (d_internal_pvt_solver->beidou_dnav_ephemeris_map[bds_dnav_eph->PRN].toc != bds_dnav_eph->toc)
-                                        {
-                                            new_annotation = true;
-                                        }
-                                }
-                            if (new_annotation == true)
-                                {
-                                    // New record!
-                                    std::map<int32_t, Beidou_Dnav_Ephemeris> new_bds_eph;
-                                    new_bds_eph[bds_dnav_eph->PRN] = *bds_dnav_eph;
-                                    d_rp->log_rinex_nav_bds_dnav(d_signal_enabled_flags, new_bds_eph);
+                                    d_rp->log_rinex_nav_bds_dnav({{bds_dnav_eph->PRN, *bds_dnav_eph}});  // New record!
                                 }
                         }
                     d_internal_pvt_solver->beidou_dnav_ephemeris_map[bds_dnav_eph->PRN] = *bds_dnav_eph;
@@ -2493,7 +2424,7 @@ int rtklib_pvt_gs::work(int noutput_items, gr_vector_const_void_star& input_item
                                         }
                                     if (d_rinex_output_enabled)
                                         {
-                                            d_rp->print_rinex_annotation(d_user_pvt_solver.get(), d_gnss_observables_map, d_rx_time, d_signal_enabled_flags, flag_write_RINEX_obs_output);
+                                            d_rp->print_rinex_annotation(d_user_pvt_solver.get(), d_gnss_observables_map, d_rx_time, flag_write_RINEX_obs_output);
                                         }
                                     if (d_rtcm_enabled)
                                         {

--- a/src/algorithms/PVT/gnuradio_blocks/rtklib_pvt_gs.h
+++ b/src/algorithms/PVT/gnuradio_blocks/rtklib_pvt_gs.h
@@ -199,7 +199,7 @@ private:
     std::chrono::time_point<std::chrono::system_clock> d_start;
     std::chrono::time_point<std::chrono::system_clock> d_end;
 
-    std::string d_queue_name;
+    const std::string d_queue_name;
     std::string d_dump_filename;
     std::string d_xml_base_path;
     std::string d_local_time_str;
@@ -215,35 +215,35 @@ private:
     std::queue<GnssTime> d_TimeChannelTagTimestamps;
 
     boost::posix_time::time_duration d_utc_diff_time;
-    std::unique_ptr<Geohash> d_geohash;
+    const std::unique_ptr<Geohash> d_geohash;
 
-    size_t d_gps_ephemeris_sptr_type_hash_code;
-    size_t d_gps_iono_sptr_type_hash_code;
-    size_t d_gps_utc_model_sptr_type_hash_code;
-    size_t d_gps_cnav_ephemeris_sptr_type_hash_code;
-    size_t d_gps_cnav_iono_sptr_type_hash_code;
-    size_t d_gps_cnav_utc_model_sptr_type_hash_code;
-    size_t d_gps_almanac_sptr_type_hash_code;
-    size_t d_galileo_ephemeris_sptr_type_hash_code;
-    size_t d_galileo_iono_sptr_type_hash_code;
-    size_t d_galileo_utc_model_sptr_type_hash_code;
-    size_t d_galileo_almanac_helper_sptr_type_hash_code;
-    size_t d_galileo_almanac_sptr_type_hash_code;
-    size_t d_glonass_gnav_ephemeris_sptr_type_hash_code;
-    size_t d_glonass_gnav_utc_model_sptr_type_hash_code;
-    size_t d_glonass_gnav_almanac_sptr_type_hash_code;
-    size_t d_beidou_dnav_ephemeris_sptr_type_hash_code;
-    size_t d_beidou_dnav_iono_sptr_type_hash_code;
-    size_t d_beidou_dnav_utc_model_sptr_type_hash_code;
-    size_t d_beidou_dnav_almanac_sptr_type_hash_code;
-    size_t d_galileo_has_data_sptr_type_hash_code;
+    const size_t d_gps_ephemeris_sptr_type_hash_code;
+    const size_t d_gps_iono_sptr_type_hash_code;
+    const size_t d_gps_utc_model_sptr_type_hash_code;
+    const size_t d_gps_cnav_ephemeris_sptr_type_hash_code;
+    const size_t d_gps_cnav_iono_sptr_type_hash_code;
+    const size_t d_gps_cnav_utc_model_sptr_type_hash_code;
+    const size_t d_gps_almanac_sptr_type_hash_code;
+    const size_t d_galileo_ephemeris_sptr_type_hash_code;
+    const size_t d_galileo_iono_sptr_type_hash_code;
+    const size_t d_galileo_utc_model_sptr_type_hash_code;
+    const size_t d_galileo_almanac_helper_sptr_type_hash_code;
+    const size_t d_galileo_almanac_sptr_type_hash_code;
+    const size_t d_glonass_gnav_ephemeris_sptr_type_hash_code;
+    const size_t d_glonass_gnav_utc_model_sptr_type_hash_code;
+    const size_t d_glonass_gnav_almanac_sptr_type_hash_code;
+    const size_t d_beidou_dnav_ephemeris_sptr_type_hash_code;
+    const size_t d_beidou_dnav_iono_sptr_type_hash_code;
+    const size_t d_beidou_dnav_utc_model_sptr_type_hash_code;
+    const size_t d_beidou_dnav_almanac_sptr_type_hash_code;
+    const size_t d_galileo_has_data_sptr_type_hash_code;
 
-    double d_rinex_version;
+    const double d_rinex_version;
     double d_rx_time;
     uint64_t d_local_counter_ms;
     uint64_t d_timestamp_rx_clock_offset_correction_msg_ms;
 
-    int32_t d_rinexobs_rate_ms;
+    const int32_t d_rinexobs_rate_ms;
     int32_t d_rtcm_MT1045_rate_ms;  // Galileo Broadcast Ephemeris
     int32_t d_rtcm_MT1019_rate_ms;  // GPS Broadcast Ephemeris (orbits)
     int32_t d_rtcm_MT1020_rate_ms;  // GLONASS Broadcast Ephemeris (orbits)
@@ -251,24 +251,24 @@ private:
     int32_t d_rtcm_MT1087_rate_ms;  // GLONASS MSM7. The type 7 Multiple Signal Message format for the Russian GLONASS system
     int32_t d_rtcm_MT1097_rate_ms;  // Galileo MSM7. The type 7 Multiple Signal Message format for Europe’s Galileo system
     int32_t d_rtcm_MSM_rate_ms;
-    int32_t d_kml_rate_ms;
-    int32_t d_gpx_rate_ms;
-    int32_t d_geojson_rate_ms;
-    int32_t d_nmea_rate_ms;
-    int32_t d_an_rate_ms;
-    int32_t d_output_rate_ms;
-    int32_t d_display_rate_ms;
-    int32_t d_report_rate_ms;
-    int32_t d_max_obs_block_rx_clock_offset_ms;
+    const int32_t d_kml_rate_ms;
+    const int32_t d_gpx_rate_ms;
+    const int32_t d_geojson_rate_ms;
+    const int32_t d_nmea_rate_ms;
+    const int32_t d_an_rate_ms;
+    const int32_t d_output_rate_ms;
+    const int32_t d_display_rate_ms;
+    const int32_t d_report_rate_ms;
+    const int32_t d_max_obs_block_rx_clock_offset_ms;
 
-    uint32_t d_nchannels;
-    uint32_t d_signal_enabled_flags;
-    uint32_t d_observable_interval_ms;
+    const uint32_t d_nchannels;
+    const uint32_t d_signal_enabled_flags;
+    const uint32_t d_observable_interval_ms;
     uint32_t d_pvt_errors_counter;
 
     bool d_dump;
-    bool d_dump_mat;
-    bool d_rinex_output_enabled;
+    const bool d_dump_mat;
+    const bool d_rinex_output_enabled;
     bool d_geojson_output_enabled;
     bool d_gpx_output_enabled;
     bool d_kml_output_enabled;
@@ -276,16 +276,16 @@ private:
     bool d_rtcm_enabled;
     bool d_first_fix;
     bool d_xml_storage;
-    bool d_flag_monitor_pvt_enabled;
-    bool d_flag_monitor_ephemeris_enabled;
-    bool d_show_local_time_zone;
-    bool d_enable_rx_clock_correction;
+    const bool d_flag_monitor_pvt_enabled;
+    const bool d_flag_monitor_ephemeris_enabled;
+    const bool d_show_local_time_zone;
+    const bool d_enable_rx_clock_correction;
     bool d_enable_has_messages;
-    bool d_an_printer_enabled;
+    const bool d_an_printer_enabled;
     bool d_log_timetag;
-    bool d_use_has_corrections;
-    bool d_use_unhealthy_sats;
-    bool d_osnma_strict;
+    const bool d_use_has_corrections;
+    const bool d_use_unhealthy_sats;
+    const bool d_osnma_strict;
 };
 
 

--- a/src/algorithms/PVT/libs/rinex_printer.cc
+++ b/src/algorithms/PVT/libs/rinex_printer.cc
@@ -456,6 +456,49 @@ std::string getFilePath(const std::string& type, const std::string& base_name, c
 }
 
 
+std::string getNavFilePath(uint32_t signal_enabled_flags, int version, const std::string& base_name, const std::string& base_rinex_path)
+{
+    std::string type;
+    const Signal_Enabled_Flags flags(signal_enabled_flags);
+
+    const auto has_gps = flags.check_any_enabled(GPS_1C, GPS_2S, GPS_L5);
+    const auto has_galileo = flags.check_any_enabled(GAL_1B, GAL_E5a, GAL_E5b, GAL_E6);
+    const auto has_glonass = flags.check_any_enabled(GLO_1G, GLO_2G);
+    const auto has_beidou = flags.check_any_enabled(BDS_B1, BDS_B3);
+    const auto only_gps = has_gps && !(has_galileo || has_glonass || has_beidou);
+    const auto only_galileo = has_galileo && !(has_gps || has_glonass || has_beidou);
+    const auto only_glonass = has_glonass && !(has_gps || has_galileo || has_beidou);
+    const auto only_beidou = has_beidou && !(has_gps || has_galileo || has_glonass);
+
+    if (only_gps)
+        {
+            type = "RINEX_FILE_TYPE_GPS_NAV";
+        }
+    else if (only_galileo)
+        {
+            type = "RINEX_FILE_TYPE_GAL_NAV";
+        }
+    else if (only_glonass)
+        {
+            type = "RINEX_FILE_TYPE_GLO_NAV";
+        }
+    else if (only_beidou)
+        {
+            type = "RINEX_FILE_TYPE_BDS_NAV";
+        }
+    else if (version == 2)
+        {
+            type = "RINEX_FILE_TYPE_GPS_NAV";  // Will need one file for GPS and one for GlONASS
+        }
+    else
+        {
+            type = "RINEX_FILE_TYPE_MIXED_NAV";
+        }
+
+    return base_rinex_path + fs::path::preferred_separator + createFilename(type, base_name);
+}
+
+
 /*
  * (modified versions from GNSSTk https://github.com/SGL-UT/gnsstk)
  * If the string is bigger than length, truncate it from the right.
@@ -1812,48 +1855,64 @@ void update_nav_header_from_info(std::fstream& out, const std::string& filename,
     override_stream_with_new_data(out, filename, data, pos);
 }
 
+
+int get_version(uint32_t signal_enabled_flags, int version)
+{
+    if (version == 2)
+        {
+            const Signal_Enabled_Flags flags(signal_enabled_flags);
+
+            if (flags.check_only_enabled(GPS_1C) ||
+                flags.check_only_enabled(GLO_1G) ||
+                flags.check_only_enabled(GPS_1C, GLO_1G))
+                {
+                    return 2;
+                }
+
+            std::cout << "Changing RINEX version to 3.02, because version 2.11 is incompatible with signal selection.\n";
+        }
+
+    return 3;  // Only support version 2.11 and 3.02
+}
+
 }  // namespace
 
 
-Rinex_Printer::Rinex_Printer(int version,
+Rinex_Printer::Rinex_Printer(uint32_t signal_enabled_flags,
+    int version,
     const std::string& base_path,
     const std::string& base_name,
-    bool pre_2009_file) : Rinex_Printer(base_name, getAndCreateBaseRinexPath(base_path), version, pre_2009_file)
+    bool pre_2009_file) : Rinex_Printer(signal_enabled_flags, base_name, getAndCreateBaseRinexPath(base_path), version, pre_2009_file)
 {
 }
 
 
-Rinex_Printer::Rinex_Printer(const std::string& base_name,
+Rinex_Printer::Rinex_Printer(uint32_t signal_enabled_flags,
+    const std::string& base_name,
     const std::string& base_rinex_path,
     int version,
     bool pre_2009_file) : observationType(getObservationTypes()),
                           observationCode(getObservationCodes()),
-                          navfilename(getFilePath("RINEX_FILE_TYPE_GPS_NAV", base_name, base_rinex_path)),
-                          obsfilename(getFilePath("RINEX_FILE_TYPE_OBS", base_name, base_rinex_path)),
-                          sbsfilename(getFilePath("RINEX_FILE_TYPE_SBAS", base_name, base_rinex_path)),
-                          navGalfilename(getFilePath("RINEX_FILE_TYPE_GAL_NAV", base_name, base_rinex_path)),
-                          navGlofilename(getFilePath("RINEX_FILE_TYPE_GLO_NAV", base_name, base_rinex_path)),
-                          navBdsfilename(getFilePath("RINEX_FILE_TYPE_BDS_NAV", base_name, base_rinex_path)),
-                          navMixfilename(getFilePath("RINEX_FILE_TYPE_MIXED_NAV", base_name, base_rinex_path)),
+                          d_version(get_version(signal_enabled_flags, version)),
+                          d_stringVersion(d_version == 2 ? "2.11" : "3.02"),  // Only version 2.11 and 3.02
                           d_fake_cnav_iode(1),
                           d_rinex_header_updated(false),
                           d_rinex_header_written(false),
-                          d_pre_2009_file(pre_2009_file)
-
+                          d_pre_2009_file(pre_2009_file),
+                          d_signal_enabled_flags(signal_enabled_flags),
+                          navfilename(getNavFilePath(signal_enabled_flags, d_version, base_name, base_rinex_path)),
+                          obsfilename(getFilePath("RINEX_FILE_TYPE_OBS", base_name, base_rinex_path)),
+                          navGlofilename(getFilePath("RINEX_FILE_TYPE_GLO_NAV", base_name, base_rinex_path)),
+                          output_navfilename({navfilename})
 {
-    std::map<std::string, std::fstream&> fileMap = {
+    const std::map<std::string, std::fstream&> fileMap = {
         {navfilename, navFile},
         {obsfilename, obsFile},
-        {sbsfilename, sbsFile},
-        {navGalfilename, navGalFile},
-        {navMixfilename, navMixFile},
-        {navGlofilename, navGloFile},
-        {navBdsfilename, navBdsFile},
-    };
+        {navGlofilename, navGloFile}};
 
     bool all_open = true;
 
-    for (auto& it : fileMap)
+    for (const auto& it : fileMap)
         {
             it.second.open(it.first, std::ios::out | std::ios::in | std::ios::app);
             all_open = all_open && it.second.is_open();
@@ -1863,17 +1922,6 @@ Rinex_Printer::Rinex_Printer(const std::string& base_name,
         {
             std::cout << "RINEX files cannot be saved. Wrong permissions?\n";
         }
-
-    if (version == 2)
-        {
-            d_version = 2;
-            d_stringVersion = "2.11";
-        }
-    else
-        {
-            d_version = 3;
-            d_stringVersion = "3.02";
-        }
 }
 
 
@@ -1881,15 +1929,10 @@ Rinex_Printer::~Rinex_Printer()
 {
     DLOG(INFO) << "RINEX printer destructor called.";
 
-    std::map<std::string, std::fstream&> fileMap = {
+    const std::map<std::string, std::fstream&> fileMap = {
         {navfilename, navFile},
         {obsfilename, obsFile},
-        {sbsfilename, sbsFile},
-        {navGalfilename, navGalFile},
-        {navMixfilename, navMixFile},
-        {navGlofilename, navGloFile},
-        {navBdsfilename, navBdsFile},
-    };
+        {navGlofilename, navGloFile}};
 
     std::map<std::string, decltype(navFile.tellp())> filePosMap;
 
@@ -1900,7 +1943,7 @@ Rinex_Printer::~Rinex_Printer()
 
     try
         {
-            for (auto& it : fileMap)
+            for (const auto& it : fileMap)
                 {
                     it.second.close();
                 }
@@ -1927,7 +1970,6 @@ Rinex_Printer::~Rinex_Printer()
 void Rinex_Printer::print_rinex_annotation(const Rtklib_Solver* pvt_solver,
     const std::map<int, Gnss_Synchro>& gnss_observables_map,
     double rx_time,
-    uint32_t signal_enabled_flags,
     bool flag_write_RINEX_obs_output)
 {
     const auto galileo_ephemeris_iter = pvt_solver->galileo_ephemeris_map.cbegin();
@@ -1936,7 +1978,7 @@ void Rinex_Printer::print_rinex_annotation(const Rtklib_Solver* pvt_solver,
     const auto glonass_gnav_ephemeris_iter = pvt_solver->glonass_gnav_ephemeris_map.cbegin();
     const auto beidou_dnav_ephemeris_iter = pvt_solver->beidou_dnav_ephemeris_map.cbegin();
 
-    const Signal_Enabled_Flags flags(signal_enabled_flags);
+    const Signal_Enabled_Flags flags(d_signal_enabled_flags);
     const auto signal = enabled_signal_flags_to_string(flags);
     const auto has_gps = flags.check_any_enabled(GPS_1C, GPS_2S, GPS_L5);
     const auto has_galileo = flags.check_any_enabled(GAL_1B, GAL_E5a, GAL_E5b, GAL_E6);
@@ -1960,36 +2002,31 @@ void Rinex_Printer::print_rinex_annotation(const Rtklib_Solver* pvt_solver,
                 {
                     rinex_obs_header(obsFile, gps_ephemeris_iter->second, rx_time);
                     rinex_nav_header(navFile, pvt_solver->gps_iono, pvt_solver->gps_utc_model, gps_ephemeris_iter->second);
-                    output_navfilename.push_back(navfilename);
                     log_rinex_nav(navFile, pvt_solver->gps_ephemeris_map);
                 }
             else if ((flags.check_only_enabled(GPS_2S) || flags.check_only_enabled(GPS_L5)) && has_gps_cnav_eph)
                 {
                     rinex_obs_header(obsFile, gps_cnav_ephemeris_iter->second, rx_time, signal);
                     rinex_nav_header(navFile, pvt_solver->gps_cnav_iono, pvt_solver->gps_cnav_utc_model);
-                    output_navfilename.push_back(navfilename);
                     log_rinex_nav(navFile, pvt_solver->gps_cnav_ephemeris_map);
                 }
             else if (only_galileo && has_galileo_eph)
                 {
                     rinex_obs_header(obsFile, galileo_ephemeris_iter->second, rx_time, signal);
-                    rinex_nav_header(navGalFile, pvt_solver->galileo_iono, pvt_solver->galileo_utc_model);
-                    output_navfilename.push_back(navGalfilename);
-                    log_rinex_nav(navGalFile, pvt_solver->galileo_ephemeris_map);
+                    rinex_nav_header(navFile, pvt_solver->galileo_iono, pvt_solver->galileo_utc_model);
+                    log_rinex_nav(navFile, pvt_solver->galileo_ephemeris_map);
                 }
             else if (only_glonass && has_glonass_eph)
                 {
                     rinex_obs_header(obsFile, glonass_gnav_ephemeris_iter->second, rx_time, signal);
-                    rinex_nav_header(navGloFile, pvt_solver->glonass_gnav_utc_model, glonass_gnav_ephemeris_iter->second);
-                    output_navfilename.push_back(navGlofilename);
-                    log_rinex_nav(navGloFile, pvt_solver->glonass_gnav_ephemeris_map);
+                    rinex_nav_header(navFile, pvt_solver->glonass_gnav_utc_model, glonass_gnav_ephemeris_iter->second);
+                    log_rinex_nav(navFile, pvt_solver->glonass_gnav_ephemeris_map);
                 }
             else if (only_beidou && has_beidou_dnav_eph)
                 {
                     rinex_obs_header(obsFile, beidou_dnav_ephemeris_iter->second, rx_time, signal);
-                    rinex_nav_header(navBdsFile, pvt_solver->beidou_dnav_iono, pvt_solver->beidou_dnav_utc_model);
-                    output_navfilename.push_back(navBdsfilename);
-                    log_rinex_nav(navBdsFile, pvt_solver->beidou_dnav_ephemeris_map);
+                    rinex_nav_header(navFile, pvt_solver->beidou_dnav_iono, pvt_solver->beidou_dnav_utc_model);
+                    log_rinex_nav(navFile, pvt_solver->beidou_dnav_ephemeris_map);
                 }
             else if ((flags.check_only_enabled(GPS_1C, GPS_2S) ||
                          flags.check_only_enabled(GPS_1C, GPS_L5) ||
@@ -1998,7 +2035,6 @@ void Rinex_Printer::print_rinex_annotation(const Rtklib_Solver* pvt_solver,
                 {
                     rinex_obs_header(obsFile, gps_ephemeris_iter->second, gps_cnav_ephemeris_iter->second, rx_time, signal);
                     rinex_nav_header(navFile, pvt_solver->gps_iono, pvt_solver->gps_utc_model, gps_ephemeris_iter->second);
-                    output_navfilename.push_back(navfilename);
 
                     if (flags.check_any_enabled(GPS_L5))
                         {
@@ -2013,17 +2049,15 @@ void Rinex_Printer::print_rinex_annotation(const Rtklib_Solver* pvt_solver,
                      has_gps_lnav_eph && has_galileo_eph)
                 {
                     rinex_obs_header(obsFile, gps_ephemeris_iter->second, galileo_ephemeris_iter->second, rx_time, signal);
-                    rinex_nav_header(navMixFile, pvt_solver->gps_iono, pvt_solver->gps_utc_model, gps_ephemeris_iter->second, pvt_solver->galileo_iono, pvt_solver->galileo_utc_model);
-                    output_navfilename.push_back(navMixfilename);
-                    log_rinex_nav(navMixFile, pvt_solver->gps_ephemeris_map, pvt_solver->galileo_ephemeris_map);
+                    rinex_nav_header(navFile, pvt_solver->gps_iono, pvt_solver->gps_utc_model, gps_ephemeris_iter->second, pvt_solver->galileo_iono, pvt_solver->galileo_utc_model);
+                    log_rinex_nav(navFile, pvt_solver->gps_ephemeris_map, pvt_solver->galileo_ephemeris_map);
                 }
             else if (flags.check_only_enabled(GPS_L5, GAL_E5a) &&
                      has_gps_cnav_eph && has_galileo_eph)
                 {
                     rinex_obs_header(obsFile, gps_cnav_ephemeris_iter->second, galileo_ephemeris_iter->second, rx_time, signal, signal);
-                    rinex_nav_header(navMixFile, pvt_solver->gps_cnav_iono, pvt_solver->gps_cnav_utc_model, pvt_solver->galileo_iono, pvt_solver->galileo_utc_model);
-                    output_navfilename.push_back(navMixfilename);
-                    log_rinex_nav(navMixFile, pvt_solver->gps_cnav_ephemeris_map, pvt_solver->galileo_ephemeris_map);
+                    rinex_nav_header(navFile, pvt_solver->gps_cnav_iono, pvt_solver->gps_cnav_utc_model, pvt_solver->galileo_iono, pvt_solver->galileo_utc_model);
+                    log_rinex_nav(navFile, pvt_solver->gps_cnav_ephemeris_map, pvt_solver->galileo_ephemeris_map);
                 }
             else if ((flags.check_only_enabled(GPS_1C, GLO_1G) || flags.check_only_enabled(GPS_1C, GLO_2G) || flags.check_only_enabled(GPS_1C, GLO_1G, GLO_2G)) &&
                      has_gps_lnav_eph && has_glonass_eph)
@@ -2031,15 +2065,13 @@ void Rinex_Printer::print_rinex_annotation(const Rtklib_Solver* pvt_solver,
                     rinex_obs_header(obsFile, gps_ephemeris_iter->second, glonass_gnav_ephemeris_iter->second, rx_time, signal);
                     if (d_version == 3)
                         {
-                            rinex_nav_header(navMixFile, pvt_solver->gps_iono, pvt_solver->gps_utc_model, gps_ephemeris_iter->second, pvt_solver->glonass_gnav_utc_model);
-                            output_navfilename.push_back(navMixfilename);
-                            log_rinex_nav(navMixFile, pvt_solver->gps_ephemeris_map, pvt_solver->glonass_gnav_ephemeris_map);
+                            rinex_nav_header(navFile, pvt_solver->gps_iono, pvt_solver->gps_utc_model, gps_ephemeris_iter->second, pvt_solver->glonass_gnav_utc_model);
+                            log_rinex_nav(navFile, pvt_solver->gps_ephemeris_map, pvt_solver->glonass_gnav_ephemeris_map);
                         }
                     if (d_version == 2)
                         {
                             rinex_nav_header(navFile, pvt_solver->gps_iono, pvt_solver->gps_utc_model, gps_ephemeris_iter->second);
                             rinex_nav_header(navGloFile, pvt_solver->glonass_gnav_utc_model, glonass_gnav_ephemeris_iter->second);
-                            output_navfilename.push_back(navfilename);
                             output_navfilename.push_back(navGlofilename);
                             log_rinex_nav(navFile, pvt_solver->gps_ephemeris_map);
                             log_rinex_nav(navGloFile, pvt_solver->glonass_gnav_ephemeris_map);
@@ -2049,17 +2081,15 @@ void Rinex_Printer::print_rinex_annotation(const Rtklib_Solver* pvt_solver,
                      has_gps_cnav_eph && has_glonass_eph)
                 {
                     rinex_obs_header(obsFile, gps_cnav_ephemeris_iter->second, glonass_gnav_ephemeris_iter->second, rx_time, signal);
-                    rinex_nav_header(navMixFile, pvt_solver->gps_cnav_iono, pvt_solver->gps_cnav_utc_model, pvt_solver->glonass_gnav_utc_model);
-                    output_navfilename.push_back(navfilename);
-                    log_rinex_nav(navMixFile, pvt_solver->gps_cnav_ephemeris_map, pvt_solver->glonass_gnav_ephemeris_map);
+                    rinex_nav_header(navFile, pvt_solver->gps_cnav_iono, pvt_solver->gps_cnav_utc_model, pvt_solver->glonass_gnav_utc_model);
+                    log_rinex_nav(navFile, pvt_solver->gps_cnav_ephemeris_map, pvt_solver->glonass_gnav_ephemeris_map);
                 }
             else if ((flags.check_only_enabled(GAL_1B, GLO_1G) || flags.check_only_enabled(GAL_1B, GLO_2G)) &&
                      has_galileo_eph && has_glonass_eph)
                 {
                     rinex_obs_header(obsFile, galileo_ephemeris_iter->second, glonass_gnav_ephemeris_iter->second, rx_time, signal, signal);
-                    rinex_nav_header(navMixFile, pvt_solver->galileo_iono, pvt_solver->galileo_utc_model, pvt_solver->glonass_gnav_utc_model);
-                    output_navfilename.push_back(navMixfilename);
-                    log_rinex_nav(navMixFile, pvt_solver->galileo_ephemeris_map, pvt_solver->glonass_gnav_ephemeris_map);
+                    rinex_nav_header(navFile, pvt_solver->galileo_iono, pvt_solver->galileo_utc_model, pvt_solver->glonass_gnav_utc_model);
+                    log_rinex_nav(navFile, pvt_solver->galileo_ephemeris_map, pvt_solver->glonass_gnav_ephemeris_map);
                 }
             else if ((flags.check_only_enabled(GPS_1C, GAL_1B, GPS_L5, GAL_E5a) ||
                          flags.check_only_enabled(GPS_1C, GAL_1B, GPS_L5, GAL_E5a, GAL_E6) ||
@@ -2067,16 +2097,14 @@ void Rinex_Printer::print_rinex_annotation(const Rtklib_Solver* pvt_solver,
                      has_gps_lnav_eph && has_gps_cnav_eph && has_galileo_eph)
                 {
                     rinex_obs_header(obsFile, gps_ephemeris_iter->second, gps_cnav_ephemeris_iter->second, galileo_ephemeris_iter->second, rx_time, signal, signal);
-                    rinex_nav_header(navMixFile, pvt_solver->gps_iono, pvt_solver->gps_utc_model, gps_ephemeris_iter->second, pvt_solver->galileo_iono, pvt_solver->galileo_utc_model);
-                    output_navfilename.push_back(navMixfilename);
-                    log_rinex_nav(navMixFile, pvt_solver->gps_ephemeris_map, pvt_solver->galileo_ephemeris_map);
+                    rinex_nav_header(navFile, pvt_solver->gps_iono, pvt_solver->gps_utc_model, gps_ephemeris_iter->second, pvt_solver->galileo_iono, pvt_solver->galileo_utc_model);
+                    log_rinex_nav(navFile, pvt_solver->gps_ephemeris_map, pvt_solver->galileo_ephemeris_map);
                 }
             else if ((flags.check_only_enabled(GPS_1C, GAL_1B, GAL_E5a) || flags.check_only_enabled(GPS_1C, GAL_1B, GAL_E5b)) && has_gps_lnav_eph && has_galileo_eph)
                 {
                     rinex_obs_header(obsFile, gps_ephemeris_iter->second, galileo_ephemeris_iter->second, rx_time, signal);
-                    rinex_nav_header(navMixFile, pvt_solver->gps_iono, pvt_solver->gps_utc_model, gps_ephemeris_iter->second, pvt_solver->galileo_iono, pvt_solver->galileo_utc_model);
-                    output_navfilename.push_back(navMixfilename);
-                    log_rinex_nav(navMixFile, pvt_solver->gps_ephemeris_map, pvt_solver->galileo_ephemeris_map);
+                    rinex_nav_header(navFile, pvt_solver->gps_iono, pvt_solver->gps_utc_model, gps_ephemeris_iter->second, pvt_solver->galileo_iono, pvt_solver->galileo_utc_model);
+                    log_rinex_nav(navFile, pvt_solver->gps_ephemeris_map, pvt_solver->galileo_ephemeris_map);
                 }
             else if (flags.check_only_enabled(GPS_1C, GAL_E6) && has_gps_lnav_eph)
                 {
@@ -2084,16 +2112,14 @@ void Rinex_Printer::print_rinex_annotation(const Rtklib_Solver* pvt_solver,
                         {
                             // we have Galileo ephemeris, maybe from assistance
                             rinex_obs_header(obsFile, gps_ephemeris_iter->second, galileo_ephemeris_iter->second, rx_time, signal);
-                            rinex_nav_header(navMixFile, pvt_solver->gps_iono, pvt_solver->gps_utc_model, gps_ephemeris_iter->second, pvt_solver->galileo_iono, pvt_solver->galileo_utc_model);
-                            output_navfilename.push_back(navMixfilename);
-                            log_rinex_nav(navMixFile, pvt_solver->gps_ephemeris_map, pvt_solver->galileo_ephemeris_map);
+                            rinex_nav_header(navFile, pvt_solver->gps_iono, pvt_solver->gps_utc_model, gps_ephemeris_iter->second, pvt_solver->galileo_iono, pvt_solver->galileo_utc_model);
+                            log_rinex_nav(navFile, pvt_solver->gps_ephemeris_map, pvt_solver->galileo_ephemeris_map);
                         }
                     else
                         {
                             // we do not have galileo ephemeris, print only GPS data
                             rinex_obs_header(obsFile, gps_ephemeris_iter->second, rx_time);
                             rinex_nav_header(navFile, pvt_solver->gps_iono, pvt_solver->gps_utc_model, gps_ephemeris_iter->second);
-                            output_navfilename.push_back(navfilename);
                             log_rinex_nav(navFile, pvt_solver->gps_ephemeris_map);
                         }
                 }
@@ -2187,7 +2213,7 @@ void Rinex_Printer::print_rinex_annotation(const Rtklib_Solver* pvt_solver,
                         }
                     if (!d_rinex_header_updated && (pvt_solver->galileo_utc_model.A0 != 0))
                         {
-                            update_nav_header(navGalFile, pvt_solver->galileo_iono, pvt_solver->galileo_utc_model);
+                            update_nav_header(navFile, pvt_solver->galileo_iono, pvt_solver->galileo_utc_model);
                             update_obs_header(obsFile, get_leap_second_line(pvt_solver->galileo_utc_model));
                             d_rinex_header_updated = true;
                         }
@@ -2200,7 +2226,7 @@ void Rinex_Printer::print_rinex_annotation(const Rtklib_Solver* pvt_solver,
                         }
                     if (!d_rinex_header_updated && (pvt_solver->glonass_gnav_utc_model.d_tau_c != 0))
                         {
-                            update_nav_header(navGloFile, pvt_solver->glonass_gnav_utc_model);
+                            update_nav_header(navFile, pvt_solver->glonass_gnav_utc_model);
                             d_rinex_header_updated = true;
                         }
                 }
@@ -2213,7 +2239,7 @@ void Rinex_Printer::print_rinex_annotation(const Rtklib_Solver* pvt_solver,
                     if (!d_rinex_header_updated && (pvt_solver->beidou_dnav_utc_model.A0_UTC != 0))
                         {
                             update_obs_header(obsFile, get_leap_second_line(pvt_solver->beidou_dnav_utc_model));
-                            update_nav_header(navBdsFile, pvt_solver->beidou_dnav_utc_model, pvt_solver->beidou_dnav_iono);
+                            update_nav_header(navFile, pvt_solver->beidou_dnav_utc_model, pvt_solver->beidou_dnav_iono);
                             d_rinex_header_updated = true;
                         }
                 }
@@ -2224,7 +2250,7 @@ void Rinex_Printer::print_rinex_annotation(const Rtklib_Solver* pvt_solver,
                     if (!d_rinex_header_updated && (pvt_solver->gps_utc_model.A0 != 0))
                         {
                             update_obs_header(obsFile, get_leap_second_line(pvt_solver->gps_utc_model, d_version));
-                            update_nav_header(navMixFile, pvt_solver->gps_iono, pvt_solver->gps_utc_model, gps_ephemeris_iter->second, pvt_solver->galileo_iono, pvt_solver->galileo_utc_model);
+                            update_nav_header(navFile, pvt_solver->gps_iono, pvt_solver->gps_utc_model, gps_ephemeris_iter->second, pvt_solver->galileo_iono, pvt_solver->galileo_utc_model);
                             d_rinex_header_updated = true;
                         }
                 }
@@ -2235,7 +2261,7 @@ void Rinex_Printer::print_rinex_annotation(const Rtklib_Solver* pvt_solver,
                     if (!d_rinex_header_updated && (pvt_solver->gps_utc_model.A0 != 0))
                         {
                             update_obs_header(obsFile, get_leap_second_line(pvt_solver->gps_utc_model, d_version));
-                            update_nav_header(navMixFile, pvt_solver->gps_iono, pvt_solver->gps_utc_model, gps_ephemeris_iter->second, pvt_solver->glonass_gnav_utc_model);
+                            update_nav_header(navFile, pvt_solver->gps_iono, pvt_solver->gps_utc_model, gps_ephemeris_iter->second, pvt_solver->glonass_gnav_utc_model);
                             d_rinex_header_updated = true;  // do not write header anymore
                         }
                 }
@@ -2248,7 +2274,7 @@ void Rinex_Printer::print_rinex_annotation(const Rtklib_Solver* pvt_solver,
                     if (!d_rinex_header_updated && (pvt_solver->gps_cnav_utc_model.A0 != 0) && (pvt_solver->galileo_utc_model.A0 != 0))
                         {
                             update_obs_header(obsFile, get_leap_second_line(pvt_solver->gps_cnav_utc_model));
-                            update_nav_header(navMixFile, pvt_solver->gps_cnav_utc_model, pvt_solver->gps_cnav_iono, pvt_solver->galileo_iono, pvt_solver->galileo_utc_model);
+                            update_nav_header(navFile, pvt_solver->gps_cnav_utc_model, pvt_solver->gps_cnav_iono, pvt_solver->galileo_iono, pvt_solver->galileo_utc_model);
                             d_rinex_header_updated = true;  // do not write header anymore
                         }
                 }
@@ -2261,7 +2287,7 @@ void Rinex_Printer::print_rinex_annotation(const Rtklib_Solver* pvt_solver,
                     if (!d_rinex_header_updated && (pvt_solver->galileo_utc_model.A0 != 0))
                         {
                             update_obs_header(obsFile, get_leap_second_line(pvt_solver->galileo_utc_model));
-                            update_nav_header(navMixFile, pvt_solver->galileo_iono, pvt_solver->galileo_utc_model, pvt_solver->glonass_gnav_utc_model);
+                            update_nav_header(navFile, pvt_solver->galileo_iono, pvt_solver->galileo_utc_model, pvt_solver->glonass_gnav_utc_model);
                             d_rinex_header_updated = true;  // do not write header anymore
                         }
                 }
@@ -2274,7 +2300,7 @@ void Rinex_Printer::print_rinex_annotation(const Rtklib_Solver* pvt_solver,
                     if (!d_rinex_header_updated && (pvt_solver->gps_cnav_utc_model.A0 != 0))
                         {
                             update_obs_header(obsFile, get_leap_second_line(pvt_solver->gps_cnav_utc_model));
-                            update_nav_header(navMixFile, pvt_solver->gps_cnav_iono, pvt_solver->gps_cnav_utc_model, pvt_solver->glonass_gnav_utc_model);
+                            update_nav_header(navFile, pvt_solver->gps_cnav_iono, pvt_solver->gps_cnav_utc_model, pvt_solver->glonass_gnav_utc_model);
                             d_rinex_header_updated = true;  // do not write header anymore
                         }
                 }
@@ -2288,12 +2314,12 @@ void Rinex_Printer::print_rinex_annotation(const Rtklib_Solver* pvt_solver,
                                     if (pvt_solver->gps_cnav_utc_model.A0 != 0)
                                         {
                                             update_obs_header(obsFile, get_leap_second_line(pvt_solver->gps_cnav_utc_model));
-                                            update_nav_header(navMixFile, pvt_solver->gps_cnav_utc_model, pvt_solver->gps_cnav_iono, pvt_solver->galileo_iono, pvt_solver->galileo_utc_model);
+                                            update_nav_header(navFile, pvt_solver->gps_cnav_utc_model, pvt_solver->gps_cnav_iono, pvt_solver->galileo_iono, pvt_solver->galileo_utc_model);
                                         }
                                     else
                                         {
                                             update_obs_header(obsFile, get_leap_second_line(pvt_solver->gps_utc_model, d_version));
-                                            update_nav_header(navMixFile, pvt_solver->gps_iono, pvt_solver->gps_utc_model, gps_ephemeris_iter->second, pvt_solver->galileo_iono, pvt_solver->galileo_utc_model);
+                                            update_nav_header(navFile, pvt_solver->gps_iono, pvt_solver->gps_utc_model, gps_ephemeris_iter->second, pvt_solver->galileo_iono, pvt_solver->galileo_utc_model);
                                         }
                                     d_rinex_header_updated = true;  // do not write header anymore
                                 }
@@ -2307,7 +2333,7 @@ void Rinex_Printer::print_rinex_annotation(const Rtklib_Solver* pvt_solver,
                             if (!d_rinex_header_updated && (pvt_solver->gps_utc_model.A0 != 0) && (pvt_solver->galileo_utc_model.A0 != 0))
                                 {
                                     update_obs_header(obsFile, get_leap_second_line(pvt_solver->gps_utc_model, d_version));
-                                    update_nav_header(navMixFile, pvt_solver->gps_iono, pvt_solver->gps_utc_model, gps_ephemeris_iter->second, pvt_solver->galileo_iono, pvt_solver->galileo_utc_model);
+                                    update_nav_header(navFile, pvt_solver->gps_iono, pvt_solver->gps_utc_model, gps_ephemeris_iter->second, pvt_solver->galileo_iono, pvt_solver->galileo_utc_model);
                                     d_rinex_header_updated = true;  // do not write header anymore
                                 }
                         }
@@ -2321,7 +2347,7 @@ void Rinex_Printer::print_rinex_annotation(const Rtklib_Solver* pvt_solver,
                     if (!d_rinex_header_updated && (pvt_solver->gps_utc_model.A0 != 0) && (pvt_solver->galileo_utc_model.A0 != 0) && (has_gps_lnav_eph))
                         {
                             update_obs_header(obsFile, get_leap_second_line(pvt_solver->gps_utc_model, d_version));
-                            update_nav_header(navMixFile, pvt_solver->gps_iono, pvt_solver->gps_utc_model, gps_ephemeris_iter->second, pvt_solver->galileo_iono, pvt_solver->galileo_utc_model);
+                            update_nav_header(navFile, pvt_solver->gps_iono, pvt_solver->gps_utc_model, gps_ephemeris_iter->second, pvt_solver->galileo_iono, pvt_solver->galileo_utc_model);
                             d_rinex_header_updated = true;
                         }
                 }
@@ -2334,7 +2360,7 @@ void Rinex_Printer::print_rinex_annotation(const Rtklib_Solver* pvt_solver,
                             if (!d_rinex_header_updated && (pvt_solver->gps_utc_model.A0 != 0))
                                 {
                                     update_obs_header(obsFile, get_leap_second_line(pvt_solver->gps_utc_model, d_version));
-                                    update_nav_header(navMixFile, pvt_solver->gps_iono, pvt_solver->gps_utc_model, gps_ephemeris_iter->second, pvt_solver->galileo_iono, pvt_solver->galileo_utc_model);
+                                    update_nav_header(navFile, pvt_solver->gps_iono, pvt_solver->gps_utc_model, gps_ephemeris_iter->second, pvt_solver->galileo_iono, pvt_solver->galileo_utc_model);
                                     d_rinex_header_updated = true;
                                 }
                         }
@@ -2354,168 +2380,40 @@ void Rinex_Printer::print_rinex_annotation(const Rtklib_Solver* pvt_solver,
 }
 
 
-void Rinex_Printer::log_rinex_nav_gps_nav(uint32_t signal_enabled_flags, const std::map<int32_t, Gps_Ephemeris>& new_eph)
+void Rinex_Printer::log_rinex_nav_gps_nav(const std::map<int32_t, Gps_Ephemeris>& new_eph)
 {
-    std::map<int32_t, Galileo_Ephemeris> new_gal_eph;
-    std::map<int32_t, Glonass_Gnav_Ephemeris> new_glo_eph;
-    const Signal_Enabled_Flags flags(signal_enabled_flags);
-
-    if (!flags.check_any_enabled(GPS_1C))
-        {
-            return;
-        }
-
-    if (flags.check_any_enabled(GAL_1B, GAL_E5a, GAL_E5b, GAL_E6))
-        {
-            if (flags.check_any_enabled(GAL_E6) && navMixFile.tellp() == 0)
-                {
-                    log_rinex_nav(navFile, new_eph);
-                }
-            else
-                {
-                    log_rinex_nav(navMixFile, new_eph, new_gal_eph);
-                }
-        }
-    else if (flags.check_any_enabled(GLO_1G, GLO_2G))
-        {
-            if (d_version == 3)
-                {
-                    log_rinex_nav(navMixFile, new_eph, new_glo_eph);
-                }
-            else if (d_version == 2)
-                {
-                    if (flags.check_any_enabled(GLO_1G))
-                        {
-                            log_rinex_nav(navFile, new_glo_eph);
-                        }
-                    else
-                        {
-                            log_rinex_nav(navFile, new_eph);
-                        }
-                }
-        }
-    else
-        {
-            log_rinex_nav(navFile, new_eph);
-        }
+    log_rinex_nav(navFile, new_eph);
 }
 
 
-void Rinex_Printer::log_rinex_nav_gps_cnav(uint32_t signal_enabled_flags, const std::map<int32_t, Gps_CNAV_Ephemeris>& new_cnav_eph)
+void Rinex_Printer::log_rinex_nav_gps_cnav(const std::map<int32_t, Gps_CNAV_Ephemeris>& new_cnav_eph)
 {
-    std::map<int32_t, Galileo_Ephemeris> new_gal_eph;
-    std::map<int32_t, Glonass_Gnav_Ephemeris> new_glo_eph;
-    const Signal_Enabled_Flags flags(signal_enabled_flags);
-
-    if (!flags.check_any_enabled(GPS_2S, GPS_L5))
-        {
-            return;
-        }
-
-    if (flags.check_any_enabled(GAL_1B, GAL_E5a, GAL_E5b, GAL_E6))
-        {
-            log_rinex_nav(navMixFile, new_cnav_eph, new_gal_eph);
-        }
-    else if (flags.check_any_enabled(GLO_1G, GLO_2G))
-        {
-            log_rinex_nav(navMixFile, new_cnav_eph, new_glo_eph);
-        }
-    else
-        {
-            log_rinex_nav(navFile, new_cnav_eph);
-        }
+    log_rinex_nav(navFile, new_cnav_eph);
 }
 
 
-void Rinex_Printer::log_rinex_nav_gal_nav(uint32_t signal_enabled_flags, const std::map<int32_t, Galileo_Ephemeris>& new_gal_eph)
+void Rinex_Printer::log_rinex_nav_gal_nav(const std::map<int32_t, Galileo_Ephemeris>& new_gal_eph)
 {
-    std::map<int32_t, Glonass_Gnav_Ephemeris> new_glo_eph;
-    std::map<int32_t, Gps_CNAV_Ephemeris> new_cnav_eph;
-    std::map<int32_t, Gps_Ephemeris> new_eph;
-    const Signal_Enabled_Flags flags(signal_enabled_flags);
-
-    if (!flags.check_any_enabled(GAL_1B, GAL_E5a, GAL_E5b, GAL_E6))
-        {
-            return;
-        }
-
-    if (flags.check_any_enabled(GPS_1C, GPS_2S, GPS_L5))
-        {
-            if (flags.check_any_enabled(GAL_E6) && navMixFile.tellp() == 0)
-                {
-                    return;
-                }
-
-            if (flags.check_any_enabled(GPS_1C))
-                {
-                    log_rinex_nav(navMixFile, new_eph, new_gal_eph);
-                }
-            else
-                {
-                    log_rinex_nav(navMixFile, new_cnav_eph, new_gal_eph);
-                }
-        }
-    else if (flags.check_any_enabled(GLO_1G, GLO_2G))
-        {
-            log_rinex_nav(navMixFile, new_gal_eph, new_glo_eph);
-        }
-    else
-        {
-            log_rinex_nav(navGalFile, new_gal_eph);
-        }
+    log_rinex_nav(navFile, new_gal_eph);
 }
 
 
-void Rinex_Printer::log_rinex_nav_glo_gnav(uint32_t signal_enabled_flags, const std::map<int32_t, Glonass_Gnav_Ephemeris>& new_glo_eph)
+void Rinex_Printer::log_rinex_nav_glo_gnav(const std::map<int32_t, Glonass_Gnav_Ephemeris>& new_glo_eph)
 {
-    std::map<int32_t, Galileo_Ephemeris> new_gal_eph;
-    std::map<int32_t, Gps_CNAV_Ephemeris> new_cnav_eph;
-    std::map<int32_t, Gps_Ephemeris> new_eph;
-    const Signal_Enabled_Flags flags(signal_enabled_flags);
-
-    if (!flags.check_any_enabled(GLO_1G, GLO_2G))
+    if (d_version == 3)
         {
-            return;
+            log_rinex_nav(navFile, new_glo_eph);
         }
-
-    if (flags.check_any_enabled(GPS_1C, GPS_2S, GPS_L5))
-        {
-            if (flags.check_any_enabled(GPS_1C))
-                {
-                    if (d_version == 3)
-                        {
-                            log_rinex_nav(navMixFile, new_eph, new_glo_eph);
-                        }
-                    else if (d_version == 2)
-                        {
-                            log_rinex_nav(navGloFile, new_glo_eph);
-                        }
-                }
-            else
-                {
-                    log_rinex_nav(navMixFile, new_cnav_eph, new_glo_eph);
-                }
-        }
-
-    else if (flags.check_any_enabled(GAL_1B, GAL_E5a, GAL_E5b, GAL_E6))
-        {
-            log_rinex_nav(navMixFile, new_gal_eph, new_glo_eph);
-        }
-    else
+    else if (d_version == 2)
         {
             log_rinex_nav(navGloFile, new_glo_eph);
         }
 }
 
 
-void Rinex_Printer::log_rinex_nav_bds_dnav(uint32_t signal_enabled_flags, const std::map<int32_t, Beidou_Dnav_Ephemeris>& new_bds_eph)
+void Rinex_Printer::log_rinex_nav_bds_dnav(const std::map<int32_t, Beidou_Dnav_Ephemeris>& new_bds_eph)
 {
-    const Signal_Enabled_Flags flags(signal_enabled_flags);
-
-    if (flags.check_any_enabled(BDS_B1) || flags.check_any_enabled(BDS_B3))
-        {
-            log_rinex_nav(navBdsFile, new_bds_eph);
-        }
+    log_rinex_nav(navFile, new_bds_eph);
 }
 
 
@@ -2658,9 +2556,6 @@ void Rinex_Printer::rinex_nav_header(std::fstream& out, const Glonass_Gnav_Utc_M
 
 void Rinex_Printer::rinex_nav_header(std::fstream& out, const Gps_Iono& gps_iono, const Gps_Utc_Model& gps_utc_model, const Gps_Ephemeris& eph, const Glonass_Gnav_Utc_Model& glonass_gnav_utc_model)
 {
-    d_stringVersion = "3.02";
-    d_version = 3;
-
     add_navigation_header_start(out, "M: MIXED", "GNSS", Rinex_Printer::getLocalTime(), d_stringVersion);
 
     // -------- Line ionospheric info 1
@@ -2685,9 +2580,6 @@ void Rinex_Printer::rinex_nav_header(std::fstream& out, const Gps_Iono& gps_iono
 
 void Rinex_Printer::rinex_nav_header(std::fstream& out, const Gps_CNAV_Iono& gps_iono, const Gps_CNAV_Utc_Model& gps_utc_model, const Glonass_Gnav_Utc_Model& glonass_gnav_utc_model)
 {
-    d_stringVersion = "3.02";
-    d_version = 3;
-
     add_navigation_header_start(out, "M: MIXED", "GNSS", Rinex_Printer::getLocalTime(), d_stringVersion);
 
     // -------- Line ionospheric info 1
@@ -3036,9 +2928,6 @@ void Rinex_Printer::rinex_nav_header(std::fstream& out, const Gps_Iono& gps_iono
 
 void Rinex_Printer::rinex_nav_header(std::fstream& out, const Gps_CNAV_Iono& gps_cnav_iono, const Gps_CNAV_Utc_Model& gps_cnav_utc_model, const Beidou_Dnav_Iono& bds_dnav_iono, const Beidou_Dnav_Utc_Model& bds_dnav_utc_model)
 {
-    d_stringVersion = "3.02";
-    d_version = 3;
-
     add_navigation_header_start(out, "M: MIXED", "GNSS", Rinex_Printer::getLocalTime(), d_stringVersion);
 
     // -------- Line ionospheric info 1, only version 3 supported
@@ -3247,7 +3136,7 @@ void Rinex_Printer::update_nav_header(std::fstream& out, const Galileo_Iono& gal
         {"", "LEAP SECONDS", get_leap_second_line(utc_model)},
     };
 
-    update_nav_header_from_info(out, navGalfilename, nav_header_info);
+    update_nav_header_from_info(out, navfilename, nav_header_info);
     std::cout << "The RINEX Navigation file header has been updated with UTC and IONO info.\n";
 }
 
@@ -3321,7 +3210,7 @@ void Rinex_Printer::update_nav_header(std::fstream& out, const Gps_Utc_Model& ut
             };
         }
 
-    update_nav_header_from_info(out, navGalfilename, nav_header_info);
+    update_nav_header_from_info(out, navfilename, nav_header_info);
     std::cout << "The RINEX Navigation file header has been updated with UTC and IONO info.\n";
 }
 
@@ -3369,7 +3258,7 @@ void Rinex_Printer::update_nav_header(std::fstream& out, const Gps_Iono& gps_ion
         {"", "LEAP SECONDS", get_leap_second_line(galileo_utc_model)},
     };
 
-    update_nav_header_from_info(out, navMixfilename, nav_header_info);
+    update_nav_header_from_info(out, navfilename, nav_header_info);
     std::cout << "The RINEX Navigation file header has been updated with UTC and IONO info.\n";
 }
 
@@ -3384,7 +3273,7 @@ void Rinex_Printer::update_nav_header(std::fstream& out, const Gps_Iono& gps_ion
         {"", "LEAP SECONDS", get_leap_second_line(gps_utc_model)},
     };
 
-    update_nav_header_from_info(out, navMixfilename, nav_header_info);
+    update_nav_header_from_info(out, navfilename, nav_header_info);
     std::cout << "The RINEX Navigation file header has been updated with UTC and IONO info.\n";
 }
 
@@ -3399,7 +3288,7 @@ void Rinex_Printer::update_nav_header(std::fstream& out, const Gps_CNAV_Iono& gp
         {"", "LEAP SECONDS", get_leap_second_line(gps_utc_model)},
     };
 
-    update_nav_header_from_info(out, navMixfilename, nav_header_info);
+    update_nav_header_from_info(out, navfilename, nav_header_info);
     std::cout << "The RINEX Navigation file header has been updated with UTC and IONO info.\n";
 }
 
@@ -3414,7 +3303,7 @@ void Rinex_Printer::update_nav_header(std::fstream& out, const Galileo_Iono& gal
         {"", "LEAP SECONDS", get_leap_second_line(galileo_utc_model)},
     };
 
-    update_nav_header_from_info(out, navMixfilename, nav_header_info);
+    update_nav_header_from_info(out, navfilename, nav_header_info);
     std::cout << "The RINEX Navigation file header has been updated with UTC and IONO info.\n";
 }
 
@@ -3912,8 +3801,6 @@ void Rinex_Printer::log_rinex_nav(std::fstream& out, const std::map<int32_t, Glo
 
 void Rinex_Printer::log_rinex_nav(std::fstream& out, const std::map<int32_t, Gps_Ephemeris>& gps_eph_map, const std::map<int32_t, Galileo_Ephemeris>& galileo_eph_map)
 {
-    d_version = 3;
-    d_stringVersion = "3.02";
     Rinex_Printer::log_rinex_nav(out, gps_eph_map);
     Rinex_Printer::log_rinex_nav(out, galileo_eph_map);
 }
@@ -3921,8 +3808,6 @@ void Rinex_Printer::log_rinex_nav(std::fstream& out, const std::map<int32_t, Gps
 
 void Rinex_Printer::log_rinex_nav(std::fstream& out, const std::map<int32_t, Gps_CNAV_Ephemeris>& gps_cnav_eph_map, const std::map<int32_t, Galileo_Ephemeris>& galileo_eph_map)
 {
-    d_version = 3;
-    d_stringVersion = "3.02";
     Rinex_Printer::log_rinex_nav(out, gps_cnav_eph_map);
     Rinex_Printer::log_rinex_nav(out, galileo_eph_map);
 }
@@ -3944,8 +3829,6 @@ void Rinex_Printer::log_rinex_nav(std::fstream& out, const std::map<int32_t, Gps
 
 void Rinex_Printer::log_rinex_nav(std::fstream& out, const std::map<int32_t, Galileo_Ephemeris>& galileo_eph_map, const std::map<int32_t, Glonass_Gnav_Ephemeris>& glonass_gnav_eph_map)
 {
-    d_version = 3;
-    d_stringVersion = "3.02";
     Rinex_Printer::log_rinex_nav(out, galileo_eph_map);
     Rinex_Printer::log_rinex_nav(out, glonass_gnav_eph_map);
 }
@@ -4149,8 +4032,6 @@ void Rinex_Printer::rinex_obs_header(std::fstream& out, const Gps_CNAV_Ephemeris
 
 void Rinex_Printer::rinex_obs_header(std::fstream& out, const Galileo_Ephemeris& galileo_eph, const Glonass_Gnav_Ephemeris& /*glonass_gnav_eph*/, double d_TOW_first_observation, const std::string& galileo_bands, const std::string& glonass_bands)
 {
-    d_version = 3;
-
     const std::string constellation_legend = "G = GPS  R = GLONASS  E = GALILEO  S = GEO  M = MIXED";
     add_observation_header_start(out, "Mixed", "MIXED (GALILEO/GLONASS)", Rinex_Printer::getLocalTime(), "3.02", constellation_legend, "NON_GEODETIC", "TYPE");
 
@@ -4274,8 +4155,6 @@ void Rinex_Printer::rinex_obs_header(std::fstream& out, const Gps_Ephemeris& eph
 
 void Rinex_Printer::rinex_obs_header(std::fstream& out, const Gps_Ephemeris& gps_eph, const Gps_CNAV_Ephemeris& /*eph_cnav*/, const Galileo_Ephemeris& /*galileo_eph*/, double d_TOW_first_observation, const std::string& gps_bands, const std::string& galileo_bands)
 {
-    d_version = 3;
-
     const std::string constellation_legend = "G = GPS  R = GLONASS  E = GALILEO  S = GEO  M = MIXED";
     add_observation_header_start(out, "Mixed", "MIXED (GPS/GALILEO)", Rinex_Printer::getLocalTime(), "3.02", constellation_legend);
 
@@ -4300,8 +4179,6 @@ void Rinex_Printer::rinex_obs_header(std::fstream& out, const Gps_Ephemeris& gps
 
 void Rinex_Printer::rinex_obs_header(std::fstream& out, const Gps_CNAV_Ephemeris& eph_cnav, const Galileo_Ephemeris& /*galileo_eph*/, double d_TOW_first_observation, const std::string& gps_bands, const std::string& galileo_bands)
 {
-    d_version = 3;
-
     const std::string constellation_legend = "G = GPS  R = GLONASS  E = GALILEO  S = GEO  M = MIXED";
     add_observation_header_start(out, "Mixed", "MIXED (GPS/GALILEO)", Rinex_Printer::getLocalTime(), "3.02", constellation_legend);
 
@@ -4326,8 +4203,6 @@ void Rinex_Printer::rinex_obs_header(std::fstream& out, const Gps_CNAV_Ephemeris
 
 void Rinex_Printer::rinex_obs_header(std::fstream& out, const Galileo_Ephemeris& eph, double d_TOW_first_observation, const std::string& bands)
 {
-    d_version = 3;
-
     const std::string version = bands.find("E6") != std::string::npos ? "3.05" : "3.02";
     const std::string constellation_legend = "G = GPS  R = GLONASS  E = GALILEO  S = GEO  M = MIXED";
     add_observation_header_start(out, "Galileo", "GALILEO", Rinex_Printer::getLocalTime(), version, constellation_legend);
@@ -4351,8 +4226,6 @@ void Rinex_Printer::rinex_obs_header(std::fstream& out, const Galileo_Ephemeris&
 
 void Rinex_Printer::rinex_obs_header(std::fstream& out, const Gps_Ephemeris& gps_eph, const Galileo_Ephemeris& /*galileo_eph*/, double d_TOW_first_observation, const std::string& galileo_bands)
 {
-    d_version = 3;
-
     const std::string constellation_legend = "G = GPS  R = GLONASS  E = GALILEO  S = GEO  M = MIXED";
     add_observation_header_start(out, "Mixed", "MIXED (GPS/GALILEO)", Rinex_Printer::getLocalTime(), "3.02", constellation_legend);
 
@@ -4377,8 +4250,6 @@ void Rinex_Printer::rinex_obs_header(std::fstream& out, const Gps_Ephemeris& gps
 
 void Rinex_Printer::rinex_obs_header(std::fstream& out, const Beidou_Dnav_Ephemeris& eph, double d_TOW_first_observation, const std::string& bands)
 {
-    d_version = 3;
-
     const std::string constellation_legend = "G = GPS  R = GLONASS  E = GALILEO  C = BEIDOU  M = MIXED";
     add_observation_header_start(out, "Beidou", "BEIDOU", Rinex_Printer::getLocalTime(), "3.02", constellation_legend);
 

--- a/src/algorithms/PVT/libs/rinex_printer.h
+++ b/src/algorithms/PVT/libs/rinex_printer.h
@@ -86,7 +86,8 @@ public:
     /*!
      * \brief Constructor. Creates GNSS Navigation and Observables RINEX files.
      */
-    explicit Rinex_Printer(int version = 0,
+    explicit Rinex_Printer(uint32_t signal_enabled_flags,
+        int version = 3,
         const std::string& base_path = ".",
         const std::string& base_name = "-",
         bool pre_2009_file = false);
@@ -107,38 +108,32 @@ public:
     void print_rinex_annotation(const Rtklib_Solver* pvt_solver,
         const std::map<int, Gnss_Synchro>& gnss_observables_map,
         double rx_time,
-        uint32_t signal_enabled_flags,
         bool flag_write_RINEX_obs_output);
 
     /*!
      * \brief Print RINEX annotation for GPS NAV message
      */
-    void log_rinex_nav_gps_nav(uint32_t signal_enabled_flags,
-        const std::map<int32_t, Gps_Ephemeris>& new_eph);
+    void log_rinex_nav_gps_nav(const std::map<int32_t, Gps_Ephemeris>& new_eph);
 
     /*!
      * \brief Print RINEX annotation for GPS CNAV message
      */
-    void log_rinex_nav_gps_cnav(uint32_t signal_enabled_flags,
-        const std::map<int32_t, Gps_CNAV_Ephemeris>& new_cnav_eph);
+    void log_rinex_nav_gps_cnav(const std::map<int32_t, Gps_CNAV_Ephemeris>& new_cnav_eph);
 
     /*!
      * \brief Print RINEX annotation for Galileo NAV message
      */
-    void log_rinex_nav_gal_nav(uint32_t signal_enabled_flags,
-        const std::map<int32_t, Galileo_Ephemeris>& new_gal_eph);
+    void log_rinex_nav_gal_nav(const std::map<int32_t, Galileo_Ephemeris>& new_gal_eph);
 
     /*!
      * \brief Print RINEX annotation for Glonass GNAV message
      */
-    void log_rinex_nav_glo_gnav(uint32_t signal_enabled_flags,
-        const std::map<int32_t, Glonass_Gnav_Ephemeris>& new_glo_eph);
+    void log_rinex_nav_glo_gnav(const std::map<int32_t, Glonass_Gnav_Ephemeris>& new_glo_eph);
 
     /*!
      * \brief Print RINEX annotation for BeiDou DNAV message
      */
-    void log_rinex_nav_bds_dnav(uint32_t signal_enabled_flags,
-        const std::map<int32_t, Beidou_Dnav_Ephemeris>& new_bds_eph);
+    void log_rinex_nav_bds_dnav(const std::map<int32_t, Beidou_Dnav_Ephemeris>& new_bds_eph);
 
     /*!
      * \brief Returns true is the RINEX file headers are already written
@@ -167,7 +162,8 @@ public:
 
 private:
     // Not the best, but reorder params to select the correct constructor
-    explicit Rinex_Printer(const std::string& base_name,
+    explicit Rinex_Printer(uint32_t signal_enabled_flags,
+        const std::string& base_name,
         const std::string& base_rinex_path,
         int version,
         bool pre_2009_file);
@@ -699,30 +695,23 @@ private:
     const std::map<std::string, std::string> observationType;  // PSEUDORANGE, CARRIER_PHASE, DOPPLER, SIGNAL_STRENGTH
     const std::map<std::string, std::string> observationCode;  // GNSS observation descriptors
 
-    std::fstream obsFile;     // Output file stream for RINEX observation file
-    std::fstream navFile;     // Output file stream for RINEX navigation data file
-    std::fstream sbsFile;     // Output file stream for RINEX SBAS raw data file
-    std::fstream navGalFile;  // Output file stream for RINEX Galileo navigation data file
-    std::fstream navGloFile;  // Output file stream for RINEX GLONASS navigation data file
-    std::fstream navBdsFile;  // Output file stream for RINEX Beidou navigation data file
-    std::fstream navMixFile;  // Output file stream for RINEX Mixed navigation data file
-
-    const std::string navfilename;                // Name of RINEX navigation file for GPS L1
-    const std::string obsfilename;                // Name of RINEX observation file
-    const std::string sbsfilename;                // Name of RINEX SBAS file
-    const std::string navGalfilename;             // Name of RINEX navigation file for Galileo
-    const std::string navGlofilename;             // Name of RINEX navigation file for Glonass
-    const std::string navBdsfilename;             // Name of RINEX navigation file for BeiDou
-    const std::string navMixfilename;             // Name of RINEX navigation file for fixed signals
-    std::vector<std::string> output_navfilename;  // Name of output RINEX navigation file(s)
-
-    std::string d_stringVersion;  // RINEX version (2.10/2.11 or 3.01/3.02)
+    const int d_version;                // RINEX version (2 for 2.10/2.11 and 3 for 3.01)
+    const std::string d_stringVersion;  // RINEX version (2.10/2.11 or 3.01/3.02)
 
     double d_fake_cnav_iode;
-    int d_version;  // RINEX version (2 for 2.10/2.11 and 3 for 3.01)
     bool d_rinex_header_updated;
     bool d_rinex_header_written;
     const bool d_pre_2009_file;
+    const uint32_t d_signal_enabled_flags;
+
+    const std::string navfilename;                // Name of RINEX navigation file
+    const std::string obsfilename;                // Name of RINEX observation file
+    const std::string navGlofilename;             // Name of RINEX navigation file for Glonass
+    std::vector<std::string> output_navfilename;  // Name of output RINEX navigation file(s)
+
+    std::fstream obsFile;     // Output file stream for RINEX observation file
+    std::fstream navFile;     // Output file stream for RINEX navigation data file
+    std::fstream navGloFile;  // Output file stream for RINEX GLONASS navigation data file
 };
 
 

--- a/tests/unit-tests/signal-processing-blocks/pvt/rinex_printer_test.cc
+++ b/tests/unit-tests/signal-processing-blocks/pvt/rinex_printer_test.cc
@@ -835,7 +835,7 @@ TEST_F(RinexPrinterTest, MixedObsLog)
     EXPECT_EQ(0, expected_epoch.compare(line_epoch));
     EXPECT_EQ(0, expected_sat.compare(line_sat));
 
-    // fs::remove(navfile);
+    fs::remove(navfile);
     fs::remove(obsfile);
 }
 

--- a/tests/unit-tests/signal-processing-blocks/pvt/rinex_printer_test.cc
+++ b/tests/unit-tests/signal-processing-blocks/pvt/rinex_printer_test.cc
@@ -187,9 +187,9 @@ TEST_F(RinexPrinterTest, GalileoObsHeader)
     gs.PRN = 1;
     gnss_observables_map[1] = std::move(gs);
 
-    auto rp = std::make_shared<Rinex_Printer>();
+    auto rp = std::make_shared<Rinex_Printer>(signal_enabled_flags);
 
-    rp->print_rinex_annotation(pvt_solution.get(), gnss_observables_map, 0.0, signal_enabled_flags, true);
+    rp->print_rinex_annotation(pvt_solution.get(), gnss_observables_map, 0.0, true);
 
     std::string obsfile = rp->get_obsfilename();
     std::string navfile = rp->get_navfilename()[0];
@@ -221,9 +221,9 @@ TEST_F(RinexPrinterTest, GalileoObsHeader)
     fs::remove(obsfile);
     fs::remove(navfile);
 
-    auto rp2 = std::make_shared<Rinex_Printer>();
+    auto rp2 = std::make_shared<Rinex_Printer>(GAL_1B | GAL_E5b);
 
-    rp2->print_rinex_annotation(pvt_solution.get(), gnss_observables_map, 0.0, GAL_1B | GAL_E5b, true);
+    rp2->print_rinex_annotation(pvt_solution.get(), gnss_observables_map, 0.0, true);
     obsfile = rp2->get_obsfilename();
     navfile = rp2->get_navfilename()[0];
 
@@ -268,9 +268,9 @@ TEST_F(RinexPrinterTest, GlonassObsHeader)
     gs.PRN = 1;
     gnss_observables_map[1] = std::move(gs);
 
-    auto rp = std::make_shared<Rinex_Printer>(3);
+    auto rp = std::make_shared<Rinex_Printer>(signal_enabled_flags);
 
-    rp->print_rinex_annotation(pvt_solution.get(), gnss_observables_map, 0.0, signal_enabled_flags, true);
+    rp->print_rinex_annotation(pvt_solution.get(), gnss_observables_map, 0.0, true);
 
     std::string obsfile = rp->get_obsfilename();
     std::string navfile = rp->get_navfilename()[0];
@@ -328,9 +328,9 @@ TEST_F(RinexPrinterTest, MixedObsHeader)
     gnss_observables_map[1] = gs;
     gnss_observables_map[2] = std::move(gs);
 
-    auto rp = std::make_shared<Rinex_Printer>();
+    auto rp = std::make_shared<Rinex_Printer>(signal_enabled_flags);
 
-    rp->print_rinex_annotation(pvt_solution.get(), gnss_observables_map, 0.0, signal_enabled_flags, true);
+    rp->print_rinex_annotation(pvt_solution.get(), gnss_observables_map, 0.0, true);
 
     std::string obsfile = rp->get_obsfilename();
     std::string navfile = rp->get_navfilename()[0];
@@ -397,9 +397,9 @@ TEST_F(RinexPrinterTest, MixedObsHeaderGpsGlo)
     gnss_observables_map[1] = gs;
     gnss_observables_map[2] = std::move(gs);
 
-    auto rp = std::make_shared<Rinex_Printer>();
+    auto rp = std::make_shared<Rinex_Printer>(signal_enabled_flags);
 
-    rp->print_rinex_annotation(pvt_solution.get(), gnss_observables_map, 0.0, signal_enabled_flags, true);
+    rp->print_rinex_annotation(pvt_solution.get(), gnss_observables_map, 0.0, true);
 
     std::string obsfile = rp->get_obsfilename();
     std::string navfile = rp->get_navfilename()[0];
@@ -485,8 +485,8 @@ TEST_F(RinexPrinterTest, GalileoObsLog)
     gnss_observables_map.insert(std::pair<int, Gnss_Synchro>(3, gs3));
     gnss_observables_map.insert(std::pair<int, Gnss_Synchro>(4, gs4));
 
-    auto rp = std::make_shared<Rinex_Printer>();
-    rp->print_rinex_annotation(pvt_solution.get(), gnss_observables_map, 0.0, signal_enabled_flags, true);
+    auto rp = std::make_shared<Rinex_Printer>(signal_enabled_flags);
+    rp->print_rinex_annotation(pvt_solution.get(), gnss_observables_map, 0.0, true);
 
     std::string obsfile = rp->get_obsfilename();
     std::string navfile = rp->get_navfilename()[0];
@@ -550,8 +550,8 @@ TEST_F(RinexPrinterTest, GlonassObsLog)
     gnss_observables_map.insert(std::pair<int, Gnss_Synchro>(3, gs3));
     gnss_observables_map.insert(std::pair<int, Gnss_Synchro>(4, gs4));
 
-    auto rp = std::make_shared<Rinex_Printer>();
-    rp->print_rinex_annotation(pvt_solution.get(), gnss_observables_map, 0.0, signal_enabled_flags, true);
+    auto rp = std::make_shared<Rinex_Printer>(signal_enabled_flags);
+    rp->print_rinex_annotation(pvt_solution.get(), gnss_observables_map, 0.0, true);
 
     std::string obsfile = rp->get_obsfilename();
     std::string navfile = rp->get_navfilename()[0];
@@ -630,8 +630,8 @@ TEST_F(RinexPrinterTest, GpsObsLogDualBand)
     gnss_observables_map.insert(std::pair<int, Gnss_Synchro>(3, gs3));
     gnss_observables_map.insert(std::pair<int, Gnss_Synchro>(4, gs4));
 
-    auto rp = std::make_shared<Rinex_Printer>();
-    rp->print_rinex_annotation(pvt_solution.get(), gnss_observables_map, 0.0, signal_enabled_flags, true);
+    auto rp = std::make_shared<Rinex_Printer>(signal_enabled_flags);
+    rp->print_rinex_annotation(pvt_solution.get(), gnss_observables_map, 0.0, true);
 
     std::string obsfile = rp->get_obsfilename();
     std::string navfile = rp->get_navfilename()[0];
@@ -707,9 +707,9 @@ TEST_F(RinexPrinterTest, GalileoObsLogDualBand)
     gnss_observables_map.insert(std::pair<int, Gnss_Synchro>(3, gs3));
     gnss_observables_map.insert(std::pair<int, Gnss_Synchro>(4, gs4));
 
-    auto rp = std::make_shared<Rinex_Printer>();
+    auto rp = std::make_shared<Rinex_Printer>(signal_enabled_flags);
 
-    rp->print_rinex_annotation(pvt_solution.get(), gnss_observables_map, 0.0, signal_enabled_flags, true);
+    rp->print_rinex_annotation(pvt_solution.get(), gnss_observables_map, 0.0, true);
 
     std::string obsfile = rp->get_obsfilename();
     std::string navfile = rp->get_navfilename()[0];
@@ -817,9 +817,9 @@ TEST_F(RinexPrinterTest, MixedObsLog)
     gnss_observables_map.insert(std::pair<int, Gnss_Synchro>(7, gs7));
     gnss_observables_map.insert(std::pair<int, Gnss_Synchro>(8, gs8));
 
-    auto rp = std::make_shared<Rinex_Printer>();
+    auto rp = std::make_shared<Rinex_Printer>(signal_enabled_flags);
 
-    rp->print_rinex_annotation(pvt_solution.get(), gnss_observables_map, 0.0, signal_enabled_flags, true);
+    rp->print_rinex_annotation(pvt_solution.get(), gnss_observables_map, 0.0, true);
 
     std::string obsfile = rp->get_obsfilename();
     std::string navfile = rp->get_navfilename()[0];
@@ -835,7 +835,7 @@ TEST_F(RinexPrinterTest, MixedObsLog)
     EXPECT_EQ(0, expected_epoch.compare(line_epoch));
     EXPECT_EQ(0, expected_sat.compare(line_sat));
 
-    fs::remove(navfile);
+    // fs::remove(navfile);
     fs::remove(obsfile);
 }
 
@@ -927,9 +927,9 @@ TEST_F(RinexPrinterTest, MixedObsLogGpsGlo)
     gnss_observables_map.insert(std::pair<int, Gnss_Synchro>(7, gs7));
     gnss_observables_map.insert(std::pair<int, Gnss_Synchro>(8, gs8));
 
-    auto rp = std::make_shared<Rinex_Printer>();
+    auto rp = std::make_shared<Rinex_Printer>(signal_enabled_flags);
 
-    rp->print_rinex_annotation(pvt_solution.get(), gnss_observables_map, 0.0, signal_enabled_flags, true);
+    rp->print_rinex_annotation(pvt_solution.get(), gnss_observables_map, 0.0, true);
 
     std::string obsfile = rp->get_obsfilename();
     std::string navfile = rp->get_navfilename()[0];


### PR DESCRIPTION
Main changes :
- Pass enabled signals to RINEX printer constructor since it never changes
- Simplify RINEX file version by setting it in the constructor
- Remove the necessity to have multiple files open for each possible RINEX file name

Some additional cleanups :
- Simplify functions that log the new ephemeris since we now have only one file open (can be two for RINEX v2)
- Simplify the checks to see if we need to log an ephemeris
- Make some variables `const` 