### PR TITLE
Fix two step threshold with bit_transition_flag

### DIFF
--- a/src/algorithms/acquisition/gnuradio_blocks/pcps_acquisition.cc
+++ b/src/algorithms/acquisition/gnuradio_blocks/pcps_acquisition.cc
@@ -704,7 +704,7 @@ void pcps_acquisition::acquisition_core(uint64_t sample_count)
         }
     else
         {
-            if (result.test_statistics > d_threshold)
+            if (result.test_statistics > get_threshold())
                 {
                     handle_threshold_reached(result);
                 }


### PR DESCRIPTION
While refactoring the acquisition class this bug was introduced, `get_threshold` will return the threshold based on `d_step_two`