### PR TITLE
Fix core dump when SignalSource.channels is missing

### DIFF
--- a/src/algorithms/signal_source/adapters/plutosdr_signal_source.cc
+++ b/src/algorithms/signal_source/adapters/plutosdr_signal_source.cc
@@ -58,6 +58,11 @@ PlutosdrSignalSource::PlutosdrSignalSource(const ConfigurationInterface* configu
       filter_auto_(configuration->property(role + ".filter_auto", false)),
       dump_(configuration->property(role + ".dump", false))
 {
+    const int channels = configuration->property(role + ".channels", 0);
+    if (channels < 1)
+        {
+            LOG(FATAL) << "Configuration error: SignalSource.channels missing or invalid!";
+        }
     if (filter_auto_)
         {
             filter_source_ = configuration->property(role + ".filter_source", std::string("Auto"));


### PR DESCRIPTION
## Description of the change

This PR fixes a bug that causes GNSS-SDR to crash with a core dump
(Assertion `!d_channels.empty()` failed) if the `SignalSource.channels`
parameter is missing or invalid in the configuration file.

Added a safety check in the `PlutosdrSignalSource` constructor to read
the `channels` parameter from the configuration and verify that
`channels >= 1`. If the channels are not configured correctly, it now
gracefully logs a `FATAL` error with a clear message instead of crashing.

## How to verify it

1. Create a configuration file with `SignalSource.implementation=Plutosdr_Signal_Source`
   but omit the `SignalSource.channels` parameter.
2. Run GNSS-SDR.
3. Instead of a core dump, the program will cleanly exit with:
   `Configuration error: SignalSource.channels missing or invalid!`