### PR TITLE
Cleanup telemetry decoders

### DIFF
--- a/src/algorithms/libs/dump_logger_helper.h
+++ b/src/algorithms/libs/dump_logger_helper.h
@@ -1,0 +1,30 @@
+/*!
+ * \file dump_logger_helper.h
+ * \brief Utility functions for logging to a file
+ * \authors <ul>
+ *          <li> Mathieu Favreau, 2026. favreau.mathieu(at)hotmail.com
+ *          </ul>
+ *
+ * -----------------------------------------------------------------------------
+ *
+ * GNSS-SDR is a Global Navigation Satellite System software-defined receiver.
+ * This file is part of GNSS-SDR.
+ *
+ * Copyright (C) 2010-2025  (see AUTHORS file for a list of contributors)
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ *
+ * -----------------------------------------------------------------------------
+ */
+
+#ifndef GNSS_SDR_DUMP_LOGGER_HELPER_H
+#define GNSS_SDR_DUMP_LOGGER_HELPER_H
+
+#include <fstream>
+
+template <typename T>
+void write_value(std::ofstream& file, T value)
+{
+    file.write(reinterpret_cast<char*>(&value), sizeof(T));
+}
+
+#endif  // GNSS_SDR_DUMP_LOGGER_HELPER_H

--- a/src/algorithms/telemetry_decoder/gnuradio_blocks/beidou_b1i_telemetry_decoder_gs.cc
+++ b/src/algorithms/telemetry_decoder/gnuradio_blocks/beidou_b1i_telemetry_decoder_gs.cc
@@ -19,21 +19,19 @@
 #include "beidou_b1i_telemetry_decoder_gs.h"
 #include "Beidou_B1I.h"
 #include "Beidou_DNAV.h"
-#include "beidou_dnav_almanac.h"
 #include "beidou_dnav_ephemeris.h"
 #include "beidou_dnav_iono.h"
 #include "beidou_dnav_utc_model.h"
-#include "display.h"
+#include "dump_logger_helper.h"
 #include "gnss_sdr_make_unique.h"  // for std::make_unique in C++11
 #include "gnss_synchro.h"
+#include "tlm_conf.h"
 #include "tlm_crc_stats.h"
 #include "tlm_utils.h"
 #include "tow_to_trk.h"
 #include <pmt/pmt.h>        // for make_any
 #include <pmt/pmt_sugar.h>  // for mp
-#include <cstddef>          // for size_t
 #include <cstdlib>          // for abs
-#include <exception>        // for exception
 #include <iomanip>          // for setprecision
 #include <iostream>         // for cout
 
@@ -58,6 +56,7 @@ beidou_b1i_telemetry_decoder_gs::beidou_b1i_telemetry_decoder_gs(
     const Tlm_Conf &conf) : telemetry_impl_interface("beidou_b1i_telemetry_decoder_gs",
                                 gr::io_signature::make(1, 1, sizeof(Gnss_Synchro)),
                                 gr::io_signature::make(1, 1, sizeof(Gnss_Synchro))),
+                            d_satellite(satellite.get_system(), satellite.get_PRN()),
                             d_dump_filename(conf.dump_filename),
                             d_sample_counter(0),
                             d_preamble_index(0),
