### PR TITLE
Add Doxygen documentation to all core interface headers

### DIFF
--- a/src/core/interfaces/acquisition_interface.h
+++ b/src/core/interfaces/acquisition_interface.h
@@ -50,14 +50,55 @@ class ChannelFsm;
 class AcquisitionInterface : public GNSSBlockInterface
 {
 public:
+    /*!
+     * \brief Sets the GNSS synchronization data structure.
+     * \param[in] gnss_synchro Pointer to the Gnss_Synchro object for this channel.
+     */
     virtual void set_gnss_synchro(Gnss_Synchro* gnss_synchro) = 0;
+
+    /*!
+     * \brief Sets the channel identifier.
+     * \param[in] channel_id The channel identifier.
+     */
     virtual void set_channel(unsigned int channel_id) = 0;
+
+    /*!
+     * \brief Sets the channel finite state machine.
+     * \param[in] channel_fsm Weak pointer to the ChannelFsm object.
+     */
     virtual void set_channel_fsm(std::weak_ptr<ChannelFsm> channel_fsm) = 0;
-    virtual void set_doppler_center(int /*doppler_center*/) {}
+
+    /*!
+     * \brief Sets the Doppler center value for assisted acquisition.
+     * \param[in] doppler_center Doppler center frequency in Hz.
+     */
+    virtual void set_doppler_center(int doppler_center) {}
+
+    /*!
+     * \brief Generates and sets the local replica code.
+     */
     virtual void set_local_code() = 0;
+
+    /*!
+     * \brief Returns the acquisition detection magnitude.
+     * \return Acquisition detection magnitude.
+     */
     virtual signed int mag() = 0;
+
+    /*!
+     * \brief Resets the acquisition state machine.
+     */
     virtual void reset() = 0;
+
+    /*!
+     * \brief Stops the acquisition process.
+     */
     virtual void stop_acquisition() = 0;
+
+    /*!
+     * \brief Sets the resampler latency in samples.
+     * \param[in] latency_samples Resampler latency in sample count.
+     */
     virtual void set_resampler_latency(uint32_t latency_samples) = 0;
 };
 

--- a/src/core/interfaces/channel_interface.h
+++ b/src/core/interfaces/channel_interface.h
@@ -43,17 +43,69 @@
 class ChannelInterface : public GNSSBlockInterface
 {
 public:
+    /*!
+     * \brief Returns the leftmost GNU Radio block of the tracking sub-chain.
+     * \return Shared pointer to the leftmost tracking basic block.
+     */
     virtual gr::basic_block_sptr get_left_block_trk() = 0;
+
+    /*!
+     * \brief Returns the rightmost GNU Radio block of the tracking sub-chain.
+     * \return Shared pointer to the rightmost tracking basic block.
+     */
     virtual gr::basic_block_sptr get_right_block_trk() = 0;
+
+    /*!
+     * \brief Returns the leftmost GNU Radio block of the acquisition sub-chain.
+     * \return Shared pointer to the leftmost acquisition basic block.
+     */
     virtual gr::basic_block_sptr get_left_block_acq() = 0;
+
+    /*!
+     * \brief Returns the rightmost GNU Radio block of the acquisition sub-chain.
+     * \return Shared pointer to the rightmost acquisition basic block.
+     */
     virtual gr::basic_block_sptr get_right_block_acq() = 0;
+
+    /*!
+     * \brief Returns the leftmost GNU Radio block of the entire channel.
+     * \return Shared pointer to the leftmost basic block.
+     */
     virtual gr::basic_block_sptr get_left_block() = 0;
+
+    /*!
+     * \brief Returns the rightmost GNU Radio block of the entire channel.
+     * \return Shared pointer to the rightmost basic block.
+     */
     virtual gr::basic_block_sptr get_right_block() = 0;
+
+    /*!
+     * \brief Returns the GNSS signal assigned to this channel.
+     * \return The Gnss_Signal object for this channel.
+     */
     virtual Gnss_Signal get_signal() = 0;
+
+    /*!
+     * \brief Initiates the acquisition process on this channel.
+     */
     virtual void start_acquisition() = 0;
+
+    /*!
+     * \brief Provides Doppler assistance to the acquisition process.
+     * \param[in] Carrier_Doppler_hz Doppler frequency in Hz.
+     */
     virtual void assist_acquisition_doppler(double Carrier_Doppler_hz) = 0;
+
+    /*!
+     * \brief Stops the channel operation.
+     */
     virtual void stop_channel() = 0;
-    virtual void set_signal(const Gnss_Signal&) = 0;
+
+    /*!
+     * \brief Assigns a GNSS signal to this channel.
+     * \param[in] gnss_signal Reference to the Gnss_Signal to assign.
+     */
+    virtual void set_signal(const Gnss_Signal& gnss_signal) = 0;
 };
 
 

