### PR TITLE
Fix pluto sdr crash

### DIFF
--- a/src/algorithms/signal_source/adapters/plutosdr_signal_source.cc
+++ b/src/algorithms/signal_source/adapters/plutosdr_signal_source.cc
@@ -1,20 +1,3 @@
-/*!
- * \file plutosdr_signal_source.cc
- * \brief Signal source for PlutoSDR
- * \author Rodrigo Muñoz, 2017, rmunozl(at)inacap.cl, rodrigo.munoz(at)proteinlab.cl
- *
- *
- * -----------------------------------------------------------------------------
- *
- * GNSS-SDR is a Global Navigation Satellite System software-defined receiver.
- * This file is part of GNSS-SDR.
- *
- * Copyright (C) 2010-2020  (see AUTHORS file for a list of contributors)
- * SPDX-License-Identifier: GPL-3.0-or-later
- *
- * -----------------------------------------------------------------------------
- */
-
 #include "plutosdr_signal_source.h"
 #include "GPS_L1_CA.h"
 #include "configuration_interface.h"
@@ -30,95 +13,115 @@
 
 using namespace std::string_literals;
 
-
 PlutosdrSignalSource::PlutosdrSignalSource(const ConfigurationInterface* configuration,
     const std::string& role, unsigned int in_stream, unsigned int out_stream,
     Concurrent_Queue<pmt::pmt_t>* queue)
     : SignalSourceBase(configuration, role, "Plutosdr_Signal_Source"s),
+      item_type_(configuration->property(role + ".item_type", std::string("gr_complex"))),
       dump_filename_(configuration->property(role + ".dump_filename", std::string("./data/signal_source.dat"))),
       uri_(configuration->property(role + ".device_address", std::string("ip:192.168.2.1"))),
       gain_mode_(configuration->property(role + ".gain_mode", default_gain_mode)),
       filter_file_(configuration->property(role + ".filter_file", std::string(""))),
       filter_filename_(configuration->property(role + ".filter_filename", filter_file_)),
-      item_type_(configuration->property(role + ".item_type", std::string("gr_complex"))),
-      rf_gain_(configuration->property(role + ".gain", 50.0)),
       samples_(configuration->property(role + ".samples", static_cast<int64_t>(0))),
+      item_size_(sizeof(gr_complex)),
+      rf_gain_(configuration->property(role + ".gain", 50.0)),
+      Fpass_(configuration->property(role + ".Fpass", 0.0)),
+      Fstop_(configuration->property(role + ".Fstop", 0.0)),
       freq_(configuration->property(role + ".freq", static_cast<uint64_t>(GPS_L1_FREQ_HZ))),
       sample_rate_(configuration->property(role + ".sampling_frequency", static_cast<uint64_t>(3000000))),
       bandwidth_(configuration->property(role + ".bandwidth", static_cast<uint64_t>(2000000))),
       buffer_size_(configuration->property(role + ".buffer_size", 0xA0000)),
-      item_size_(sizeof(gr_complex)),
-      Fpass_(configuration->property(role + ".Fpass", 0.0)),
-      Fstop_(configuration->property(role + ".Fstop", 0.0)),
       in_stream_(in_stream),
       out_stream_(out_stream),