@@ -83,6 +82,7 @@ beidou_b1i_telemetry_decoder_gs::beidou_b1i_telemetry_decoder_gs(
                             d_enable_navdata_monitor(conf.enable_navdata_monitor),
                             d_dump_crc_stats(conf.dump_crc_stats),
                             d_tow_to_trk(conf.tow_to_trk)
+
 {
     configure_basic_outputs();
 
@@ -94,7 +94,6 @@ beidou_b1i_telemetry_decoder_gs::beidou_b1i_telemetry_decoder_gs(
             d_nav_msg_packet.signal = std::string("B1");
         }
 
-    d_satellite = Gnss_Satellite(satellite.get_system(), satellite.get_PRN());
     LOG(INFO) << "Initializing BeiDou B1I Telemetry Decoding for satellite " << this->d_satellite;
 
     // Setting samples of preamble code
@@ -128,37 +127,7 @@ beidou_b1i_telemetry_decoder_gs::beidou_b1i_telemetry_decoder_gs(
 beidou_b1i_telemetry_decoder_gs::~beidou_b1i_telemetry_decoder_gs()
 {
     DLOG(INFO) << "BeiDou B1I Telemetry decoder block (channel " << d_channel << ") destructor called.";
-    size_t pos = 0;
-    if (d_dump_file.is_open() == true)
-        {
-            pos = d_dump_file.tellp();
-            try
-                {
-                    d_dump_file.close();
-                }
-            catch (const std::exception &ex)
-                {
-                    LOG(WARNING) << "Exception in destructor closing the dump file " << ex.what();
-                }
-            if (pos == 0)
-                {
-                    if (!tlm_remove_file(d_dump_filename))
-                        {
-                            LOG(WARNING) << "Error deleting temporary file";
-                        }
-                }
-        }
-    if (d_dump && (pos != 0) && d_dump_mat)
-        {
-            save_tlm_matfile(d_dump_filename);
-            if (d_remove_dat)
-                {
-                    if (!tlm_remove_file(d_dump_filename))
-                        {
-                            LOG(WARNING) << "Error deleting temporary file";
-                        }
-                }
-        }
+    tlm_cleanup_and_save_files(d_dump_file, d_dump_filename, d_dump, d_dump_mat, d_remove_dat);
 }
 
 
@@ -300,11 +269,7 @@ void beidou_b1i_telemetry_decoder_gs::decode_subframe(float *frame_symbols, doub
             const std::shared_ptr<Beidou_Dnav_Ephemeris> tmp_obj = std::make_shared<Beidou_Dnav_Ephemeris>(d_nav.get_ephemeris());
             this->message_port_pub(pmt::mp("telemetry"), pmt::make_any(tmp_obj));
             LOG(INFO) << "BEIDOU DNAV Ephemeris have been received in channel" << d_channel << " from satellite " << d_satellite << " with CN0=" << cn0 << " dB-Hz";
-#if __cplusplus == 201103L
-            const int default_precision = std::cout.precision();
-#else
-            const auto default_precision{std::cout.precision()};
-#endif
+            const auto default_precision = std::cout.precision();
             std::cout << "New BEIDOU B1I DNAV message received in channel " << d_channel
                       << ": ephemeris from satellite " << d_satellite
                       << " with CN0=" << std::setprecision(2) << cn0 << std::setprecision(default_precision) << " dB-Hz" << std::endl;
@@ -315,11 +280,7 @@ void beidou_b1i_telemetry_decoder_gs::decode_subframe(float *frame_symbols, doub
             const std::shared_ptr<Beidou_Dnav_Utc_Model> tmp_obj = std::make_shared<Beidou_Dnav_Utc_Model>(d_nav.get_utc_model());
             this->message_port_pub(pmt::mp("telemetry"), pmt::make_any(tmp_obj));
             LOG(INFO) << "BEIDOU DNAV UTC Model data have been received in channel" << d_channel << " from satellite " << d_satellite << " with CN0=" << cn0 << " dB-Hz";
-#if __cplusplus == 201103L
-            const int default_precision = std::cout.precision();
-#else
-            const auto default_precision{std::cout.precision()};
-#endif
+            const auto default_precision = std::cout.precision();
             std::cout << "New BEIDOU B1I DNAV utc model message received in channel "
                       << d_channel
                       << ": UTC model parameters from satellite " << d_satellite
@@ -332,11 +293,7 @@ void beidou_b1i_telemetry_decoder_gs::decode_subframe(float *frame_symbols, doub
             const std::shared_ptr<Beidou_Dnav_Iono> tmp_obj = std::make_shared<Beidou_Dnav_Iono>(d_nav.get_iono());
             this->message_port_pub(pmt::mp("telemetry"), pmt::make_any(tmp_obj));
             LOG(INFO) << "BEIDOU DNAV Iono data have been received in channel" << d_channel << " from satellite " << d_satellite << " with CN0=" << cn0 << " dB-Hz";
-#if __cplusplus == 201103L
-            const int default_precision = std::cout.precision();
-#else
-            const auto default_precision{std::cout.precision()};
-#endif
+            const auto default_precision = std::cout.precision();
             std::cout << "New BEIDOU B1I DNAV Iono message received in channel " << d_channel
                       << ": Iono model parameters from satellite " << d_satellite
                       << " with CN0=" << cn0 << std::setprecision(default_precision)
@@ -348,11 +305,7 @@ void beidou_b1i_telemetry_decoder_gs::decode_subframe(float *frame_symbols, doub
             // std::shared_ptr<Beidou_Dnav_Almanac> tmp_obj = std::make_shared<Beidou_Dnav_Almanac>(d_nav.get_almanac(slot_nbr));
             // this->message_port_pub(pmt::mp("telemetry"), pmt::make_any(tmp_obj));
             LOG(INFO) << "BEIDOU DNAV Almanac data have been received in channel" << d_channel << " from satellite " << d_satellite << " with CN0=" << cn0 << " dB-Hz";
-#if __cplusplus == 201103L
-            const int default_precision = std::cout.precision();
-#else
-            const auto default_precision{std::cout.precision()};
-#endif
+            const auto default_precision = std::cout.precision();
             std::cout << "New BEIDOU B1I DNAV almanac received in channel " << d_channel
                       << " from satellite " << d_satellite
                       << " with CN0=" << std::setprecision(2) << cn0 << std::setprecision(default_precision)
@@ -663,19 +616,11 @@ int beidou_b1i_telemetry_decoder_gs::general_work(int noutput_items __attribute_
                     // MULTIPLEXED FILE RECORDING - Record results to file
                     try
                         {
-                            double tmp_double;
-                            uint64_t tmp_ulong_int;
-                            int32_t tmp_int;
-                            tmp_double = static_cast<double>(d_TOW_at_current_symbol_ms) / 1000.0;
-                            d_dump_file.write(reinterpret_cast<char *>(&tmp_double), sizeof(double));
-                            tmp_ulong_int = current_symbol.Tracking_sample_counter;
-                            d_dump_file.write(reinterpret_cast<char *>(&tmp_ulong_int), sizeof(uint64_t));
-                            tmp_double = static_cast<double>(d_TOW_at_Preamble_ms) / 1000.0;
-                            d_dump_file.write(reinterpret_cast<char *>(&tmp_double), sizeof(double));
-                            tmp_int = (current_symbol.Prompt_I > 0.0 ? 1 : -1);
-                            d_dump_file.write(reinterpret_cast<char *>(&tmp_int), sizeof(int32_t));
-                            tmp_int = static_cast<int32_t>(current_symbol.PRN);
-                            d_dump_file.write(reinterpret_cast<char *>(&tmp_int), sizeof(int32_t));
+                            write_value(d_dump_file, static_cast<double>(d_TOW_at_current_symbol_ms) / 1000.0);
+                            write_value(d_dump_file, current_symbol.Tracking_sample_counter);
+                            write_value(d_dump_file, static_cast<double>(d_TOW_at_Preamble_ms) / 1000.0);
+                            write_value(d_dump_file, current_symbol.Prompt_I > 0.0 ? 1 : -1);
+                            write_value(d_dump_file, static_cast<int32_t>(current_symbol.PRN));
                         }
                     catch (const std::ofstream::failure &e)
                         {
@@ -686,12 +631,12 @@ int beidou_b1i_telemetry_decoder_gs::general_work(int noutput_items __attribute_
             // SEND TOW TO THE TRACKING BLOCK
             if (d_tow_to_trk)
                 {
-                    const std::shared_ptr<TOW_to_trk> tmp_tow_obj = std::make_shared<TOW_to_trk>(TOW_to_trk(
+                    const std::shared_ptr<TOW_to_trk> tmp_tow_obj = std::make_shared<TOW_to_trk>(
                         std::string(current_symbol.Signal),
                         d_channel,
                         d_TOW_at_current_symbol_ms,
                         current_symbol.Tracking_sample_counter,
-                        d_nav.get_ephemeris().WN, d_satellite.get_PRN()));
+                        d_nav.get_ephemeris().WN, d_satellite.get_PRN());
                     this->message_port_pub(pmt::mp("telemetry_to_trk"), pmt::make_any(tmp_tow_obj));
                 }
 

--- a/src/algorithms/telemetry_decoder/gnuradio_blocks/beidou_b1i_telemetry_decoder_gs.cc
+++ b/src/algorithms/telemetry_decoder/gnuradio_blocks/beidou_b1i_telemetry_decoder_gs.cc
@@ -82,7 +82,6 @@ beidou_b1i_telemetry_decoder_gs::beidou_b1i_telemetry_decoder_gs(
                             d_enable_navdata_monitor(conf.enable_navdata_monitor),
                             d_dump_crc_stats(conf.dump_crc_stats),
                             d_tow_to_trk(conf.tow_to_trk)
-
 {
     configure_basic_outputs();
 

--- a/src/algorithms/telemetry_decoder/gnuradio_blocks/beidou_b1i_telemetry_decoder_gs.h
+++ b/src/algorithms/telemetry_decoder/gnuradio_blocks/beidou_b1i_telemetry_decoder_gs.h
@@ -23,10 +23,7 @@
 #include "beidou_dnav_navigation_message.h"
 #include "nav_message_packet.h"
 #include "telemetry_impl_interface.h"
-#include "tlm_conf.h"
 #include <boost/circular_buffer.hpp>
-#include <gnuradio/types.h>  // for gr_vector_const_void_star
-#include <array>
 
 
 /** \addtogroup Telemetry_Decoder
@@ -115,12 +112,12 @@ private:
 
     bool d_flag_valid_word;
     bool d_sent_tlm_failed_msg;
-    bool d_dump;
-    bool d_dump_mat;
-    bool d_remove_dat;
-    bool d_enable_navdata_monitor;
+    const bool d_dump;
+    const bool d_dump_mat;
+    const bool d_remove_dat;
+    const bool d_enable_navdata_monitor;
     bool d_dump_crc_stats;
-    bool d_tow_to_trk;
+    const bool d_tow_to_trk;
 };
 
 

--- a/src/algorithms/telemetry_decoder/gnuradio_blocks/beidou_b3i_telemetry_decoder_gs.cc
+++ b/src/algorithms/telemetry_decoder/gnuradio_blocks/beidou_b3i_telemetry_decoder_gs.cc
@@ -17,21 +17,20 @@
 #include "beidou_b3i_telemetry_decoder_gs.h"
 #include "Beidou_B3I.h"
 #include "Beidou_DNAV.h"
-#include "beidou_dnav_almanac.h"
 #include "beidou_dnav_ephemeris.h"
 #include "beidou_dnav_iono.h"
 #include "beidou_dnav_utc_model.h"
 #include "display.h"
+#include "dump_logger_helper.h"
 #include "gnss_sdr_make_unique.h"  // for std::make_unique in C++11
 #include "gnss_synchro.h"
+#include "tlm_conf.h"
 #include "tlm_crc_stats.h"
 #include "tlm_utils.h"
 #include "tow_to_trk.h"
 #include <pmt/pmt.h>        // for make_any
 #include <pmt/pmt_sugar.h>  // for mp
-#include <cstddef>          // for size_t
 #include <cstdlib>          // for abs
-#include <exception>        // for exception
 #include <iomanip>          // for setprecision
 #include <iostream>         // for cout
 
@@ -126,37 +125,7 @@ beidou_b3i_telemetry_decoder_gs::beidou_b3i_telemetry_decoder_gs(
 beidou_b3i_telemetry_decoder_gs::~beidou_b3i_telemetry_decoder_gs()
 {
     DLOG(INFO) << "BeiDou B3I Telemetry decoder block (channel " << d_channel << ") destructor called.";
-    size_t pos = 0;
-    if (d_dump_file.is_open() == true)
-        {
-            pos = d_dump_file.tellp();
-            try
-                {
-                    d_dump_file.close();
-                }
-            catch (const std::exception &ex)
-                {
-                    LOG(WARNING) << "Exception in destructor closing the dump file " << ex.what();
-                }
-            if (pos == 0)
-                {
-                    if (!tlm_remove_file(d_dump_filename))
-                        {
-                            LOG(WARNING) << "Error deleting temporary file";
-                        }
-                }
-        }
-    if (d_dump && (pos != 0) && d_dump_mat)
-        {
-            save_tlm_matfile(d_dump_filename);
-            if (d_remove_dat)
-                {
-                    if (!tlm_remove_file(d_dump_filename))
-                        {
-                            LOG(WARNING) << "Error deleting temporary file";
-                        }
-                }
-        }
+    tlm_cleanup_and_save_files(d_dump_file, d_dump_filename, d_dump, d_dump_mat, d_remove_dat);
 }
 
 
@@ -301,11 +270,7 @@ void beidou_b3i_telemetry_decoder_gs::decode_subframe(float *frame_symbols, doub
             this->message_port_pub(pmt::mp("telemetry"), pmt::make_any(tmp_obj));
             LOG(INFO) << "BEIDOU DNAV Ephemeris have been received in channel"
                       << d_channel << " from satellite " << d_satellite << " with CN0=" << cn0 << " dB-Hz";
-#if __cplusplus == 201103L
-            const int default_precision = std::cout.precision();
-#else
-            const auto default_precision{std::cout.precision()};
-#endif
+            const auto default_precision = std::cout.precision();
             std::cout << TEXT_YELLOW << "New BEIDOU B3I DNAV message received in channel " << d_channel
                       << ": ephemeris from satellite " << d_satellite
                       << " with CN0=" << std::setprecision(2) << cn0 << std::setprecision(default_precision)
@@ -319,11 +284,7 @@ void beidou_b3i_telemetry_decoder_gs::decode_subframe(float *frame_symbols, doub
             this->message_port_pub(pmt::mp("telemetry"), pmt::make_any(tmp_obj));
             LOG(INFO) << "BEIDOU DNAV UTC Model data have been received in channel"
                       << d_channel << " from satellite " << d_satellite;
-#if __cplusplus == 201103L
-            const int default_precision = std::cout.precision();
-#else
-            const auto default_precision{std::cout.precision()};
-#endif
+            const auto default_precision = std::cout.precision();
             std::cout << TEXT_YELLOW << "New BEIDOU B3I DNAV utc model message received in channel "
                       << d_channel << ": UTC model parameters from satellite "
                       << d_satellite
@@ -338,11 +299,7 @@ void beidou_b3i_telemetry_decoder_gs::decode_subframe(float *frame_symbols, doub
             this->message_port_pub(pmt::mp("telemetry"), pmt::make_any(tmp_obj));
             LOG(INFO) << "BEIDOU DNAV Iono data have been received in channel" << d_channel
                       << " from satellite " << d_satellite << " with CN0=" << cn0 << " dB-Hz";
-#if __cplusplus == 201103L
-            const int default_precision = std::cout.precision();
-#else
-            const auto default_precision{std::cout.precision()};
-#endif
+            const auto default_precision = std::cout.precision();
             std::cout << TEXT_YELLOW << "New BEIDOU B3I DNAV Iono message received in channel "
                       << d_channel << ": Iono model parameters from satellite "
                       << d_satellite << " with CN0=" << std::setprecision(2) << cn0 << std::setprecision(default_precision)
@@ -357,11 +314,7 @@ void beidou_b3i_telemetry_decoder_gs::decode_subframe(float *frame_symbols, doub
             //            pmt::make_any(tmp_obj));
             LOG(INFO) << "BEIDOU DNAV Almanac data have been received in channel"
                       << d_channel << " from satellite " << d_satellite << " with CN0=" << cn0 << " dB-Hz";
-#if __cplusplus == 201103L
-            const int default_precision = std::cout.precision();
-#else
-            const auto default_precision{std::cout.precision()};
-#endif
+            const auto default_precision = std::cout.precision();
             std::cout << TEXT_YELLOW << "New BEIDOU B3I DNAV almanac received in channel " << d_channel
                       << " from satellite " << d_satellite
                       << " with CN0=" << std::setprecision(2) << cn0 << std::setprecision(default_precision)
@@ -681,19 +634,11 @@ int beidou_b3i_telemetry_decoder_gs::general_work(
                     // MULTIPLEXED FILE RECORDING - Record results to file
                     try
                         {
-                            double tmp_double;
-                            uint64_t tmp_ulong_int;
-                            int32_t tmp_int;
-                            tmp_double = static_cast<double>(d_TOW_at_current_symbol_ms) / 1000.0;
-                            d_dump_file.write(reinterpret_cast<char *>(&tmp_double), sizeof(double));
-                            tmp_ulong_int = current_symbol.Tracking_sample_counter;
-                            d_dump_file.write(reinterpret_cast<char *>(&tmp_ulong_int), sizeof(uint64_t));
-                            tmp_double = static_cast<double>(d_TOW_at_Preamble_ms) / 1000.0;
-                            d_dump_file.write(reinterpret_cast<char *>(&tmp_double), sizeof(double));
-                            tmp_int = (current_symbol.Prompt_I > 0.0 ? 1 : -1);
-                            d_dump_file.write(reinterpret_cast<char *>(&tmp_int), sizeof(int32_t));
-                            tmp_int = static_cast<int32_t>(current_symbol.PRN);
-                            d_dump_file.write(reinterpret_cast<char *>(&tmp_int), sizeof(int32_t));
+                            write_value(d_dump_file, static_cast<double>(d_TOW_at_current_symbol_ms) / 1000.0);
+                            write_value(d_dump_file, current_symbol.Tracking_sample_counter);
+                            write_value(d_dump_file, static_cast<double>(d_TOW_at_Preamble_ms) / 1000.0);
+                            write_value(d_dump_file, current_symbol.Prompt_I > 0.0 ? 1 : -1);
+                            write_value(d_dump_file, static_cast<int32_t>(current_symbol.PRN));
                         }
                     catch (const std::ofstream::failure &e)
                         {
@@ -704,12 +649,12 @@ int beidou_b3i_telemetry_decoder_gs::general_work(
             // SEND TOW TO THE TRACKING BLOCK
             if (d_tow_to_trk)
                 {
-                    const std::shared_ptr<TOW_to_trk> tmp_tow_obj = std::make_shared<TOW_to_trk>(TOW_to_trk(
+                    const std::shared_ptr<TOW_to_trk> tmp_tow_obj = std::make_shared<TOW_to_trk>(
                         std::string(current_symbol.Signal),
                         d_channel,
                         d_TOW_at_current_symbol_ms,
                         current_symbol.Tracking_sample_counter,
-                        d_nav.get_ephemeris().WN, d_satellite.get_PRN()));
+                        d_nav.get_ephemeris().WN, d_satellite.get_PRN());
                     this->message_port_pub(pmt::mp("telemetry_to_trk"), pmt::make_any(tmp_tow_obj));
                 }
 

--- a/src/algorithms/telemetry_decoder/gnuradio_blocks/beidou_b3i_telemetry_decoder_gs.h
+++ b/src/algorithms/telemetry_decoder/gnuradio_blocks/beidou_b3i_telemetry_decoder_gs.h
@@ -20,10 +20,7 @@
 #include "beidou_dnav_navigation_message.h"
 #include "nav_message_packet.h"
 #include "telemetry_impl_interface.h"
-#include "tlm_conf.h"
 #include <boost/circular_buffer.hpp>
-#include <gnuradio/types.h>  // for gr_vector_const_void_star
-#include <array>
 
 
 /** \addtogroup Telemetry_Decoder
@@ -110,12 +107,12 @@ private:
     bool d_flag_preamble;    // Flag indicating when preamble was found
     bool d_flag_valid_word;
     bool d_sent_tlm_failed_msg;
-    bool d_dump;
-    bool d_dump_mat;
-    bool d_remove_dat;
-    bool d_enable_navdata_monitor;
+    const bool d_dump;
+    const bool d_dump_mat;
+    const bool d_remove_dat;
+    const bool d_enable_navdata_monitor;
     bool d_dump_crc_stats;
-    bool d_tow_to_trk;
+    const bool d_tow_to_trk;
 };
 
 

--- a/src/algorithms/telemetry_decoder/gnuradio_blocks/galileo_telemetry_decoder_gs.cc
+++ b/src/algorithms/telemetry_decoder/gnuradio_blocks/galileo_telemetry_decoder_gs.cc
@@ -19,11 +19,11 @@
 
 
 #include "galileo_telemetry_decoder_gs.h"
-#include "Galileo_E1.h"              // for GALILEO_E1_CODE_PERIOD_MS
-#include "Galileo_E5a.h"             // for GALILEO_E5A_CODE_PERIOD_MS
-#include "Galileo_E5b.h"             // for GALILEO_E5B_CODE_PERIOD_MS
-#include "Galileo_E6.h"              // for GALILEO_E6_CODE_PERIOD_MS
-#include "display.h"                 // for colours in terminal: TEXT_BLUE, TEXT_RESET, ...
+#include "Galileo_E1.h"   // for GALILEO_E1_CODE_PERIOD_MS
+#include "Galileo_E5a.h"  // for GALILEO_E5A_CODE_PERIOD_MS
+#include "Galileo_E6.h"   // for GALILEO_E6_CODE_PERIOD_MS
+#include "display.h"      // for colours in terminal: TEXT_BLUE, TEXT_RESET, ...
+#include "dump_logger_helper.h"
 #include "galileo_almanac_helper.h"  // for Galileo_Almanac_Helper
 #include "galileo_ephemeris.h"       // for Galileo_Ephemeris
 #include "galileo_has_page.h"        // For Galileo_HAS_page
@@ -31,22 +31,22 @@
 #include "galileo_utc_model.h"       // for Galileo_Utc_Model
 #include "gnss_sdr_make_unique.h"    // for std::make_unique in C++11
 #include "gnss_synchro.h"            // for Gnss_Synchro
-#include "tlm_crc_stats.h"           // for Tlm_CRC_Stats
-#include "tlm_utils.h"               // for save_tlm_matfile, tlm_remove_file
-#include "tow_to_trk.h"              // for TOW_to_trk
-#include "viterbi_decoder.h"         // for Viterbi_Decoder
-#include <pmt/pmt_sugar.h>           // for pmt::mp
-#include <array>                     // for std::array
-#include <cmath>                     // for std::fmod, std::abs
-#include <cstddef>                   // for size_t
-#include <exception>                 // for std::exception
-#include <iomanip>                   // for std::setprecision
-#include <iostream>                  // for std::cout
-#include <limits>                    // for std::numeric_limits
-#include <map>                       // for std::map
-#include <stdexcept>                 // for std::out_of_range
-#include <tuple>                     // for std::tuple
-#include <typeinfo>                  // for typeid
+#include "tlm_conf.h"
+#include "tlm_crc_stats.h"    // for Tlm_CRC_Stats
+#include "tlm_utils.h"        // for save_tlm_matfile, tlm_remove_file
+#include "tow_to_trk.h"       // for TOW_to_trk
+#include "viterbi_decoder.h"  // for Viterbi_Decoder
+#include <pmt/pmt_sugar.h>    // for pmt::mp
+#include <array>              // for std::array
+#include <cmath>              // for std::fmod, std::abs
+#include <cstddef>            // for size_t
+#include <iomanip>            // for std::setprecision
+#include <iostream>           // for std::cout
+#include <limits>             // for std::numeric_limits
+#include <map>                // for std::map
+#include <stdexcept>          // for std::out_of_range
+#include <tuple>              // for std::tuple
+#include <typeinfo>           // for typeid
 
 #if USE_GLOG_AND_GFLAGS
 #include <glog/logging.h>
@@ -285,37 +285,7 @@ galileo_telemetry_decoder_gs::galileo_telemetry_decoder_gs(
 galileo_telemetry_decoder_gs::~galileo_telemetry_decoder_gs()
 {
     DLOG(INFO) << "Galileo Telemetry decoder block (channel " << d_channel << ") destructor called.";
-    size_t pos = 0;
-    if (d_dump_file.is_open() == true)
-        {
-            pos = d_dump_file.tellp();
-            try
-                {
-                    d_dump_file.close();
-                }
-            catch (const std::exception &ex)
-                {
-                    LOG(WARNING) << "Exception in destructor closing the dump file " << ex.what();
-                }
-            if (pos == 0)
-                {
-                    if (!tlm_remove_file(d_dump_filename))
-                        {
-                            LOG(WARNING) << "Error deleting temporary file";
-                        }
-                }
-        }
-    if (d_dump && (pos != 0) && d_dump_mat)
-        {
-            save_tlm_matfile(d_dump_filename);
-            if (d_remove_dat)
-                {
-                    if (!tlm_remove_file(d_dump_filename))
-                        {
-                            LOG(WARNING) << "Error deleting temporary file";
-                        }
-                }
-        }
+    tlm_cleanup_and_save_files(d_dump_file, d_dump_filename, d_dump, d_dump_mat, d_remove_dat);
 }
 
 
@@ -463,11 +433,7 @@ void galileo_telemetry_decoder_gs::decode_INAV_word(float *page_part_symbols, in
             const std::shared_ptr<Galileo_Ephemeris> tmp_obj = std::make_shared<Galileo_Ephemeris>(d_inav_nav.get_ephemeris());
             if (d_band == '1')
                 {
-#if __cplusplus == 201103L
-                    const int default_precision = std::cout.precision();
-#else
-                    const auto default_precision{std::cout.precision()};
-#endif
+                    const auto default_precision = std::cout.precision();
                     std::cout << "New Galileo E1 I/NAV message received in channel " << d_channel
                               << ": ephemeris from satellite " << d_satellite << " with CN0="
                               << std::setprecision(2) << cn0 << std::setprecision(default_precision)
@@ -475,11 +441,7 @@ void galileo_telemetry_decoder_gs::decode_INAV_word(float *page_part_symbols, in
                 }
             else if (d_band == '7')
                 {
-#if __cplusplus == 201103L
-                    const int default_precision = std::cout.precision();
-#else
-                    const auto default_precision{std::cout.precision()};
-#endif
+                    const auto default_precision = std::cout.precision();
                     std::cout << TEXT_BLUE
                               << "New Galileo E5b I/NAV message received in channel " << d_channel
                               << ": ephemeris from satellite " << d_satellite << " with CN0="
@@ -496,11 +458,7 @@ void galileo_telemetry_decoder_gs::decode_INAV_word(float *page_part_symbols, in
                 {
                     const std::shared_ptr<Galileo_Ephemeris> tmp_obj = std::make_shared<Galileo_Ephemeris>(d_inav_nav.get_reduced_ced());
                     this->message_port_pub(pmt::mp("telemetry"), pmt::make_any(tmp_obj));
-#if __cplusplus == 201103L
-                    const int default_precision = std::cout.precision();
-#else
-                    const auto default_precision{std::cout.precision()};
-#endif
+                    const auto default_precision = std::cout.precision();
                     std::cout << "New Galileo E1 I/NAV reduced CED message received in channel "
                               << d_channel << " from satellite " << d_satellite << " with CN0="
                               << std::setprecision(2) << cn0 << std::setprecision(default_precision)
@@ -515,11 +473,7 @@ void galileo_telemetry_decoder_gs::decode_INAV_word(float *page_part_symbols, in
             this->message_port_pub(pmt::mp("telemetry"), pmt::make_any(tmp_obj));
             if (d_band == '1')
                 {
-#if __cplusplus == 201103L
-                    const int default_precision = std::cout.precision();
-#else
-                    const auto default_precision{std::cout.precision()};
-#endif
+                    const auto default_precision = std::cout.precision();
                     std::cout << "New Galileo E1 I/NAV message received in channel " << d_channel
                               << ": iono/GST model parameters from satellite " << d_satellite
                               << " with CN0=" << std::setprecision(2) << cn0 << std::setprecision(default_precision)
@@ -527,11 +481,7 @@ void galileo_telemetry_decoder_gs::decode_INAV_word(float *page_part_symbols, in
                 }
             else if (d_band == '7')
                 {
-#if __cplusplus == 201103L
-                    const int default_precision = std::cout.precision();
-#else
-                    const auto default_precision{std::cout.precision()};
-#endif
+                    const auto default_precision = std::cout.precision();
                     std::cout << TEXT_BLUE << "New Galileo E5b I/NAV message received in channel "
                               << d_channel << ": iono/GST model parameters from satellite "
                               << d_satellite << " with CN0=" << std::setprecision(2) << cn0 << std::setprecision(default_precision)
@@ -547,11 +497,7 @@ void galileo_telemetry_decoder_gs::decode_INAV_word(float *page_part_symbols, in
             this->message_port_pub(pmt::mp("telemetry"), pmt::make_any(tmp_obj));
             if (d_band == '1')
                 {
-#if __cplusplus == 201103L
-                    const int default_precision = std::cout.precision();
-#else
-                    const auto default_precision{std::cout.precision()};
-#endif
+                    const auto default_precision = std::cout.precision();
                     std::cout << "New Galileo E1 I/NAV message received in channel " << d_channel
                               << ": UTC model parameters from satellite " << d_satellite
                               << " with CN0=" << std::setprecision(2) << cn0 << std::setprecision(default_precision)
@@ -559,11 +505,7 @@ void galileo_telemetry_decoder_gs::decode_INAV_word(float *page_part_symbols, in
                 }
             else if (d_band == '7')
                 {
-#if __cplusplus == 201103L
-                    const int default_precision = std::cout.precision();
-#else
-                    const auto default_precision{std::cout.precision()};
-#endif
+                    const auto default_precision = std::cout.precision();
                     std::cout << TEXT_BLUE << "New Galileo E5b I/NAV message received in channel "
                               << d_channel
                               << ": UTC model parameters from satellite " << d_satellite
@@ -582,22 +524,14 @@ void galileo_telemetry_decoder_gs::decode_INAV_word(float *page_part_symbols, in
             // debug
             if (d_band == '1')
                 {
-#if __cplusplus == 201103L
-                    const int default_precision = std::cout.precision();
-#else
-                    const auto default_precision{std::cout.precision()};
-#endif
+                    const auto default_precision = std::cout.precision();
                     std::cout << "Galileo E1 I/NAV almanac received in channel " << d_channel
                               << " from satellite " << d_satellite << " with CN0="
                               << std::setprecision(2) << cn0 << std::setprecision(default_precision) << " dB-Hz" << std::endl;
                 }
             else if (d_band == '7')
                 {
-#if __cplusplus == 201103L
-                    const int default_precision = std::cout.precision();
-#else
-                    const auto default_precision{std::cout.precision()};
-#endif
+                    const auto default_precision = std::cout.precision();
                     std::cout << TEXT_BLUE << "Galileo E5b I/NAV almanac received in channel "
                               << d_channel << " from satellite " << d_satellite << " with CN0="
                               << std::setprecision(2) << cn0 << std::setprecision(default_precision)
@@ -672,11 +606,7 @@ void galileo_telemetry_decoder_gs::decode_FNAV_word(float *page_symbols, int32_t
         {
             const std::shared_ptr<Galileo_Ephemeris> tmp_obj = std::make_shared<Galileo_Ephemeris>(d_fnav_nav.get_ephemeris());
             this->message_port_pub(pmt::mp("telemetry"), pmt::make_any(tmp_obj));
-#if __cplusplus == 201103L
-            const int default_precision = std::cout.precision();
-#else
-            const auto default_precision{std::cout.precision()};
-#endif
+            const auto default_precision = std::cout.precision();
             std::cout << TEXT_MAGENTA << "New Galileo E5a F/NAV message received in channel "
                       << d_channel << ": ephemeris from satellite " << d_satellite << " with CN0="
                       << std::setprecision(2) << cn0 << std::setprecision(default_precision)
@@ -687,11 +617,7 @@ void galileo_telemetry_decoder_gs::decode_FNAV_word(float *page_symbols, int32_t
         {
             const std::shared_ptr<Galileo_Iono> tmp_obj = std::make_shared<Galileo_Iono>(d_fnav_nav.get_iono());
             this->message_port_pub(pmt::mp("telemetry"), pmt::make_any(tmp_obj));
-#if __cplusplus == 201103L
-            const int default_precision = std::cout.precision();
-#else
-            const auto default_precision{std::cout.precision()};
-#endif
+            const auto default_precision = std::cout.precision();
             std::cout << TEXT_MAGENTA << "New Galileo E5a F/NAV message received in channel "
                       << d_channel << ": iono/GST model parameters from satellite " << d_satellite
                       << " with CN0=" << std::setprecision(2) << cn0 << std::setprecision(default_precision)
@@ -703,11 +629,7 @@ void galileo_telemetry_decoder_gs::decode_FNAV_word(float *page_symbols, int32_t
             const std::shared_ptr<Galileo_Utc_Model> tmp_obj = std::make_shared<Galileo_Utc_Model>(d_fnav_nav.get_utc_model());
             LOG(INFO) << "Galileo leap second Delta_tLS=" << tmp_obj->Delta_tLS;
             this->message_port_pub(pmt::mp("telemetry"), pmt::make_any(tmp_obj));
-#if __cplusplus == 201103L
-            const int default_precision = std::cout.precision();
-#else
-            const auto default_precision{std::cout.precision()};
-#endif
+            const auto default_precision = std::cout.precision();
             std::cout << TEXT_MAGENTA << "New Galileo E5a F/NAV message received in channel "
                       << d_channel << ": UTC model parameters from satellite " << d_satellite
                       << " with CN0=" << std::setprecision(2) << cn0 << std::setprecision(default_precision)
@@ -768,11 +690,7 @@ void galileo_telemetry_decoder_gs::decode_CNAV_word(uint64_t time_stamp, float *
                     if (is_page_dummy != d_cnav_dummy_page)
                         {
                             d_cnav_dummy_page = is_page_dummy;
-#if __cplusplus == 201103L
-                            const int default_precision = std::cout.precision();
-#else
-                            const auto default_precision{std::cout.precision()};
-#endif
+                            const auto default_precision = std::cout.precision();
                             std::cout << TEXT_MAGENTA << "Receiving Galileo E6 CNAV dummy pages in channel "
                                       << d_channel << " from satellite "
                                       << d_satellite << " with CN0="
@@ -791,11 +709,7 @@ void galileo_telemetry_decoder_gs::decode_CNAV_word(uint64_t time_stamp, float *
                     if (d_print_cnav_page == true)
                         {
                             d_print_cnav_page = false;  // only print the first page
-#if __cplusplus == 201103L
-                            const int default_precision = std::cout.precision();
-#else
-                            const auto default_precision{std::cout.precision()};
-#endif
+                            const auto default_precision = std::cout.precision();
                             std::cout << TEXT_MAGENTA << "Receiving Galileo E6 HAS pages"
                                       << (d_cnav_nav.is_HAS_in_test_mode() == true ? " (test mode) " : " ")
                                       << "in channel " << d_channel << " from satellite " << d_satellite
@@ -1390,33 +1304,27 @@ int galileo_telemetry_decoder_gs::general_work(int noutput_items __attribute__((
                     // MULTIPLEXED FILE RECORDING - Record results to file
                     try
                         {
-                            double tmp_double;
-                            uint64_t tmp_ulong_int;
-                            int32_t tmp_int;
-                            tmp_double = static_cast<double>(d_TOW_at_current_symbol_ms) / 1000.0;
-                            d_dump_file.write(reinterpret_cast<char *>(&tmp_double), sizeof(double));
-                            tmp_ulong_int = current_symbol.Tracking_sample_counter;
-                            d_dump_file.write(reinterpret_cast<char *>(&tmp_ulong_int), sizeof(uint64_t));
-                            tmp_double = static_cast<double>(d_TOW_at_Preamble_ms) / 1000.0;
-                            d_dump_file.write(reinterpret_cast<char *>(&tmp_double), sizeof(double));
+                            write_value(d_dump_file, static_cast<double>(d_TOW_at_current_symbol_ms) / 1000.0);
+                            write_value(d_dump_file, current_symbol.Tracking_sample_counter);
+                            write_value(d_dump_file, static_cast<double>(d_TOW_at_Preamble_ms) / 1000.0);
+
                             switch (d_frame_type)
                                 {
                                 case 1:
-                                    tmp_int = (current_symbol.Prompt_I > 0.0 ? 1 : -1);
+                                    write_value(d_dump_file, current_symbol.Prompt_I > 0.0 ? 1 : -1);
                                     break;
                                 case 2:
-                                    tmp_int = (current_symbol.Prompt_Q > 0.0 ? 1 : -1);
+                                    write_value(d_dump_file, current_symbol.Prompt_Q > 0.0 ? 1 : -1);
                                     break;
                                 case 3:
-                                    tmp_int = (current_symbol.Prompt_I > 0.0 ? 1 : -1);
+                                    write_value(d_dump_file, current_symbol.Prompt_I > 0.0 ? 1 : -1);
                                     break;
                                 default:
-                                    tmp_int = 0;
+                                    write_value(d_dump_file, 0);
                                     break;
                                 }
-                            d_dump_file.write(reinterpret_cast<char *>(&tmp_int), sizeof(int32_t));
-                            tmp_int = static_cast<int32_t>(current_symbol.PRN);
-                            d_dump_file.write(reinterpret_cast<char *>(&tmp_int), sizeof(int32_t));
+
+                            write_value(d_dump_file, static_cast<int32_t>(current_symbol.PRN));
                         }
                     catch (const std::ofstream::failure &e)
                         {
@@ -1440,12 +1348,12 @@ int galileo_telemetry_decoder_gs::general_work(int noutput_items __attribute__((
                             gal_week = 0;
                             break;
                         }
-                    const std::shared_ptr<TOW_to_trk> tmp_tow_obj = std::make_shared<TOW_to_trk>(TOW_to_trk(
+                    const std::shared_ptr<TOW_to_trk> tmp_tow_obj = std::make_shared<TOW_to_trk>(
                         std::string(current_symbol.Signal),
                         d_channel,
                         d_TOW_at_current_symbol_ms,
                         current_symbol.Tracking_sample_counter,
-                        gal_week, d_satellite.get_PRN()));
+                        gal_week, d_satellite.get_PRN());
                     this->message_port_pub(pmt::mp("telemetry_to_trk"), pmt::make_any(tmp_tow_obj));
                 }
 

--- a/src/algorithms/telemetry_decoder/gnuradio_blocks/galileo_telemetry_decoder_gs.h
+++ b/src/algorithms/telemetry_decoder/gnuradio_blocks/galileo_telemetry_decoder_gs.h
@@ -21,17 +21,14 @@
 #ifndef GNSS_SDR_GALILEO_TELEMETRY_DECODER_GS_H
 #define GNSS_SDR_GALILEO_TELEMETRY_DECODER_GS_H
 
-#include "galileo_cnav_message.h"      // for Galileo_Cnav_Message
-#include "galileo_fnav_message.h"      // for Galileo_Fnav_Message
-#include "galileo_inav_message.h"      // for Galileo_Inav_Message
-#include "gnss_time.h"                 // for GnssTime
-#include "nav_message_packet.h"        // for Nav_Message_Packet
+#include "galileo_cnav_message.h"  // for Galileo_Cnav_Message
+#include "galileo_fnav_message.h"  // for Galileo_Fnav_Message
+#include "galileo_inav_message.h"  // for Galileo_Inav_Message
+#include "gnss_time.h"
+#include "nav_message_packet.h"
 #include "telemetry_impl_interface.h"  // for telemetry_impl_interface
-#include "tlm_conf.h"                  // for Tlm_Conf
 #include <boost/circular_buffer.hpp>   // for boost::circular_buffer
-#include <gnuradio/types.h>            // for gr_vector_const_void_star
-#include <pmt/pmt.h>                   // for pmt::pmt_t
-#include <vector>                      // for std::vector
+
 
 /** \addtogroup Telemetry_Decoder
  * \{ */
@@ -111,7 +108,7 @@ private:
     int32_t d_mm;
     int32_t d_codelength;
     int32_t d_datalength;
-    int32_t d_frame_type;
+    const int32_t d_frame_type;
     int32_t d_bits_per_preamble;
     int32_t d_samples_per_preamble;
     int32_t d_preamble_period_symbols;
@@ -134,21 +131,21 @@ private:
     bool d_flag_frame_sync;
     bool d_flag_PLL_180_deg_phase_locked;
     bool d_flag_preamble;
-    bool d_dump;
-    bool d_dump_mat;
-    bool d_remove_dat;
+    const bool d_dump;
+    const bool d_dump_mat;
+    const bool d_remove_dat;
     bool d_first_eph_sent;
     bool d_cnav_dummy_page;
     bool d_print_cnav_page;
-    bool d_enable_navdata_monitor;
+    const bool d_enable_navdata_monitor;
     bool d_dump_crc_stats;
     bool d_enable_reed_solomon_inav;
     bool d_valid_timetag;
     bool d_E6_TOW_set;
-    bool d_there_are_e1_channels;
-    bool d_there_are_e6_channels;
-    bool d_use_ced;
-    bool d_tow_to_trk;
+    const bool d_there_are_e1_channels;
+    const bool d_there_are_e6_channels;
+    const bool d_use_ced;
+    const bool d_tow_to_trk;
 };
 
 

--- a/src/algorithms/telemetry_decoder/gnuradio_blocks/glonass_l1_ca_telemetry_decoder_gs.cc
+++ b/src/algorithms/telemetry_decoder/gnuradio_blocks/glonass_l1_ca_telemetry_decoder_gs.cc
@@ -17,10 +17,12 @@
 
 
 #include "glonass_l1_ca_telemetry_decoder_gs.h"
+#include "dump_logger_helper.h"
 #include "glonass_gnav_almanac.h"
 #include "glonass_gnav_ephemeris.h"
 #include "glonass_gnav_utc_model.h"
 #include "gnss_sdr_make_unique.h"  // for std::make_unique in C++11
+#include "tlm_conf.h"
 #include "tlm_crc_stats.h"
 #include "tlm_utils.h"
 #include "tow_to_trk.h"
@@ -28,9 +30,7 @@
 #include <pmt/pmt.h>        // for make_any
 #include <pmt/pmt_sugar.h>  // for mp
 #include <cmath>            // for floor, round
-#include <cstddef>          // for size_t
 #include <cstdlib>          // for abs
-#include <exception>        // for exception
 #include <iomanip>          // for std::setprecision
 #include <iostream>         // for cout
 
@@ -105,37 +105,7 @@ glonass_l1_ca_telemetry_decoder_gs::glonass_l1_ca_telemetry_decoder_gs(
 glonass_l1_ca_telemetry_decoder_gs::~glonass_l1_ca_telemetry_decoder_gs()
 {
     DLOG(INFO) << "Glonass L1 Telemetry decoder block (channel " << d_channel << ") destructor called.";
-    size_t pos = 0;
-    if (d_dump_file.is_open() == true)
-        {
-            pos = d_dump_file.tellp();
-            try
-                {
-                    d_dump_file.close();
-                }
-            catch (const std::exception &ex)
-                {
-                    LOG(WARNING) << "Exception in destructor closing the dump file " << ex.what();
-                }
-            if (pos == 0)
-                {
-                    if (!tlm_remove_file(d_dump_filename))
-                        {
-                            LOG(WARNING) << "Error deleting temporary file";
-                        }
-                }
-        }
-    if (d_dump && (pos != 0) && d_dump_mat)
-        {
-            save_tlm_matfile(d_dump_filename);
-            if (d_remove_dat)
-                {
-                    if (!tlm_remove_file(d_dump_filename))
-                        {
-                            LOG(WARNING) << "Error deleting temporary file";
-                        }
-                }
-        }
+    tlm_cleanup_and_save_files(d_dump_file, d_dump_filename, d_dump, d_dump_mat, d_remove_dat);
 }
 
 
@@ -197,11 +167,7 @@ void glonass_l1_ca_telemetry_decoder_gs::decode_string(const double *frame_symbo
             const std::shared_ptr<Glonass_Gnav_Ephemeris> tmp_obj = std::make_shared<Glonass_Gnav_Ephemeris>(d_nav.get_ephemeris());
             this->message_port_pub(pmt::mp("telemetry"), pmt::make_any(tmp_obj));
             LOG(INFO) << "GLONASS GNAV Ephemeris have been received in channel" << d_channel << " from satellite " << d_satellite;
-#if __cplusplus == 201103L
-            const int default_precision = std::cout.precision();
-#else
-            const auto default_precision{std::cout.precision()};
-#endif
+            const auto default_precision = std::cout.precision();
             std::cout << "New GLONASS L1 GNAV message received in channel " << d_channel
                       << ": ephemeris from satellite " << d_satellite
                       << " with CN0=" << std::setprecision(2) << cn0 << std::setprecision(default_precision)
@@ -213,11 +179,7 @@ void glonass_l1_ca_telemetry_decoder_gs::decode_string(const double *frame_symbo
             const std::shared_ptr<Glonass_Gnav_Utc_Model> tmp_obj = std::make_shared<Glonass_Gnav_Utc_Model>(d_nav.get_utc_model());
             this->message_port_pub(pmt::mp("telemetry"), pmt::make_any(tmp_obj));
             LOG(INFO) << "GLONASS GNAV UTC Model data have been received in channel" << d_channel << " from satellite " << d_satellite;
-#if __cplusplus == 201103L
-            const int default_precision = std::cout.precision();
-#else
-            const auto default_precision{std::cout.precision()};
-#endif
+            const auto default_precision = std::cout.precision();
             std::cout << "New GLONASS L1 GNAV message received in channel " << d_channel
                       << ": UTC model parameters from satellite " << d_satellite
                       << " with CN0=" << std::setprecision(2) << cn0 << std::setprecision(default_precision)
@@ -230,11 +192,7 @@ void glonass_l1_ca_telemetry_decoder_gs::decode_string(const double *frame_symbo
                 tmp_obj = std::make_shared<Glonass_Gnav_Almanac>(d_nav.get_almanac(slot_nbr));
             this->message_port_pub(pmt::mp("telemetry"), pmt::make_any(tmp_obj));
             LOG(INFO) << "GLONASS GNAV Almanac data have been received in channel" << d_channel << " in slot number " << slot_nbr;
-#if __cplusplus == 201103L
-            const int default_precision = std::cout.precision();
-#else
-            const auto default_precision{std::cout.precision()};
-#endif
+            const auto default_precision = std::cout.precision();
             std::cout << "New GLONASS L1 GNAV almanac received in channel " << d_channel << " from satellite " << d_satellite
                       << " with CN0=" << std::setprecision(2) << cn0 << std::setprecision(default_precision)
                       << " dB-Hz" << std::endl;
@@ -435,12 +393,12 @@ int glonass_l1_ca_telemetry_decoder_gs::general_work(int noutput_items __attribu
             // SEND TOW TO THE TRACKING BLOCK
             if (d_tow_to_trk)
                 {
-                    const std::shared_ptr<TOW_to_trk> tmp_tow_obj = std::make_shared<TOW_to_trk>(TOW_to_trk(
+                    const std::shared_ptr<TOW_to_trk> tmp_tow_obj = std::make_shared<TOW_to_trk>(
                         std::string(current_symbol.Signal),
                         d_channel,
                         current_symbol.TOW_at_current_symbol_ms,
                         current_symbol.Tracking_sample_counter,
-                        d_nav.get_ephemeris().d_WN, d_satellite.get_PRN()));
+                        d_nav.get_ephemeris().d_WN, d_satellite.get_PRN());
                     this->message_port_pub(pmt::mp("telemetry_to_trk"), pmt::make_any(tmp_tow_obj));
                 }
         }
@@ -457,19 +415,11 @@ int glonass_l1_ca_telemetry_decoder_gs::general_work(int noutput_items __attribu
             // MULTIPLEXED FILE RECORDING - Record results to file
             try
                 {
-                    double tmp_double;
-                    uint64_t tmp_ulong_int;
-                    int32_t tmp_int;
-                    tmp_double = d_TOW_at_current_symbol;
-                    d_dump_file.write(reinterpret_cast<char *>(&tmp_double), sizeof(double));
-                    tmp_ulong_int = current_symbol.Tracking_sample_counter;
-                    d_dump_file.write(reinterpret_cast<char *>(&tmp_ulong_int), sizeof(uint64_t));
-                    tmp_double = 0;
-                    d_dump_file.write(reinterpret_cast<char *>(&tmp_double), sizeof(double));
-                    tmp_int = (current_symbol.Prompt_I > 0.0 ? 1 : -1);
-                    d_dump_file.write(reinterpret_cast<char *>(&tmp_int), sizeof(int32_t));
-                    tmp_int = static_cast<int32_t>(current_symbol.PRN);
-                    d_dump_file.write(reinterpret_cast<char *>(&tmp_int), sizeof(int32_t));
+                    write_value(d_dump_file, d_TOW_at_current_symbol);
+                    write_value(d_dump_file, current_symbol.Tracking_sample_counter);
+                    write_value(d_dump_file, 0);
+                    write_value(d_dump_file, current_symbol.Prompt_I > 0.0 ? 1 : -1);
+                    write_value(d_dump_file, static_cast<int32_t>(current_symbol.PRN));
                 }
             catch (const std::ofstream::failure &e)
                 {

--- a/src/algorithms/telemetry_decoder/gnuradio_blocks/glonass_l1_ca_telemetry_decoder_gs.h
+++ b/src/algorithms/telemetry_decoder/gnuradio_blocks/glonass_l1_ca_telemetry_decoder_gs.h
@@ -24,16 +24,12 @@
 #include "gnss_synchro.h"
 #include "nav_message_packet.h"
 #include "telemetry_impl_interface.h"
-#include "tlm_conf.h"
 #include <boost/circular_buffer.hpp>
-#include <gnuradio/types.h>  // for gr_vector_const_void_star
-#include <array>
 
 /** \addtogroup Telemetry_Decoder
  * \{ */
 /** \addtogroup Telemetry_Decoder_gnuradio_blocks
  * \{ */
-
 
 class glonass_l1_ca_telemetry_decoder_gs;
 
@@ -101,12 +97,12 @@ private:
 
     bool d_flag_frame_sync;  // Indicate when a frame sync is achieved
     bool d_flag_preamble;    // Flag indicating when preamble was found
-    bool d_dump;
-    bool d_dump_mat;
-    bool d_remove_dat;
-    bool d_enable_navdata_monitor;
+    const bool d_dump;
+    const bool d_dump_mat;
+    const bool d_remove_dat;
+    const bool d_enable_navdata_monitor;
     bool d_dump_crc_stats;
-    bool d_tow_to_trk;
+    const bool d_tow_to_trk;
 };
 
 

--- a/src/algorithms/telemetry_decoder/gnuradio_blocks/glonass_l2_ca_telemetry_decoder_gs.cc
+++ b/src/algorithms/telemetry_decoder/gnuradio_blocks/glonass_l2_ca_telemetry_decoder_gs.cc
@@ -17,10 +17,12 @@
 
 #include "glonass_l2_ca_telemetry_decoder_gs.h"
 #include "display.h"
+#include "dump_logger_helper.h"
 #include "glonass_gnav_almanac.h"
 #include "glonass_gnav_ephemeris.h"
 #include "glonass_gnav_utc_model.h"
 #include "gnss_sdr_make_unique.h"  // for std::make_unique in C++11
+#include "tlm_conf.h"
 #include "tlm_crc_stats.h"
 #include "tlm_utils.h"
 #include "tow_to_trk.h"
@@ -28,9 +30,7 @@
 #include <pmt/pmt.h>        // for make_any
 #include <pmt/pmt_sugar.h>  // for mp
 #include <cmath>            // for floor, round
-#include <cstddef>          // for size_t
 #include <cstdlib>          // for abs
-#include <exception>        // for exception
 #include <iomanip>          // for std::setprecision
 #include <iostream>         // for cout
 
@@ -105,37 +105,7 @@ glonass_l2_ca_telemetry_decoder_gs::glonass_l2_ca_telemetry_decoder_gs(
 glonass_l2_ca_telemetry_decoder_gs::~glonass_l2_ca_telemetry_decoder_gs()
 {
     DLOG(INFO) << "Glonass L2 Telemetry decoder block (channel " << d_channel << ") destructor called.";
-    size_t pos = 0;
-    if (d_dump_file.is_open() == true)
-        {
-            pos = d_dump_file.tellp();
-            try
-                {
-                    d_dump_file.close();
-                }
-            catch (const std::exception &ex)
-                {
-                    LOG(WARNING) << "Exception in destructor closing the dump file " << ex.what();
-                }
-            if (pos == 0)
-                {
-                    if (!tlm_remove_file(d_dump_filename))
-                        {
-                            LOG(WARNING) << "Error deleting temporary file";
-                        }
-                }
-        }
-    if (d_dump && (pos != 0) && d_dump_mat)
-        {
-            save_tlm_matfile(d_dump_filename);
-            if (d_remove_dat)
-                {
-                    if (!tlm_remove_file(d_dump_filename))
-                        {
-                            LOG(WARNING) << "Error deleting temporary file";
-                        }
-                }
-        }
+    tlm_cleanup_and_save_files(d_dump_file, d_dump_filename, d_dump, d_dump_mat, d_remove_dat);
 }
 
 
@@ -197,11 +167,7 @@ void glonass_l2_ca_telemetry_decoder_gs::decode_string(const double *frame_symbo
             const std::shared_ptr<Glonass_Gnav_Ephemeris> tmp_obj = std::make_shared<Glonass_Gnav_Ephemeris>(d_nav.get_ephemeris());
             this->message_port_pub(pmt::mp("telemetry"), pmt::make_any(tmp_obj));
             LOG(INFO) << "GLONASS GNAV Ephemeris have been received in channel" << d_channel << " from satellite " << d_satellite;
-#if __cplusplus == 201103L
-            const int default_precision = std::cout.precision();
-#else
-            const auto default_precision{std::cout.precision()};
-#endif
+            const auto default_precision = std::cout.precision();
             std::cout << TEXT_CYAN << "New GLONASS L2 GNAV message received in channel " << d_channel
                       << ": ephemeris from satellite " << d_satellite
                       << " with CN0=" << std::setprecision(2) << cn0 << std::setprecision(default_precision)
@@ -213,11 +179,7 @@ void glonass_l2_ca_telemetry_decoder_gs::decode_string(const double *frame_symbo
             const std::shared_ptr<Glonass_Gnav_Utc_Model> tmp_obj = std::make_shared<Glonass_Gnav_Utc_Model>(d_nav.get_utc_model());
             this->message_port_pub(pmt::mp("telemetry"), pmt::make_any(tmp_obj));
             LOG(INFO) << "GLONASS GNAV UTC Model data have been received in channel" << d_channel << " from satellite " << d_satellite;
-#if __cplusplus == 201103L
-            const int default_precision = std::cout.precision();
-#else
-            const auto default_precision{std::cout.precision()};
-#endif
+            const auto default_precision = std::cout.precision();
             std::cout << TEXT_CYAN << "New GLONASS L2 GNAV message received in channel " << d_channel
                       << ": UTC model parameters from satellite " << d_satellite
                       << " with CN0=" << std::setprecision(2) << cn0 << std::setprecision(default_precision)
@@ -230,11 +192,7 @@ void glonass_l2_ca_telemetry_decoder_gs::decode_string(const double *frame_symbo
                 tmp_obj = std::make_shared<Glonass_Gnav_Almanac>(d_nav.get_almanac(slot_nbr));
             this->message_port_pub(pmt::mp("telemetry"), pmt::make_any(tmp_obj));
             LOG(INFO) << "GLONASS GNAV Almanac data have been received in channel" << d_channel << " in slot number " << slot_nbr;
-#if __cplusplus == 201103L
-            const int default_precision = std::cout.precision();
-#else
-            const auto default_precision{std::cout.precision()};
-#endif
+            const auto default_precision = std::cout.precision();
             std::cout << TEXT_CYAN << "New GLONASS L2 GNAV almanac received in channel " << d_channel
                       << " from satellite " << d_satellite
                       << " with CN0=" << std::setprecision(2) << cn0 << std::setprecision(default_precision)
@@ -433,12 +391,12 @@ int glonass_l2_ca_telemetry_decoder_gs::general_work(int noutput_items __attribu
             // SEND TOW TO THE TRACKING BLOCK
             if (d_tow_to_trk)
                 {
-                    const std::shared_ptr<TOW_to_trk> tmp_tow_obj = std::make_shared<TOW_to_trk>(TOW_to_trk(
+                    const std::shared_ptr<TOW_to_trk> tmp_tow_obj = std::make_shared<TOW_to_trk>(
                         std::string(current_symbol.Signal),
                         d_channel,
                         current_symbol.TOW_at_current_symbol_ms,
                         current_symbol.Tracking_sample_counter,
-                        d_nav.get_ephemeris().d_WN, d_satellite.get_PRN()));
+                        d_nav.get_ephemeris().d_WN, d_satellite.get_PRN());
                     this->message_port_pub(pmt::mp("telemetry_to_trk"), pmt::make_any(tmp_tow_obj));
                 }
         }
@@ -455,19 +413,11 @@ int glonass_l2_ca_telemetry_decoder_gs::general_work(int noutput_items __attribu
             // MULTIPLEXED FILE RECORDING - Record results to file
             try
                 {
-                    double tmp_double;
-                    uint64_t tmp_ulong_int;
-                    int32_t tmp_int;
-                    tmp_double = d_TOW_at_current_symbol;
-                    d_dump_file.write(reinterpret_cast<char *>(&tmp_double), sizeof(double));
-                    tmp_ulong_int = current_symbol.Tracking_sample_counter;
-                    d_dump_file.write(reinterpret_cast<char *>(&tmp_ulong_int), sizeof(uint64_t));
-                    tmp_double = 0;
-                    d_dump_file.write(reinterpret_cast<char *>(&tmp_double), sizeof(double));
-                    tmp_int = (current_symbol.Prompt_I > 0.0 ? 1 : -1);
-                    d_dump_file.write(reinterpret_cast<char *>(&tmp_int), sizeof(int32_t));
-                    tmp_int = static_cast<int32_t>(current_symbol.PRN);
-                    d_dump_file.write(reinterpret_cast<char *>(&tmp_int), sizeof(int32_t));
+                    write_value(d_dump_file, d_TOW_at_current_symbol);
+                    write_value(d_dump_file, current_symbol.Tracking_sample_counter);
+                    write_value(d_dump_file, 0);
+                    write_value(d_dump_file, current_symbol.Prompt_I > 0.0 ? 1 : -1);
+                    write_value(d_dump_file, static_cast<int32_t>(current_symbol.PRN));
                 }
             catch (const std::ofstream::failure &e)
                 {

--- a/src/algorithms/telemetry_decoder/gnuradio_blocks/glonass_l2_ca_telemetry_decoder_gs.h
+++ b/src/algorithms/telemetry_decoder/gnuradio_blocks/glonass_l2_ca_telemetry_decoder_gs.h
@@ -23,10 +23,7 @@
 #include "gnss_synchro.h"
 #include "nav_message_packet.h"
 #include "telemetry_impl_interface.h"
-#include "tlm_conf.h"
 #include <boost/circular_buffer.hpp>
-#include <gnuradio/types.h>  // for gr_vector_const_void_star
-#include <array>
 
 /** \addtogroup Telemetry_Decoder
  * \{ */
@@ -96,12 +93,12 @@ private:
 
     bool d_flag_frame_sync;  // Indicate when a frame sync is achieved
     bool d_flag_preamble;    // Flag indicating when preamble was found
-    bool d_dump;
-    bool d_dump_mat;
-    bool d_remove_dat;
-    bool d_enable_navdata_monitor;
+    const bool d_dump;
+    const bool d_dump_mat;
+    const bool d_remove_dat;
+    const bool d_enable_navdata_monitor;
     bool d_dump_crc_stats;
-    bool d_tow_to_trk;
+    const bool d_tow_to_trk;
 };
 
 

--- a/src/algorithms/telemetry_decoder/gnuradio_blocks/gps_l1_ca_telemetry_decoder_gs.cc
+++ b/src/algorithms/telemetry_decoder/gnuradio_blocks/gps_l1_ca_telemetry_decoder_gs.cc
@@ -20,10 +20,14 @@
  */
 
 #include "gps_l1_ca_telemetry_decoder_gs.h"
+#include "dump_logger_helper.h"
 #include "gnss_sdr_make_unique.h"  // for std::make_unique in C++11
-#include "gps_ephemeris.h"         // for Gps_Ephemeris
-#include "gps_iono.h"              // for Gps_Iono
-#include "gps_utc_model.h"         // for Gps_Utc_Model
+#include "gnss_synchro.h"
+#include "gnss_time.h"      // for timetags produced by Tracking
+#include "gps_ephemeris.h"  // for Gps_Ephemeris
+#include "gps_iono.h"       // for Gps_Iono
+#include "gps_utc_model.h"  // for Gps_Utc_Model
+#include "tlm_conf.h"
 #include "tlm_crc_stats.h"
 #include "tlm_utils.h"
 #include "tow_to_trk.h"
@@ -32,9 +36,7 @@
 #include <algorithm>        // for min
 #include <bitset>           // for bitset
 #include <cmath>            // for round
-#include <cstddef>          // for size_t
 #include <cstring>          // for memcpy
-#include <exception>        // for exception
 #include <iomanip>          // for setprecision
 #include <iostream>         // for cout
 #include <vector>
@@ -93,6 +95,7 @@ gps_l1_ca_telemetry_decoder_gs::gps_l1_ca_telemetry_decoder_gs(
                            d_channel(0),
                            d_required_symbols(GPS_SUBFRAME_BITS),
                            d_prev_GPS_frame_4bytes(0),
+                           d_max_symbols_without_valid_frame(d_required_symbols * 20),
                            d_stat(0),
                            d_TOW_at_Preamble_ms(0),
                            d_TOW_at_current_symbol_ms(0),
@@ -109,7 +112,8 @@ gps_l1_ca_telemetry_decoder_gs::gps_l1_ca_telemetry_decoder_gs(
                            d_enable_navdata_monitor(conf.enable_navdata_monitor),
                            d_dump_crc_stats(conf.dump_crc_stats),
                            d_tow_to_trk(conf.tow_to_trk),
-                           d_have_last_decoded_tow(false)
+                           d_have_last_decoded_tow(false)  // rise alarm 120 segs without valid tlm
+
 {
     configure_basic_outputs();
 
@@ -142,7 +146,6 @@ gps_l1_ca_telemetry_decoder_gs::gps_l1_ca_telemetry_decoder_gs(
 
     // set the preamble
     // preamble bits to sampled symbols
-    d_max_symbols_without_valid_frame = d_required_symbols * 20;  // rise alarm 120 segs without valid tlm
     int32_t n = 0;
     for (int32_t i = 0; i < d_bits_per_preamble; i++)
         {
@@ -179,37 +182,7 @@ gps_l1_ca_telemetry_decoder_gs::~gps_l1_ca_telemetry_decoder_gs()
     DLOG(INFO) << ((d_system == L1LnavSystem::GPS) ? "GPS" : "QZSS")
                << " L1 C/A Telemetry decoder block (channel "
                << d_channel << ") destructor called.";
-    size_t pos = 0;
-    if (d_dump_file.is_open() == true)
-        {
-            pos = d_dump_file.tellp();
-            try
-                {
-                    d_dump_file.close();
-                }
-            catch (const std::exception &ex)
-                {
-                    LOG(WARNING) << "Exception in destructor closing the dump file " << ex.what();
-                }
-            if (pos == 0)
-                {
-                    if (!tlm_remove_file(d_dump_filename))
-                        {
-                            LOG(WARNING) << "Error deleting temporary file";
-                        }
-                }
-        }
-    if (d_dump && (pos != 0) && d_dump_mat)
-        {
-            save_tlm_matfile(d_dump_filename);
-            if (d_remove_dat)
-                {
-                    if (!tlm_remove_file(d_dump_filename))
-                        {
-                            LOG(WARNING) << "Error deleting temporary file";
-                        }
-                }
-        }
+    tlm_cleanup_and_save_files(d_dump_file, d_dump_filename, d_dump, d_dump_mat, d_remove_dat);
 }
 
 
@@ -436,11 +409,7 @@ bool gps_l1_ca_telemetry_decoder_gs::decode_subframe(double cn0, bool flag_inver
                         }
                     if (received_subframe_ok)
                         {
-#if __cplusplus == 201103L
-                            const int default_precision = std::cout.precision();
-#else
-                            const auto default_precision{std::cout.precision()};
-#endif
+                            const auto default_precision = std::cout.precision();
                             std::cout << "New " << ((d_system == L1LnavSystem::GPS) ? "GPS" : "QZSS") << " NAV message received in channel " << this->d_channel << ": "
                                       << "subframe "
                                       << subframe_ID << " from satellite "
@@ -742,19 +711,11 @@ int gps_l1_ca_telemetry_decoder_gs::general_work(int noutput_items __attribute__
                     // MULTIPLEXED FILE RECORDING - Record results to file
                     try
                         {
-                            double tmp_double;
-                            uint64_t tmp_ulong_int;
-                            int32_t tmp_int;
-                            tmp_double = static_cast<double>(d_TOW_at_current_symbol_ms) / 1000.0;
-                            d_dump_file.write(reinterpret_cast<char *>(&tmp_double), sizeof(double));
-                            tmp_ulong_int = current_symbol.Tracking_sample_counter;
-                            d_dump_file.write(reinterpret_cast<char *>(&tmp_ulong_int), sizeof(uint64_t));
-                            tmp_double = static_cast<double>(d_TOW_at_Preamble_ms) / 1000.0;
-                            d_dump_file.write(reinterpret_cast<char *>(&tmp_double), sizeof(double));
-                            tmp_int = (current_symbol.Prompt_I > 0.0 ? 1 : -1);
-                            d_dump_file.write(reinterpret_cast<char *>(&tmp_int), sizeof(int32_t));
-                            tmp_int = static_cast<int32_t>(current_symbol.PRN);
-                            d_dump_file.write(reinterpret_cast<char *>(&tmp_int), sizeof(int32_t));
+                            write_value(d_dump_file, static_cast<double>(d_TOW_at_current_symbol_ms) / 1000.0);
+                            write_value(d_dump_file, current_symbol.Tracking_sample_counter);
+                            write_value(d_dump_file, static_cast<double>(d_TOW_at_Preamble_ms) / 1000.0);
+                            write_value(d_dump_file, current_symbol.Prompt_I > 0.0 ? 1 : -1);
+                            write_value(d_dump_file, static_cast<int32_t>(current_symbol.PRN));
                         }
                     catch (const std::ofstream::failure &e)
                         {
@@ -765,12 +726,12 @@ int gps_l1_ca_telemetry_decoder_gs::general_work(int noutput_items __attribute__
             // SEND TOW TO THE TRACKING BLOCK
             if (d_tow_to_trk)
                 {
-                    const std::shared_ptr<TOW_to_trk> tmp_tow_obj = std::make_shared<TOW_to_trk>(TOW_to_trk(
+                    const std::shared_ptr<TOW_to_trk> tmp_tow_obj = std::make_shared<TOW_to_trk>(
                         ((d_system == L1LnavSystem::GPS) ? std::string("1C") : std::string("J1")),
                         d_channel,
                         d_TOW_at_current_symbol_ms,
                         current_symbol.Tracking_sample_counter,
-                        d_nav->get_GPS_week(), d_nav->get_satellite_PRN()));
+                        d_nav->get_GPS_week(), d_nav->get_satellite_PRN());
                     this->message_port_pub(pmt::mp("telemetry_to_trk"), pmt::make_any(tmp_tow_obj));
                 }
 

--- a/src/algorithms/telemetry_decoder/gnuradio_blocks/gps_l1_ca_telemetry_decoder_gs.h
+++ b/src/algorithms/telemetry_decoder/gnuradio_blocks/gps_l1_ca_telemetry_decoder_gs.h
@@ -19,16 +19,10 @@
 #ifndef GNSS_SDR_GPS_L1_CA_TELEMETRY_DECODER_GS_H
 #define GNSS_SDR_GPS_L1_CA_TELEMETRY_DECODER_GS_H
 
-#include "GPS_L1_CA.h"
-#include "gnss_synchro.h"
-#include "gnss_time.h"  // for timetags produced by Tracking
 #include "gps_navigation_message.h"
 #include "nav_message_packet.h"
 #include "telemetry_impl_interface.h"
-#include "tlm_conf.h"
 #include <boost/circular_buffer.hpp>
-#include <gnuradio/types.h>  // for gr_vector_const_void_star
-#include <array>             // for array
 
 
 /** \addtogroup Telemetry_Decoder
@@ -43,6 +37,7 @@ enum class L1LnavSystem
     QZSS
 };
 
+class Gnss_Synchro;
 class gps_l1_ca_telemetry_decoder_gs;
 
 using gps_l1_ca_telemetry_decoder_gs_sptr = gnss_shared_ptr<gps_l1_ca_telemetry_decoder_gs>;
@@ -84,7 +79,7 @@ private:
     bool decode_subframe(double cn0, bool flag_invert);
     bool is_tow_consistent(uint32_t decoded_tow_s);
 
-    L1LnavSystem d_system;
+    const L1LnavSystem d_system;
     std::unique_ptr<Gps_Navigation_Message> d_nav;
     Gnss_Satellite d_satellite;
     Nav_Message_Packet d_nav_msg_packet;
@@ -101,15 +96,15 @@ private:
     uint64_t d_preamble_index;
     uint64_t d_last_valid_preamble;
 
-    int32_t d_bits_per_preamble;
-    int32_t d_samples_per_preamble;
-    int32_t d_preamble_period_symbols;
+    const int32_t d_bits_per_preamble;
+    const int32_t d_samples_per_preamble;
+    const int32_t d_preamble_period_symbols;
     int32_t d_CRC_error_counter;
     int32_t d_channel;
 
-    uint32_t d_required_symbols;
+    const uint32_t d_required_symbols;
     uint32_t d_prev_GPS_frame_4bytes;
-    uint32_t d_max_symbols_without_valid_frame;
+    const uint32_t d_max_symbols_without_valid_frame;
     uint32_t d_stat;
     uint32_t d_TOW_at_Preamble_ms;
     uint32_t d_TOW_at_current_symbol_ms;
@@ -121,12 +116,12 @@ private:
     bool d_sent_tlm_failed_msg;
     bool d_flag_PLL_180_deg_phase_locked;
     bool d_flag_TOW_set;
-    bool d_dump;
-    bool d_dump_mat;
-    bool d_remove_dat;
-    bool d_enable_navdata_monitor;
+    const bool d_dump;
+    const bool d_dump_mat;
+    const bool d_remove_dat;
+    const bool d_enable_navdata_monitor;
     bool d_dump_crc_stats;
-    bool d_tow_to_trk;
+    const bool d_tow_to_trk;
     bool d_have_last_decoded_tow;
 };
 

--- a/src/algorithms/telemetry_decoder/gnuradio_blocks/gps_l2c_telemetry_decoder_gs.cc
+++ b/src/algorithms/telemetry_decoder/gnuradio_blocks/gps_l2c_telemetry_decoder_gs.cc
@@ -18,11 +18,13 @@
 #include "gps_l2c_telemetry_decoder_gs.h"
 #include "GPS_L2C.h"  // for GPS_L2_CNAV_DATA_PAGE_BITS, GPS_L...
 #include "display.h"
+#include "dump_logger_helper.h"
 #include "gnss_sdr_make_unique.h"  // for std::make_unique in C++11
 #include "gnss_synchro.h"
 #include "gps_cnav_ephemeris.h"  // for Gps_CNAV_Ephemeris
 #include "gps_cnav_iono.h"       // for Gps_CNAV_Iono
 #include "gps_cnav_utc_model.h"  // for Gps_CNAV_Utc_Model
+#include "tlm_conf.h"
 #include "tlm_crc_stats.h"
 #include "tlm_utils.h"
 #include "tow_to_trk.h"
@@ -31,8 +33,6 @@
 #include <pmt/pmt_sugar.h>  // for mp
 #include <bitset>           // for bitset
 #include <cmath>            // for round
-#include <cstddef>          // for size_t
-#include <exception>        // for exception
 #include <iomanip>          // for setprecision
 #include <iostream>         // for cout
 
@@ -60,6 +60,7 @@ gps_l2c_telemetry_decoder_gs::gps_l2c_telemetry_decoder_gs(
                             d_sample_counter(0),
                             d_last_valid_preamble(0),
                             d_channel(0),
+                            d_max_symbols_without_valid_frame(GPS_L2_CNAV_DATA_PAGE_BITS * GPS_L2_SYMBOLS_PER_BIT * 5),
                             d_dump(conf.dump),
                             d_sent_tlm_failed_msg(false),
                             d_flag_PLL_180_deg_phase_locked(false),
@@ -68,7 +69,8 @@ gps_l2c_telemetry_decoder_gs::gps_l2c_telemetry_decoder_gs(
                             d_remove_dat(conf.remove_dat),
                             d_enable_navdata_monitor(conf.enable_navdata_monitor),
                             d_dump_crc_stats(conf.dump_crc_stats),
-                            d_tow_to_trk(conf.tow_to_trk)
+                            d_tow_to_trk(conf.tow_to_trk)  // rise alarm if 5 consecutive subframes have no valid CRC
+
 {
     configure_basic_outputs();
 
@@ -79,8 +81,6 @@ gps_l2c_telemetry_decoder_gs::gps_l2c_telemetry_decoder_gs(
             d_nav_msg_packet.system = std::string("G");
             d_nav_msg_packet.signal = std::string("2S");
         }
-
-    d_max_symbols_without_valid_frame = GPS_L2_CNAV_DATA_PAGE_BITS * GPS_L2_SYMBOLS_PER_BIT * 5;  // rise alarm if 5 consecutive subframes have no valid CRC
 
     d_satellite = Gnss_Satellite(satellite.get_system(), satellite.get_PRN());
     DLOG(INFO) << "GPS L2C M TELEMETRY PROCESSING: satellite " << d_satellite;
@@ -104,37 +104,7 @@ gps_l2c_telemetry_decoder_gs::gps_l2c_telemetry_decoder_gs(
 gps_l2c_telemetry_decoder_gs::~gps_l2c_telemetry_decoder_gs()
 {
     DLOG(INFO) << "GPS L2C Telemetry decoder block (channel " << d_channel << ") destructor called.";
-    size_t pos = 0;
-    if (d_dump_file.is_open() == true)
-        {
-            pos = d_dump_file.tellp();
-            try
-                {
-                    d_dump_file.close();
-                }
-            catch (const std::exception &ex)
-                {
-                    LOG(WARNING) << "Exception in destructor closing the dump file " << ex.what();
-                }
-            if (pos == 0)
-                {
-                    if (!tlm_remove_file(d_dump_filename))
-                        {
-                            LOG(WARNING) << "Error deleting temporary file";
-                        }
-                }
-        }
-    if (d_dump && (pos != 0) && d_dump_mat)
-        {
-            save_tlm_matfile(d_dump_filename);
-            if (d_remove_dat)
-                {
-                    if (!tlm_remove_file(d_dump_filename))
-                        {
-                            LOG(WARNING) << "Error deleting temporary file";
-                        }
-                }
-        }
+    tlm_cleanup_and_save_files(d_dump_file, d_dump_filename, d_dump, d_dump_mat, d_remove_dat);
 }
 
 
@@ -237,11 +207,7 @@ int gps_l2c_telemetry_decoder_gs::general_work(int noutput_items __attribute__((
                     // get ephemeris object for this SV
                     const std::shared_ptr<Gps_CNAV_Ephemeris> tmp_obj = std::make_shared<Gps_CNAV_Ephemeris>(d_CNAV_Message.get_ephemeris());
                     this->message_port_pub(pmt::mp("telemetry"), pmt::make_any(tmp_obj));
-#if __cplusplus == 201103L
-                    const int default_precision = std::cout.precision();
-#else
-                    const auto default_precision{std::cout.precision()};
-#endif
+                    const auto default_precision = std::cout.precision();
                     std::cout << TEXT_BLUE << "New GPS CNAV message received in channel " << d_channel
                               << ": ephemeris from satellite " << d_satellite
                               << " with CN0=" << std::setprecision(2) << current_synchro_data.CN0_dB_hz << std::setprecision(default_precision)
@@ -251,11 +217,7 @@ int gps_l2c_telemetry_decoder_gs::general_work(int noutput_items __attribute__((
                 {
                     const std::shared_ptr<Gps_CNAV_Iono> tmp_obj = std::make_shared<Gps_CNAV_Iono>(d_CNAV_Message.get_iono());
                     this->message_port_pub(pmt::mp("telemetry"), pmt::make_any(tmp_obj));
-#if __cplusplus == 201103L
-                    const int default_precision = std::cout.precision();
-#else
-                    const auto default_precision{std::cout.precision()};
-#endif
+                    const auto default_precision = std::cout.precision();
                     std::cout << TEXT_BLUE << "New GPS CNAV message received in channel " << d_channel
                               << ": iono model parameters from satellite " << d_satellite
                               << " with CN0=" << std::setprecision(2) << current_synchro_data.CN0_dB_hz << std::setprecision(default_precision)
@@ -266,11 +228,7 @@ int gps_l2c_telemetry_decoder_gs::general_work(int noutput_items __attribute__((
                 {
                     const std::shared_ptr<Gps_CNAV_Utc_Model> tmp_obj = std::make_shared<Gps_CNAV_Utc_Model>(d_CNAV_Message.get_utc_model());
                     this->message_port_pub(pmt::mp("telemetry"), pmt::make_any(tmp_obj));
-#if __cplusplus == 201103L
-                    const int default_precision = std::cout.precision();
-#else
-                    const auto default_precision{std::cout.precision()};
-#endif
+                    const auto default_precision = std::cout.precision();
                     std::cout << TEXT_BLUE << "New GPS CNAV message received in channel " << d_channel
                               << ": UTC model parameters from satellite " << d_satellite
                               << " with CN0=" << std::setprecision(2) << current_synchro_data.CN0_dB_hz << std::setprecision(default_precision)
@@ -327,19 +285,11 @@ int gps_l2c_telemetry_decoder_gs::general_work(int noutput_items __attribute__((
             // MULTIPLEXED FILE RECORDING - Record results to file
             try
                 {
-                    double tmp_double;
-                    uint64_t tmp_ulong_int;
-                    int32_t tmp_int;
-                    tmp_double = d_TOW_at_current_symbol;
-                    d_dump_file.write(reinterpret_cast<char *>(&tmp_double), sizeof(double));
-                    tmp_ulong_int = current_synchro_data.Tracking_sample_counter;
-                    d_dump_file.write(reinterpret_cast<char *>(&tmp_ulong_int), sizeof(uint64_t));
-                    tmp_double = d_TOW_at_Preamble;
-                    d_dump_file.write(reinterpret_cast<char *>(&tmp_double), sizeof(double));
-                    tmp_int = (current_synchro_data.Prompt_I > 0.0 ? 1 : -1);
-                    d_dump_file.write(reinterpret_cast<char *>(&tmp_int), sizeof(int32_t));
-                    tmp_int = static_cast<int32_t>(current_synchro_data.PRN);
-                    d_dump_file.write(reinterpret_cast<char *>(&tmp_int), sizeof(int32_t));
+                    write_value(d_dump_file, static_cast<double>(d_TOW_at_current_symbol));
+                    write_value(d_dump_file, current_synchro_data.Tracking_sample_counter);
+                    write_value(d_dump_file, d_TOW_at_Preamble);
+                    write_value(d_dump_file, current_synchro_data.Prompt_I > 0.0 ? 1 : -1);
+                    write_value(d_dump_file, static_cast<int32_t>(current_synchro_data.PRN));
                 }
             catch (const std::ofstream::failure &e)
                 {
@@ -349,12 +299,12 @@ int gps_l2c_telemetry_decoder_gs::general_work(int noutput_items __attribute__((
 
     if (d_tow_to_trk)
         {
-            const std::shared_ptr<TOW_to_trk> tmp_tow_obj = std::make_shared<TOW_to_trk>(TOW_to_trk(
+            const std::shared_ptr<TOW_to_trk> tmp_tow_obj = std::make_shared<TOW_to_trk>(
                 std::string("L2"),
                 d_channel,
                 current_synchro_data.TOW_at_current_symbol_ms,
                 current_synchro_data.Tracking_sample_counter,
-                d_CNAV_Message.get_ephemeris().WN, d_satellite.get_PRN()));
+                d_CNAV_Message.get_ephemeris().WN, d_satellite.get_PRN());
             this->message_port_pub(pmt::mp("telemetry_to_trk"), pmt::make_any(tmp_tow_obj));
         }
 

--- a/src/algorithms/telemetry_decoder/gnuradio_blocks/gps_l2c_telemetry_decoder_gs.h
+++ b/src/algorithms/telemetry_decoder/gnuradio_blocks/gps_l2c_telemetry_decoder_gs.h
@@ -21,8 +21,6 @@
 #include "gps_cnav_navigation_message.h"
 #include "nav_message_packet.h"
 #include "telemetry_impl_interface.h"
-#include "tlm_conf.h"
-#include <gnuradio/types.h>  // for gr_vector_const_void_star
 
 extern "C"
 {
@@ -87,17 +85,17 @@ private:
 
     int32_t d_channel;
 
-    uint32_t d_max_symbols_without_valid_frame;
+    const uint32_t d_max_symbols_without_valid_frame;
 
-    bool d_dump;
+    const bool d_dump;
     bool d_sent_tlm_failed_msg;
     bool d_flag_PLL_180_deg_phase_locked;
     bool d_flag_valid_word;
-    bool d_dump_mat;
-    bool d_remove_dat;
-    bool d_enable_navdata_monitor;
+    const bool d_dump_mat;
+    const bool d_remove_dat;
+    const bool d_enable_navdata_monitor;
     bool d_dump_crc_stats;
-    bool d_tow_to_trk;
+    const bool d_tow_to_trk;
 };
 
 

--- a/src/algorithms/telemetry_decoder/gnuradio_blocks/gps_l5_telemetry_decoder_gs.cc
+++ b/src/algorithms/telemetry_decoder/gnuradio_blocks/gps_l5_telemetry_decoder_gs.cc
@@ -17,12 +17,15 @@
 
 
 #include "gps_l5_telemetry_decoder_gs.h"
+#include "GPS_L5.h"
 #include "display.h"
+#include "dump_logger_helper.h"
 #include "gnss_sdr_make_unique.h"  // for std::make_unique in C++11
 #include "gnss_synchro.h"
 #include "gps_cnav_ephemeris.h"
 #include "gps_cnav_iono.h"
 #include "gps_cnav_utc_model.h"  // for Gps_CNAV_Utc_Model
+#include "tlm_conf.h"
 #include "tlm_crc_stats.h"
 #include "tlm_utils.h"
 #include "tow_to_trk.h"
@@ -30,9 +33,7 @@
 #include <pmt/pmt.h>        // for make_any
 #include <pmt/pmt_sugar.h>  // for mp
 #include <bitset>           // for std::bitset
-#include <cstddef>          // for size_t
 #include <cstdlib>          // for std::llabs
-#include <exception>        // for std::exception
 #include <iomanip>          // for std::setprecision
 #include <iostream>         // for std::cout
 
@@ -62,6 +63,7 @@ gps_l5_telemetry_decoder_gs::gps_l5_telemetry_decoder_gs(
                          d_channel(0),
                          d_TOW_at_current_symbol_ms(0U),
                          d_TOW_at_Preamble_ms(0U),
+                         d_max_symbols_without_valid_frame(GPS_L5_CNAV_DATA_PAGE_BITS * GPS_L5_SYMBOLS_PER_BIT * 10),
                          d_flag_PLL_180_deg_phase_locked(false),
                          d_flag_valid_word(false),
                          d_sent_tlm_failed_msg(false),
@@ -70,7 +72,7 @@ gps_l5_telemetry_decoder_gs::gps_l5_telemetry_decoder_gs(
                          d_remove_dat(conf.remove_dat),
                          d_enable_navdata_monitor(conf.enable_navdata_monitor),
                          d_dump_crc_stats(conf.dump_crc_stats),
-                         d_tow_to_trk(conf.tow_to_trk)
+                         d_tow_to_trk(conf.tow_to_trk)  // rise alarm if 20 consecutive subframes have no valid CRC
 {
     configure_basic_outputs();
 
@@ -89,8 +91,6 @@ gps_l5_telemetry_decoder_gs::gps_l5_telemetry_decoder_gs(
                     d_nav_msg_packet.signal = std::string("J5");
                 }
         }
-
-    d_max_symbols_without_valid_frame = GPS_L5_CNAV_DATA_PAGE_BITS * GPS_L5_SYMBOLS_PER_BIT * 10;  // rise alarm if 20 consecutive subframes have no valid CRC
 
     d_CNAV_Message = std::make_unique<Gps_CNAV_Navigation_Message>(d_system);
     d_satellite = Gnss_Satellite(satellite.get_system(), satellite.get_PRN());
@@ -115,37 +115,7 @@ gps_l5_telemetry_decoder_gs::gps_l5_telemetry_decoder_gs(
 gps_l5_telemetry_decoder_gs::~gps_l5_telemetry_decoder_gs()
 {
     DLOG(INFO) << ((d_system == CnavSystem::GPS) ? "GPS" : "QZSS") << " L5 Telemetry decoder block (channel " << d_channel << ") destructor called.";
-    size_t pos = 0;
-    if (d_dump_file.is_open() == true)
-        {
-            pos = d_dump_file.tellp();
-            try
-                {
-                    d_dump_file.close();
-                }
-            catch (const std::exception &ex)
-                {
-                    LOG(WARNING) << "Exception in destructor closing the dump file " << ex.what();
-                }
-            if (pos == 0)
-                {
-                    if (!tlm_remove_file(d_dump_filename))
-                        {
-                            LOG(WARNING) << "Error deleting temporary file";
-                        }
-                }
-        }
-    if (d_dump && (pos != 0) && d_dump_mat)
-        {
-            save_tlm_matfile(d_dump_filename);
-            if (d_remove_dat)
-                {
-                    if (!tlm_remove_file(d_dump_filename))
-                        {
-                            LOG(WARNING) << "Error deleting temporary file";
-                        }
-                }
-        }
+    tlm_cleanup_and_save_files(d_dump_file, d_dump_filename, d_dump, d_dump_mat, d_remove_dat);
 }
 
 
@@ -155,14 +125,12 @@ void gps_l5_telemetry_decoder_gs::set_satellite(const Gnss_Satellite &satellite)
     DLOG(INFO) << ((d_system == CnavSystem::GPS) ? "GPS" : "QZSS")
                << " L5 CNAV telemetry decoder in channel "
                << this->d_channel << " set to satellite " << d_satellite;
-    d_CNAV_Message = std::make_unique<Gps_CNAV_Navigation_Message>(d_system);
 }
 
 
 void gps_l5_telemetry_decoder_gs::set_channel(int32_t channel)
 {
     d_channel = channel;
-    d_CNAV_Message = std::make_unique<Gps_CNAV_Navigation_Message>(d_system);
     DLOG(INFO) << ((d_system == CnavSystem::GPS) ? "GPS" : "QZSS")
                << " L5 CNAV channel set to " << channel;
 
@@ -252,11 +220,7 @@ int gps_l5_telemetry_decoder_gs::general_work(int noutput_items __attribute__((u
                     // get ephemeris object for this SV
                     const std::shared_ptr<Gps_CNAV_Ephemeris> tmp_obj = std::make_shared<Gps_CNAV_Ephemeris>(d_CNAV_Message->get_ephemeris());
                     this->message_port_pub(pmt::mp("telemetry"), pmt::make_any(tmp_obj));
-#if __cplusplus == 201103L
-                    const int default_precision = std::cout.precision();
-#else
-                    const auto default_precision{std::cout.precision()};
-#endif
+                    const auto default_precision = std::cout.precision();
                     std::cout << TEXT_MAGENTA << "New " << ((d_system == CnavSystem::GPS) ? "GPS" : "QZSS")
                               << " L5 CNAV message received in channel " << d_channel
                               << ": ephemeris from satellite " << d_satellite
@@ -267,11 +231,7 @@ int gps_l5_telemetry_decoder_gs::general_work(int noutput_items __attribute__((u
                 {
                     const std::shared_ptr<Gps_CNAV_Iono> tmp_obj = std::make_shared<Gps_CNAV_Iono>(d_CNAV_Message->get_iono());
                     this->message_port_pub(pmt::mp("telemetry"), pmt::make_any(tmp_obj));
-#if __cplusplus == 201103L
-                    const int default_precision = std::cout.precision();
-#else
-                    const auto default_precision{std::cout.precision()};
-#endif
+                    const auto default_precision = std::cout.precision();
                     std::cout << TEXT_MAGENTA << "New " << ((d_system == CnavSystem::GPS) ? "GPS" : "QZSS")
                               << " L5 CNAV message received in channel " << d_channel
                               << ": iono model parameters from satellite " << d_satellite
@@ -283,11 +243,7 @@ int gps_l5_telemetry_decoder_gs::general_work(int noutput_items __attribute__((u
                 {
                     const std::shared_ptr<Gps_CNAV_Utc_Model> tmp_obj = std::make_shared<Gps_CNAV_Utc_Model>(d_CNAV_Message->get_utc_model());
                     this->message_port_pub(pmt::mp("telemetry"), pmt::make_any(tmp_obj));
-#if __cplusplus == 201103L
-                    const int default_precision = std::cout.precision();
-#else
-                    const auto default_precision{std::cout.precision()};
-#endif
+                    const auto default_precision = std::cout.precision();
                     std::cout << TEXT_MAGENTA << "New " << ((d_system == CnavSystem::GPS) ? "GPS" : "QZSS")
                               << " L5 CNAV message received in channel " << d_channel
                               << ": UTC model parameters from satellite " << d_satellite
@@ -365,19 +321,11 @@ int gps_l5_telemetry_decoder_gs::general_work(int noutput_items __attribute__((u
                     // MULTIPLEXED FILE RECORDING - Record results to file
                     try
                         {
-                            double tmp_double;
-                            uint64_t tmp_ulong_int;
-                            int32_t tmp_int;
-                            tmp_double = static_cast<double>(d_TOW_at_current_symbol_ms) / 1000.0;
-                            d_dump_file.write(reinterpret_cast<char *>(&tmp_double), sizeof(double));
-                            tmp_ulong_int = current_synchro_data.Tracking_sample_counter;
-                            d_dump_file.write(reinterpret_cast<char *>(&tmp_ulong_int), sizeof(uint64_t));
-                            tmp_double = static_cast<double>(d_TOW_at_Preamble_ms) / 1000.0;
-                            d_dump_file.write(reinterpret_cast<char *>(&tmp_double), sizeof(double));
-                            tmp_int = (current_synchro_data.Prompt_Q > 0.0 ? 1 : -1);
-                            d_dump_file.write(reinterpret_cast<char *>(&tmp_int), sizeof(int32_t));
-                            tmp_int = static_cast<int32_t>(current_synchro_data.PRN);
-                            d_dump_file.write(reinterpret_cast<char *>(&tmp_int), sizeof(int32_t));
+                            write_value(d_dump_file, static_cast<double>(d_TOW_at_current_symbol_ms) / 1000.0);
+                            write_value(d_dump_file, current_synchro_data.Tracking_sample_counter);
+                            write_value(d_dump_file, static_cast<double>(d_TOW_at_Preamble_ms) / 1000.0);
+                            write_value(d_dump_file, (current_synchro_data.Prompt_Q > 0.0 ? 1 : -1));
+                            write_value(d_dump_file, static_cast<int32_t>(current_synchro_data.PRN));
                         }
                     catch (const std::ofstream::failure &e)
                         {
@@ -390,12 +338,12 @@ int gps_l5_telemetry_decoder_gs::general_work(int noutput_items __attribute__((u
             // SEND TOW TO THE TRACKING BLOCK
             if (d_tow_to_trk)
                 {
-                    const std::shared_ptr<TOW_to_trk> tmp_tow_obj = std::make_shared<TOW_to_trk>(TOW_to_trk(
+                    const std::shared_ptr<TOW_to_trk> tmp_tow_obj = std::make_shared<TOW_to_trk>(
                         std::string(((d_system == CnavSystem::GPS) ? "L5" : "J5")),
                         d_channel,
                         d_TOW_at_current_symbol_ms,
                         current_synchro_data.Tracking_sample_counter,
-                        d_CNAV_Message->get_ephemeris().WN, d_satellite.get_PRN()));
+                        d_CNAV_Message->get_ephemeris().WN, d_satellite.get_PRN());
                     this->message_port_pub(pmt::mp("telemetry_to_trk"), pmt::make_any(tmp_tow_obj));
                 }
 

--- a/src/algorithms/telemetry_decoder/gnuradio_blocks/gps_l5_telemetry_decoder_gs.cc
+++ b/src/algorithms/telemetry_decoder/gnuradio_blocks/gps_l5_telemetry_decoder_gs.cc
@@ -63,7 +63,7 @@ gps_l5_telemetry_decoder_gs::gps_l5_telemetry_decoder_gs(
                          d_channel(0),
                          d_TOW_at_current_symbol_ms(0U),
                          d_TOW_at_Preamble_ms(0U),
-                         d_max_symbols_without_valid_frame(GPS_L5_CNAV_DATA_PAGE_BITS * GPS_L5_SYMBOLS_PER_BIT * 10),
+                         d_max_symbols_without_valid_frame(GPS_L5_CNAV_DATA_PAGE_BITS * GPS_L5_SYMBOLS_PER_BIT * 10),  // rise alarm if 20 consecutive subframes have no valid CRC
                          d_flag_PLL_180_deg_phase_locked(false),
                          d_flag_valid_word(false),
                          d_sent_tlm_failed_msg(false),
@@ -72,7 +72,7 @@ gps_l5_telemetry_decoder_gs::gps_l5_telemetry_decoder_gs(
                          d_remove_dat(conf.remove_dat),
                          d_enable_navdata_monitor(conf.enable_navdata_monitor),
                          d_dump_crc_stats(conf.dump_crc_stats),
-                         d_tow_to_trk(conf.tow_to_trk)  // rise alarm if 20 consecutive subframes have no valid CRC
+                         d_tow_to_trk(conf.tow_to_trk)
 {
     configure_basic_outputs();
 
@@ -125,6 +125,7 @@ void gps_l5_telemetry_decoder_gs::set_satellite(const Gnss_Satellite &satellite)
     DLOG(INFO) << ((d_system == CnavSystem::GPS) ? "GPS" : "QZSS")
                << " L5 CNAV telemetry decoder in channel "
                << this->d_channel << " set to satellite " << d_satellite;
+    d_CNAV_Message = std::make_unique<Gps_CNAV_Navigation_Message>(d_system);
 }
 
 
@@ -136,6 +137,7 @@ void gps_l5_telemetry_decoder_gs::set_channel(int32_t channel)
 
     configure_dump_file(d_channel, d_dump, d_dump_filename, d_dump_file);
     configure_crc_stats_channel(d_channel, d_dump_crc_stats, d_Tlm_CRC_Stats);
+    d_CNAV_Message = std::make_unique<Gps_CNAV_Navigation_Message>(d_system);
 }
 
 

--- a/src/algorithms/telemetry_decoder/gnuradio_blocks/gps_l5_telemetry_decoder_gs.h
+++ b/src/algorithms/telemetry_decoder/gnuradio_blocks/gps_l5_telemetry_decoder_gs.h
@@ -18,13 +18,10 @@
 #define GNSS_SDR_GPS_L5_TELEMETRY_DECODER_GS_H
 
 
-#include "GPS_L5.h"                       // for GPS_L5I_NH_CODE_LENGTH
 #include "gps_cnav_navigation_message.h"  // for Gps_CNAV_Navigation_Message
 #include "nav_message_packet.h"
 #include "telemetry_impl_interface.h"
-#include "tlm_conf.h"
 #include <boost/circular_buffer.hpp>
-#include <gnuradio/types.h>  // for gr_vector_const_void_star
 
 extern "C"
 {
@@ -71,7 +68,7 @@ private:
     cnav_msg_decoder_t d_cnav_decoder{};
 
     Gnss_Satellite d_satellite;
-    CnavSystem d_system;
+    const CnavSystem d_system;
 
     std::unique_ptr<Gps_CNAV_Navigation_Message> d_CNAV_Message;
 
@@ -88,17 +85,17 @@ private:
 
     uint32_t d_TOW_at_current_symbol_ms;
     uint32_t d_TOW_at_Preamble_ms;
-    uint32_t d_max_symbols_without_valid_frame;
+    const uint32_t d_max_symbols_without_valid_frame;
 
     bool d_flag_PLL_180_deg_phase_locked;
     bool d_flag_valid_word;
     bool d_sent_tlm_failed_msg;
-    bool d_dump;
-    bool d_dump_mat;
-    bool d_remove_dat;
-    bool d_enable_navdata_monitor;
+    const bool d_dump;
+    const bool d_dump_mat;
+    const bool d_remove_dat;
+    const bool d_enable_navdata_monitor;
     bool d_dump_crc_stats;
-    bool d_tow_to_trk;
+    const bool d_tow_to_trk;
 };
 
 

--- a/src/algorithms/telemetry_decoder/gnuradio_blocks/telemetry_impl_interface.h
+++ b/src/algorithms/telemetry_decoder/gnuradio_blocks/telemetry_impl_interface.h
@@ -27,6 +27,7 @@
 #include <string>
 #include <utility>
 
+class Tlm_Conf;
 class Tlm_CRC_Stats;
 
 /** \addtogroup Telemetry_Decoder

--- a/src/algorithms/telemetry_decoder/libs/tlm_utils.cc
+++ b/src/algorithms/telemetry_decoder/libs/tlm_utils.cc
@@ -23,6 +23,12 @@
 #include <iostream>
 #include <vector>
 
+#if USE_GLOG_AND_GFLAGS
+#include <glog/logging.h>
+#else
+#include <absl/log/log.h>
+#endif
+
 
 int save_tlm_matfile(const std::string &dumpfile)
 {
@@ -120,4 +126,40 @@ bool tlm_remove_file(const std::string &file_to_remove)
 {
     errorlib::error_code ec;
     return fs::remove(fs::path(file_to_remove), ec);
+}
+
+
+void tlm_cleanup_and_save_files(std::ofstream &dump_file, const std::string &dump_filename, bool dump, bool dump_mat, bool remove_dat)
+{
+    size_t pos = 0;
+    if (dump_file.is_open() == true)
+        {
+            pos = dump_file.tellp();
+            try
+                {
+                    dump_file.close();
+                }
+            catch (const std::exception &ex)
+                {
+                    LOG(WARNING) << "Exception closing dump file " << ex.what();
+                }
+            if (pos == 0)
+                {
+                    if (!tlm_remove_file(dump_filename))
+                        {
+                            LOG(WARNING) << "Error deleting temporary file";
+                        }
+                }
+        }
+    if (dump && (pos != 0) && dump_mat)
+        {
+            save_tlm_matfile(dump_filename);
+            if (remove_dat)
+                {
+                    if (!tlm_remove_file(dump_filename))
+                        {
+                            LOG(WARNING) << "Error deleting temporary file";
+                        }
+                }
+        }
 }

--- a/src/algorithms/telemetry_decoder/libs/tlm_utils.h
+++ b/src/algorithms/telemetry_decoder/libs/tlm_utils.h
@@ -28,6 +28,8 @@ int save_tlm_matfile(const std::string &dumpfile);
 
 bool tlm_remove_file(const std::string &file_to_remove);
 
+void tlm_cleanup_and_save_files(std::ofstream &dump_file, const std::string &dump_filename, bool dump, bool dump_mat, bool remove_dat);
+
 /** \} */
 /** \} */
 #endif  // GNSS_SDR_TLM_UTILS_H


### PR DESCRIPTION
- Added function `write_value` to simplify writing to dump files
- Added function `tlm_cleanup_and_save_files` to remove duplicated code
- Removed conditional build for C++11
- Removed unnecessary copy of `TOW_to_trk` object
- Made some members `const`
- Removed includes