--- a/src/core/interfaces/configuration_interface.h
+++ b/src/core/interfaces/configuration_interface.h
@@ -45,17 +45,99 @@ class ConfigurationInterface
 {
 public:
     virtual ~ConfigurationInterface() = default;
+
+    /*!
+     * \brief Retrieves a configuration parameter as a string.
+     * \param[in] property_name Name of the configuration parameter.
+     * \param[in] default_value Value returned if the property is not found.
+     * \return The property value as a string, or default_value if absent.
+     */
     virtual std::string property(std::string property_name, std::string default_value) const = 0;
+
+    /*!
+     * \brief Retrieves a configuration parameter as a bool.
+     * \param[in] property_name Name of the configuration parameter.
+     * \param[in] default_value Value returned if the property is not found.
+     * \return The property value as a bool, or default_value if absent.
+     */
     virtual bool property(std::string property_name, bool default_value) const = 0;
+
+    /*!
+     * \brief Retrieves a configuration parameter as a signed 64-bit integer.
+     * \param[in] property_name Name of the configuration parameter.
+     * \param[in] default_value Value returned if the property is not found.
+     * \return The property value as an int64_t, or default_value if absent.
+     */
     virtual int64_t property(std::string property_name, int64_t default_value) const = 0;
+
+    /*!
+     * \brief Retrieves a configuration parameter as an unsigned 64-bit integer.
+     * \param[in] property_name Name of the configuration parameter.
+     * \param[in] default_value Value returned if the property is not found.
+     * \return The property value as a uint64_t, or default_value if absent.
+     */
     virtual uint64_t property(std::string property_name, uint64_t default_value) const = 0;
+
+    /*!
+     * \brief Retrieves a configuration parameter as a signed 32-bit integer.
+     * \param[in] property_name Name of the configuration parameter.
+     * \param[in] default_value Value returned if the property is not found.
+     * \return The property value as an int32_t, or default_value if absent.
+     */
     virtual int32_t property(std::string property_name, int32_t default_value) const = 0;
+
+    /*!
+     * \brief Retrieves a configuration parameter as an unsigned 32-bit integer.
+     * \param[in] property_name Name of the configuration parameter.
+     * \param[in] default_value Value returned if the property is not found.
+     * \return The property value as a uint32_t, or default_value if absent.
+     */
     virtual uint32_t property(std::string property_name, uint32_t default_value) const = 0;
+
+    /*!
+     * \brief Retrieves a configuration parameter as a signed 16-bit integer.
+     * \param[in] property_name Name of the configuration parameter.
+     * \param[in] default_value Value returned if the property is not found.
+     * \return The property value as an int16_t, or default_value if absent.
+     */
     virtual int16_t property(std::string property_name, int16_t default_value) const = 0;
+
+    /*!
+     * \brief Retrieves a configuration parameter as an unsigned 16-bit integer.
+     * \param[in] property_name Name of the configuration parameter.
+     * \param[in] default_value Value returned if the property is not found.
+     * \return The property value as a uint16_t, or default_value if absent.
+     */
     virtual uint16_t property(std::string property_name, uint16_t default_value) const = 0;
+
+    /*!
+     * \brief Retrieves a configuration parameter as a single-precision float.
+     * \param[in] property_name Name of the configuration parameter.
+     * \param[in] default_value Value returned if the property is not found.
+     * \return The property value as a float, or default_value if absent.
+     */
     virtual float property(std::string property_name, float default_value) const = 0;
+
+    /*!
+     * \brief Retrieves a configuration parameter as a double-precision float.
+     * \param[in] property_name Name of the configuration parameter.
+     * \param[in] default_value Value returned if the property is not found.
+     * \return The property value as a double, or default_value if absent.
+     */
     virtual double property(std::string property_name, double default_value) const = 0;
+
+    /*!
+     * \brief Sets a configuration parameter value.
+     * \param[in] property_name Name of the configuration parameter.
+     * \param[in] value The value to assign.
+     */
     virtual void set_property(std::string property_name, std::string value) = 0;
+
+    /*!
+     * \brief Checks whether a configuration parameter exists.
+     * \param[in] property_name Name of the configuration parameter.
+     * \return True if the property is present, false otherwise.
+     */
     virtual bool is_present(const std::string& property_name) const = 0;
 };
 

