### PR TITLE
Cleanup gnss factory to remove class

### DIFF
--- a/src/core/receiver/gnss_block_factory.cc
+++ b/src/core/receiver/gnss_block_factory.cc
@@ -912,9 +912,11 @@ std::unique_ptr<GNSSBlockInterface> get_block_force_impl(
 
 }  // namespace
 
+namespace block_factory
+{
 
-std::unique_ptr<SignalSourceInterface> GNSSBlockFactory::GetSignalSource(
-    const ConfigurationInterface* configuration, Concurrent_Queue<pmt::pmt_t>* queue, int ID) const
+std::unique_ptr<SignalSourceInterface> GetSignalSource(
+    const ConfigurationInterface* configuration, Concurrent_Queue<pmt::pmt_t>* queue, int ID)
 {
     const auto role = findRole(configuration, "SignalSource"s, ID);
     const auto implementation = configuration->property(role + impl_prop, ""s);
@@ -923,8 +925,8 @@ std::unique_ptr<SignalSourceInterface> GNSSBlockFactory::GetSignalSource(
 }
 
 
-std::unique_ptr<GNSSBlockInterface> GNSSBlockFactory::GetSignalConditioner(
-    const ConfigurationInterface* configuration, int ID) const
+std::unique_ptr<GNSSBlockInterface> GetSignalConditioner(
+    const ConfigurationInterface* configuration, int ID)
 {
     const auto role_conditioner = findRole(configuration, "SignalConditioner"s, ID);
     const auto role_datatypeadapter = findRole(configuration, "DataTypeAdapter"s, ID);
@@ -996,25 +998,25 @@ std::unique_ptr<GNSSBlockInterface> GNSSBlockFactory::GetSignalConditioner(
 }
 
 
-std::unique_ptr<GNSSBlockInterface> GNSSBlockFactory::GetObservables(const ConfigurationInterface* configuration) const
+std::unique_ptr<GNSSBlockInterface> GetObservables(const ConfigurationInterface* configuration)
 {
     const auto channel_count = get_channel_count(configuration);
     return get_block_force_impl(configuration, "Observables", "Hybrid_Observables", channel_count + 1, channel_count);  // 1 for monitor channel sample counter
 }
 
 
-std::unique_ptr<GNSSBlockInterface> GNSSBlockFactory::GetPVT(const ConfigurationInterface* configuration) const
+std::unique_ptr<GNSSBlockInterface> GetPVT(const ConfigurationInterface* configuration)
 {
     return get_block_force_impl(configuration, "PVT", "RTKLIB_PVT", get_channel_count(configuration), 0);
 }
 
 
 // ************************** GNSS CHANNEL *************************************
-std::unique_ptr<GNSSBlockInterface> GNSSBlockFactory::GetChannel(
+std::unique_ptr<GNSSBlockInterface> GetChannel(
     const ConfigurationInterface* configuration,
     const std::string& signal,
     int channel,
-    Concurrent_Queue<pmt::pmt_t>* queue) const
+    Concurrent_Queue<pmt::pmt_t>* queue)
 {
     const auto acq_role_name = get_role_name(configuration, "Acquisition_", signal, channel);
     const auto trk_role_name = get_role_name(configuration, "Tracking_", signal, channel);
@@ -1054,9 +1056,9 @@ std::unique_ptr<GNSSBlockInterface> GNSSBlockFactory::GetChannel(
 }
 
 
-std::vector<std::unique_ptr<GNSSBlockInterface>> GNSSBlockFactory::GetChannels(
+std::vector<std::unique_ptr<GNSSBlockInterface>> GetChannels(
     const ConfigurationInterface* configuration,
-    Concurrent_Queue<pmt::pmt_t>* queue) const
+    Concurrent_Queue<pmt::pmt_t>* queue)
 {
     int channel_absolute_id = 0;
     std::vector<std::unique_ptr<GNSSBlockInterface>> channels(get_channel_count(configuration));
@@ -1087,42 +1089,44 @@ std::vector<std::unique_ptr<GNSSBlockInterface>> GNSSBlockFactory::GetChannels(
 }
 
 
-std::unique_ptr<GNSSBlockInterface> GNSSBlockFactory::GetBlock(
+std::unique_ptr<GNSSBlockInterface> GetBlock(
     const ConfigurationInterface* configuration,
     const std::string& role,
     unsigned int in_streams,
     unsigned int out_streams,
-    Concurrent_Queue<pmt::pmt_t>* queue) const
+    Concurrent_Queue<pmt::pmt_t>* queue)
 {
     return get_block(configuration, role, in_streams, out_streams, queue);
 }
 
 
-std::unique_ptr<AcquisitionInterface> GNSSBlockFactory::GetAcqBlock(
+std::unique_ptr<AcquisitionInterface> GetAcqBlock(
     const ConfigurationInterface* configuration,
     const std::string& role,
     unsigned int in_streams,
-    unsigned int out_streams) const
+    unsigned int out_streams)
 {
     return get_block(configuration, role, in_streams, out_streams, get_acq_block);
 }
 
 
-std::unique_ptr<TrackingInterface> GNSSBlockFactory::GetTrkBlock(
+std::unique_ptr<TrackingInterface> GetTrkBlock(
     const ConfigurationInterface* configuration,
     const std::string& role,
     unsigned int in_streams,
-    unsigned int out_streams) const
+    unsigned int out_streams)
 {
     return get_block(configuration, role, in_streams, out_streams, get_trk_block);
 }
 
 
-std::unique_ptr<TelemetryDecoderInterface> GNSSBlockFactory::GetTlmBlock(
+std::unique_ptr<TelemetryDecoderInterface> GetTlmBlock(
     const ConfigurationInterface* configuration,
     const std::string& role,
     unsigned int in_streams,
-    unsigned int out_streams) const
+    unsigned int out_streams)
 {
     return get_block(configuration, role, in_streams, out_streams, get_tlm_block);
 }
+
+};  // namespace block_factory

--- a/src/core/receiver/gnss_block_factory.h
+++ b/src/core/receiver/gnss_block_factory.h
@@ -46,59 +46,54 @@ class TelemetryDecoderInterface;
 /*!
  * \brief Class that produces all kinds of GNSS blocks
  */
-class GNSSBlockFactory
+
+namespace block_factory
 {
-public:
-    GNSSBlockFactory() = default;
-    ~GNSSBlockFactory() = default;
 
-    std::unique_ptr<SignalSourceInterface> GetSignalSource(const ConfigurationInterface* configuration,
-        Concurrent_Queue<pmt::pmt_t>* queue, int ID = -1) const;
+std::unique_ptr<SignalSourceInterface> GetSignalSource(const ConfigurationInterface* configuration, Concurrent_Queue<pmt::pmt_t>* queue, int ID = -1);
 
-    std::unique_ptr<GNSSBlockInterface> GetSignalConditioner(const ConfigurationInterface* configuration, int ID = -1) const;
+std::unique_ptr<GNSSBlockInterface> GetSignalConditioner(const ConfigurationInterface* configuration, int ID = -1);
 
-    std::vector<std::unique_ptr<GNSSBlockInterface>> GetChannels(const ConfigurationInterface* configuration,
-        Concurrent_Queue<pmt::pmt_t>* queue) const;
+std::vector<std::unique_ptr<GNSSBlockInterface>> GetChannels(const ConfigurationInterface* configuration, Concurrent_Queue<pmt::pmt_t>* queue);
 
-    std::unique_ptr<GNSSBlockInterface> GetObservables(const ConfigurationInterface* configuration) const;
+std::unique_ptr<GNSSBlockInterface> GetObservables(const ConfigurationInterface* configuration);
 
-    std::unique_ptr<GNSSBlockInterface> GetPVT(const ConfigurationInterface* configuration) const;
+std::unique_ptr<GNSSBlockInterface> GetPVT(const ConfigurationInterface* configuration);
 
-    /*!
-     * \brief Returns the block with the required role implementation and its configuration parameters
-     */
-    std::unique_ptr<GNSSBlockInterface> GetBlock(const ConfigurationInterface* configuration,
-        const std::string& role,
-        unsigned int in_streams,
-        unsigned int out_streams,
-        Concurrent_Queue<pmt::pmt_t>* queue = nullptr) const;
+/*!
+ * \brief Returns the block with the required role implementation and its configuration parameters
+ */
+std::unique_ptr<GNSSBlockInterface> GetBlock(const ConfigurationInterface* configuration,
+    const std::string& role,
+    unsigned int in_streams,
+    unsigned int out_streams,
+    Concurrent_Queue<pmt::pmt_t>* queue = nullptr);
 
-private:
-    std::unique_ptr<GNSSBlockInterface> GetChannel(
-        const ConfigurationInterface* configuration,
-        const std::string& signal,
-        int channel,
-        Concurrent_Queue<pmt::pmt_t>* queue) const;
+std::unique_ptr<GNSSBlockInterface> GetChannel(
+    const ConfigurationInterface* configuration,
+    const std::string& signal,
+    int channel,
+    Concurrent_Queue<pmt::pmt_t>* queue);
 
-    std::unique_ptr<AcquisitionInterface> GetAcqBlock(
-        const ConfigurationInterface* configuration,
-        const std::string& role,
-        unsigned int in_streams,
-        unsigned int out_streams) const;
+std::unique_ptr<AcquisitionInterface> GetAcqBlock(
+    const ConfigurationInterface* configuration,
+    const std::string& role,
+    unsigned int in_streams,
+    unsigned int out_streams);
 
-    std::unique_ptr<TrackingInterface> GetTrkBlock(
-        const ConfigurationInterface* configuration,
-        const std::string& role,
-        unsigned int in_streams,
-        unsigned int out_streams) const;
+std::unique_ptr<TrackingInterface> GetTrkBlock(
+    const ConfigurationInterface* configuration,
+    const std::string& role,
+    unsigned int in_streams,
+    unsigned int out_streams);
 
-    std::unique_ptr<TelemetryDecoderInterface> GetTlmBlock(
-        const ConfigurationInterface* configuration,
-        const std::string& role,
-        unsigned int in_streams,
-        unsigned int out_streams) const;
-};
+std::unique_ptr<TelemetryDecoderInterface> GetTlmBlock(
+    const ConfigurationInterface* configuration,
+    const std::string& role,
+    unsigned int in_streams,
+    unsigned int out_streams);
 
+};  // namespace block_factory
 
 /** \} */
 /** \} */

--- a/src/core/receiver/gnss_flowgraph.cc
+++ b/src/core/receiver/gnss_flowgraph.cc
@@ -127,8 +127,6 @@ void GNSSFlowgraph::init()
     /*
      * Instantiates the receiver blocks
      */
-    auto block_factory = std::make_unique<GNSSBlockFactory>();
-
     channels_status_ = channel_status_msg_receiver_make();
 
     if (configuration_->property("Channels_E6.count", 0) > 0)
@@ -178,7 +176,7 @@ void GNSSFlowgraph::init()
     for (int i = 0; i < sources_count_; i++)
         {
             DLOG(INFO) << "Creating source " << i;
-            auto check_not_nullptr = block_factory->GetSignalSource(configuration_.get(), queue_.get(), i);
+            auto check_not_nullptr = block_factory::GetSignalSource(configuration_.get(), queue_.get(), i);
             if (!check_not_nullptr)
                 {
                     std::cout << "GNSS-SDR program ended.\n";
@@ -195,7 +193,7 @@ void GNSSFlowgraph::init()
                         }
                     for (auto j = 0U; j < RF_Channels; ++j)
                         {
-                            sig_conditioner_.push_back(block_factory->GetSignalConditioner(configuration_.get(), signal_conditioner_ID));
+                            sig_conditioner_.push_back(block_factory::GetSignalConditioner(configuration_.get(), signal_conditioner_ID));
                             signal_conditioner_ID++;
                         }
                 }
@@ -209,11 +207,11 @@ void GNSSFlowgraph::init()
             signal_conditioner_connected_ = std::vector<bool>(sig_conditioner_.size(), false);
         }
 
-    observables_ = block_factory->GetObservables(configuration_.get());
+    observables_ = block_factory::GetObservables(configuration_.get());
 
-    pvt_ = block_factory->GetPVT(configuration_.get());
+    pvt_ = block_factory::GetPVT(configuration_.get());
 
-    auto channels = block_factory->GetChannels(configuration_.get(), queue_.get());
+    auto channels = block_factory::GetChannels(configuration_.get(), queue_.get());
 
     channels_count_ = static_cast<int>(channels.size());
     for (int i = 0; i < channels_count_; i++)

--- a/tests/unit-tests/control-plane/gnss_block_factory_test.cc
+++ b/tests/unit-tests/control-plane/gnss_block_factory_test.cc
@@ -20,14 +20,11 @@
  */
 
 #include "acquisition_interface.h"
-#include "channel.h"
 #include "concurrent_queue.h"
 #include "gnss_block_factory.h"
 #include "gnss_block_interface.h"
 #include "gnss_sdr_make_unique.h"
 #include "in_memory_configuration.h"
-#include "observables_interface.h"
-#include "pvt_interface.h"
 #include "signal_source_interface.h"
 #include "tracking_interface.h"
 #include <gtest/gtest.h>
@@ -37,16 +34,14 @@
 
 TEST(GNSSBlockFactoryTest, InstantiateFileSignalSource)
 {
-    std::shared_ptr<InMemoryConfiguration> configuration = std::make_shared<InMemoryConfiguration>();
+    auto configuration = std::make_shared<InMemoryConfiguration>();
     configuration->set_property("SignalSource.implementation", "File_Signal_Source");
     std::string path = std::string(TEST_PATH);
     std::string filename = path + "signal_samples/GPS_L1_CA_ID_1_Fs_4Msps_2ms.dat";
     configuration->set_property("SignalSource.filename", std::move(filename));
-    std::shared_ptr<Concurrent_Queue<pmt::pmt_t>> queue = std::make_shared<Concurrent_Queue<pmt::pmt_t>>();
-    // Example of a factory as a shared_ptr
-    std::shared_ptr<GNSSBlockFactory> factory = std::make_shared<GNSSBlockFactory>();
+    auto queue = std::make_shared<Concurrent_Queue<pmt::pmt_t>>();
     // Example of a block as a shared_ptr
-    auto signal_source = factory->GetSignalSource(configuration.get(), queue.get());
+    auto signal_source = block_factory::GetSignalSource(configuration.get(), queue.get());
     EXPECT_STREQ("SignalSource", signal_source->role().c_str());
     EXPECT_STREQ("File_Signal_Source", signal_source->implementation().c_str());
 }
@@ -54,36 +49,31 @@ TEST(GNSSBlockFactoryTest, InstantiateFileSignalSource)
 
 TEST(GNSSBlockFactoryTest, InstantiateWrongSignalSource)
 {
-    std::shared_ptr<InMemoryConfiguration> configuration = std::make_shared<InMemoryConfiguration>();
+    auto configuration = std::make_shared<InMemoryConfiguration>();
     configuration->set_property("SignalSource.implementation", "Parapsychological_Source");
-    std::shared_ptr<Concurrent_Queue<pmt::pmt_t>> queue = std::make_shared<Concurrent_Queue<pmt::pmt_t>>();
-    // Example of a factory as a unique_ptr
-    std::unique_ptr<GNSSBlockFactory> factory = std::make_unique<GNSSBlockFactory>();
+    auto queue = std::make_shared<Concurrent_Queue<pmt::pmt_t>>();
     // Example of a block as a unique_ptr
-    auto signal_source = factory->GetSignalSource(configuration.get(), queue.get());
+    auto signal_source = block_factory::GetSignalSource(configuration.get(), queue.get());
     EXPECT_EQ(nullptr, signal_source);
 }
 
 
 TEST(GNSSBlockFactoryTest, InstantiateWrongSignalSource2)
 {
-    std::shared_ptr<InMemoryConfiguration> configuration = std::make_shared<InMemoryConfiguration>();
+    auto configuration = std::make_shared<InMemoryConfiguration>();
     configuration->set_property("SignalSource.implementation", "Pass_Through");
-    std::shared_ptr<Concurrent_Queue<pmt::pmt_t>> queue = std::make_shared<Concurrent_Queue<pmt::pmt_t>>();
-    // Example of a factory as a unique_ptr
-    std::unique_ptr<GNSSBlockFactory> factory = std::make_unique<GNSSBlockFactory>();
+    auto queue = std::make_shared<Concurrent_Queue<pmt::pmt_t>>();
     // Example of a block as a unique_ptr
-    auto signal_source = factory->GetSignalSource(configuration.get(), queue.get());
+    auto signal_source = block_factory::GetSignalSource(configuration.get(), queue.get());
     EXPECT_EQ(nullptr, signal_source);
 }
 
 
 TEST(GNSSBlockFactoryTest, InstantiateSignalConditioner)
 {
-    std::shared_ptr<InMemoryConfiguration> configuration = std::make_shared<InMemoryConfiguration>();
+    auto configuration = std::make_shared<InMemoryConfiguration>();
     configuration->set_property("SignalConditioner.implementation", "Signal_Conditioner");
-    std::unique_ptr<GNSSBlockFactory> factory = std::make_unique<GNSSBlockFactory>();
-    std::unique_ptr<GNSSBlockInterface> signal_conditioner = factory->GetSignalConditioner(configuration.get());
+    auto signal_conditioner = block_factory::GetSignalConditioner(configuration.get());
     EXPECT_STREQ("SignalConditioner", signal_conditioner->role().c_str());
     EXPECT_STREQ("Signal_Conditioner", signal_conditioner->implementation().c_str());
 }
@@ -91,28 +81,26 @@ TEST(GNSSBlockFactoryTest, InstantiateSignalConditioner)
 
 TEST(GNSSBlockFactoryTest, InstantiateWrongSignalConditioner)
 {
-    std::shared_ptr<InMemoryConfiguration> configuration = std::make_shared<InMemoryConfiguration>();
+    auto configuration = std::make_shared<InMemoryConfiguration>();
     configuration->set_property("SignalConditioner.implementation", "Signal_Ruinder");
-    std::unique_ptr<GNSSBlockFactory> factory = std::make_unique<GNSSBlockFactory>();
-    std::unique_ptr<GNSSBlockInterface> signal_conditioner = factory->GetSignalConditioner(configuration.get());
+    auto signal_conditioner = block_factory::GetSignalConditioner(configuration.get());
     EXPECT_EQ(nullptr, signal_conditioner);
 }
 
 
 TEST(GNSSBlockFactoryTest, InstantiateWrongSignalConditioner2)
 {
-    std::shared_ptr<InMemoryConfiguration> configuration = std::make_shared<InMemoryConfiguration>();
+    auto configuration = std::make_shared<InMemoryConfiguration>();
     configuration->set_property("SignalConditioner.implementation", "Fir_Filter");
-    std::unique_ptr<GNSSBlockFactory> factory = std::make_unique<GNSSBlockFactory>();
-    std::unique_ptr<GNSSBlockInterface> signal_conditioner = factory->GetSignalConditioner(configuration.get());
+    auto signal_conditioner = block_factory::GetSignalConditioner(configuration.get());
     EXPECT_EQ(nullptr, signal_conditioner);
 }
 
 
 TEST(GNSSBlockFactoryTest, InstantiateFIRFilter)
 {
-    std::shared_ptr<InMemoryConfiguration> configuration = std::make_shared<InMemoryConfiguration>();
-    std::shared_ptr<Concurrent_Queue<pmt::pmt_t>> queue = std::make_shared<Concurrent_Queue<pmt::pmt_t>>();
+    auto configuration = std::make_shared<InMemoryConfiguration>();
+    auto queue = std::make_shared<Concurrent_Queue<pmt::pmt_t>>();
 
     configuration->set_property("InputFilter.implementation", "Fir_Filter");
 
@@ -135,8 +123,7 @@ TEST(GNSSBlockFactoryTest, InstantiateFIRFilter)
     configuration->set_property("InputFilter.filter_type", "bandpass");
     configuration->set_property("InputFilter.grid_density", "16");
 
-    std::unique_ptr<GNSSBlockFactory> factory = std::make_unique<GNSSBlockFactory>();
-    std::unique_ptr<GNSSBlockInterface> input_filter = factory->GetBlock(configuration.get(), "InputFilter", 1, 1);
+    auto input_filter = block_factory::GetBlock(configuration.get(), "InputFilter", 1, 1);
 
     EXPECT_STREQ("InputFilter", input_filter->role().c_str());
     EXPECT_STREQ("Fir_Filter", input_filter->implementation().c_str());
@@ -145,8 +132,8 @@ TEST(GNSSBlockFactoryTest, InstantiateFIRFilter)
 
 TEST(GNSSBlockFactoryTest, InstantiateFreqXlatingFIRFilter)
 {
-    std::shared_ptr<InMemoryConfiguration> configuration = std::make_shared<InMemoryConfiguration>();
-    std::shared_ptr<Concurrent_Queue<pmt::pmt_t>> queue = std::make_shared<Concurrent_Queue<pmt::pmt_t>>();
+    auto configuration = std::make_shared<InMemoryConfiguration>();
+    auto queue = std::make_shared<Concurrent_Queue<pmt::pmt_t>>();
 
     configuration->set_property("InputFilter.implementation", "Freq_Xlating_Fir_Filter");
 
@@ -172,8 +159,7 @@ TEST(GNSSBlockFactoryTest, InstantiateFreqXlatingFIRFilter)
     configuration->set_property("InputFilter.sampling_frequency", "4000000");
     configuration->set_property("InputFilter.IF", "34000");
 
-    std::unique_ptr<GNSSBlockFactory> factory = std::make_unique<GNSSBlockFactory>();
-    std::unique_ptr<GNSSBlockInterface> input_filter = factory->GetBlock(configuration.get(), "InputFilter", 1, 1);
+    auto input_filter = block_factory::GetBlock(configuration.get(), "InputFilter", 1, 1);
 
     EXPECT_STREQ("InputFilter", input_filter->role().c_str());
     EXPECT_STREQ("Freq_Xlating_Fir_Filter", input_filter->implementation().c_str());
@@ -182,11 +168,10 @@ TEST(GNSSBlockFactoryTest, InstantiateFreqXlatingFIRFilter)
 
 TEST(GNSSBlockFactoryTest, InstantiatePulseBlankingFilter)
 {
-    std::shared_ptr<InMemoryConfiguration> configuration = std::make_shared<InMemoryConfiguration>();
-    std::shared_ptr<Concurrent_Queue<pmt::pmt_t>> queue = std::make_shared<Concurrent_Queue<pmt::pmt_t>>();
+    auto configuration = std::make_shared<InMemoryConfiguration>();
+    auto queue = std::make_shared<Concurrent_Queue<pmt::pmt_t>>();
     configuration->set_property("InputFilter.implementation", "Pulse_Blanking_Filter");
-    std::unique_ptr<GNSSBlockFactory> factory = std::make_unique<GNSSBlockFactory>();
-    std::unique_ptr<GNSSBlockInterface> input_filter = factory->GetBlock(configuration.get(), "InputFilter", 1, 1);
+    auto input_filter = block_factory::GetBlock(configuration.get(), "InputFilter", 1, 1);
     EXPECT_STREQ("InputFilter", input_filter->role().c_str());
     EXPECT_STREQ("Pulse_Blanking_Filter", input_filter->implementation().c_str());
 }
@@ -194,11 +179,10 @@ TEST(GNSSBlockFactoryTest, InstantiatePulseBlankingFilter)
 
 TEST(GNSSBlockFactoryTest, InstantiateNotchFilter)
 {
-    std::shared_ptr<InMemoryConfiguration> configuration = std::make_shared<InMemoryConfiguration>();
-    std::shared_ptr<Concurrent_Queue<pmt::pmt_t>> queue = std::make_shared<Concurrent_Queue<pmt::pmt_t>>();
+    auto configuration = std::make_shared<InMemoryConfiguration>();
+    auto queue = std::make_shared<Concurrent_Queue<pmt::pmt_t>>();
     configuration->set_property("InputFilter.implementation", "Notch_Filter");
-    std::unique_ptr<GNSSBlockFactory> factory = std::make_unique<GNSSBlockFactory>();
-    std::unique_ptr<GNSSBlockInterface> input_filter = factory->GetBlock(configuration.get(), "InputFilter", 1, 1);
+    auto input_filter = block_factory::GetBlock(configuration.get(), "InputFilter", 1, 1);
     EXPECT_STREQ("InputFilter", input_filter->role().c_str());
     EXPECT_STREQ("Notch_Filter", input_filter->implementation().c_str());
 }
@@ -206,11 +190,10 @@ TEST(GNSSBlockFactoryTest, InstantiateNotchFilter)
 
 TEST(GNSSBlockFactoryTest, InstantiateNotchFilterLite)
 {
-    std::shared_ptr<InMemoryConfiguration> configuration = std::make_shared<InMemoryConfiguration>();
-    std::shared_ptr<Concurrent_Queue<pmt::pmt_t>> queue = std::make_shared<Concurrent_Queue<pmt::pmt_t>>();
+    auto configuration = std::make_shared<InMemoryConfiguration>();
+    auto queue = std::make_shared<Concurrent_Queue<pmt::pmt_t>>();
     configuration->set_property("InputFilter.implementation", "Notch_Filter_Lite");
-    std::unique_ptr<GNSSBlockFactory> factory = std::make_unique<GNSSBlockFactory>();
-    std::unique_ptr<GNSSBlockInterface> input_filter = factory->GetBlock(configuration.get(), "InputFilter", 1, 1);
+    auto input_filter = block_factory::GetBlock(configuration.get(), "InputFilter", 1, 1);
     EXPECT_STREQ("InputFilter", input_filter->role().c_str());
     EXPECT_STREQ("Notch_Filter_Lite", input_filter->implementation().c_str());
 }
@@ -218,21 +201,19 @@ TEST(GNSSBlockFactoryTest, InstantiateNotchFilterLite)
 
 TEST(GNSSBlockFactoryTest, InstantiateWrongFilter)
 {
-    std::shared_ptr<InMemoryConfiguration> configuration = std::make_shared<InMemoryConfiguration>();
-    std::shared_ptr<Concurrent_Queue<pmt::pmt_t>> queue = std::make_shared<Concurrent_Queue<pmt::pmt_t>>();
+    auto configuration = std::make_shared<InMemoryConfiguration>();
+    auto queue = std::make_shared<Concurrent_Queue<pmt::pmt_t>>();
     configuration->set_property("InputFilter.implementation", "Pollen_Filter");
-    std::unique_ptr<GNSSBlockFactory> factory = std::make_unique<GNSSBlockFactory>();
-    std::unique_ptr<GNSSBlockInterface> input_filter = factory->GetBlock(configuration.get(), "InputFilter", 1, 1);
+    auto input_filter = block_factory::GetBlock(configuration.get(), "InputFilter", 1, 1);
     EXPECT_EQ(nullptr, input_filter);
 }
 
 
 TEST(GNSSBlockFactoryTest, InstantiateDirectResampler)
 {
-    std::shared_ptr<InMemoryConfiguration> configuration = std::make_shared<InMemoryConfiguration>();
+    auto configuration = std::make_shared<InMemoryConfiguration>();
     configuration->set_property("Resampler.implementation", "Direct_Resampler");
-    std::unique_ptr<GNSSBlockFactory> factory = std::make_unique<GNSSBlockFactory>();
-    std::unique_ptr<GNSSBlockInterface> resampler = factory->GetBlock(configuration.get(), "Resampler", 1, 1);
+    auto resampler = block_factory::GetBlock(configuration.get(), "Resampler", 1, 1);
     EXPECT_STREQ("Resampler", resampler->role().c_str());
     EXPECT_STREQ("Direct_Resampler", resampler->implementation().c_str());
 }
@@ -240,21 +221,18 @@ TEST(GNSSBlockFactoryTest, InstantiateDirectResampler)
 
 TEST(GNSSBlockFactoryTest, InstantiateWrongResampler)
 {
-    std::shared_ptr<InMemoryConfiguration> configuration = std::make_shared<InMemoryConfiguration>();
+    auto configuration = std::make_shared<InMemoryConfiguration>();
     configuration->set_property("Resampler.implementation", "RaNdOm_Resampler");
-    std::unique_ptr<GNSSBlockFactory> factory = std::make_unique<GNSSBlockFactory>();
-    std::unique_ptr<GNSSBlockInterface> resampler = factory->GetBlock(configuration.get(), "Resampler", 1, 1);
+    auto resampler = block_factory::GetBlock(configuration.get(), "Resampler", 1, 1);
     EXPECT_EQ(nullptr, resampler);
 }
 
 
 TEST(GNSSBlockFactoryTest, InstantiateGpsL1CaPcpsAcquisition)
 {
-    std::shared_ptr<InMemoryConfiguration> configuration = std::make_shared<InMemoryConfiguration>();
+    auto configuration = std::make_shared<InMemoryConfiguration>();
     configuration->set_property("Acquisition.implementation", "GPS_L1_CA_PCPS_Acquisition");
-    std::unique_ptr<GNSSBlockFactory> factory = std::make_unique<GNSSBlockFactory>();
-    std::shared_ptr<GNSSBlockInterface> acq_ = factory->GetBlock(configuration.get(), "Acquisition", 1, 0);
-    std::shared_ptr<AcquisitionInterface> acquisition = std::dynamic_pointer_cast<AcquisitionInterface>(acq_);
+    auto acquisition = block_factory::GetBlock(configuration.get(), "Acquisition", 1, 0);
     EXPECT_STREQ("Acquisition", acquisition->role().c_str());
     EXPECT_STREQ("GPS_L1_CA_PCPS_Acquisition", acquisition->implementation().c_str());
 }
@@ -262,11 +240,9 @@ TEST(GNSSBlockFactoryTest, InstantiateGpsL1CaPcpsAcquisition)
 
 TEST(GNSSBlockFactoryTest, InstantiateGpsL1CaPcpsQuickSyncAcquisition)
 {
-    std::shared_ptr<InMemoryConfiguration> configuration = std::make_shared<InMemoryConfiguration>();
+    auto configuration = std::make_shared<InMemoryConfiguration>();
     configuration->set_property("Acquisition.implementation", "GPS_L1_CA_PCPS_QuickSync_Acquisition");
-    std::shared_ptr<GNSSBlockFactory> factory = std::make_shared<GNSSBlockFactory>();
-    std::shared_ptr<GNSSBlockInterface> acq_ = factory->GetBlock(configuration.get(), "Acquisition", 1, 0);
-    std::shared_ptr<AcquisitionInterface> acquisition = std::dynamic_pointer_cast<AcquisitionInterface>(acq_);
+    auto acquisition = block_factory::GetBlock(configuration.get(), "Acquisition", 1, 0);
     EXPECT_STREQ("Acquisition", acquisition->role().c_str());
     EXPECT_STREQ("GPS_L1_CA_PCPS_QuickSync_Acquisition", acquisition->implementation().c_str());
 }
@@ -274,11 +250,9 @@ TEST(GNSSBlockFactoryTest, InstantiateGpsL1CaPcpsQuickSyncAcquisition)
 
 TEST(GNSSBlockFactoryTest, InstantiateGalileoE1PcpsQuickSyncAmbiguousAcquisition)
 {
-    std::shared_ptr<InMemoryConfiguration> configuration = std::make_shared<InMemoryConfiguration>();
+    auto configuration = std::make_shared<InMemoryConfiguration>();
     configuration->set_property("Acquisition.implementation", "Galileo_E1_PCPS_QuickSync_Ambiguous_Acquisition");
-    std::shared_ptr<GNSSBlockFactory> factory = std::make_shared<GNSSBlockFactory>();
-    std::shared_ptr<GNSSBlockInterface> acq_ = factory->GetBlock(configuration.get(), "Acquisition", 1, 0);
-    std::shared_ptr<AcquisitionInterface> acquisition = std::dynamic_pointer_cast<AcquisitionInterface>(acq_);
+    auto acquisition = block_factory::GetBlock(configuration.get(), "Acquisition", 1, 0);
     EXPECT_STREQ("Acquisition", acquisition->role().c_str());
     EXPECT_STREQ("Galileo_E1_PCPS_QuickSync_Ambiguous_Acquisition", acquisition->implementation().c_str());
 }
@@ -286,11 +260,9 @@ TEST(GNSSBlockFactoryTest, InstantiateGalileoE1PcpsQuickSyncAmbiguousAcquisition
 
 TEST(GNSSBlockFactoryTest, InstantiateGalileoE1PcpsAmbiguousAcquisition)
 {
-    std::shared_ptr<InMemoryConfiguration> configuration = std::make_shared<InMemoryConfiguration>();
+    auto configuration = std::make_shared<InMemoryConfiguration>();
     configuration->set_property("Acquisition.implementation", "Galileo_E1_PCPS_Ambiguous_Acquisition");
-    std::unique_ptr<GNSSBlockFactory> factory = std::make_unique<GNSSBlockFactory>();
-    std::shared_ptr<GNSSBlockInterface> acq_ = factory->GetBlock(configuration.get(), "Acquisition", 1, 0);
-    std::shared_ptr<AcquisitionInterface> acquisition = std::dynamic_pointer_cast<AcquisitionInterface>(acq_);
+    auto acquisition = block_factory::GetBlock(configuration.get(), "Acquisition", 1, 0);
     EXPECT_STREQ("Acquisition", acquisition->role().c_str());
     EXPECT_STREQ("Galileo_E1_PCPS_Ambiguous_Acquisition", acquisition->implementation().c_str());
 }
@@ -298,21 +270,18 @@ TEST(GNSSBlockFactoryTest, InstantiateGalileoE1PcpsAmbiguousAcquisition)
 
 TEST(GNSSBlockFactoryTest, InstantiateWrongAcquisition)
 {
-    std::shared_ptr<InMemoryConfiguration> configuration = std::make_shared<InMemoryConfiguration>();
+    auto configuration = std::make_shared<InMemoryConfiguration>();
     configuration->set_property("Acquisition.implementation", "GPS_L1_CA_PCPS_Alchemy");
-    std::unique_ptr<GNSSBlockFactory> factory = std::make_unique<GNSSBlockFactory>();
-    std::shared_ptr<GNSSBlockInterface> acq_ = factory->GetBlock(configuration.get(), "Acquisition", 1, 0);
+    auto acq_ = block_factory::GetBlock(configuration.get(), "Acquisition", 1, 0);
     EXPECT_EQ(nullptr, acq_);
 }
 
 
 TEST(GNSSBlockFactoryTest, InstantiateDllPllTrackingAdapterGpsL1Ca)
 {
-    std::shared_ptr<InMemoryConfiguration> configuration = std::make_shared<InMemoryConfiguration>();
+    auto configuration = std::make_shared<InMemoryConfiguration>();
     configuration->set_property("Tracking.implementation", "GPS_L1_CA_DLL_PLL_Tracking");
-    std::unique_ptr<GNSSBlockFactory> factory = std::make_unique<GNSSBlockFactory>();
-    std::shared_ptr<GNSSBlockInterface> trk_ = factory->GetBlock(configuration.get(), "Tracking", 1, 1);
-    std::shared_ptr<TrackingInterface> tracking = std::dynamic_pointer_cast<TrackingInterface>(trk_);
+    auto tracking = block_factory::GetBlock(configuration.get(), "Tracking", 1, 1);
     EXPECT_STREQ("Tracking", tracking->role().c_str());
     EXPECT_STREQ("GPS_L1_CA_DLL_PLL_Tracking", tracking->implementation().c_str());
 }
@@ -320,11 +289,9 @@ TEST(GNSSBlockFactoryTest, InstantiateDllPllTrackingAdapterGpsL1Ca)
 
 TEST(GNSSBlockFactoryTest, InstantiateGpsL1CaTcpConnectorTracking)
 {
-    std::shared_ptr<InMemoryConfiguration> configuration = std::make_shared<InMemoryConfiguration>();
+    auto configuration = std::make_shared<InMemoryConfiguration>();
     configuration->set_property("Tracking.implementation", "GPS_L1_CA_TCP_CONNECTOR_Tracking");
-    std::unique_ptr<GNSSBlockFactory> factory = std::make_unique<GNSSBlockFactory>();
-    std::shared_ptr<GNSSBlockInterface> trk_ = factory->GetBlock(configuration.get(), "Tracking", 1, 1);
-    std::shared_ptr<TrackingInterface> tracking = std::dynamic_pointer_cast<TrackingInterface>(trk_);
+    auto tracking = block_factory::GetBlock(configuration.get(), "Tracking", 1, 1);
     EXPECT_STREQ("Tracking", tracking->role().c_str());
     EXPECT_STREQ("GPS_L1_CA_TCP_CONNECTOR_Tracking", tracking->implementation().c_str());
 }
@@ -332,11 +299,9 @@ TEST(GNSSBlockFactoryTest, InstantiateGpsL1CaTcpConnectorTracking)
 
 TEST(GNSSBlockFactoryTest, InstantiateDllPllTrackingAdapterGalileoE1)
 {
-    std::shared_ptr<InMemoryConfiguration> configuration = std::make_shared<InMemoryConfiguration>();
+    auto configuration = std::make_shared<InMemoryConfiguration>();
     configuration->set_property("Tracking.implementation", "Galileo_E1_DLL_PLL_VEML_Tracking");
-    std::unique_ptr<GNSSBlockFactory> factory = std::make_unique<GNSSBlockFactory>();
-    std::shared_ptr<GNSSBlockInterface> trk_ = factory->GetBlock(configuration.get(), "Tracking", 1, 1);
-    std::shared_ptr<TrackingInterface> tracking = std::dynamic_pointer_cast<TrackingInterface>(trk_);
+    auto tracking = block_factory::GetBlock(configuration.get(), "Tracking", 1, 1);
     EXPECT_STREQ("Tracking", tracking->role().c_str());
     EXPECT_STREQ("Galileo_E1_DLL_PLL_VEML_Tracking", tracking->implementation().c_str());
 }
@@ -344,20 +309,18 @@ TEST(GNSSBlockFactoryTest, InstantiateDllPllTrackingAdapterGalileoE1)
 
 TEST(GNSSBlockFactoryTest, InstantiateWrongTracking)
 {
-    std::shared_ptr<InMemoryConfiguration> configuration = std::make_shared<InMemoryConfiguration>();
+    auto configuration = std::make_shared<InMemoryConfiguration>();
     configuration->set_property("Tracking.implementation", "The perfect tracking");
-    std::unique_ptr<GNSSBlockFactory> factory = std::make_unique<GNSSBlockFactory>();
-    std::shared_ptr<GNSSBlockInterface> trk_ = factory->GetBlock(configuration.get(), "Tracking", 1, 1);
+    auto trk_ = block_factory::GetBlock(configuration.get(), "Tracking", 1, 1);
     EXPECT_EQ(nullptr, trk_);
 }
 
 
 TEST(GNSSBlockFactoryTest, InstantiateTelemetryDecoderAdapterGpsL1Ca)
 {
-    std::shared_ptr<InMemoryConfiguration> configuration = std::make_shared<InMemoryConfiguration>();
+    auto configuration = std::make_shared<InMemoryConfiguration>();
     configuration->set_property("TelemetryDecoder.implementation", "GPS_L1_CA_Telemetry_Decoder");
-    std::unique_ptr<GNSSBlockFactory> factory = std::make_unique<GNSSBlockFactory>();
-    std::shared_ptr<GNSSBlockInterface> telemetry_decoder = factory->GetBlock(configuration.get(), "TelemetryDecoder", 1, 1);
+    auto telemetry_decoder = block_factory::GetBlock(configuration.get(), "TelemetryDecoder", 1, 1);
     EXPECT_STREQ("TelemetryDecoder", telemetry_decoder->role().c_str());
     EXPECT_STREQ("GPS_L1_CA_Telemetry_Decoder", telemetry_decoder->implementation().c_str());
 }
@@ -365,36 +328,33 @@ TEST(GNSSBlockFactoryTest, InstantiateTelemetryDecoderAdapterGpsL1Ca)
 
 TEST(GNSSBlockFactoryTest, InstantiateWrongTelemetryDecoder)
 {
-    std::shared_ptr<InMemoryConfiguration> configuration = std::make_shared<InMemoryConfiguration>();
+    auto configuration = std::make_shared<InMemoryConfiguration>();
     configuration->set_property("TelemetryDecoder.implementation", "GPS_Xenomorphic_Telemetry_Decoder");
-    std::unique_ptr<GNSSBlockFactory> factory = std::make_unique<GNSSBlockFactory>();
-    std::shared_ptr<GNSSBlockInterface> telemetry_decoder = factory->GetBlock(configuration.get(), "TelemetryDecoder", 1, 1);
+    auto telemetry_decoder = block_factory::GetBlock(configuration.get(), "TelemetryDecoder", 1, 1);
     EXPECT_EQ(nullptr, telemetry_decoder);
 }
 
 
 TEST(GNSSBlockFactoryTest, InstantiateEmptyTelemetryDecoder)
 {
-    std::shared_ptr<InMemoryConfiguration> configuration = std::make_shared<InMemoryConfiguration>();
+    auto configuration = std::make_shared<InMemoryConfiguration>();
     configuration->set_property("TelemetryDecoder.implementation", std::string(""));
-    std::unique_ptr<GNSSBlockFactory> factory = std::make_unique<GNSSBlockFactory>();
-    std::shared_ptr<GNSSBlockInterface> telemetry_decoder = factory->GetBlock(configuration.get(), "TelemetryDecoder", 1, 1);
+    auto telemetry_decoder = block_factory::GetBlock(configuration.get(), "TelemetryDecoder", 1, 1);
     EXPECT_EQ(nullptr, telemetry_decoder);
 }
 
 
 TEST(GNSSBlockFactoryTest, InstantiateChannels)
 {
-    std::shared_ptr<InMemoryConfiguration> configuration = std::make_shared<InMemoryConfiguration>();
+    auto configuration = std::make_shared<InMemoryConfiguration>();
     configuration->set_property("Channels_1C.count", "2");
     configuration->set_property("Channels_1E.count", "0");
     configuration->set_property("Channels.in_acquisition", "2");
     configuration->set_property("Acquisition_1C.implementation", "GPS_L1_CA_PCPS_Acquisition");
     configuration->set_property("Tracking_1C.implementation", "GPS_L1_CA_DLL_PLL_Tracking");
     configuration->set_property("TelemetryDecoder_1C.implementation", "GPS_L1_CA_Telemetry_Decoder");
-    std::shared_ptr<Concurrent_Queue<pmt::pmt_t>> queue = std::make_shared<Concurrent_Queue<pmt::pmt_t>>();
-    std::unique_ptr<GNSSBlockFactory> factory = std::make_unique<GNSSBlockFactory>();
-    std::vector<std::unique_ptr<GNSSBlockInterface>> channels = factory->GetChannels(configuration.get(), queue.get());
+    auto queue = std::make_shared<Concurrent_Queue<pmt::pmt_t>>();
+    auto channels = block_factory::GetChannels(configuration.get(), queue.get());
     EXPECT_EQ(static_cast<unsigned int>(2), channels.size());
     channels.erase(channels.begin(), channels.end());
 }
@@ -402,40 +362,36 @@ TEST(GNSSBlockFactoryTest, InstantiateChannels)
 
 TEST(GNSSBlockFactoryTest, InstantiateWrongObservables)
 {
-    std::shared_ptr<InMemoryConfiguration> configuration = std::make_shared<InMemoryConfiguration>();
+    auto configuration = std::make_shared<InMemoryConfiguration>();
     configuration->set_property("Observables.implementation", "Supercalifragilistic_Observables");
-    std::unique_ptr<GNSSBlockFactory> factory = std::make_unique<GNSSBlockFactory>();
-    auto observables = factory->GetObservables(configuration.get());
+    auto observables = block_factory::GetObservables(configuration.get());
     EXPECT_EQ(nullptr, observables);
 }
 
 
 TEST(GNSSBlockFactoryTest, InstantiateWrongObservables2)
 {
-    std::shared_ptr<InMemoryConfiguration> configuration = std::make_shared<InMemoryConfiguration>();
+    auto configuration = std::make_shared<InMemoryConfiguration>();
     configuration->set_property("Observables.implementation", "Pass_Through");
-    std::unique_ptr<GNSSBlockFactory> factory = std::make_unique<GNSSBlockFactory>();
-    auto observables = factory->GetObservables(configuration.get());
+    auto observables = block_factory::GetObservables(configuration.get());
     EXPECT_EQ(nullptr, observables);
 }
 
 
 TEST(GNSSBlockFactoryTest, InstantiateWrongObservables3)
 {
-    std::shared_ptr<InMemoryConfiguration> configuration = std::make_shared<InMemoryConfiguration>();
+    auto configuration = std::make_shared<InMemoryConfiguration>();
     configuration->set_property("Observables.implementation", "RTKLIB_PVT");
-    std::unique_ptr<GNSSBlockFactory> factory = std::make_unique<GNSSBlockFactory>();
-    auto observables = factory->GetObservables(configuration.get());
+    auto observables = block_factory::GetObservables(configuration.get());
     EXPECT_EQ(nullptr, observables);
 }
 
 
 TEST(GNSSBlockFactoryTest, InstantiateObservables)
 {
-    std::shared_ptr<InMemoryConfiguration> configuration = std::make_shared<InMemoryConfiguration>();
+    auto configuration = std::make_shared<InMemoryConfiguration>();
     configuration->set_property("Observables.implementation", "Hybrid_Observables");
-    std::unique_ptr<GNSSBlockFactory> factory = std::make_unique<GNSSBlockFactory>();
-    std::unique_ptr<GNSSBlockInterface> observables = factory->GetObservables(configuration.get());
+    auto observables = block_factory::GetObservables(configuration.get());
     EXPECT_STREQ("Observables", observables->role().c_str());
     EXPECT_STREQ("Hybrid_Observables", observables->implementation().c_str());
 }
@@ -443,11 +399,9 @@ TEST(GNSSBlockFactoryTest, InstantiateObservables)
 
 TEST(GNSSBlockFactoryTest, InstantiateRTKLIBPvt)
 {
-    std::shared_ptr<InMemoryConfiguration> configuration = std::make_shared<InMemoryConfiguration>();
+    auto configuration = std::make_shared<InMemoryConfiguration>();
     configuration->set_property("PVT.implementation", "RTKLIB_PVT");
-    std::unique_ptr<GNSSBlockFactory> factory = std::make_unique<GNSSBlockFactory>();
-    std::shared_ptr<GNSSBlockInterface> pvt_ = factory->GetPVT(configuration.get());
-    std::shared_ptr<PvtInterface> pvt = std::dynamic_pointer_cast<PvtInterface>(pvt_);
+    auto pvt = block_factory::GetPVT(configuration.get());
     EXPECT_STREQ("PVT", pvt->role().c_str());
     EXPECT_STREQ("RTKLIB_PVT", pvt->implementation().c_str());
 }
@@ -455,32 +409,26 @@ TEST(GNSSBlockFactoryTest, InstantiateRTKLIBPvt)
 
 TEST(GNSSBlockFactoryTest, InstantiateWrongPvt)
 {
-    std::shared_ptr<InMemoryConfiguration> configuration = std::make_shared<InMemoryConfiguration>();
+    auto configuration = std::make_shared<InMemoryConfiguration>();
     configuration->set_property("PVT.implementation", "Pepito");
-    auto factory = std::make_unique<GNSSBlockFactory>();
-    std::shared_ptr<GNSSBlockInterface> pvt_ = factory->GetPVT(configuration.get());
-    auto pvt = std::dynamic_pointer_cast<PvtInterface>(pvt_);
+    auto pvt = block_factory::GetPVT(configuration.get());
     EXPECT_EQ(nullptr, pvt);
 }
 
 
 TEST(GNSSBlockFactoryTest, InstantiateWrongPvt2)
 {
-    std::shared_ptr<InMemoryConfiguration> configuration = std::make_shared<InMemoryConfiguration>();
+    auto configuration = std::make_shared<InMemoryConfiguration>();
     configuration->set_property("PVT.implementation", "Pass_Through");
-    auto factory = std::make_unique<GNSSBlockFactory>();
-    std::shared_ptr<GNSSBlockInterface> pvt_ = factory->GetPVT(configuration.get());
-    auto pvt = std::dynamic_pointer_cast<PvtInterface>(pvt_);
+    auto pvt = block_factory::GetPVT(configuration.get());
     EXPECT_EQ(nullptr, pvt);
 }
 
 
 TEST(GNSSBlockFactoryTest, InstantiateWrongPvt3)
 {
-    std::shared_ptr<InMemoryConfiguration> configuration = std::make_shared<InMemoryConfiguration>();
+    auto configuration = std::make_shared<InMemoryConfiguration>();
     configuration->set_property("PVT.implementation", "Quantum_Particle_PVT");
-    auto factory = std::make_unique<GNSSBlockFactory>();
-    std::shared_ptr<GNSSBlockInterface> pvt_ = factory->GetPVT(configuration.get());
-    auto pvt = std::dynamic_pointer_cast<PvtInterface>(pvt_);
+    auto pvt = block_factory::GetPVT(configuration.get());
     EXPECT_EQ(nullptr, pvt);
 }

--- a/tests/unit-tests/signal-processing-blocks/acquisition/galileo_e1_pcps_8ms_ambiguous_acquisition_gsoc2013_test.cc
+++ b/tests/unit-tests/signal-processing-blocks/acquisition/galileo_e1_pcps_8ms_ambiguous_acquisition_gsoc2013_test.cc
@@ -16,9 +16,9 @@
  */
 
 
+#include "acquisition_interface.h"
 #include "concurrent_queue.h"
 #include "fir_filter.h"
-#include "galileo_e1_pcps_8ms_ambiguous_acquisition.h"
 #include "gen_signal_source.h"
 #include "gnss_block_factory.h"
 #include "gnss_block_interface.h"
@@ -32,20 +32,30 @@
 #include <gnuradio/blocks/file_source.h>
 #include <gnuradio/blocks/null_sink.h>
 #include <gnuradio/top_block.h>
+#include <gtest/gtest.h>
 #include <pmt/pmt.h>
 #include <chrono>
 #include <memory>
 #include <thread>
 #include <utility>
+
 #if HAS_GENERIC_LAMBDA
 #else
 #include <boost/bind/bind.hpp>
 #endif
+
 #ifdef GR_GREATER_38
 #include <gnuradio/analog/sig_source.h>
 #else
 #include <gnuradio/analog/sig_source_c.h>
 #endif
+
+#if USE_GLOG_AND_GFLAGS
+#include <glog/logging.h>
+#else
+#include <absl/log/log.h>
+#endif
+
 #if PMT_USES_BOOST_ANY
 namespace wht = boost;
 #else
@@ -65,7 +75,7 @@ class GalileoE1Pcps8msAmbiguousAcquisitionGSoC2013Test_msg_rx : public gr::block
 {
 private:
     friend GalileoE1Pcps8msAmbiguousAcquisitionGSoC2013Test_msg_rx_sptr GalileoE1Pcps8msAmbiguousAcquisitionGSoC2013Test_msg_rx_make(Concurrent_Queue<int>& queue);
-    void msg_handler_channel_events(const pmt::pmt_t msg);
+    void msg_handler_channel_events(pmt::pmt_t msg);
     explicit GalileoE1Pcps8msAmbiguousAcquisitionGSoC2013Test_msg_rx(Concurrent_Queue<int>& queue);
     Concurrent_Queue<int>& channel_internal_queue;
 
@@ -81,12 +91,11 @@ GalileoE1Pcps8msAmbiguousAcquisitionGSoC2013Test_msg_rx_sptr GalileoE1Pcps8msAmb
 }
 
 
-void GalileoE1Pcps8msAmbiguousAcquisitionGSoC2013Test_msg_rx::msg_handler_channel_events(const pmt::pmt_t msg)
+void GalileoE1Pcps8msAmbiguousAcquisitionGSoC2013Test_msg_rx::msg_handler_channel_events(pmt::pmt_t msg)
 {
     try
         {
-            int64_t message = pmt::to_long(std::move(msg));
-            rx_message = message;
+            rx_message = pmt::to_long(std::move(msg));
             channel_internal_queue.push(rx_message);
         }
     catch (const wht::bad_any_cast& e)
@@ -97,7 +106,7 @@ void GalileoE1Pcps8msAmbiguousAcquisitionGSoC2013Test_msg_rx::msg_handler_channe
 }
 
 
-GalileoE1Pcps8msAmbiguousAcquisitionGSoC2013Test_msg_rx::GalileoE1Pcps8msAmbiguousAcquisitionGSoC2013Test_msg_rx(Concurrent_Queue<int>& queue) : gr::block("GalileoE1Pcps8msAmbiguousAcquisitionGSoC2013Test_msg_rx", gr::io_signature::make(0, 0, 0), gr::io_signature::make(0, 0, 0)), channel_internal_queue(queue)
+GalileoE1Pcps8msAmbiguousAcquisitionGSoC2013Test_msg_rx::GalileoE1Pcps8msAmbiguousAcquisitionGSoC2013Test_msg_rx(Concurrent_Queue<int>& queue) : gr::block("GalileoE1Pcps8msAmbiguousAcquisitionGSoC2013Test_msg_rx", gr::io_signature::make(0, 0, 0), gr::io_signature::make(0, 0, 0)), channel_internal_queue(queue), rx_message(0)
 {
     this->message_port_register_in(pmt::mp("events"));
     this->set_msg_handler(pmt::mp("events"),
@@ -110,7 +119,6 @@ GalileoE1Pcps8msAmbiguousAcquisitionGSoC2013Test_msg_rx::GalileoE1Pcps8msAmbiguo
         boost::bind(&GalileoE1Pcps8msAmbiguousAcquisitionGSoC2013Test_msg_rx::msg_handler_channel_events, this, _1));
 #endif
 #endif
-    rx_message = 0;
 }
 
 GalileoE1Pcps8msAmbiguousAcquisitionGSoC2013Test_msg_rx::~GalileoE1Pcps8msAmbiguousAcquisitionGSoC2013Test_msg_rx() = default;
@@ -121,13 +129,8 @@ GalileoE1Pcps8msAmbiguousAcquisitionGSoC2013Test_msg_rx::~GalileoE1Pcps8msAmbigu
 class GalileoE1Pcps8msAmbiguousAcquisitionGSoC2013Test : public ::testing::Test
 {
 protected:
-    GalileoE1Pcps8msAmbiguousAcquisitionGSoC2013Test()
+    GalileoE1Pcps8msAmbiguousAcquisitionGSoC2013Test() : item_size(sizeof(gr_complex))
     {
-        item_size = sizeof(gr_complex);
-        stop = false;
-        message = 0;
-        factory = std::make_shared<GNSSBlockFactory>();
-        gnss_synchro = Gnss_Synchro();
         init();
     }
 
@@ -144,13 +147,12 @@ protected:
     Concurrent_Queue<int> channel_internal_queue;
     std::shared_ptr<Concurrent_Queue<pmt::pmt_t>> queue;
     gr::top_block_sptr top_block;
-    std::shared_ptr<GalileoE1Pcps8msAmbiguousAcquisition> acquisition;
-    std::shared_ptr<GNSSBlockFactory> factory;
+    std::unique_ptr<AcquisitionInterface> acquisition;
     std::shared_ptr<InMemoryConfiguration> config;
     Gnss_Synchro gnss_synchro;
     size_t item_size;
-    bool stop;
-    int message;
+    bool stop{false};
+    int message{0};
     std::thread ch_thread;
 
     unsigned int integration_time_ms = 0;
@@ -430,7 +432,7 @@ void GalileoE1Pcps8msAmbiguousAcquisitionGSoC2013Test::stop_queue()
 TEST_F(GalileoE1Pcps8msAmbiguousAcquisitionGSoC2013Test, Instantiate)
 {
     config_1();
-    auto acq_ = factory->GetBlock(config.get(), "Acquisition_1B", 1, 0);
+    auto acq_ = block_factory::GetBlock(config.get(), "Acquisition_1B", 1, 0);
 }
 
 
@@ -444,8 +446,7 @@ TEST_F(GalileoE1Pcps8msAmbiguousAcquisitionGSoC2013Test, ConnectAndRun)
     queue = std::make_shared<Concurrent_Queue<pmt::pmt_t>>();
     top_block = gr::make_top_block("Acquisition test");
 
-    std::shared_ptr<GNSSBlockInterface> acq_ = factory->GetBlock(config.get(), "Acquisition_1B", 1, 0);
-    acquisition = std::dynamic_pointer_cast<GalileoE1Pcps8msAmbiguousAcquisition>(acq_);
+    acquisition = block_factory::GetAcqBlock(config.get(), "Acquisition_1B", 1, 0);
     auto msg_rx = GalileoE1Pcps8msAmbiguousAcquisitionGSoC2013Test_msg_rx_make(channel_internal_queue);
 
     ASSERT_NO_THROW({
@@ -482,8 +483,7 @@ TEST_F(GalileoE1Pcps8msAmbiguousAcquisitionGSoC2013Test, ValidationOfResults)
     queue = std::make_shared<Concurrent_Queue<pmt::pmt_t>>();
     top_block = gr::make_top_block("Acquisition test");
 
-    std::shared_ptr<GNSSBlockInterface> acq_ = factory->GetBlock(config.get(), "Acquisition_1B", 1, 0, queue.get());
-    acquisition = std::dynamic_pointer_cast<GalileoE1Pcps8msAmbiguousAcquisition>(acq_);
+    acquisition = block_factory::GetAcqBlock(config.get(), "Acquisition_1B", 1, 0);
     auto msg_rx = GalileoE1Pcps8msAmbiguousAcquisitionGSoC2013Test_msg_rx_make(channel_internal_queue);
 
     ASSERT_NO_THROW({
@@ -555,8 +555,7 @@ TEST_F(GalileoE1Pcps8msAmbiguousAcquisitionGSoC2013Test, ValidationOfResultsProb
     config_2();
     queue = std::make_shared<Concurrent_Queue<pmt::pmt_t>>();
     top_block = gr::make_top_block("Acquisition test");
-    std::shared_ptr<GNSSBlockInterface> acq_ = factory->GetBlock(config.get(), "Acquisition_1B", 1, 0);
-    acquisition = std::dynamic_pointer_cast<GalileoE1Pcps8msAmbiguousAcquisition>(acq_);
+    acquisition = block_factory::GetAcqBlock(config.get(), "Acquisition_1B", 1, 0);
     auto msg_rx = GalileoE1Pcps8msAmbiguousAcquisitionGSoC2013Test_msg_rx_make(channel_internal_queue);
 
     ASSERT_NO_THROW({

--- a/tests/unit-tests/signal-processing-blocks/acquisition/galileo_e1_pcps_ambiguous_acquisition_gsoc2013_test.cc
+++ b/tests/unit-tests/signal-processing-blocks/acquisition/galileo_e1_pcps_ambiguous_acquisition_gsoc2013_test.cc
@@ -129,7 +129,6 @@ class GalileoE1PcpsAmbiguousAcquisitionGSoC2013Test : public ::testing::Test
 protected:
     GalileoE1PcpsAmbiguousAcquisitionGSoC2013Test() : item_size(sizeof(gr_complex)), stop(false), message(0)
     {
-        factory = std::make_shared<GNSSBlockFactory>();
     }
 
     ~GalileoE1PcpsAmbiguousAcquisitionGSoC2013Test() = default;
@@ -146,7 +145,6 @@ protected:
     std::shared_ptr<Concurrent_Queue<pmt::pmt_t>> queue;
     gr::top_block_sptr top_block;
     std::shared_ptr<AcquisitionInterface> acquisition;
-    std::shared_ptr<GNSSBlockFactory> factory;
     std::shared_ptr<InMemoryConfiguration> config;
     Gnss_Synchro gnss_synchro;
     size_t item_size;
@@ -434,8 +432,7 @@ void GalileoE1PcpsAmbiguousAcquisitionGSoC2013Test::stop_queue()
 TEST_F(GalileoE1PcpsAmbiguousAcquisitionGSoC2013Test, Instantiate)
 {
     config_1();
-    std::shared_ptr<GNSSBlockInterface> acq_ = factory->GetBlock(config.get(), "Acquisition_1B", 1, 0);
-    acquisition = std::dynamic_pointer_cast<AcquisitionInterface>(acq_);
+    acquisition = block_factory::GetAcqBlock(config.get(), "Acquisition_1B", 1, 0);
 }
 
 
@@ -448,8 +445,7 @@ TEST_F(GalileoE1PcpsAmbiguousAcquisitionGSoC2013Test, ConnectAndRun)
     queue = std::make_shared<Concurrent_Queue<pmt::pmt_t>>();
     config_1();
 
-    std::shared_ptr<GNSSBlockInterface> acq_ = factory->GetBlock(config.get(), "Acquisition_1B", 1, 0);
-    acquisition = std::dynamic_pointer_cast<AcquisitionInterface>(acq_);
+    acquisition = block_factory::GetAcqBlock(config.get(), "Acquisition_1B", 1, 0);
     auto msg_rx = GalileoE1PcpsAmbiguousAcquisitionGSoC2013Test_msg_rx_make(channel_internal_queue);
 
     ASSERT_NO_THROW({
@@ -477,8 +473,7 @@ TEST_F(GalileoE1PcpsAmbiguousAcquisitionGSoC2013Test, ValidationOfResults)
     config_1();
     top_block = gr::make_top_block("Acquisition test");
     queue = std::make_shared<Concurrent_Queue<pmt::pmt_t>>();
-    std::shared_ptr<GNSSBlockInterface> acq_ = factory->GetBlock(config.get(), "Acquisition_1B", 1, 0);
-    acquisition = std::dynamic_pointer_cast<AcquisitionInterface>(acq_);
+    acquisition = block_factory::GetAcqBlock(config.get(), "Acquisition_1B", 1, 0);
     auto msg_rx = GalileoE1PcpsAmbiguousAcquisitionGSoC2013Test_msg_rx_make(channel_internal_queue);
 
     ASSERT_NO_THROW({
@@ -547,8 +542,7 @@ TEST_F(GalileoE1PcpsAmbiguousAcquisitionGSoC2013Test, ValidationOfResultsProbabi
     config_2();
     top_block = gr::make_top_block("Acquisition test");
     queue = std::make_shared<Concurrent_Queue<pmt::pmt_t>>();
-    std::shared_ptr<GNSSBlockInterface> acq_ = factory->GetBlock(config.get(), "Acquisition_1B", 1, 0);
-    acquisition = std::dynamic_pointer_cast<AcquisitionInterface>(acq_);
+    acquisition = block_factory::GetAcqBlock(config.get(), "Acquisition_1B", 1, 0);
     auto msg_rx = GalileoE1PcpsAmbiguousAcquisitionGSoC2013Test_msg_rx_make(channel_internal_queue);
 
     ASSERT_NO_THROW({

--- a/tests/unit-tests/signal-processing-blocks/acquisition/galileo_e1_pcps_ambiguous_acquisition_gsoc_test.cc
+++ b/tests/unit-tests/signal-processing-blocks/acquisition/galileo_e1_pcps_ambiguous_acquisition_gsoc_test.cc
@@ -139,7 +139,6 @@ class GalileoE1PcpsAmbiguousAcquisitionGSoCTest : public ::testing::Test
 protected:
     GalileoE1PcpsAmbiguousAcquisitionGSoCTest() : item_size(sizeof(gr_complex)), stop(false), message(0)
     {
-        factory = std::make_shared<GNSSBlockFactory>();
         config = std::make_shared<InMemoryConfiguration>();
     }
 
@@ -153,7 +152,6 @@ protected:
     Concurrent_Queue<int> channel_internal_queue;
     std::shared_ptr<Concurrent_Queue<pmt::pmt_t>> queue;
     gr::top_block_sptr top_block;
-    std::shared_ptr<GNSSBlockFactory> factory;
     std::shared_ptr<InMemoryConfiguration> config;
     Gnss_Synchro gnss_synchro;
     size_t item_size;
@@ -217,8 +215,7 @@ void GalileoE1PcpsAmbiguousAcquisitionGSoCTest::stop_queue()
 TEST_F(GalileoE1PcpsAmbiguousAcquisitionGSoCTest, Instantiate)
 {
     init();
-    std::shared_ptr<GNSSBlockInterface> acq_ = factory->GetBlock(config.get(), "Acquisition_1B", 1, 0);
-    std::shared_ptr<AcquisitionInterface> acquisition = std::dynamic_pointer_cast<AcquisitionInterface>(acq_);
+    auto acquisition = block_factory::GetBlock(config.get(), "Acquisition_1B", 1, 0);
     EXPECT_STREQ("Galileo_E1_PCPS_Ambiguous_Acquisition", acquisition->implementation().c_str());
 }
 
@@ -233,8 +230,7 @@ TEST_F(GalileoE1PcpsAmbiguousAcquisitionGSoCTest, ConnectAndRun)
     top_block = gr::make_top_block("Acquisition test");
 
     init();
-    std::shared_ptr<GNSSBlockInterface> acq_ = factory->GetBlock(config.get(), "Acquisition_1B", 1, 0);
-    std::shared_ptr<AcquisitionInterface> acquisition = std::dynamic_pointer_cast<AcquisitionInterface>(acq_);
+    auto acquisition = block_factory::GetBlock(config.get(), "Acquisition_1B", 1, 0);
     auto msg_rx = GalileoE1PcpsAmbiguousAcquisitionGSoCTest_msg_rx_make(channel_internal_queue);
 
     ASSERT_NO_THROW({
@@ -264,8 +260,7 @@ TEST_F(GalileoE1PcpsAmbiguousAcquisitionGSoCTest, ValidationOfResults)
     top_block = gr::make_top_block("Acquisition test");
 
     init();
-    std::shared_ptr<GNSSBlockInterface> acq_ = factory->GetBlock(config.get(), "Acquisition_1B", 1, 0);
-    std::shared_ptr<AcquisitionInterface> acquisition = std::dynamic_pointer_cast<AcquisitionInterface>(acq_);
+    auto acquisition = block_factory::GetAcqBlock(config.get(), "Acquisition_1B", 1, 0);
     auto msg_rx = GalileoE1PcpsAmbiguousAcquisitionGSoCTest_msg_rx_make(channel_internal_queue);
 
     ASSERT_NO_THROW({

--- a/tests/unit-tests/signal-processing-blocks/acquisition/galileo_e1_pcps_ambiguous_acquisition_test.cc
+++ b/tests/unit-tests/signal-processing-blocks/acquisition/galileo_e1_pcps_ambiguous_acquisition_test.cc
@@ -132,7 +132,6 @@ class GalileoE1PcpsAmbiguousAcquisitionTest : public ::testing::Test
 protected:
     GalileoE1PcpsAmbiguousAcquisitionTest() : item_size(sizeof(gr_complex)), doppler_max(10000), doppler_step(250)
     {
-        factory = std::make_shared<GNSSBlockFactory>();
         config = std::make_shared<InMemoryConfiguration>();
     }
 
@@ -142,7 +141,6 @@ protected:
     void plot_grid();
 
     gr::top_block_sptr top_block;
-    std::shared_ptr<GNSSBlockFactory> factory;
     std::shared_ptr<InMemoryConfiguration> config;
     Gnss_Synchro gnss_synchro;
     size_t item_size;
@@ -262,8 +260,7 @@ void GalileoE1PcpsAmbiguousAcquisitionTest::plot_grid()
 TEST_F(GalileoE1PcpsAmbiguousAcquisitionTest, Instantiate)
 {
     init();
-    std::shared_ptr<GNSSBlockInterface> acq_ = factory->GetBlock(config.get(), "Acquisition_1B", 1, 0);
-    std::shared_ptr<AcquisitionInterface> acquisition = std::dynamic_pointer_cast<AcquisitionInterface>(acq_);
+    auto acquisition = block_factory::GetAcqBlock(config.get(), "Acquisition_1B", 1, 0);
 }
 
 
@@ -276,8 +273,7 @@ TEST_F(GalileoE1PcpsAmbiguousAcquisitionTest, ConnectAndRun)
     top_block = gr::make_top_block("Acquisition test");
     std::shared_ptr<Concurrent_Queue<pmt::pmt_t>> queue = std::make_shared<Concurrent_Queue<pmt::pmt_t>>();
     init();
-    std::shared_ptr<GNSSBlockInterface> acq_ = factory->GetBlock(config.get(), "Acquisition_1B", 1, 0);
-    std::shared_ptr<AcquisitionInterface> acquisition = std::dynamic_pointer_cast<AcquisitionInterface>(acq_);
+    auto acquisition = block_factory::GetAcqBlock(config.get(), "Acquisition_1B", 1, 0);
     auto msg_rx = GalileoE1PcpsAmbiguousAcquisitionTest_msg_rx_make();
 
     ASSERT_NO_THROW({
@@ -322,8 +318,7 @@ TEST_F(GalileoE1PcpsAmbiguousAcquisitionTest, ValidationOfResults)
     double expected_doppler_hz = -632;
     init();
     top_block = gr::make_top_block("Acquisition test");
-    std::shared_ptr<GNSSBlockInterface> acq_ = factory->GetBlock(config.get(), "Acquisition_1B", 1, 0);
-    std::shared_ptr<AcquisitionInterface> acquisition = std::dynamic_pointer_cast<AcquisitionInterface>(acq_);
+    auto acquisition = block_factory::GetAcqBlock(config.get(), "Acquisition_1B", 1, 0);
     auto msg_rx = GalileoE1PcpsAmbiguousAcquisitionTest_msg_rx_make();
 
     ASSERT_NO_THROW({

--- a/tests/unit-tests/signal-processing-blocks/acquisition/galileo_e1_pcps_cccwsr_ambiguous_acquisition_gsoc2013_test.cc
+++ b/tests/unit-tests/signal-processing-blocks/acquisition/galileo_e1_pcps_cccwsr_ambiguous_acquisition_gsoc2013_test.cc
@@ -19,7 +19,6 @@
 
 #include "concurrent_queue.h"
 #include "fir_filter.h"
-#include "galileo_e1_pcps_cccwsr_ambiguous_acquisition.h"
 #include "gen_signal_source.h"
 #include "gnss_block_factory.h"
 #include "gnss_block_interface.h"
@@ -122,7 +121,6 @@ class GalileoE1PcpsCccwsrAmbiguousAcquisitionTest : public ::testing::Test
 protected:
     GalileoE1PcpsCccwsrAmbiguousAcquisitionTest()
     {
-        factory = std::make_shared<GNSSBlockFactory>();
         item_size = sizeof(gr_complex);
         stop = false;
         message = 0;
@@ -143,8 +141,7 @@ protected:
     Concurrent_Queue<int> channel_internal_queue;
     std::shared_ptr<Concurrent_Queue<pmt::pmt_t>> queue;
     gr::top_block_sptr top_block;
-    std::shared_ptr<GalileoE1PcpsCccwsrAmbiguousAcquisition> acquisition;
-    std::shared_ptr<GNSSBlockFactory> factory;
+    std::unique_ptr<AcquisitionInterface> acquisition;
     std::shared_ptr<InMemoryConfiguration> config;
     Gnss_Synchro gnss_synchro;
     size_t item_size;
@@ -431,8 +428,7 @@ void GalileoE1PcpsCccwsrAmbiguousAcquisitionTest::stop_queue()
 TEST_F(GalileoE1PcpsCccwsrAmbiguousAcquisitionTest, Instantiate)
 {
     config_1();
-    std::shared_ptr<GNSSBlockInterface> acq_ = factory->GetBlock(config.get(), "Acquisition_1B", 1, 0);
-    acquisition = std::dynamic_pointer_cast<GalileoE1PcpsCccwsrAmbiguousAcquisition>(acq_);
+    acquisition = block_factory::GetAcqBlock(config.get(), "Acquisition_1B", 1, 0);
 }
 
 
@@ -446,8 +442,7 @@ TEST_F(GalileoE1PcpsCccwsrAmbiguousAcquisitionTest, ConnectAndRun)
     top_block = gr::make_top_block("Acquisition test");
     queue = std::make_shared<Concurrent_Queue<pmt::pmt_t>>();
 
-    std::shared_ptr<GNSSBlockInterface> acq_ = factory->GetBlock(config.get(), "Acquisition_1B", 1, 0);
-    acquisition = std::dynamic_pointer_cast<GalileoE1PcpsCccwsrAmbiguousAcquisition>(acq_);
+    acquisition = block_factory::GetAcqBlock(config.get(), "Acquisition_1B", 1, 0);
     auto msg_rx = GalileoE1PcpsCccwsrAmbiguousAcquisitionTest_msg_rx_make(channel_internal_queue);
 
     ASSERT_NO_THROW({
@@ -475,8 +470,7 @@ TEST_F(GalileoE1PcpsCccwsrAmbiguousAcquisitionTest, ValidationOfResults)
     config_1();
     top_block = gr::make_top_block("Acquisition test");
     queue = std::make_shared<Concurrent_Queue<pmt::pmt_t>>();
-    std::shared_ptr<GNSSBlockInterface> acq_ = factory->GetBlock(config.get(), "Acquisition_1B", 1, 0);
-    acquisition = std::dynamic_pointer_cast<GalileoE1PcpsCccwsrAmbiguousAcquisition>(acq_);
+    acquisition = block_factory::GetAcqBlock(config.get(), "Acquisition_1B", 1, 0);
     auto msg_rx = GalileoE1PcpsCccwsrAmbiguousAcquisitionTest_msg_rx_make(channel_internal_queue);
 
     ASSERT_NO_THROW({
@@ -553,8 +547,7 @@ TEST_F(GalileoE1PcpsCccwsrAmbiguousAcquisitionTest, ValidationOfResultsProbabili
     config_2();
     top_block = gr::make_top_block("Acquisition test");
     queue = std::make_shared<Concurrent_Queue<pmt::pmt_t>>();
-    std::shared_ptr<GNSSBlockInterface> acq_ = factory->GetBlock(config.get(), "Acquisition_1B", 1, 0);
-    acquisition = std::dynamic_pointer_cast<GalileoE1PcpsCccwsrAmbiguousAcquisition>(acq_);
+    acquisition = block_factory::GetAcqBlock(config.get(), "Acquisition_1B", 1, 0);
     auto msg_rx = GalileoE1PcpsCccwsrAmbiguousAcquisitionTest_msg_rx_make(channel_internal_queue);
 
     ASSERT_NO_THROW({

--- a/tests/unit-tests/signal-processing-blocks/acquisition/galileo_e1_pcps_quicksync_ambiguous_acquisition_gsoc2014_test.cc
+++ b/tests/unit-tests/signal-processing-blocks/acquisition/galileo_e1_pcps_quicksync_ambiguous_acquisition_gsoc2014_test.cc
@@ -18,7 +18,6 @@
 
 
 #include "fir_filter.h"
-#include "galileo_e1_pcps_quicksync_ambiguous_acquisition.h"
 #include "gen_signal_source.h"
 #include "gnss_block_factory.h"
 #include "gnss_block_interface.h"
@@ -31,6 +30,7 @@
 #include <gnuradio/blocks/file_source.h>
 #include <gnuradio/blocks/null_sink.h>
 #include <gnuradio/top_block.h>
+#include <gtest/gtest.h>
 #include <pmt/pmt.h>
 #include <chrono>
 #include <cstdint>
@@ -39,20 +39,24 @@
 #include <stdexcept>
 #include <thread>
 #include <utility>
+
 #if USE_GLOG_AND_GFLAGS
 #include <glog/logging.h>
 #else
 #include <absl/log/log.h>
 #endif
+
 #if HAS_GENERIC_LAMBDA
 #else
 #include <boost/bind/bind.hpp>
 #endif
+
 #ifdef GR_GREATER_38
 #include <gnuradio/analog/sig_source.h>
 #else
 #include <gnuradio/analog/sig_source_c.h>
 #endif
+
 #if PMT_USES_BOOST_ANY
 namespace wht = boost;
 #else
@@ -138,7 +142,6 @@ class GalileoE1PcpsQuickSyncAmbiguousAcquisitionGSoC2014Test : public ::testing:
 protected:
     GalileoE1PcpsQuickSyncAmbiguousAcquisitionGSoC2014Test()
     {
-        factory = std::make_shared<GNSSBlockFactory>();
         item_size = sizeof(gr_complex);
         stop = false;
         message = 0;
@@ -159,8 +162,7 @@ protected:
     Concurrent_Queue<int> channel_internal_queue;
     std::shared_ptr<Concurrent_Queue<pmt::pmt_t>> queue;
     gr::top_block_sptr top_block;
-    std::shared_ptr<GalileoE1PcpsQuickSyncAmbiguousAcquisition> acquisition;
-    std::shared_ptr<GNSSBlockFactory> factory;
+    std::unique_ptr<AcquisitionInterface> acquisition;
     std::shared_ptr<InMemoryConfiguration> config;
     Gnss_Synchro gnss_synchro;
     size_t item_size;
@@ -575,8 +577,7 @@ void GalileoE1PcpsQuickSyncAmbiguousAcquisitionGSoC2014Test::stop_queue()
 TEST_F(GalileoE1PcpsQuickSyncAmbiguousAcquisitionGSoC2014Test, Instantiate)
 {
     config_1();
-    std::shared_ptr<GNSSBlockInterface> acq_ = factory->GetBlock(config.get(), "Acquisition_1B", 1, 0);
-    acquisition = std::dynamic_pointer_cast<GalileoE1PcpsQuickSyncAmbiguousAcquisition>(acq_);
+    acquisition = block_factory::GetAcqBlock(config.get(), "Acquisition_1B", 1, 0);
 }
 
 
@@ -591,8 +592,7 @@ TEST_F(GalileoE1PcpsQuickSyncAmbiguousAcquisitionGSoC2014Test, ConnectAndRun)
 
     config_1();
 
-    std::shared_ptr<GNSSBlockInterface> acq_ = factory->GetBlock(config.get(), "Acquisition_1B", 1, 0);
-    acquisition = std::dynamic_pointer_cast<GalileoE1PcpsQuickSyncAmbiguousAcquisition>(acq_);
+    acquisition = block_factory::GetAcqBlock(config.get(), "Acquisition_1B", 1, 0);
     auto msg_rx = GalileoE1PcpsQuickSyncAmbiguousAcquisitionGSoC2014Test_msg_rx_make(channel_internal_queue);
 
     ASSERT_NO_THROW({
@@ -626,8 +626,7 @@ TEST_F(GalileoE1PcpsQuickSyncAmbiguousAcquisitionGSoC2014Test, ValidationOfResul
     top_block = gr::make_top_block("Acquisition test");
     queue = std::make_shared<Concurrent_Queue<pmt::pmt_t>>();
 
-    std::shared_ptr<GNSSBlockInterface> acq_ = factory->GetBlock(config.get(), "Acquisition_1B", 1, 0);
-    acquisition = std::dynamic_pointer_cast<GalileoE1PcpsQuickSyncAmbiguousAcquisition>(acq_);
+    acquisition = block_factory::GetAcqBlock(config.get(), "Acquisition_1B", 1, 0);
     auto msg_rx = GalileoE1PcpsQuickSyncAmbiguousAcquisitionGSoC2014Test_msg_rx_make(channel_internal_queue);
 
     ASSERT_NO_THROW({
@@ -702,8 +701,7 @@ TEST_F(GalileoE1PcpsQuickSyncAmbiguousAcquisitionGSoC2014Test, ValidationOfResul
 //     top_block = gr::make_top_block("Acquisition test");
 //     queue = std::make_shared<Concurrent_Queue<pmt::pmt_t>>();
 
-//     std::shared_ptr<GNSSBlockInterface> acq_ = factory->GetBlock(config.get(), "Acquisition_1B", 1, 0);
-//     acquisition = std::dynamic_pointer_cast<GalileoE1PcpsQuickSyncAmbiguousAcquisition>(acq_);
+//     acquisition = block_factory::GetAcqBlock(config.get(), "Acquisition_1B", 1, 0);
 //     auto msg_rx = GalileoE1PcpsQuickSyncAmbiguousAcquisitionGSoC2014Test_msg_rx_make(channel_internal_queue);
 
 //     ASSERT_NO_THROW({
@@ -775,8 +773,7 @@ TEST_F(GalileoE1PcpsQuickSyncAmbiguousAcquisitionGSoC2014Test, ValidationOfResul
     top_block = gr::make_top_block("Acquisition test");
     queue = std::make_shared<Concurrent_Queue<pmt::pmt_t>>();
 
-    std::shared_ptr<GNSSBlockInterface> acq_ = factory->GetBlock(config.get(), "Acquisition_1B", 1, 0);
-    acquisition = std::dynamic_pointer_cast<GalileoE1PcpsQuickSyncAmbiguousAcquisition>(acq_);
+    acquisition = block_factory::GetAcqBlock(config.get(), "Acquisition_1B", 1, 0);
     auto msg_rx = GalileoE1PcpsQuickSyncAmbiguousAcquisitionGSoC2014Test_msg_rx_make(channel_internal_queue);
 
     ASSERT_NO_THROW({

--- a/tests/unit-tests/signal-processing-blocks/acquisition/galileo_e1_pcps_tong_ambiguous_acquisition_gsoc2013_test.cc
+++ b/tests/unit-tests/signal-processing-blocks/acquisition/galileo_e1_pcps_tong_ambiguous_acquisition_gsoc2013_test.cc
@@ -19,7 +19,6 @@
 #include "concurrent_queue.h"
 #include "configuration_interface.h"
 #include "fir_filter.h"
-#include "galileo_e1_pcps_tong_ambiguous_acquisition.h"
 #include "gen_signal_source.h"
 #include "gnss_block_factory.h"
 #include "gnss_block_interface.h"
@@ -38,15 +37,18 @@
 #include <memory>
 #include <thread>
 #include <utility>
+
 #if HAS_GENERIC_LAMBDA
 #else
 #include <boost/bind/bind.hpp>
 #endif
+
 #ifdef GR_GREATER_38
 #include <gnuradio/analog/sig_source.h>
 #else
 #include <gnuradio/analog/sig_source_c.h>
 #endif
+
 #if PMT_USES_BOOST_ANY
 namespace wht = boost;
 #else
@@ -122,7 +124,6 @@ class GalileoE1PcpsTongAmbiguousAcquisitionGSoC2013Test : public ::testing::Test
 protected:
     GalileoE1PcpsTongAmbiguousAcquisitionGSoC2013Test()
     {
-        factory = std::make_shared<GNSSBlockFactory>();
         item_size = sizeof(gr_complex);
         stop = false;
         message = 0;
@@ -143,8 +144,7 @@ protected:
     Concurrent_Queue<int> channel_internal_queue;
     std::shared_ptr<Concurrent_Queue<pmt::pmt_t>> queue;
     gr::top_block_sptr top_block;
-    std::shared_ptr<GalileoE1PcpsTongAmbiguousAcquisition> acquisition;
-    std::shared_ptr<GNSSBlockFactory> factory;
+    std::unique_ptr<AcquisitionInterface> acquisition;
     std::shared_ptr<InMemoryConfiguration> config;
     Gnss_Synchro gnss_synchro;
     size_t item_size;
@@ -433,8 +433,7 @@ void GalileoE1PcpsTongAmbiguousAcquisitionGSoC2013Test::stop_queue()
 TEST_F(GalileoE1PcpsTongAmbiguousAcquisitionGSoC2013Test, Instantiate)
 {
     config_1();
-    std::shared_ptr<GNSSBlockInterface> acq_ = factory->GetBlock(config.get(), "Acquisition_1B", 1, 0);
-    acquisition = std::dynamic_pointer_cast<GalileoE1PcpsTongAmbiguousAcquisition>(acq_);
+    acquisition = block_factory::GetAcqBlock(config.get(), "Acquisition_1B", 1, 0);
 }
 
 
@@ -446,8 +445,7 @@ TEST_F(GalileoE1PcpsTongAmbiguousAcquisitionGSoC2013Test, ConnectAndRun)
     top_block = gr::make_top_block("Acquisition test");
     queue = std::make_shared<Concurrent_Queue<pmt::pmt_t>>();
     config_1();
-    std::shared_ptr<GNSSBlockInterface> acq_ = factory->GetBlock(config.get(), "Acquisition_1B", 1, 0);
-    acquisition = std::dynamic_pointer_cast<GalileoE1PcpsTongAmbiguousAcquisition>(acq_);
+    acquisition = block_factory::GetAcqBlock(config.get(), "Acquisition_1B", 1, 0);
 
     ASSERT_NO_THROW({
         acquisition->connect(top_block);
@@ -473,8 +471,7 @@ TEST_F(GalileoE1PcpsTongAmbiguousAcquisitionGSoC2013Test, ValidationOfResults)
     config_1();
     top_block = gr::make_top_block("Acquisition test");
     queue = std::make_shared<Concurrent_Queue<pmt::pmt_t>>();
-    std::shared_ptr<GNSSBlockInterface> acq_ = factory->GetBlock(config.get(), "Acquisition_1B", 1, 0);
-    acquisition = std::dynamic_pointer_cast<GalileoE1PcpsTongAmbiguousAcquisition>(acq_);
+    acquisition = block_factory::GetAcqBlock(config.get(), "Acquisition_1B", 1, 0);
     auto msg_rx = GalileoE1PcpsTongAmbiguousAcquisitionGSoC2013Test_msg_rx_make(channel_internal_queue);
 
     ASSERT_NO_THROW({
@@ -547,8 +544,7 @@ TEST_F(GalileoE1PcpsTongAmbiguousAcquisitionGSoC2013Test, ValidationOfResultsPro
     config_2();
     top_block = gr::make_top_block("Acquisition test");
     queue = std::make_shared<Concurrent_Queue<pmt::pmt_t>>();
-    std::shared_ptr<GNSSBlockInterface> acq_ = factory->GetBlock(config.get(), "Acquisition_1B", 1, 0);
-    acquisition = std::dynamic_pointer_cast<GalileoE1PcpsTongAmbiguousAcquisition>(acq_);
+    acquisition = block_factory::GetAcqBlock(config.get(), "Acquisition_1B", 1, 0);
     auto msg_rx = GalileoE1PcpsTongAmbiguousAcquisitionGSoC2013Test_msg_rx_make(channel_internal_queue);
 
     ASSERT_NO_THROW({

--- a/tests/unit-tests/signal-processing-blocks/acquisition/galileo_e5a_pcps_acquisition_gsoc2014_gensource_test.cc
+++ b/tests/unit-tests/signal-processing-blocks/acquisition/galileo_e5a_pcps_acquisition_gsoc2014_gensource_test.cc
@@ -17,7 +17,6 @@
 
 #include "concurrent_queue.h"
 #include "fir_filter.h"
-#include "galileo_e5a_noncoherent_iq_acquisition_caf.h"
 #include "gen_signal_source.h"
 #include "gnss_block_factory.h"
 #include "gnss_block_interface.h"
@@ -31,18 +30,28 @@
 #include <gnuradio/blocks/file_source.h>
 #include <gnuradio/blocks/null_sink.h>
 #include <gnuradio/top_block.h>
+#include <gtest/gtest.h>
 #include <pmt/pmt.h>
 #include <chrono>
 #include <utility>
+
 #if HAS_GENERIC_LAMBDA
 #else
 #include <boost/bind/bind.hpp>
 #endif
+
 #ifdef GR_GREATER_38
 #include <gnuradio/analog/sig_source.h>
 #else
 #include <gnuradio/analog/sig_source_c.h>
 #endif
+
+#if USE_GLOG_AND_GFLAGS
+#include <glog/logging.h>
+#else
+#include <absl/log/log.h>
+#endif
+
 #if PMT_USES_BOOST_ANY
 namespace wht = boost;
 #else
@@ -139,7 +148,7 @@ protected:
     Concurrent_Queue<int> channel_internal_queue;
     std::shared_ptr<Concurrent_Queue<pmt::pmt_t>> queue;
     gr::top_block_sptr top_block;
-    std::shared_ptr<GalileoE5aNoncoherentIQAcquisitionCaf> acquisition;
+    std::unique_ptr<AcquisitionInterface> acquisition;
 
     std::shared_ptr<InMemoryConfiguration> config;
     Gnss_Synchro gnss_synchro;
@@ -533,7 +542,7 @@ void GalileoE5aPcpsAcquisitionGSoC2014GensourceTest::stop_queue()
 TEST_F(GalileoE5aPcpsAcquisitionGSoC2014GensourceTest, Instantiate)
 {
     config_1();
-    acquisition = std::make_shared<GalileoE5aNoncoherentIQAcquisitionCaf>(config.get(), "Acquisition_5X", 1, 0);
+    acquisition = block_factory::GetAcqBlock(config.get(), "Acquisition_5X", 1, 0);
 }
 
 
@@ -544,7 +553,7 @@ TEST_F(GalileoE5aPcpsAcquisitionGSoC2014GensourceTest, ConnectAndRun)
     int nsamples = 21000 * 3;
     std::chrono::time_point<std::chrono::system_clock> start, end;
     std::chrono::duration<double> elapsed_seconds(0);
-    acquisition = std::make_shared<GalileoE5aNoncoherentIQAcquisitionCaf>(config.get(), "Acquisition_5X", 1, 0);
+    acquisition = block_factory::GetAcqBlock(config.get(), "Acquisition_5X", 1, 0);
     auto msg_rx = GalileoE5aPcpsAcquisitionGSoC2014GensourceTest_msg_rx_make(channel_internal_queue);
     queue = std::make_shared<Concurrent_Queue<pmt::pmt_t>>();
     top_block = gr::make_top_block("Acquisition test");
@@ -574,7 +583,7 @@ TEST_F(GalileoE5aPcpsAcquisitionGSoC2014GensourceTest, ValidationOfSIM)
     config_1();
     queue = std::make_shared<Concurrent_Queue<pmt::pmt_t>>();
     top_block = gr::make_top_block("Acquisition test");
-    acquisition = std::make_shared<GalileoE5aNoncoherentIQAcquisitionCaf>(config.get(), "Acquisition_5X", 1, 0);
+    acquisition = block_factory::GetAcqBlock(config.get(), "Acquisition_5X", 1, 0);
     auto msg_rx = GalileoE5aPcpsAcquisitionGSoC2014GensourceTest_msg_rx_make(channel_internal_queue);
 
     ASSERT_NO_THROW({

--- a/tests/unit-tests/signal-processing-blocks/acquisition/gps_l1_ca_pcps_opencl_acquisition_gsoc2013_test.cc
+++ b/tests/unit-tests/signal-processing-blocks/acquisition/gps_l1_ca_pcps_opencl_acquisition_gsoc2013_test.cc
@@ -17,10 +17,12 @@
  */
 
 
+#include "acquisition_interface.h"
 #include "concurrent_queue.h"
 #include "configuration_interface.h"
 #include "fir_filter.h"
 #include "gen_signal_source.h"
+#include "gnss_block_factory.h"
 #include "gnss_block_interface.h"
 #include "gnss_sdr_valve.h"
 #include "gnss_synchro.h"
@@ -32,20 +34,30 @@
 #include <gnuradio/blocks/file_source.h>
 #include <gnuradio/blocks/null_sink.h>
 #include <gnuradio/top_block.h>
+#include <gtest/gtest.h>
 #include <pmt/pmt.h>
 #include <chrono>
 #include <memory>
 #include <thread>
 #include <utility>
+
 #if HAS_GENERIC_LAMBDA
 #else
 #include <boost/bind/bind.hpp>
 #endif
+
 #ifdef GR_GREATER_38
 #include <gnuradio/analog/sig_source.h>
 #else
 #include <gnuradio/analog/sig_source_c.h>
 #endif
+
+#if USE_GLOG_AND_GFLAGS
+#include <glog/logging.h>
+#else
+#include <absl/log/log.h>
+#endif
+
 #if PMT_USES_BOOST_ANY
 namespace wht = boost;
 #else
@@ -148,7 +160,7 @@ protected:
     Concurrent_Queue<int> channel_internal_queue;
     std::shared_ptr<Concurrent_Queue<pmt::pmt_t>> queue;
     gr::top_block_sptr top_block;
-    std::shared_ptr<GpsL1CaPcpsOpenClAcquisition> acquisition;
+    std::unique_ptr<AcquisitionInterface> acquisition;
     std::shared_ptr<InMemoryConfiguration> config;
     Gnss_Synchro gnss_synchro;
     size_t item_size;
@@ -433,7 +445,7 @@ void GpsL1CaPcpsOpenClAcquisitionGSoC2013Test::stop_queue()
 TEST_F(GpsL1CaPcpsOpenClAcquisitionGSoC2013Test, Instantiate)
 {
     config_1();
-    acquisition = std::make_shared<GpsL1CaPcpsOpenClAcquisition>(config.get(), "Acquisition_1C", 1, 0);
+    acquisition = block_factory::GetAcqBlock(config.get(), "Acquisition_1C", 1, 0);
 }
 
 
@@ -444,7 +456,7 @@ TEST_F(GpsL1CaPcpsOpenClAcquisitionGSoC2013Test, ConnectAndRun)
     std::chrono::duration<double> elapsed_seconds(0);
 
     config_1();
-    acquisition = std::make_shared<GpsL1CaPcpsOpenClAcquisition>(config.get(), "Acquisition_1C", 1, 0);
+    acquisition = block_factory::GetAcqBlock(config.get(), "Acquisition_1C", 1, 0);
     auto msg_rx = GpsL1CaPcpsOpenClAcquisitionGSoC2013Test_msg_rx_make(channel_internal_queue);
 
     ASSERT_NO_THROW({
@@ -471,7 +483,7 @@ TEST_F(GpsL1CaPcpsOpenClAcquisitionGSoC2013Test, ValidationOfResults)
 {
     config_1();
 
-    acquisition = std::make_shared<GpsL1CaPcpsOpenClAcquisition>(config.get(), "Acquisition", 1, 0);
+    acquisition = block_factory::GetAcqBlock(config.get(), "Acquisition_1C", 1, 0);
     auto msg_rx = GpsL1CaPcpsOpenClAcquisitionGSoC2013Test_msg_rx_make(channel_internal_queue);
 
     ASSERT_NO_THROW({
@@ -545,7 +557,7 @@ TEST_F(GpsL1CaPcpsOpenClAcquisitionGSoC2013Test, ValidationOfResultsProbabilitie
 {
     config_2();
 
-    acquisition = std::make_shared<GpsL1CaPcpsOpenClAcquisition>(config.get(), "Acquisition_1C", 1, 0);
+    acquisition = block_factory::GetAcqBlock(config.get(), "Acquisition_1C", 1, 0);
     auto msg_rx = GpsL1CaPcpsOpenClAcquisitionGSoC2013Test_msg_rx_make(channel_internal_queue);
 
     ASSERT_NO_THROW({

--- a/tests/unit-tests/signal-processing-blocks/acquisition/gps_l1_ca_pcps_quicksync_acquisition_gsoc2014_test.cc
+++ b/tests/unit-tests/signal-processing-blocks/acquisition/gps_l1_ca_pcps_quicksync_acquisition_gsoc2014_test.cc
@@ -17,11 +17,12 @@
  */
 
 
+#include "acquisition_interface.h"
 #include "concurrent_queue.h"
+#include "gnss_block_factory.h"
 #include "gnss_block_interface.h"
 #include "gnss_sdr_valve.h"
 #include "gnss_synchro.h"
-#include "gps_l1_ca_pcps_quicksync_acquisition.h"
 #include "in_memory_configuration.h"
 #include "signal_generator.h"
 #include "signal_generator_c.h"
@@ -155,7 +156,7 @@ protected:
     Concurrent_Queue<int> channel_internal_queue;
     std::shared_ptr<Concurrent_Queue<pmt::pmt_t>> queue;
     gr::top_block_sptr top_block;
-    std::shared_ptr<GpsL1CaPcpsQuickSyncAcquisition> acquisition;
+    std::unique_ptr<AcquisitionInterface> acquisition;
     std::shared_ptr<InMemoryConfiguration> config;
     Gnss_Synchro gnss_synchro;
     size_t item_size;
@@ -558,7 +559,7 @@ void GpsL1CaPcpsQuickSyncAcquisitionGSoC2014Test::stop_queue()
 TEST_F(GpsL1CaPcpsQuickSyncAcquisitionGSoC2014Test, Instantiate)
 {
     config_1();
-    acquisition = std::make_shared<GpsL1CaPcpsQuickSyncAcquisition>(config.get(), "Acquisition_1C", 1, 0);
+    acquisition = block_factory::GetAcqBlock(config.get(), "Acquisition_1C", 1, 0);
 }
 
 
@@ -572,7 +573,7 @@ TEST_F(GpsL1CaPcpsQuickSyncAcquisitionGSoC2014Test, ConnectAndRun)
     auto msg_rx = GpsL1CaPcpsAcquisitionGSoC2013Test_msg_rx_make(channel_internal_queue);
 
     config_1();
-    acquisition = std::make_shared<GpsL1CaPcpsQuickSyncAcquisition>(config.get(), "Acquisition_1C", 1, 0);
+    acquisition = block_factory::GetAcqBlock(config.get(), "Acquisition_1C", 1, 0);
 
     ASSERT_NO_THROW({
         acquisition->connect(top_block);
@@ -599,7 +600,7 @@ TEST_F(GpsL1CaPcpsQuickSyncAcquisitionGSoC2014Test, ValidationOfResults)
     config_1();
     top_block = gr::make_top_block("Acquisition test");
     queue = std::make_shared<Concurrent_Queue<pmt::pmt_t>>();
-    acquisition = std::make_shared<GpsL1CaPcpsQuickSyncAcquisition>(config.get(), "Acquisition_1C", 1, 0);
+    acquisition = block_factory::GetAcqBlock(config.get(), "Acquisition_1C", 1, 0);
     auto msg_rx = GpsL1CaPcpsAcquisitionGSoC2013Test_msg_rx_make(channel_internal_queue);
 
     ASSERT_NO_THROW({
@@ -754,7 +755,7 @@ TEST_F(GpsL1CaPcpsQuickSyncAcquisitionGSoC2014Test, ValidationOfResultsProbabili
     config_2();
     top_block = gr::make_top_block("Acquisition test");
     queue = std::make_shared<Concurrent_Queue<pmt::pmt_t>>();
-    acquisition = std::make_shared<GpsL1CaPcpsQuickSyncAcquisition>(config.get(), "Acquisition_1C", 1, 0);
+    acquisition = block_factory::GetAcqBlock(config.get(), "Acquisition_1C", 1, 0);
     auto msg_rx = GpsL1CaPcpsAcquisitionGSoC2013Test_msg_rx_make(channel_internal_queue);
 
     ASSERT_NO_THROW({

--- a/tests/unit-tests/signal-processing-blocks/acquisition/gps_l1_ca_pcps_tong_acquisition_gsoc2013_test.cc
+++ b/tests/unit-tests/signal-processing-blocks/acquisition/gps_l1_ca_pcps_tong_acquisition_gsoc2013_test.cc
@@ -17,6 +17,7 @@
  */
 
 
+#include "acquisition_interface.h"
 #include "concurrent_queue.h"
 #include "configuration_interface.h"
 #include "fir_filter.h"
@@ -24,7 +25,6 @@
 #include "gnss_block_interface.h"
 #include "gnss_sdr_valve.h"
 #include "gnss_synchro.h"
-#include "gps_l1_ca_pcps_tong_acquisition.h"
 #include "in_memory_configuration.h"
 #include "signal_generator.h"
 #include "signal_generator_c.h"
@@ -38,15 +38,24 @@
 #include <memory>
 #include <thread>
 #include <utility>
+
 #if HAS_GENERIC_LAMBDA
 #else
 #include <boost/bind/bind.hpp>
 #endif
+
 #ifdef GR_GREATER_38
 #include <gnuradio/analog/sig_source.h>
 #else
 #include <gnuradio/analog/sig_source_c.h>
 #endif
+
+#if USE_GLOG_AND_GFLAGS
+#include <glog/logging.h>
+#else
+#include <absl/log/log.h>
+#endif
+
 #if PMT_USES_BOOST_ANY
 namespace wht = boost;
 #else
@@ -142,7 +151,7 @@ protected:
     Concurrent_Queue<int> channel_internal_queue;
     std::shared_ptr<Concurrent_Queue<pmt::pmt_t>> queue;
     gr::top_block_sptr top_block;
-    std::shared_ptr<GpsL1CaPcpsTongAcquisition> acquisition;
+    std::unique_ptr<AcquisitionInterface> acquisition;
     std::shared_ptr<InMemoryConfiguration> config;
     Gnss_Synchro gnss_synchro;
     size_t item_size;
@@ -426,7 +435,7 @@ void GpsL1CaPcpsTongAcquisitionGSoC2013Test::stop_queue()
 TEST_F(GpsL1CaPcpsTongAcquisitionGSoC2013Test, Instantiate)
 {
     config_1();
-    acquisition = std::make_shared<GpsL1CaPcpsTongAcquisition>(config.get(), "Acquisition_1C", 1, 0);
+    acquisition = block_factory::GetAcqBlock(config.get(), "Acquisition_1C", 1, 0);
 }
 
 
@@ -439,7 +448,7 @@ TEST_F(GpsL1CaPcpsTongAcquisitionGSoC2013Test, ConnectAndRun)
     queue = std::make_shared<Concurrent_Queue<pmt::pmt_t>>();
 
     config_1();
-    acquisition = std::make_shared<GpsL1CaPcpsTongAcquisition>(config.get(), "Acquisition_1C", 1, 0);
+    acquisition = block_factory::GetAcqBlock(config.get(), "Acquisition_1C", 1, 0);
     auto msg_rx = GpsL1CaPcpsTongAcquisitionGSoC2013Test_msg_rx_make(channel_internal_queue);
 
     ASSERT_NO_THROW({
@@ -468,7 +477,7 @@ TEST_F(GpsL1CaPcpsTongAcquisitionGSoC2013Test, ValidationOfResults)
     top_block = gr::make_top_block("Acquisition test");
     queue = std::make_shared<Concurrent_Queue<pmt::pmt_t>>();
 
-    acquisition = std::make_shared<GpsL1CaPcpsTongAcquisition>(config.get(), "Acquisition_1C", 1, 0);
+    acquisition = block_factory::GetAcqBlock(config.get(), "Acquisition_1C", 1, 0);
     auto msg_rx = GpsL1CaPcpsTongAcquisitionGSoC2013Test_msg_rx_make(channel_internal_queue);
 
     ASSERT_NO_THROW({
@@ -541,7 +550,7 @@ TEST_F(GpsL1CaPcpsTongAcquisitionGSoC2013Test, ValidationOfResultsProbabilities)
     config_2();
     top_block = gr::make_top_block("Acquisition test");
     queue = std::make_shared<Concurrent_Queue<pmt::pmt_t>>();
-    acquisition = std::make_shared<GpsL1CaPcpsTongAcquisition>(config.get(), "Acquisition_1C", 1, 0);
+    acquisition = block_factory::GetAcqBlock(config.get(), "Acquisition_1C", 1, 0);
     auto msg_rx = GpsL1CaPcpsTongAcquisitionGSoC2013Test_msg_rx_make(channel_internal_queue);
 
     ASSERT_NO_THROW({

--- a/tests/unit-tests/signal-processing-blocks/observables/hybrid_observables_test.cc
+++ b/tests/unit-tests/signal-processing-blocks/observables/hybrid_observables_test.cc
@@ -305,7 +305,6 @@ public:
 
     HybridObservablesTest()
     {
-        factory = std::make_shared<GNSSBlockFactory>();
         config = std::make_shared<InMemoryConfiguration>();
         item_size = sizeof(gr_complex);
         mapStringValues_["1C"] = evGPS_1C;
@@ -1963,9 +1962,9 @@ TEST_F(HybridObservablesTest, ValidationOfResults)
 
             // create the tracking channels and create the telemetry decoders
 
-            std::shared_ptr<GNSSBlockInterface> trk_ = factory->GetBlock(config.get(), "Tracking", 1, 1);
+            std::shared_ptr<GNSSBlockInterface> trk_ = block_factory::GetBlock(config.get(), "Tracking", 1, 1);
             tracking_ch_vec.push_back(std::dynamic_pointer_cast<TrackingInterface>(trk_));
-            std::shared_ptr<GNSSBlockInterface> tlm_ = factory->GetBlock(config.get(), "TelemetryDecoder", 1, 1);
+            std::shared_ptr<GNSSBlockInterface> tlm_ = block_factory::GetBlock(config.get(), "TelemetryDecoder", 1, 1);
             tlm_ch_vec.push_back(std::dynamic_pointer_cast<TelemetryDecoderInterface>(tlm_));
 
             // create null sinks for observables output

--- a/tests/unit-tests/signal-processing-blocks/observables/hybrid_observables_test_fpga.cc
+++ b/tests/unit-tests/signal-processing-blocks/observables/hybrid_observables_test_fpga.cc
@@ -277,7 +277,6 @@ public:
 
     HybridObservablesTestFpga()
     {
-        factory = std::make_shared<GNSSBlockFactory>();
         config = std::make_shared<InMemoryConfiguration>();
         item_size = sizeof(gr_complex);
     }
@@ -297,7 +296,6 @@ public:
         bool high_dyn);
 
     gr::top_block_sptr top_block;
-    std::shared_ptr<GNSSBlockFactory> factory;
     std::shared_ptr<InMemoryConfiguration> config;
     Gnss_Synchro gnss_synchro_master;
     std::vector<Gnss_Synchro> gnss_synchro_vec;
@@ -2061,9 +2059,9 @@ TEST_F(HybridObservablesTestFpga, ValidationOfResults)
             gnss_synchro_vec.at(n).Channel_ID = n;
 
             // create the tracking channels and create the telemetry decoders
-            std::shared_ptr<GNSSBlockInterface> trk_ = factory->GetBlock(config.get(), "Tracking", 1, 1);
+            std::shared_ptr<GNSSBlockInterface> trk_ = block_factory::GetBlock(config.get(), "Tracking", 1, 1);
             tracking_ch_vec.push_back(std::dynamic_pointer_cast<TrackingInterface>(trk_));
-            std::shared_ptr<GNSSBlockInterface> tlm_ = factory->GetBlock(config.get(), "TelemetryDecoder", 1, 1);
+            std::shared_ptr<GNSSBlockInterface> tlm_ = block_factory::GetBlock(config.get(), "TelemetryDecoder", 1, 1);
             tlm_ch_vec.push_back(std::dynamic_pointer_cast<TelemetryDecoderInterface>(tlm_));
 
             // create null sinks for observables output

--- a/tests/unit-tests/signal-processing-blocks/tracking/galileo_e1_dll_pll_veml_tracking_test.cc
+++ b/tests/unit-tests/signal-processing-blocks/tracking/galileo_e1_dll_pll_veml_tracking_test.cc
@@ -43,7 +43,6 @@ protected:
     DllPllTrackingAdapterGalileoE1Test()
         : item_size(sizeof(gr_complex))
     {
-        factory = std::make_shared<GNSSBlockFactory>();
         config = std::make_shared<InMemoryConfiguration>();
     }
 
@@ -51,7 +50,6 @@ protected:
 
     std::shared_ptr<Concurrent_Queue<pmt::pmt_t>> queue;
     gr::top_block_sptr top_block;
-    std::shared_ptr<GNSSBlockFactory> factory;
     std::shared_ptr<InMemoryConfiguration> config;
     Gnss_Synchro gnss_synchro;
     size_t item_size;
@@ -83,7 +81,7 @@ void DllPllTrackingAdapterGalileoE1Test::init()
 TEST_F(DllPllTrackingAdapterGalileoE1Test, Instantiate)
 {
     init();
-    auto tracking = factory->GetBlock(config.get(), "Tracking_1B", 1, 1);
+    auto tracking = block_factory::GetBlock(config.get(), "Tracking_1B", 1, 1);
     EXPECT_STREQ("Galileo_E1_DLL_PLL_VEML_Tracking", tracking->implementation().c_str());
 }
 
@@ -100,7 +98,7 @@ TEST_F(DllPllTrackingAdapterGalileoE1Test, ConnectAndRun)
     top_block = gr::make_top_block("Tracking test");
 
     // Example using smart pointers and the block factory
-    std::shared_ptr<GNSSBlockInterface> trk_ = factory->GetBlock(config.get(), "Tracking_1B", 1, 1);
+    std::shared_ptr<GNSSBlockInterface> trk_ = block_factory::GetBlock(config.get(), "Tracking_1B", 1, 1);
     std::shared_ptr<TrackingInterface> tracking = std::dynamic_pointer_cast<TrackingInterface>(trk_);
 
     ASSERT_NO_THROW({
@@ -148,7 +146,7 @@ TEST_F(DllPllTrackingAdapterGalileoE1Test, ValidationOfResults)
     top_block = gr::make_top_block("Tracking test");
 
     // Example using smart pointers and the block factory
-    std::shared_ptr<GNSSBlockInterface> trk_ = factory->GetBlock(config.get(), "Tracking_1B", 1, 1);
+    std::shared_ptr<GNSSBlockInterface> trk_ = block_factory::GetBlock(config.get(), "Tracking_1B", 1, 1);
     std::shared_ptr<TrackingInterface> tracking = std::dynamic_pointer_cast<TrackingInterface>(trk_);
 
     // gnss_synchro.Acq_delay_samples = 1753; // 4 Msps

--- a/tests/unit-tests/signal-processing-blocks/tracking/galileo_e5a_tracking_test.cc
+++ b/tests/unit-tests/signal-processing-blocks/tracking/galileo_e5a_tracking_test.cc
@@ -43,7 +43,6 @@ class GalileoE5aTrackingTest : public ::testing::Test
 protected:
     GalileoE5aTrackingTest()
     {
-        factory = std::make_shared<GNSSBlockFactory>();
         config = std::make_shared<InMemoryConfiguration>();
         item_size = sizeof(gr_complex);
         stop = false;
@@ -57,7 +56,6 @@ protected:
 
     std::shared_ptr<Concurrent_Queue<pmt::pmt_t>> queue;
     gr::top_block_sptr top_block;
-    std::shared_ptr<GNSSBlockFactory> factory;
     std::shared_ptr<InMemoryConfiguration> config;
     Gnss_Synchro gnss_synchro;
     size_t item_size;
@@ -100,7 +98,7 @@ TEST_F(GalileoE5aTrackingTest, ValidationOfResults)
     top_block = gr::make_top_block("Tracking test");
 
     // Example using smart pointers and the block factory
-    std::shared_ptr<GNSSBlockInterface> trk_ = factory->GetBlock(config.get(), "Tracking_5X", 1, 1);
+    std::shared_ptr<GNSSBlockInterface> trk_ = block_factory::GetBlock(config.get(), "Tracking_5X", 1, 1);
     std::shared_ptr<TrackingInterface> tracking = std::dynamic_pointer_cast<TrackingInterface>(trk_);
 
     // REAL

--- a/tests/unit-tests/signal-processing-blocks/tracking/galileo_e5b_dll_pll_tracking_test.cc
+++ b/tests/unit-tests/signal-processing-blocks/tracking/galileo_e5b_dll_pll_tracking_test.cc
@@ -44,7 +44,6 @@ class GalileoE5bTrackingTest : public ::testing::Test
 protected:
     GalileoE5bTrackingTest()
     {
-        factory = std::make_shared<GNSSBlockFactory>();
         config = std::make_shared<InMemoryConfiguration>();
         item_size = sizeof(gr_complex);
         stop = false;
@@ -58,7 +57,6 @@ protected:
 
     std::shared_ptr<Concurrent_Queue<pmt::pmt_t>> queue;
     gr::top_block_sptr top_block;
-    std::shared_ptr<GNSSBlockFactory> factory;
     std::shared_ptr<InMemoryConfiguration> config;
     Gnss_Synchro gnss_synchro;
     size_t item_size;
@@ -101,7 +99,7 @@ TEST_F(GalileoE5bTrackingTest, ValidationOfResults)
     top_block = gr::make_top_block("Tracking test");
 
     // Example using smart pointers and the block factory
-    std::shared_ptr<GNSSBlockInterface> trk_ = factory->GetBlock(config.get(), "Tracking_7X", 1, 1);
+    std::shared_ptr<GNSSBlockInterface> trk_ = block_factory::GetBlock(config.get(), "Tracking_7X", 1, 1);
     std::shared_ptr<TrackingInterface> tracking = std::dynamic_pointer_cast<TrackingInterface>(trk_);
 
     // REAL

--- a/tests/unit-tests/signal-processing-blocks/tracking/glonass_l1_ca_dll_pll_tracking_test.cc
+++ b/tests/unit-tests/signal-processing-blocks/tracking/glonass_l1_ca_dll_pll_tracking_test.cc
@@ -158,11 +158,9 @@ TEST_F(GlonassL1CaDllPllTrackingTest, ValidationOfResults)
 
     init();
 
-    GNSSBlockFactory factory;
     queue = std::make_shared<Concurrent_Queue<pmt::pmt_t>>();
     top_block = gr::make_top_block("Tracking test");
-    std::shared_ptr<GNSSBlockInterface> trk = factory.GetBlock(config.get(), "Tracking_1G", 1, 1);
-    std::shared_ptr<TrackingInterface> tracking = std::dynamic_pointer_cast<TrackingInterface>(trk);
+    auto tracking = block_factory::GetTrkBlock(config.get(), "Tracking_1G", 1, 1);
     auto msg_rx = GlonassL1CaDllPllTrackingTest_msg_rx_make();
 
     gnss_synchro.Acq_delay_samples = 1343;

--- a/tests/unit-tests/signal-processing-blocks/tracking/gps_l1_ca_dll_pll_tracking_test.cc
+++ b/tests/unit-tests/signal-processing-blocks/tracking/gps_l1_ca_dll_pll_tracking_test.cc
@@ -175,7 +175,6 @@ public:
     bool save_mat_xy(std::vector<double>& x, std::vector<double>& y, std::string filename);
     DllPllTrackingAdapterGpsL1CaTest() : item_size(sizeof(gr_complex))
     {
-        factory = std::make_shared<GNSSBlockFactory>();
         config = std::make_shared<InMemoryConfiguration>();
         gnss_synchro = Gnss_Synchro();
     }
@@ -189,7 +188,6 @@ public:
         int extend_correlation_symbols);
 
     gr::top_block_sptr top_block;
-    std::shared_ptr<GNSSBlockFactory> factory;
     std::shared_ptr<InMemoryConfiguration> config;
     Gnss_Synchro gnss_synchro;
     size_t item_size;
@@ -690,7 +688,7 @@ TEST_F(DllPllTrackingAdapterGpsL1CaTest, ValidationOfResults)
 
                     top_block = gr::make_top_block("Tracking test");
 
-                    std::shared_ptr<GNSSBlockInterface> trk_ = factory->GetBlock(config.get(), "Tracking_1C", 1, 1);
+                    std::shared_ptr<GNSSBlockInterface> trk_ = block_factory::GetBlock(config.get(), "Tracking_1C", 1, 1);
                     std::shared_ptr<TrackingInterface> tracking = std::dynamic_pointer_cast<TrackingInterface>(trk_);
 
                     auto msg_rx = DllPllTrackingAdapterGpsL1CaTest_msg_rx_make();

--- a/tests/unit-tests/signal-processing-blocks/tracking/gps_l1_ca_gaussian_tracking_test.cc
+++ b/tests/unit-tests/signal-processing-blocks/tracking/gps_l1_ca_gaussian_tracking_test.cc
@@ -169,7 +169,6 @@ public:
 
     GpsL1CAGaussianTrackingTest()
     {
-        factory = std::make_shared<GNSSBlockFactory>();
         config = std::make_shared<InMemoryConfiguration>();
         item_size = sizeof(gr_complex);
         gnss_synchro = Gnss_Synchro();
@@ -180,7 +179,6 @@ public:
     void configure_receiver();
 
     gr::top_block_sptr top_block;
-    std::shared_ptr<GNSSBlockFactory> factory;
     std::shared_ptr<InMemoryConfiguration> config;
     Gnss_Synchro gnss_synchro;
     size_t item_size;
@@ -444,7 +442,7 @@ TEST_F(GpsL1CAGaussianTrackingTest, ValidationOfResults)
 
     top_block = gr::make_top_block("Tracking test");
 
-    std::shared_ptr<GNSSBlockInterface> trk_ = factory->GetBlock(config.get(), "Tracking_1C", 1, 1);
+    std::shared_ptr<GNSSBlockInterface> trk_ = block_factory::GetBlock(config.get(), "Tracking_1C", 1, 1);
     std::shared_ptr<TrackingInterface> tracking = std::dynamic_pointer_cast<TrackingInterface>(trk_);  // std::make_shared<GpsL1CaDllPllCAidTracking>(config.get(), "Tracking_1C", 1, 1);
 
     auto msg_rx = GpsL1CAGaussianTrackingTest_msg_rx_make();

--- a/tests/unit-tests/signal-processing-blocks/tracking/tracking_pull-in_test.cc
+++ b/tests/unit-tests/signal-processing-blocks/tracking/tracking_pull-in_test.cc
@@ -198,7 +198,6 @@ public:
 
     TrackingPullInTest()
     {
-        factory = std::make_shared<GNSSBlockFactory>();
         config = std::make_shared<InMemoryConfiguration>();
         item_size = sizeof(gr_complex);
         gnss_synchro = Gnss_Synchro();
@@ -221,7 +220,6 @@ public:
 
     bool acquire_signal(int SV_ID);
 
-    std::shared_ptr<GNSSBlockFactory> factory;
     std::shared_ptr<InMemoryConfiguration> config;
     Gnss_Synchro gnss_synchro;
     size_t item_size;
@@ -949,7 +947,7 @@ TEST_F(TrackingPullInTest, ValidationOfResults)
 
                             // create flowgraph
                             auto top_block_trk = gr::make_top_block("Tracking test");
-                            std::shared_ptr<GNSSBlockInterface> trk_ = factory->GetBlock(config.get(), "Tracking", 1, 1);
+                            std::shared_ptr<GNSSBlockInterface> trk_ = block_factory::GetBlock(config.get(), "Tracking", 1, 1);
                             std::shared_ptr<TrackingInterface> tracking = std::dynamic_pointer_cast<TrackingInterface>(trk_);
                             auto msg_rx = TrackingPullInTest_msg_rx_make();
 

--- a/tests/unit-tests/signal-processing-blocks/tracking/tracking_pull-in_test_fpga.cc
+++ b/tests/unit-tests/signal-processing-blocks/tracking/tracking_pull-in_test_fpga.cc
@@ -368,7 +368,6 @@ public:
 
     TrackingPullInTestFpga()
     {
-        factory = std::make_shared<GNSSBlockFactory>();
         config = std::make_shared<InMemoryConfiguration>();
         item_size = sizeof(gr_complex);
         gnss_synchro = Gnss_Synchro();
@@ -384,7 +383,6 @@ public:
 
     bool acquire_signal(int SV_ID);
     gr::top_block_sptr top_block;
-    std::shared_ptr<GNSSBlockFactory> factory;
     std::shared_ptr<InMemoryConfiguration> config;
     Gnss_Synchro gnss_synchro;
     size_t item_size;
@@ -1101,7 +1099,7 @@ TEST_F(TrackingPullInTestFpga, ValidationOfResults)
 
                             // create flowgraph
                             top_block = gr::make_top_block("Tracking test");
-                            std::shared_ptr<GNSSBlockInterface> trk_ = factory->GetBlock(config.get(), "Tracking", 1, 1);
+                            std::shared_ptr<GNSSBlockInterface> trk_ = block_factory::GetBlock(config.get(), "Tracking", 1, 1);
                             std::shared_ptr<TrackingInterface> tracking = std::dynamic_pointer_cast<TrackingInterface>(trk_);
                             auto msg_rx = TrackingPullInTest_msg_rx_Fpga_make();
 

--- a/utils/front-end-cal/main.cc
+++ b/utils/front-end-cal/main.cc
@@ -234,7 +234,6 @@ bool front_end_capture(const std::shared_ptr<ConfigurationInterface>& configurat
     std::string trace_step;
 
     gr::top_block_sptr top_block;
-    GNSSBlockFactory block_factory;
     std::shared_ptr<Concurrent_Queue<pmt::pmt_t>> queue;
 
     queue = std::make_shared<Concurrent_Queue<pmt::pmt_t>>();
@@ -249,10 +248,10 @@ bool front_end_capture(const std::shared_ptr<ConfigurationInterface>& configurat
             std::shared_ptr<GNSSBlockInterface> conditioner;
 
             trace_step = "creating source";
-            source = block_factory.GetSignalSource(configuration.get(), queue.get());
+            source = block_factory::GetSignalSource(configuration.get(), queue.get());
 
             trace_step = "creating signal conditioner";
-            conditioner = block_factory.GetSignalConditioner(configuration.get());
+            conditioner = block_factory::GetSignalConditioner(configuration.get());
 
             trace_step = "unexpected in setup code";
 


### PR DESCRIPTION
- Since `GNSSBlockFactory` has no state, it can be simple functions in a namespace, which remove the necessity to create an object
- Use the factory methods in the unit tests to simplify them
- Cleanup the tests for my intellisense that give errors everywhere in those files