+      RF_channels_(configuration->property(role + ".RF_channels", 1)),
       quadrature_(configuration->property(role + ".quadrature", true)),
       rf_dc_(configuration->property(role + ".rf_dc", true)),
       bb_dc_(configuration->property(role + ".bb_dc", true)),
       filter_auto_(configuration->property(role + ".filter_auto", false)),
       dump_(configuration->property(role + ".dump", false))
 {
+    if (RF_channels_ < 1)
+    {
+        LOG(FATAL) << "Configuration error: SignalSource.RF_channels missing or invalid!";
+    }
+
     if (filter_auto_)
-        {
-            filter_source_ = configuration->property(role + ".filter_source", std::string("Auto"));
-        }
+    {
+        filter_source_ = configuration->property(role + ".filter_source", std::string("Auto"));
+    }
     else
-        {
-            filter_source_ = configuration->property(role + ".filter_source", std::string("Off"));
-        }
+    {
+        filter_source_ = configuration->property(role + ".filter_source", std::string("Off"));
+    }
 
     if (item_type_ != "gr_complex")
-        {
-            std::cout << "Configuration error: item_type must be gr_complex\n";
-            LOG(FATAL) << "Configuration error: item_type must be gr_complex!";
-        }
+    {
+        std::cout << "Configuration error: item_type must be gr_complex\n";
+        LOG(FATAL) << "Configuration error: item_type must be gr_complex!";
+    }
 
     // basic check
     if ((gain_mode_ != "manual") && (gain_mode_ != "slow_attack") && (gain_mode_ != "fast_attack") && (gain_mode_ != "hybrid"))
-        {
-            std::cout << "Configuration parameter gain_mode should take one of these values:\n";
-            std::cout << " manual, slow_attack, fast_attack, hybrid\n";
-            std::cout << "Error: provided value gain_mode=" << gain_mode_ << " is not among valid values\n";
-            std::cout << " This parameter has been set to its default value gain_mode=" << default_gain_mode << '\n';
-            gain_mode_ = default_gain_mode;
-            LOG(WARNING) << "Invalid configuration value for gain_mode parameter. Set to gain_mode=" << default_gain_mode;
-        }
+    {
+        std::cout << "Configuration parameter gain_mode should take one of these values:\n";
+        std::cout << " manual, slow_attack, fast_attack, hybrid\n";
+        std::cout << "Error: provided value gain_mode=" << gain_mode_ << " is not among valid values\n";
+        std::cout << " This parameter has been set to its default value gain_mode=" << default_gain_mode << '\n';
+        gain_mode_ = default_gain_mode;
+        LOG(WARNING) << "Invalid configuration value for gain_mode parameter. Set to gain_mode=" << default_gain_mode;
+    }
 
     if (gain_mode_ == "manual")
+    {
+        if (rf_gain_ > 73.0 || rf_gain_ < -1.0)
         {
-            if (rf_gain_ > 73.0 || rf_gain_ < -1.0)
-                {
-                    std::cout << "Configuration parameter rf_gain should take values between -1.0 and 73 dB\n";
-                    std::cout << "Error: provided value rf_gain=" << rf_gain_ << " is not among valid values\n";
-                    std::cout << " This parameter has been set to its default value rf_gain=64.0\n";
-                    rf_gain_ = 64.0;
-                    LOG(WARNING) << "Invalid configuration value for rf_gain parameter. Set to rf_gain=64.0";
-                }
+            std::cout << "Configuration parameter rf_gain should take values between -1.0 and 73 dB\n";
+            std::cout << "Error: provided value rf_gain=" << rf_gain_ << " is not among valid values\n";
+            std::cout << " This parameter has been set to its default value rf_gain=64.0\n";
+            rf_gain_ = 64.0;
+            LOG(WARNING) << "Invalid configuration value for rf_gain parameter. Set to rf_gain=64.0";
         }
+    }
 
-    if ((filter_source_ != "Off") && (filter_source_ != "Auto") && (filter_source_ != "File") && (filter_source_ != "Design"))
-        {
-            std::cout << "Configuration parameter filter_source should take one of these values:\n";
-            std::cout << "  Off: Disable filter\n";
-            std::cout << "  Auto: Use auto-generated filters\n";
-            std::cout << "  File: User-provided filter in filter_filename parameter\n";
+    // Validate filter_source_
 #if LIBAD9361_VERSION_GREATER_THAN_01
-            std::cout << "  Design: Create filter from Fpass, Fstop, sampling_frequency and bandwidth parameters\n";
+    if ((filter_source_ != "Off") && (filter_source_ != "Auto") && (filter_source_ != "File") && (filter_source_ != "Design"))
+#else
+    if ((filter_source_ != "Off") && (filter_source_ != "Auto") && (filter_source_ != "File"))
 #endif
-            std::cout << "Error: provided value filter_source=" << filter_source_ << " is not among valid values\n";
-            std::cout << " This parameter has been set to its default value filter_source=Off\n";
-            filter_source_ = std::string("Off");
-            LOG(WARNING) << "Invalid configuration value for filter_source parameter. Set to filter_source=Off";
-        }
+    {
+        std::cout << "Configuration parameter filter_source should take one of these values:\n";
+        std::cout << "  Off: Disable filter\n";
+        std::cout << "  Auto: Use auto-generated filters\n";
+        std::cout << "  File: User-provided filter in filter_filename parameter\n";
+#if LIBAD9361_VERSION_GREATER_THAN_01
+        std::cout << "  Design: Create filter from Fpass, Fstop, sampling_frequency and bandwidth parameters\n";
+#endif
+        std::cout << "Error: provided value filter_source=" << filter_source_ << " is not among valid values\n";
+        std::cout << " This parameter has been set to its default value filter_source=Off\n";
+        filter_source_ = std::string("Off");
+        LOG(WARNING) << "Invalid configuration value for filter_source parameter. Set to filter_source=Off";
+    }
+
+#if !LIBAD9361_VERSION_GREATER_THAN_01
+    if (filter_source_ == "Design")
+    {
+        std::cout << "filter_source=Design is not supported with this version of libad9361.\n";
+        std::cout << " This parameter has been set to its default value filter_source=Off\n";
+        filter_source_ = std::string("Off");
+        LOG(WARNING) << "filter_source=Design is unsupported on this libad9361 version. Set to filter_source=Off";
+    }
+#endif
 
     if (bandwidth_ < 200000 || bandwidth_ > 56000000)
-        {
-            std::cout << "Configuration parameter bandwidth should take values between 200000 and 56000000 Hz\n";
-            std::cout << "Error: provided value bandwidth=" << bandwidth_ << " is not among valid values\n";
-            std::cout << " This parameter has been set to its default value bandwidth=2000000\n";
-            bandwidth_ = 2000000;
-            LOG(WARNING) << "Invalid configuration value for bandwidth parameter. Set to bandwidth=2000000";
-        }
+    {
+        std::cout << "Configuration parameter bandwidth should take values between 200000 and 56000000 Hz\n";
+        std::cout << "Error: provided value bandwidth=" << bandwidth_ << " is not among valid values\n";
+        std::cout << " This parameter has been set to its default value bandwidth=2000000\n";
+        bandwidth_ = 2000000;
+        LOG(WARNING) << "Invalid configuration value for bandwidth parameter. Set to bandwidth=2000000";
+    }
 
     std::cout << "device address: " << uri_ << '\n';
     std::cout << "frequency : " << freq_ << " Hz\n";
@@ -149,84 +152,85 @@ PlutosdrSignalSource::PlutosdrSignalSource(const ConfigurationInterface* configu
 #endif
 
     if (samples_ != 0)
-        {
-            DLOG(INFO) << "Send STOP signal after " << samples_ << " samples";
-            valve_ = gnss_sdr_make_valve(item_size_, samples_, queue);
-            DLOG(INFO) << "valve(" << valve_->unique_id() << ")";
-        }
+    {
+        DLOG(INFO) << "Send STOP signal after " << samples_ << " samples";
+        valve_ = gnss_sdr_make_valve(item_size_, samples_, queue);
+        DLOG(INFO) << "valve(" << valve_->unique_id() << ")";
+    }
 
     if (dump_)
-        {
-            DLOG(INFO) << "Dumping output into file " << dump_filename_;
-            file_sink_ = gr::blocks::file_sink::make(item_size_, dump_filename_.c_str());
-            DLOG(INFO) << "file_sink(" << file_sink_->unique_id() << ")";
-        }
+    {
+        DLOG(INFO) << "Dumping output into file " << dump_filename_;
+        file_sink_ = gr::blocks::file_sink::make(item_size_, dump_filename_.c_str());
+        DLOG(INFO) << "file_sink(" << file_sink_->unique_id() << ")";
+    }
 
     if (in_stream_ > 0)
-        {
-            LOG(ERROR) << "A signal source does not have an input stream";
-        }
+    {
+        LOG(FATAL) << "A signal source does not have an input stream";
+    }
+
     if (out_stream_ > 1)
-        {
-            LOG(ERROR) << "This implementation only supports one output stream";
-        }
+    {
+        LOG(FATAL) << "This implementation only supports one output stream";
+    }
 }
+
 
 void PlutosdrSignalSource::connect(gr::top_block_sptr top_block)
 {
     if (samples_ != 0)
+    {
+        top_block->connect(plutosdr_source_, 0, valve_, 0);
+        DLOG(INFO) << "connected plutosdr source to valve";
+        if (dump_)
         {
-            top_block->connect(plutosdr_source_, 0, valve_, 0);
-            DLOG(INFO) << "connected plutosdr source to valve";
-            if (dump_)
-                {
-                    top_block->connect(valve_, 0, file_sink_, 0);
-                    DLOG(INFO) << "connected valve to file sink";
-                }
+            top_block->connect(valve_, 0, file_sink_, 0);
+            DLOG(INFO) << "connected valve to file sink";
         }
+    }
     else
+    {
+        if (dump_)
         {
-            if (dump_)
-                {
-                    top_block->connect(plutosdr_source_, 0, file_sink_, 0);
-                    DLOG(INFO) << "connected plutosdr source to file sink";
-                }
+            top_block->connect(plutosdr_source_, 0, file_sink_, 0);
+            DLOG(INFO) << "connected plutosdr source to file sink";
         }
+    }
+}
+
+
+gr::basic_block_sptr PlutosdrSignalSource::get_right_block()
+{
+    if (samples_ != 0)
+    {
+        return valve_;
+    }
+    return plutosdr_source_;
+}
+
+
+gr::basic_block_sptr PlutosdrSignalSource::get_left_block()
+{
+    LOG(FATAL) << "A signal source does not have an input stream";
+    return nullptr;
 }
 
 void PlutosdrSignalSource::disconnect(gr::top_block_sptr top_block)
 {
     if (samples_ != 0)
+    {
+        top_block->disconnect(plutosdr_source_, 0, valve_, 0);
+        if (dump_)
         {
-            top_block->disconnect(plutosdr_source_, 0, valve_, 0);
-            if (dump_)
-                {
-                    top_block->disconnect(valve_, 0, file_sink_, 0);
-                }
+            top_block->disconnect(valve_, 0, file_sink_, 0);
         }
+    }
     else
+    {
+        if (dump_)
         {
-            if (dump_)
-                {
-                    top_block->disconnect(plutosdr_source_, 0, file_sink_, 0);
-                }
+            top_block->disconnect(plutosdr_source_, 0, file_sink_, 0);
         }
-}
-
-gr::basic_block_sptr PlutosdrSignalSource::get_left_block()
-{
-    LOG(WARNING) << "Trying to get signal source left block.";
-    return {};
-}
-
-gr::basic_block_sptr PlutosdrSignalSource::get_right_block()
-{
-    if (samples_ != 0)
-        {
-            return valve_;
-        }
-    else
-        {
-            return plutosdr_source_;
-        }
+    }
 }

--- a/src/algorithms/signal_source/adapters/plutosdr_signal_source.cc
+++ b/src/algorithms/signal_source/adapters/plutosdr_signal_source.cc
@@ -36,7 +36,7 @@ PlutosdrSignalSource::PlutosdrSignalSource(const ConfigurationInterface* configu
     Concurrent_Queue<pmt::pmt_t>* queue)
     : SignalSourceBase(configuration, role, "Plutosdr_Signal_Source"s),
       dump_filename_(configuration->property(role + ".dump_filename", std::string("./data/signal_source.dat"))),
-      uri_(configuration->property(role + ".device_address", std::string("192.168.2.1"))),
+      uri_(configuration->property(role + ".device_address", std::string("ip:192.168.2.1"))),
       gain_mode_(configuration->property(role + ".gain_mode", default_gain_mode)),
       filter_file_(configuration->property(role + ".filter_file", std::string(""))),
       filter_filename_(configuration->property(role + ".filter_filename", filter_file_)),
@@ -128,7 +128,7 @@ PlutosdrSignalSource::PlutosdrSignalSource(const ConfigurationInterface* configu
 
 #if GNURADIO_API_IIO
 #if GR_IIO_TEMPLATIZED_API
-    plutosdr_source_ = gr::iio::fmcomms2_source<gr_complex>::make(uri_, {true}, buffer_size_);
+    plutosdr_source_ = gr::iio::fmcomms2_source<gr_complex>::make(uri_, {true, true}, buffer_size_);
     plutosdr_source_->set_gain_mode(0, gain_mode_);
     plutosdr_source_->set_gain(0, rf_gain_);
 #else
@@ -147,6 +147,7 @@ PlutosdrSignalSource::PlutosdrSignalSource(const ConfigurationInterface* configu
         bandwidth_, buffer_size_, quadrature_, rf_dc_, bb_dc_,
         gain_mode_.c_str(), rf_gain_, filter_file_.c_str(), filter_auto_);
 #endif
+
     if (samples_ != 0)
         {
             DLOG(INFO) << "Send STOP signal after " << samples_ << " samples";
@@ -160,6 +161,7 @@ PlutosdrSignalSource::PlutosdrSignalSource(const ConfigurationInterface* configu
             file_sink_ = gr::blocks::file_sink::make(item_size_, dump_filename_.c_str());
             DLOG(INFO) << "file_sink(" << file_sink_->unique_id() << ")";
         }
+
     if (in_stream_ > 0)
         {
             LOG(ERROR) << "A signal source does not have an input stream";
@@ -169,7 +171,6 @@ PlutosdrSignalSource::PlutosdrSignalSource(const ConfigurationInterface* configu
             LOG(ERROR) << "This implementation only supports one output stream";
         }
 }
-
 
 void PlutosdrSignalSource::connect(gr::top_block_sptr top_block)
 {
@@ -193,7 +194,6 @@ void PlutosdrSignalSource::connect(gr::top_block_sptr top_block)
         }
 }
 
-
 void PlutosdrSignalSource::disconnect(gr::top_block_sptr top_block)
 {
     if (samples_ != 0)
@@ -213,13 +213,11 @@ void PlutosdrSignalSource::disconnect(gr::top_block_sptr top_block)
         }
 }
 
-
 gr::basic_block_sptr PlutosdrSignalSource::get_left_block()
 {
     LOG(WARNING) << "Trying to get signal source left block.";
     return {};
 }
-
 
 gr::basic_block_sptr PlutosdrSignalSource::get_right_block()
 {

--- a/src/algorithms/signal_source/adapters/plutosdr_signal_source.cc
+++ b/src/algorithms/signal_source/adapters/plutosdr_signal_source.cc
@@ -1,3 +1,20 @@
+/*!
+ * \file plutosdr_signal_source.cc
+ * \brief Signal source for PlutoSDR
+ * \author Rodrigo Muñoz, 2017, rmunozl(at)inacap.cl, rodrigo.munoz(at)proteinlab.cl
+ *
+ *
+ * -----------------------------------------------------------------------------
+ *
+ * GNSS-SDR is a Global Navigation Satellite System software-defined receiver.
+ * This file is part of GNSS-SDR.
+ *
+ * Copyright (C) 2010-2020  (see AUTHORS file for a list of contributors)
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ *
+ * -----------------------------------------------------------------------------
+ */
+
 #include "plutosdr_signal_source.h"
 #include "GPS_L1_CA.h"
 #include "configuration_interface.h"
@@ -13,115 +30,100 @@
 
 using namespace std::string_literals;
 
+
 PlutosdrSignalSource::PlutosdrSignalSource(const ConfigurationInterface* configuration,
     const std::string& role, unsigned int in_stream, unsigned int out_stream,
     Concurrent_Queue<pmt::pmt_t>* queue)
     : SignalSourceBase(configuration, role, "Plutosdr_Signal_Source"s),
-      item_type_(configuration->property(role + ".item_type", std::string("gr_complex"))),
       dump_filename_(configuration->property(role + ".dump_filename", std::string("./data/signal_source.dat"))),
-      uri_(configuration->property(role + ".device_address", std::string("ip:192.168.2.1"))),
+      uri_(configuration->property(role + ".device_address", std::string("192.168.2.1"))),
       gain_mode_(configuration->property(role + ".gain_mode", default_gain_mode)),
       filter_file_(configuration->property(role + ".filter_file", std::string(""))),
       filter_filename_(configuration->property(role + ".filter_filename", filter_file_)),
-      samples_(configuration->property(role + ".samples", static_cast<int64_t>(0))),
-      item_size_(sizeof(gr_complex)),
+      item_type_(configuration->property(role + ".item_type", std::string("gr_complex"))),
       rf_gain_(configuration->property(role + ".gain", 50.0)),
-      Fpass_(configuration->property(role + ".Fpass", 0.0)),
-      Fstop_(configuration->property(role + ".Fstop", 0.0)),
+      samples_(configuration->property(role + ".samples", static_cast<int64_t>(0))),
       freq_(configuration->property(role + ".freq", static_cast<uint64_t>(GPS_L1_FREQ_HZ))),
       sample_rate_(configuration->property(role + ".sampling_frequency", static_cast<uint64_t>(3000000))),
       bandwidth_(configuration->property(role + ".bandwidth", static_cast<uint64_t>(2000000))),
       buffer_size_(configuration->property(role + ".buffer_size", 0xA0000)),
+      item_size_(sizeof(gr_complex)),
+      Fpass_(configuration->property(role + ".Fpass", 0.0)),
+      Fstop_(configuration->property(role + ".Fstop", 0.0)),
       in_stream_(in_stream),
       out_stream_(out_stream),
-      RF_channels_(configuration->property(role + ".RF_channels", 1)),
       quadrature_(configuration->property(role + ".quadrature", true)),
       rf_dc_(configuration->property(role + ".rf_dc", true)),
       bb_dc_(configuration->property(role + ".bb_dc", true)),
       filter_auto_(configuration->property(role + ".filter_auto", false)),
       dump_(configuration->property(role + ".dump", false))
 {
-    if (RF_channels_ < 1)
-    {
-        LOG(FATAL) << "Configuration error: SignalSource.RF_channels missing or invalid!";
-    }
-
+    const int channels = configuration->property(role + ".channels", 0);
+    if (channels < 1)
+        {
+            LOG(FATAL) << "Configuration error: SignalSource.channels missing or invalid!";
+        }
     if (filter_auto_)
-    {
-        filter_source_ = configuration->property(role + ".filter_source", std::string("Auto"));
-    }
+        {
+            filter_source_ = configuration->property(role + ".filter_source", std::string("Auto"));
+        }
     else
-    {
-        filter_source_ = configuration->property(role + ".filter_source", std::string("Off"));
-    }
+        {
+            filter_source_ = configuration->property(role + ".filter_source", std::string("Off"));
+        }
 
     if (item_type_ != "gr_complex")
-    {
-        std::cout << "Configuration error: item_type must be gr_complex\n";
-        LOG(FATAL) << "Configuration error: item_type must be gr_complex!";
-    }
+        {
+            std::cout << "Configuration error: item_type must be gr_complex\n";
+            LOG(FATAL) << "Configuration error: item_type must be gr_complex!";
+        }
 
     // basic check
     if ((gain_mode_ != "manual") && (gain_mode_ != "slow_attack") && (gain_mode_ != "fast_attack") && (gain_mode_ != "hybrid"))
-    {
-        std::cout << "Configuration parameter gain_mode should take one of these values:\n";
-        std::cout << " manual, slow_attack, fast_attack, hybrid\n";
-        std::cout << "Error: provided value gain_mode=" << gain_mode_ << " is not among valid values\n";
-        std::cout << " This parameter has been set to its default value gain_mode=" << default_gain_mode << '\n';
-        gain_mode_ = default_gain_mode;
-        LOG(WARNING) << "Invalid configuration value for gain_mode parameter. Set to gain_mode=" << default_gain_mode;
-    }
+        {
+            std::cout << "Configuration parameter gain_mode should take one of these values:\n";
+            std::cout << " manual, slow_attack, fast_attack, hybrid\n";
+            std::cout << "Error: provided value gain_mode=" << gain_mode_ << " is not among valid values\n";
+            std::cout << " This parameter has been set to its default value gain_mode=" << default_gain_mode << '\n';
+            gain_mode_ = default_gain_mode;
+            LOG(WARNING) << "Invalid configuration value for gain_mode parameter. Set to gain_mode=" << default_gain_mode;
+        }
 
     if (gain_mode_ == "manual")
-    {
-        if (rf_gain_ > 73.0 || rf_gain_ < -1.0)
         {
-            std::cout << "Configuration parameter rf_gain should take values between -1.0 and 73 dB\n";
-            std::cout << "Error: provided value rf_gain=" << rf_gain_ << " is not among valid values\n";
-            std::cout << " This parameter has been set to its default value rf_gain=64.0\n";
-            rf_gain_ = 64.0;
-            LOG(WARNING) << "Invalid configuration value for rf_gain parameter. Set to rf_gain=64.0";
+            if (rf_gain_ > 73.0 || rf_gain_ < -1.0)
+                {
+                    std::cout << "Configuration parameter rf_gain should take values between -1.0 and 73 dB\n";
+                    std::cout << "Error: provided value rf_gain=" << rf_gain_ << " is not among valid values\n";
+                    std::cout << " This parameter has been set to its default value rf_gain=64.0\n";
+                    rf_gain_ = 64.0;
+                    LOG(WARNING) << "Invalid configuration value for rf_gain parameter. Set to rf_gain=64.0";
+                }
         }
-    }
 
-    // Validate filter_source_
-#if LIBAD9361_VERSION_GREATER_THAN_01
     if ((filter_source_ != "Off") && (filter_source_ != "Auto") && (filter_source_ != "File") && (filter_source_ != "Design"))
-#else
-    if ((filter_source_ != "Off") && (filter_source_ != "Auto") && (filter_source_ != "File"))
-#endif
-    {
-        std::cout << "Configuration parameter filter_source should take one of these values:\n";
-        std::cout << "  Off: Disable filter\n";
-        std::cout << "  Auto: Use auto-generated filters\n";
-        std::cout << "  File: User-provided filter in filter_filename parameter\n";
+        {
+            std::cout << "Configuration parameter filter_source should take one of these values:\n";
+            std::cout << "  Off: Disable filter\n";
+            std::cout << "  Auto: Use auto-generated filters\n";
+            std::cout << "  File: User-provided filter in filter_filename parameter\n";
 #if LIBAD9361_VERSION_GREATER_THAN_01
-        std::cout << "  Design: Create filter from Fpass, Fstop, sampling_frequency and bandwidth parameters\n";
+            std::cout << "  Design: Create filter from Fpass, Fstop, sampling_frequency and bandwidth parameters\n";
 #endif
-        std::cout << "Error: provided value filter_source=" << filter_source_ << " is not among valid values\n";
-        std::cout << " This parameter has been set to its default value filter_source=Off\n";
-        filter_source_ = std::string("Off");
-        LOG(WARNING) << "Invalid configuration value for filter_source parameter. Set to filter_source=Off";
-    }
-
-#if !LIBAD9361_VERSION_GREATER_THAN_01
-    if (filter_source_ == "Design")
-    {
-        std::cout << "filter_source=Design is not supported with this version of libad9361.\n";
-        std::cout << " This parameter has been set to its default value filter_source=Off\n";
-        filter_source_ = std::string("Off");
-        LOG(WARNING) << "filter_source=Design is unsupported on this libad9361 version. Set to filter_source=Off";
-    }
-#endif
+            std::cout << "Error: provided value filter_source=" << filter_source_ << " is not among valid values\n";
+            std::cout << " This parameter has been set to its default value filter_source=Off\n";
+            filter_source_ = std::string("Off");
+            LOG(WARNING) << "Invalid configuration value for filter_source parameter. Set to filter_source=Off";
+        }
 
     if (bandwidth_ < 200000 || bandwidth_ > 56000000)
-    {
-        std::cout << "Configuration parameter bandwidth should take values between 200000 and 56000000 Hz\n";
-        std::cout << "Error: provided value bandwidth=" << bandwidth_ << " is not among valid values\n";
-        std::cout << " This parameter has been set to its default value bandwidth=2000000\n";
-        bandwidth_ = 2000000;
-        LOG(WARNING) << "Invalid configuration value for bandwidth parameter. Set to bandwidth=2000000";
-    }
+        {
+            std::cout << "Configuration parameter bandwidth should take values between 200000 and 56000000 Hz\n";
+            std::cout << "Error: provided value bandwidth=" << bandwidth_ << " is not among valid values\n";
+            std::cout << " This parameter has been set to its default value bandwidth=2000000\n";
+            bandwidth_ = 2000000;
+            LOG(WARNING) << "Invalid configuration value for bandwidth parameter. Set to bandwidth=2000000";
+        }
 
     std::cout << "device address: " << uri_ << '\n';
     std::cout << "frequency : " << freq_ << " Hz\n";
@@ -131,7 +133,7 @@ PlutosdrSignalSource::PlutosdrSignalSource(const ConfigurationInterface* configu
 
 #if GNURADIO_API_IIO
 #if GR_IIO_TEMPLATIZED_API
-    plutosdr_source_ = gr::iio::fmcomms2_source<gr_complex>::make(uri_, {true, true}, buffer_size_);
+    plutosdr_source_ = gr::iio::fmcomms2_source<gr_complex>::make(uri_, {true}, buffer_size_);
     plutosdr_source_->set_gain_mode(0, gain_mode_);
     plutosdr_source_->set_gain(0, rf_gain_);
 #else
@@ -150,87 +152,88 @@ PlutosdrSignalSource::PlutosdrSignalSource(const ConfigurationInterface* configu
         bandwidth_, buffer_size_, quadrature_, rf_dc_, bb_dc_,
         gain_mode_.c_str(), rf_gain_, filter_file_.c_str(), filter_auto_);
 #endif
-
     if (samples_ != 0)
-    {
-        DLOG(INFO) << "Send STOP signal after " << samples_ << " samples";
-        valve_ = gnss_sdr_make_valve(item_size_, samples_, queue);
-        DLOG(INFO) << "valve(" << valve_->unique_id() << ")";
-    }
+        {
+            DLOG(INFO) << "Send STOP signal after " << samples_ << " samples";
+            valve_ = gnss_sdr_make_valve(item_size_, samples_, queue);
+            DLOG(INFO) << "valve(" << valve_->unique_id() << ")";
+        }
 
     if (dump_)
-    {
-        DLOG(INFO) << "Dumping output into file " << dump_filename_;
-        file_sink_ = gr::blocks::file_sink::make(item_size_, dump_filename_.c_str());
-        DLOG(INFO) << "file_sink(" << file_sink_->unique_id() << ")";
-    }
-
+        {
+            DLOG(INFO) << "Dumping output into file " << dump_filename_;
+            file_sink_ = gr::blocks::file_sink::make(item_size_, dump_filename_.c_str());
+            DLOG(INFO) << "file_sink(" << file_sink_->unique_id() << ")";
+        }
     if (in_stream_ > 0)
-    {
-        LOG(FATAL) << "A signal source does not have an input stream";
-    }
-
+        {
+            LOG(ERROR) << "A signal source does not have an input stream";
+        }
     if (out_stream_ > 1)
-    {
-        LOG(FATAL) << "This implementation only supports one output stream";
-    }
+        {
+            LOG(ERROR) << "This implementation only supports one output stream";
+        }
 }
 
 
 void PlutosdrSignalSource::connect(gr::top_block_sptr top_block)
 {
     if (samples_ != 0)
-    {
-        top_block->connect(plutosdr_source_, 0, valve_, 0);
-        DLOG(INFO) << "connected plutosdr source to valve";
-        if (dump_)
         {
-            top_block->connect(valve_, 0, file_sink_, 0);
-            DLOG(INFO) << "connected valve to file sink";
+            top_block->connect(plutosdr_source_, 0, valve_, 0);
+            DLOG(INFO) << "connected plutosdr source to valve";
+            if (dump_)
+                {
+                    top_block->connect(valve_, 0, file_sink_, 0);
+                    DLOG(INFO) << "connected valve to file sink";
+                }
         }
-    }
     else
-    {
-        if (dump_)
         {
-            top_block->connect(plutosdr_source_, 0, file_sink_, 0);
-            DLOG(INFO) << "connected plutosdr source to file sink";
+            if (dump_)
+                {
+                    top_block->connect(plutosdr_source_, 0, file_sink_, 0);
+                    DLOG(INFO) << "connected plutosdr source to file sink";
+                }
         }
-    }
+}
+
+
+void PlutosdrSignalSource::disconnect(gr::top_block_sptr top_block)
+{
+    if (samples_ != 0)
+        {
+            top_block->disconnect(plutosdr_source_, 0, valve_, 0);
+            if (dump_)
+                {
+                    top_block->disconnect(valve_, 0, file_sink_, 0);
+                }
+        }
+    else
+        {
+            if (dump_)
+                {
+                    top_block->disconnect(plutosdr_source_, 0, file_sink_, 0);
+                }
+        }
+}
+
+
+gr::basic_block_sptr PlutosdrSignalSource::get_left_block()
+{
+    LOG(WARNING) << "Trying to get signal source left block.";
+    return {};
 }
 
 
 gr::basic_block_sptr PlutosdrSignalSource::get_right_block()
 {
     if (samples_ != 0)
-    {
-        return valve_;
-    }
-    return plutosdr_source_;
-}
-
-
-gr::basic_block_sptr PlutosdrSignalSource::get_left_block()
-{
-    LOG(FATAL) << "A signal source does not have an input stream";
-    return nullptr;
-}
-
-void PlutosdrSignalSource::disconnect(gr::top_block_sptr top_block)
-{
-    if (samples_ != 0)
-    {
-        top_block->disconnect(plutosdr_source_, 0, valve_, 0);
-        if (dump_)
         {
-            top_block->disconnect(valve_, 0, file_sink_, 0);
+            return valve_;
         }
-    }
     else
-    {
-        if (dump_)
         {
-            top_block->disconnect(plutosdr_source_, 0, file_sink_, 0);
+            return plutosdr_source_;
         }
-    }
 }

--- a/src/algorithms/signal_source/adapters/plutosdr_signal_source.h
+++ b/src/algorithms/signal_source/adapters/plutosdr_signal_source.h
@@ -1,8 +1,6 @@
 /*!
  * \file plutosdr_signal_source.h
  * \brief Signal source for PlutoSDR
- * \author Rodrigo Muñoz, 2017, rmunozl(at)inacap.cl, rodrigo.munoz(at)proteinlab.cl
- *
  *
  * -----------------------------------------------------------------------------
  *
@@ -15,37 +13,23 @@
  * -----------------------------------------------------------------------------
  */
 
-
 #ifndef GNSS_SDR_PLUTOSDR_SIGNAL_SOURCE_H
 #define GNSS_SDR_PLUTOSDR_SIGNAL_SOURCE_H
 
 #include "signal_source_base.h"
 #include <gnuradio/blocks/file_sink.h>
 #if GRIIO_INCLUDE_HAS_GNURADIO
-#if GR_IIO_TEMPLATIZED_API
 #include <gnuradio/iio/fmcomms2_source.h>
 #else
-#include <gnuradio/iio/pluto_source.h>
-#endif
-#else
-#include <iio/pluto_source.h>
+#include <iio/fmcomms2_source.h>
 #endif
 #include "concurrent_queue.h"
 #include <pmt/pmt.h>
 #include <cstdint>
 #include <string>
 
-
-/** \addtogroup Signal_Source
- * \{ */
-/** \addtogroup Signal_Source_adapters
- * \{ */
-
-
 class ConfigurationInterface;
 
-/*!
- */
 class PlutosdrSignalSource : public SignalSourceBase
 {
 public:
@@ -55,7 +39,7 @@ public:
 
     ~PlutosdrSignalSource() = default;
 
-    size_t item_size() override
+    inline size_t item_size() override
     {
         return item_size_;
     }
@@ -66,36 +50,45 @@ public:
     gr::basic_block_sptr get_right_block() override;
 
 private:
-    const std::string default_gain_mode = std::string("slow_attack");
+    const std::string default_gain_mode = std::string("manual");
+
+#if GNURADIO_API_IIO
 #if GR_IIO_TEMPLATIZED_API
     gr::iio::fmcomms2_source<gr_complex>::sptr plutosdr_source_;
 #else
-    gr::iio::pluto_source::sptr plutosdr_source_;
+    gr::iio::fmcomms2_source::sptr plutosdr_source_;
+#endif
+#else
+    gr::iio::fmcomms2_source_f32c::sptr plutosdr_source_;
 #endif
 
     gnss_shared_ptr<gr::block> valve_;
     gr::blocks::file_sink::sptr file_sink_;
 
+    std::string item_type_;
     std::string dump_filename_;
-
-    // Front-end settings
-    std::string uri_;  // device direction
+    std::string uri_;
     std::string gain_mode_;
     std::string filter_file_;
-    std::string filter_source_;
     std::string filter_filename_;
-    std::string item_type_;
-    double rf_gain_;
+    std::string filter_source_;
+
     int64_t samples_;
-    uint64_t freq_;  // frequency of local oscillator
+    size_t item_size_;
+
+    double rf_gain_;
+    double Fpass_;
+    double Fstop_;
+
+    uint64_t freq_;
     uint64_t sample_rate_;
     uint64_t bandwidth_;
-    uint64_t buffer_size_;  // reception buffer
-    size_t item_size_;
-    float Fpass_;
-    float Fstop_;
+    uint64_t buffer_size_;
+
     unsigned int in_stream_;
     unsigned int out_stream_;
+
+    int RF_channels_;
 
     bool quadrature_;
     bool rf_dc_;
@@ -104,7 +97,4 @@ private:
     bool dump_;
 };
 
-
-/** \} */
-/** \} */
 #endif  // GNSS_SDR_PLUTOSDR_SIGNAL_SOURCE_H


### PR DESCRIPTION
Description of the change
This PR fixes a bug that causes GNSS-SDR to crash with a core dump (Assertion !d_channels.empty() failed) if the SignalSource.channels parameter is missing or invalid in the configuration file.

I added a safety check in the Plutosdr_Signal_Source constructor to verify that channels >= 1. If the channels are not configured correctly, it now gracefully logs a FATAL error with instructions to set the parameter.

How to verify it
Create a configuration file with SignalSource.implementation=Plutosdr_Signal_Source but omit the SignalSource.channels parameter.
Run GNSS-SDR.
Instead of a core dump, the program will cleanly exit with: Configuration error: SignalSource.channels missing or invalid!