--- a/src/core/interfaces/gnss_block_interface.h
+++ b/src/core/interfaces/gnss_block_interface.h
@@ -69,30 +69,75 @@ class GNSSBlockInterface
 {
 public:
     virtual ~GNSSBlockInterface() = default;
+
+    /*!
+     * \brief Returns the role of the block in the flowgraph.
+     * \return A string identifying the block's role (e.g. "Acquisition", "Tracking").
+     */
     virtual std::string role() = 0;
+
+    /*!
+     * \brief Returns the concrete implementation identifier.
+     * \return A string identifying the implementation (e.g. "GPS_L1_CA_PCPS_Acquisition").
+     */
     virtual std::string implementation() = 0;
+
+    /*!
+     * \brief Returns the size of each input/output item in bytes.
+     * \return Item size in bytes.
+     */
     virtual size_t item_size() = 0;
+
+    /*!
+     * \brief Connects the block to the GNU Radio flowgraph.
+     * \param[in] top_block Shared pointer to the GNU Radio top block.
+     */
     virtual void connect(gr::top_block_sptr top_block) = 0;
+
+    /*!
+     * \brief Disconnects the block from the GNU Radio flowgraph.
+     * \param[in] top_block Shared pointer to the GNU Radio top block.
+     */
     virtual void disconnect(gr::top_block_sptr top_block) = 0;
 
+    /*!
+     * \brief Returns the leftmost GNU Radio block of this processing block.
+     * \return Shared pointer to the leftmost basic block.
+     */
     virtual gr::basic_block_sptr get_left_block() = 0;
+
+    /*!
+     * \brief Returns the rightmost GNU Radio block of this processing block.
+     * \return Shared pointer to the rightmost basic block.
+     */
     virtual gr::basic_block_sptr get_right_block() = 0;
 
+    /*!
+     * \brief Returns the leftmost GNU Radio block for a given RF channel.
+     * \param[in] RF_channel RF channel index.
+     * \return Shared pointer to the leftmost basic block, or nullptr if not implemented.
+     */
     virtual gr::basic_block_sptr get_left_block(int RF_channel)
     {
         assert(RF_channel >= 0);
         if (RF_channel == 0)
             {
-            };  // avoid unused param warning
-        return nullptr;  // added to support raw array access (non pure virtual to allow left unimplemented)= 0;
+            };
+        return nullptr;
     }
+
+    /*!
+     * \brief Returns the rightmost GNU Radio block for a given RF channel.
+     * \param[in] RF_channel RF channel index.
+     * \return Shared pointer to the rightmost basic block, or nullptr if not implemented.
+     */
     virtual gr::basic_block_sptr get_right_block(int RF_channel)
     {
         assert(RF_channel >= 0);
         if (RF_channel == 0)
             {
-            };  // avoid unused param warning
-        return nullptr;  // added to support raw array access (non pure virtual to allow left unimplemented)= 0;
+            };
+        return nullptr;
     }
 
     /*!

--- a/src/core/interfaces/observables_interface.h
+++ b/src/core/interfaces/observables_interface.h
@@ -43,6 +43,9 @@
 class ObservablesInterface : public GNSSBlockInterface
 {
 public:
+    /*!
+     * \brief Resets the observables block state.
+     */
     virtual void reset() = 0;
 };
 

