### PR TITLE
Fix file config is_present

### DIFF
--- a/src/core/receiver/file_configuration.cc
+++ b/src/core/receiver/file_configuration.cc
@@ -188,5 +188,10 @@ void FileConfiguration::set_property(std::string property_name, std::string valu
 
 bool FileConfiguration::is_present(const std::string& property_name) const
 {
-    return (overrided_->is_present(property_name));
+    if (overrided_->is_present(property_name))
+        {
+            return true;
+        }
+
+    return ini_reader_->HasValue("GNSS-SDR", property_name);
 }

--- a/src/core/receiver/gnss_block_factory.cc
+++ b/src/core/receiver/gnss_block_factory.cc
@@ -226,11 +226,7 @@ auto findRole(const ConfigurationInterface* configuration, const std::string& ba
     // Current behavior: if there is no "Tag0" use "Tag" instead
     if (ID < 1 && !configuration->is_present(role + impl_prop))
         {
-            const auto stub = configuration->property(role + impl_prop, ""s);
-            if (stub.empty())
-                {
-                    return base;
-                }
+            return base;  //  legacy format
         }
 
     return role;


### PR DESCRIPTION
@carlesfernandez I was wondering why you needed [in this commit](https://github.com/gnss-sdr/gnss-sdr/commit/59aa060cd059cdbbde2b9c4be2d40ca837bdc6c4) to change the logic and found the issue, `FileConfiguration::is_present` does not read from the file config, only from overridden values.

This means probably a bunch more configurations are currently broken, as I used `is_present` in `get_role_name`, so configs with acquisiton / tracking / telemetry implementations per channels will not work as intended. Could you validate the config that failed and prompted the change you made to my code is now correctly working?

I saw you made a new release yesterday, would it be a lot of work to bring back this bug fix in the release?