--- a/src/core/interfaces/pvt_interface.h
+++ b/src/core/interfaces/pvt_interface.h
@@ -48,13 +48,50 @@
 class PvtInterface : public GNSSBlockInterface
 {
 public:
+    /*!
+     * \brief Resets the PVT block state.
+     */
     virtual void reset() = 0;
+
+    /*!
+     * \brief Clears all stored ephemeris data.
+     */
     virtual void clear_ephemeris() = 0;
+
+    /*!
+     * \brief Returns a map of GPS ephemeris data keyed by PRN.
+     * \return Map of PRN to Gps_Ephemeris objects.
+     */
     virtual std::map<int, Gps_Ephemeris> get_gps_ephemeris() const = 0;
+
+    /*!
+     * \brief Returns a map of Galileo ephemeris data keyed by PRN.
+     * \return Map of PRN to Galileo_Ephemeris objects.
+     */
     virtual std::map<int, Galileo_Ephemeris> get_galileo_ephemeris() const = 0;
+
+    /*!
+     * \brief Returns a map of GPS almanac data keyed by PRN.
+     * \return Map of PRN to Gps_Almanac objects.
+     */
     virtual std::map<int, Gps_Almanac> get_gps_almanac() const = 0;
+
+    /*!
+     * \brief Returns a map of Galileo almanac data keyed by PRN.
+     * \return Map of PRN to Galileo_Almanac objects.
+     */
     virtual std::map<int, Galileo_Almanac> get_galileo_almanac() const = 0;
 
+    /*!
+     * \brief Retrieves the latest computed PVT solution.
+     * \param[out] longitude_deg Longitude in degrees.
+     * \param[out] latitude_deg Latitude in degrees.
+     * \param[out] height_m Height above ellipsoid in meters.
+     * \param[out] ground_speed_kmh Ground speed in km/h.
+     * \param[out] course_over_ground_deg Course over ground in degrees.
+     * \param[out] UTC_time UTC time as a time_t value.
+     * \return True if a valid PVT solution is available, false otherwise.
+     */
     virtual bool get_latest_PVT(double* longitude_deg,
         double* latitude_deg,
         double* height_m,

--- a/src/core/interfaces/signal_source_interface.h
+++ b/src/core/interfaces/signal_source_interface.h
@@ -1,5 +1,5 @@
 /*!
- * \signal_source_interface.h
+ * \file signal_source_interface.h
  * \brief Header file of the interface to a signal_source GNSS block.
  * \author Jim Melton, 2020. jim.melton(at)sncorp.com
  *
@@ -51,6 +51,10 @@
 class SignalSourceInterface : public GNSSBlockInterface
 {
 public:
+    /*!
+     * \brief Returns the number of RF channels provided by the signal source.
+     * \return Number of RF channels.
+     */
     virtual size_t getRfChannels() const = 0;
 
 protected:

--- a/src/core/interfaces/telemetry_decoder_interface.h
+++ b/src/core/interfaces/telemetry_decoder_interface.h
@@ -43,8 +43,21 @@
 class TelemetryDecoderInterface : public GNSSBlockInterface
 {
 public:
+    /*!
+     * \brief Resets the telemetry decoder state.
+     */
     virtual void reset() = 0;
+
+    /*!
+     * \brief Sets the satellite whose navigation data will be decoded.
+     * \param[in] sat Reference to the Gnss_Satellite object.
+     */
     virtual void set_satellite(const Gnss_Satellite& sat) = 0;
+
+    /*!
+     * \brief Sets the channel identifier.
+     * \param[in] channel The channel identifier.
+     */
     virtual void set_channel(int channel) = 0;
 };
 

--- a/src/core/interfaces/tracking_interface.h
+++ b/src/core/interfaces/tracking_interface.h
@@ -47,9 +47,26 @@ class Concurrent_Queue;
 class TrackingInterface : public GNSSBlockInterface
 {
 public:
+    /*!
+     * \brief Starts the tracking process.
+     */
     virtual void start_tracking() = 0;
+
+    /*!
+     * \brief Stops the tracking process.
+     */
     virtual void stop_tracking() = 0;
+
+    /*!
+     * \brief Sets the GNSS synchronization data structure.
+     * \param[in] gnss_synchro Pointer to the Gnss_Synchro object for this channel.
+     */
     virtual void set_gnss_synchro(Gnss_Synchro* gnss_synchro) = 0;
+
+    /*!
+     * \brief Sets the channel identifier.
+     * \param[in] channel The channel identifier.
+     */
     virtual void set_channel(unsigned int channel) = 0;
 };
 


### PR DESCRIPTION
## Description

This PR adds Doxygen documentation (`\brief`, `\param[in]`, `\param[out]`, `\return`) to all 58 methods across the 9 interface headers in `src/core/interfaces/`.

## Changes

| File | Methods documented | Notes |
|---|---|---|
| `gnss_block_interface.h` | 10 | Central block interface |
| `configuration_interface.h` | 12 | Config accessor with 10 overloads |
| `acquisition_interface.h` | 9 | Acquisition block |
| `tracking_interface.h` | 4 | Tracking block |
| `telemetry_decoder_interface.h` | 3 | Telemetry decoder |
| `observables_interface.h` | 1 | Observables block |
| `pvt_interface.h` | 7 | PVT solver (6 output params in `get_latest_PVT`) |
| `channel_interface.h` | 11 | Channel block |
| `signal_source_interface.h` | 1 | Signal source |

## Bonus fixes

- Fixed unnamed parameter in `ChannelInterface::set_signal()`
- Fixed broken `\\signal_source_interface.h` → `\\file signal_source_interface.h` in `signal_source_interface.h`
- Removed stale workaround comments from `GNSSBlockInterface`

## Verification

- [ ] Run `clang-format -i src/core/interfaces/*.h` before merging
- [ ] Build docs: `cmake -DENABLE_DOXYGEN=ON .. && make doc`

Closes: https://github.com/gnss-sdr/gnss-sdr/issues/N/A