### PR TITLE
Add gnss-sdr-tui: a real-time FTXUI-based terminal monitor for GNSS-SDR

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -157,6 +157,8 @@ option(ENABLE_GNSS_SIM_INSTALL "Enable the installation of gnss_sim on the fly" 
 
 option(ENABLE_CPUFEATURES "Make use of the cpu_features library" ON)
 
+option(ENABLE_GNSS_SDR_TUI "Build the GNSS-SDR Terminal User Interface (gnss-sdr-tui)" OFF)
+
 if(NOT (ENABLE_UNIT_TESTING_EXTRA OR ENABLE_SYSTEM_TESTING_EXTRA OR ENABLE_FPGA))
     set(ENABLE_GNSS_SIM_INSTALL OFF)
 endif()
@@ -3439,6 +3441,7 @@ add_feature_info(ENABLE_INSTALL_TESTS ENABLE_INSTALL_TESTS "Install test binarie
 add_feature_info(ENABLE_BENCHMARKS ENABLE_BENCHMARKS "Enables building of code snippet benchmarks.")
 add_feature_info(ENABLE_EXTERNAL_MATHJAX ENABLE_EXTERNAL_MATHJAX "Use MathJax from an external CDN in HTML docs when doing '${CMAKE_MAKE_PROGRAM_PRETTY_NAME} doc'.")
 add_feature_info(ENABLE_CPUFEATURES ENABLE_CPUFEATURES "Make use of the cpu_features library.")
+add_feature_info(ENABLE_GNSS_SDR_TUI ENABLE_GNSS_SDR_TUI "Build the GNSS-SDR Terminal User Interface (gnss-sdr-tui).")
 add_feature_info(ENABLE_GNSSSDR_ADHOC_CODESIGN ENABLE_GNSSSDR_ADHOC_CODESIGN "Ad-hoc sign local Darwin build-tree executables that must run after the build.")
 add_feature_info(Boost_USE_STATIC_LIBS Boost_USE_STATIC_LIBS "Use Boost static libraries.")
 

--- a/utils/CMakeLists.txt
+++ b/utils/CMakeLists.txt
@@ -11,3 +11,7 @@ if(ENABLE_UNIT_TESTING_EXTRA OR ENABLE_SYSTEM_TESTING_EXTRA OR ENABLE_FPGA)
     add_subdirectory(rinex-tools)
     add_subdirectory(rinex2assist)
 endif()
+
+if(ENABLE_GNSS_SDR_TUI)
+    add_subdirectory(gnss-sdr-tui)
+endif()

--- a/utils/gnss-sdr-tui/CMakeLists.txt
+++ b/utils/gnss-sdr-tui/CMakeLists.txt
@@ -1,0 +1,150 @@
+# GNSS-SDR is a Global Navigation Satellite System software-defined receiver.
+# This file is part of GNSS-SDR.
+#
+# SPDX-FileCopyrightText: 2025 C. Fernandez-Prades cfernandez(at)cttc.es
+# SPDX-License-Identifier: BSD-3-Clause
+
+# Allow building standalone or as a subdirectory of GNSS-SDR.
+if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
+    cmake_minimum_required(VERSION 3.14...4.3)
+    project(gnss-sdr-tui CXX)
+endif()
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+set(TUI_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR})
+
+# --- Dependencies ---
+
+find_package(Protobuf REQUIRED QUIET MODULE)
+if(Protobuf_VERSION)
+    if(${Protobuf_VERSION} VERSION_LESS "3.0.0")
+        message(FATAL_ERROR "Fatal error: Protocol Buffers >= v3.0.0 required.")
+    endif()
+    message(STATUS "Found Protobuf ${Protobuf_VERSION}: ${PROTOBUF_INCLUDE_DIR}")
+endif()
+
+# Fix CMake 4.x FindProtobuf missing IMPORTED_LOCATION
+if(TARGET protobuf::libprotobuf)
+    set_target_properties(protobuf::libprotobuf PROPERTIES
+        IMPORTED_LOCATION "${PROTOBUF_LIBRARY}"
+        INTERFACE_INCLUDE_DIRECTORIES "${PROTOBUF_INCLUDE_DIR}"
+    )
+endif()
+
+# protoc
+if(TARGET protobuf::protoc)
+    set_target_properties(protobuf::protoc PROPERTIES
+        IMPORTED_LOCATION "${Protobuf_PROTOC_EXECUTABLE}"
+    )
+    set(PROTOC_BINARY protobuf::protoc)
+else()
+    find_program(PROTOC_BINARY protoc REQUIRED)
+endif()
+
+# FTXUI via FetchContent (guard against duplicate declarations)
+if(NOT ftxui_POPULATED)
+    include(FetchContent)
+    FetchContent_Declare(ftxui
+        GIT_REPOSITORY https://github.com/ArthurSonzogni/FTXUI
+        GIT_TAG v5.0.0
+    )
+    FetchContent_MakeAvailable(ftxui)
+endif()
+
+# --- Proto compilation ---
+
+set(GNSS_PROTO_SRCS
+    ${CMAKE_CURRENT_BINARY_DIR}/gnss_synchro.pb.cc
+    ${CMAKE_CURRENT_BINARY_DIR}/monitor_pvt.pb.cc
+)
+set(GNSS_PROTO_HDRS
+    ${CMAKE_CURRENT_BINARY_DIR}/gnss_synchro.pb.h
+    ${CMAKE_CURRENT_BINARY_DIR}/monitor_pvt.pb.h
+)
+
+foreach(PROTO_FILE
+    ${TUI_SOURCE_DIR}/proto/gnss_synchro.proto
+    ${TUI_SOURCE_DIR}/proto/monitor_pvt.proto
+)
+    get_filename_component(PROTO_NAME ${PROTO_FILE} NAME_WE)
+    add_custom_command(
+        OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/${PROTO_NAME}.pb.cc
+               ${CMAKE_CURRENT_BINARY_DIR}/${PROTO_NAME}.pb.h
+        COMMAND ${PROTOC_BINARY}
+            --cpp_out ${CMAKE_CURRENT_BINARY_DIR}
+            -I ${TUI_SOURCE_DIR}/proto
+            ${PROTO_FILE}
+        DEPENDS ${PROTO_FILE}
+        COMMENT "Generating ${PROTO_NAME} protobuf sources"
+    )
+endforeach()
+
+# --- Libraries ---
+
+add_library(tui_data_store
+    ${TUI_SOURCE_DIR}/data_store.cc
+)
+target_include_directories(tui_data_store
+    PUBLIC ${TUI_SOURCE_DIR}
+)
+
+set_source_files_properties(${GNSS_PROTO_SRCS} PROPERTIES
+    GENERATED TRUE
+)
+
+add_library(tui_udp_listener
+    ${TUI_SOURCE_DIR}/udp_listener.cc
+    ${GNSS_PROTO_SRCS}
+)
+target_include_directories(tui_udp_listener
+    PUBLIC ${TUI_SOURCE_DIR} ${CMAKE_CURRENT_BINARY_DIR}
+)
+target_include_directories(tui_udp_listener
+    SYSTEM PUBLIC ${PROTOBUF_INCLUDE_DIR}
+)
+target_link_libraries(tui_udp_listener
+    PUBLIC
+        tui_data_store
+        ${PROTOBUF_LIBRARIES}
+)
+
+add_library(tui_screens
+    ${TUI_SOURCE_DIR}/screens/signal_overview.cc
+    ${TUI_SOURCE_DIR}/screens/satellite_table.cc
+    ${TUI_SOURCE_DIR}/screens/pvt_panel.cc
+    ${TUI_SOURCE_DIR}/screens/event_log.cc
+    ${TUI_SOURCE_DIR}/screens/help_screen.cc
+    ${TUI_SOURCE_DIR}/screens/satellite_detail.cc
+)
+target_include_directories(tui_screens
+    PUBLIC ${TUI_SOURCE_DIR}
+)
+target_link_libraries(tui_screens
+    PUBLIC
+        tui_data_store
+        ftxui::dom
+        ftxui::screen
+)
+
+# --- Executable ---
+
+add_executable(gnss_sdr_tui
+    ${TUI_SOURCE_DIR}/main.cc
+)
+target_link_libraries(gnss_sdr_tui
+    PRIVATE
+        tui_udp_listener
+        tui_screens
+        ftxui::component
+        ftxui::dom
+        ftxui::screen
+)
+target_include_directories(gnss_sdr_tui
+    PRIVATE ${TUI_SOURCE_DIR}
+)
+
+install(TARGETS gnss_sdr_tui
+    RUNTIME DESTINATION bin
+)

--- a/utils/gnss-sdr-tui/data_store.cc
+++ b/utils/gnss-sdr-tui/data_store.cc
@@ -1,0 +1,157 @@
+/*!
+ * \file data_store.cc
+ * \brief Thread-safe shared data model for the GNSS-SDR TUI.
+ * \author Generated for GNSS-SDR contributors
+ *
+ * -----------------------------------------------------------------------------
+ *
+ * GNSS-SDR is a Global Navigation Satellite System software-defined receiver.
+ * This file is part of GNSS-SDR.
+ *
+ * SPDX-FileCopyrightText: 2025 (see AUTHORS file for a list of contributors)
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * -----------------------------------------------------------------------------
+ */
+
+#include "data_store.h"
+#include <algorithm>
+
+void DataStore::update_satellite(int channel, const SatelliteData& data)
+{
+    const std::lock_guard<std::mutex> lock(mutex_);
+    const bool is_new = satellites_.find(channel) == satellites_.end();
+    const bool had_lock = !is_new && satellites_[channel].flag_pll_locked;
+    satellites_[channel] = data;
+
+    cn0_history_[channel].push_back(data.cn0_db_hz);
+    if (cn0_history_[channel].size() > kMaxHistory)
+        {
+            cn0_history_[channel].pop_front();
+        }
+
+    if (is_new)
+        {
+            log_.push_back({std::chrono::system_clock::now(),
+                data.system + std::to_string(data.prn) + " acquired on ch " + std::to_string(channel)});
+        }
+    else if (!had_lock && data.flag_pll_locked)
+        {
+            log_.push_back({std::chrono::system_clock::now(),
+                data.system + std::to_string(data.prn) + " PLL locked on ch " + std::to_string(channel)});
+        }
+    else if (had_lock && !data.flag_pll_locked)
+        {
+            log_.push_back({std::chrono::system_clock::now(),
+                data.system + std::to_string(data.prn) + " PLL unlock on ch " + std::to_string(channel)});
+        }
+    if (data.flag_cycle_slip)
+        {
+            log_.push_back({std::chrono::system_clock::now(),
+                data.system + std::to_string(data.prn) + " cycle slip on ch " + std::to_string(channel)});
+        }
+    while (log_.size() > kMaxLogEntries) log_.pop_front();
+}
+
+SatelliteData DataStore::get_satellite(int channel) const
+{
+    const std::lock_guard<std::mutex> lock(mutex_);
+    auto it = satellites_.find(channel);
+    if (it != satellites_.end())
+        {
+            return it->second;
+        }
+    return SatelliteData{};
+}
+
+std::map<int, SatelliteData> DataStore::get_all_satellites() const
+{
+    const std::lock_guard<std::mutex> lock(mutex_);
+    return satellites_;
+}
+
+std::vector<std::pair<int, SatelliteData>> DataStore::get_sorted_satellites() const
+{
+    const std::lock_guard<std::mutex> lock(mutex_);
+    std::vector<std::pair<int, SatelliteData>> vec(satellites_.begin(), satellites_.end());
+    std::sort(vec.begin(), vec.end(),
+        [](const auto& a, const auto& b) {
+            if (a.second.system != b.second.system)
+                return a.second.system < b.second.system;
+            return a.second.prn < b.second.prn;
+        });
+    return vec;
+}
+
+size_t DataStore::satellite_count() const
+{
+    const std::lock_guard<std::mutex> lock(mutex_);
+    return satellites_.size();
+}
+
+void DataStore::record_cn0(int channel, double cn0)
+{
+    const std::lock_guard<std::mutex> lock(mutex_);
+    cn0_history_[channel].push_back(cn0);
+    if (cn0_history_[channel].size() > kMaxHistory)
+        {
+            cn0_history_[channel].pop_front();
+        }
+}
+
+std::deque<double> DataStore::get_cn0_history(int channel) const
+{
+    const std::lock_guard<std::mutex> lock(mutex_);
+    auto it = cn0_history_.find(channel);
+    if (it != cn0_history_.end())
+        {
+            return it->second;
+        }
+    return {};
+}
+
+void DataStore::update_pvt(const PvtData& data)
+{
+    const std::lock_guard<std::mutex> lock(mutex_);
+    const bool first_fix = !pvt_.has_value();
+    pvt_ = data;
+    if (first_fix)
+        {
+            log_.push_back({std::chrono::system_clock::now(),
+                "First PVT fix: " + std::to_string(data.latitude) + ", " + std::to_string(data.longitude)});
+            while (log_.size() > kMaxLogEntries) log_.pop_front();
+        }
+}
+
+std::optional<PvtData> DataStore::get_pvt() const
+{
+    const std::lock_guard<std::mutex> lock(mutex_);
+    return pvt_;
+}
+
+void DataStore::add_log(const std::string& msg)
+{
+    const std::lock_guard<std::mutex> lock(mutex_);
+    log_.push_back({std::chrono::system_clock::now(), msg});
+    while (log_.size() > kMaxLogEntries) log_.pop_front();
+}
+
+std::deque<LogEntry> DataStore::get_logs(size_t count) const
+{
+    const std::lock_guard<std::mutex> lock(mutex_);
+    if (count == 0 || count >= log_.size())
+        {
+            return log_;
+        }
+    return std::deque<LogEntry>(log_.end() - static_cast<ptrdiff_t>(count), log_.end());
+}
+
+std::string constellation_color(const std::string& system)
+{
+    if (system == "G") return "GPS";
+    if (system == "E") return "Galileo";
+    if (system == "R") return "GLONASS";
+    if (system == "C") return "BeiDou";
+    if (system == "S") return "SBAS";
+    return "Unknown";
+}

--- a/utils/gnss-sdr-tui/data_store.h
+++ b/utils/gnss-sdr-tui/data_store.h
@@ -1,0 +1,94 @@
+/*!
+ * \file data_store.h
+ * \brief Thread-safe shared data model for the GNSS-SDR TUI.
+ * \author Generated for GNSS-SDR contributors
+ *
+ * -----------------------------------------------------------------------------
+ *
+ * GNSS-SDR is a Global Navigation Satellite System software-defined receiver.
+ * This file is part of GNSS-SDR.
+ *
+ * SPDX-FileCopyrightText: 2025 (see AUTHORS file for a list of contributors)
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * -----------------------------------------------------------------------------
+ */
+
+#ifndef GNSS_SDR_TUI_DATA_STORE_H
+#define GNSS_SDR_TUI_DATA_STORE_H
+
+#include <chrono>
+#include <deque>
+#include <map>
+#include <mutex>
+#include <optional>
+#include <string>
+#include <vector>
+
+struct SatelliteData
+{
+    std::string system;
+    std::string signal;
+    uint32_t prn{};
+    int32_t channel_id{};
+    double cn0_db_hz{};
+    double carrier_doppler_hz{};
+    double carrier_phase_rads{};
+    double pseudorange_m{};
+    double azimuth_deg{};
+    double elevation_deg{};
+    bool flag_valid_pseudorange{};
+    bool flag_pll_locked{};
+    bool flag_cycle_slip{};
+};
+
+struct PvtData
+{
+    double latitude{};
+    double longitude{};
+    double height{};
+    double hdop{};
+    double vdop{};
+    double pdop{};
+    double gdop{};
+    uint32_t valid_sats{};
+    std::string utc_time;
+};
+
+struct LogEntry
+{
+    std::chrono::system_clock::time_point timestamp;
+    std::string message;
+};
+
+class DataStore
+{
+public:
+    void update_satellite(int channel, const SatelliteData& data);
+    SatelliteData get_satellite(int channel) const;
+    std::map<int, SatelliteData> get_all_satellites() const;
+    std::vector<std::pair<int, SatelliteData>> get_sorted_satellites() const;
+    size_t satellite_count() const;
+
+    void record_cn0(int channel, double cn0);
+    std::deque<double> get_cn0_history(int channel) const;
+
+    void update_pvt(const PvtData& data);
+    std::optional<PvtData> get_pvt() const;
+
+    void add_log(const std::string& msg);
+    std::deque<LogEntry> get_logs(size_t count = 0) const;
+
+private:
+    mutable std::mutex mutex_;
+    std::map<int, SatelliteData> satellites_;
+    std::map<int, std::deque<double>> cn0_history_;
+    std::optional<PvtData> pvt_;
+    std::deque<LogEntry> log_;
+    static constexpr size_t kMaxLogEntries = 200;
+    static constexpr size_t kMaxHistory = 30;
+};
+
+std::string constellation_color(const std::string& system);
+
+#endif  // GNSS_SDR_TUI_DATA_STORE_H

--- a/utils/gnss-sdr-tui/main.cc
+++ b/utils/gnss-sdr-tui/main.cc
@@ -1,0 +1,223 @@
+/*!
+ * \file main.cc
+ * \brief Entry point for the GNSS-SDR Terminal User Interface.
+ * \author Generated for GNSS-SDR contributors
+ *
+ * -----------------------------------------------------------------------------
+ *
+ * GNSS-SDR is a Global Navigation Satellite System software-defined receiver.
+ * This file is part of GNSS-SDR.
+ *
+ * SPDX-FileCopyrightText: 2025 (see AUTHORS file for a list of contributors)
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * -----------------------------------------------------------------------------
+ */
+
+#include "data_store.h"
+#include "udp_listener.h"
+#include "screens/event_log.h"
+#include "screens/help_screen.h"
+#include "screens/pvt_panel.h"
+#include "screens/satellite_detail.h"
+#include "screens/satellite_table.h"
+#include "screens/signal_overview.h"
+#include <ftxui/component/component.hpp>
+#include <ftxui/component/screen_interactive.hpp>
+#include <ftxui/dom/elements.hpp>
+#include <atomic>
+#include <chrono>
+#include <csignal>
+#include <iostream>
+#include <sstream>
+#include <string>
+#include <thread>
+#include <vector>
+
+std::atomic<bool> g_running{true};
+
+void handle_signal(int)
+{
+    g_running = false;
+}
+
+int main(int argc, char* argv[])
+{
+    std::string address = "127.0.0.1";
+    unsigned short gnss_port = 1234;
+    unsigned short pvt_port = 1234;
+
+    for (int i = 1; i < argc; ++i)
+        {
+            const std::string arg(argv[i]);
+            if (arg == "--gnss-port" && i + 1 < argc)
+                {
+                    gnss_port = static_cast<unsigned short>(std::stoi(argv[++i]));
+                }
+            else if (arg == "--pvt-port" && i + 1 < argc)
+                {
+                    pvt_port = static_cast<unsigned short>(std::stoi(argv[++i]));
+                }
+            else if (arg == "--address" && i + 1 < argc)
+                {
+                    address = argv[++i];
+                }
+            else if (arg == "--help")
+                {
+                    std::cout << "Usage: gnss_sdr_tui [options]\n\n"
+                              << "  --gnss-port PORT    UDP port for GnssSynchro (default: 1234)\n"
+                              << "  --pvt-port PORT     UDP port for MonitorPvt (default: 1234)\n"
+                              << "  --address ADDR      UDP address (default: 127.0.0.1)\n"
+                              << "  --help              Show this help\n";
+                    return 0;
+                }
+        }
+
+    signal(SIGINT, handle_signal);
+    signal(SIGTERM, handle_signal);
+
+    DataStore data_store;
+    UdpListener listener(data_store, address, gnss_port, pvt_port);
+    listener.start();
+
+    auto screen = ftxui::ScreenInteractive::Fullscreen();
+
+    std::atomic<bool> show_help{false};
+    std::atomic<bool> show_detail{false};
+    std::atomic<int> selected_row{1};
+    std::atomic<int> detail_channel{0};
+    std::atomic<int> refresh_ms{200};
+
+    auto renderer = ftxui::Renderer([&] {
+        if (show_help)
+            {
+                return render_help_screen();
+            }
+
+        if (show_detail)
+            {
+                return render_satellite_detail(data_store, detail_channel.load());
+            }
+
+        auto overview = render_signal_overview(data_store);
+        auto table = render_satellite_table(data_store, selected_row.load());
+        auto pvt = render_pvt_panel(data_store);
+        auto log = render_event_log(data_store);
+
+        auto right = ftxui::vbox({
+            table | ftxui::flex,
+            ftxui::separator(),
+            pvt,
+        });
+
+        auto top = ftxui::hbox({
+            overview,
+            ftxui::separator(),
+            right | ftxui::flex,
+        }) | ftxui::flex;
+
+        std::ostringstream status;
+        status << " Sats: " << data_store.satellite_count()
+               << "  |  Refresh: " << refresh_ms.load() << "ms";
+        auto pvt_opt = data_store.get_pvt();
+        if (pvt_opt)
+            {
+                status << "  |  HDOP: " << std::to_string(pvt_opt->hdop).substr(0, 4)
+                       << "  |  " << pvt_opt->utc_time.substr(0, 19);
+            }
+        status << "  |  \xE2\x86\x91\xE2\x86\x93:select  Enter:detail  h:help  q:quit  +/-:speed";
+        auto status_bar = ftxui::text(status.str()) | ftxui::dim | ftxui::center;
+
+        ftxui::Elements main_el;
+        main_el.push_back(top | ftxui::flex);
+        main_el.push_back(ftxui::separator());
+        main_el.push_back(status_bar);
+        return ftxui::vbox(std::move(main_el));
+    });
+
+    auto app = renderer | ftxui::CatchEvent([&](const ftxui::Event& event) {
+        if (event == ftxui::Event::Character('q'))
+            {
+                screen.Exit();
+                return true;
+            }
+        if (event == ftxui::Event::Character('h'))
+            {
+                show_help = !show_help;
+                return true;
+            }
+        if (event == ftxui::Event::Character('+') || event == ftxui::Event::Character('='))
+            {
+                refresh_ms = std::min(1000, refresh_ms.load() + 50);
+                return true;
+            }
+        if (event == ftxui::Event::Character('-') || event == ftxui::Event::Character('_'))
+            {
+                refresh_ms = std::max(50, refresh_ms.load() - 50);
+                return true;
+            }
+        if (event == ftxui::Event::Character('e') || event == ftxui::Event::Character('\r') || event == ftxui::Event::Character('\n'))
+            {
+                if (show_detail)
+                    {
+                        show_detail = false;
+                    }
+                else
+                    {
+                        const auto sorted = data_store.get_sorted_satellites();
+                        const int idx = selected_row.load() - 1;
+                        if (idx >= 0 && idx < static_cast<int>(sorted.size()))
+                            {
+                                detail_channel = sorted[idx].first;
+                                show_detail = true;
+                            }
+                    }
+                return true;
+            }
+        if (event == ftxui::Event::Escape)
+            {
+                if (show_detail || show_help)
+                    {
+                        show_detail = false;
+                        show_help = false;
+                        return true;
+                    }
+                return false;
+            }
+        if (event == ftxui::Event::ArrowUp || event == ftxui::Event::Character('k'))
+            {
+                if (!show_detail && !show_help)
+                    {
+                        const auto n = static_cast<int>(data_store.satellite_count());
+                        selected_row = std::max(1, selected_row.load() - 1);
+                        if (selected_row > n) selected_row = n;
+                    }
+                return true;
+            }
+        if (event == ftxui::Event::ArrowDown || event == ftxui::Event::Character('j'))
+            {
+                if (!show_detail && !show_help)
+                    {
+                        const auto n = static_cast<int>(data_store.satellite_count());
+                        selected_row = std::min(std::max(1, n), selected_row.load() + 1);
+                    }
+                return true;
+            }
+        return false;
+    });
+
+    std::thread refresh([&] {
+        while (g_running)
+            {
+                std::this_thread::sleep_for(std::chrono::milliseconds(refresh_ms.load()));
+                screen.PostEvent(ftxui::Event::Custom);
+            }
+    });
+
+    screen.Loop(app);
+
+    g_running = false;
+    refresh.join();
+    listener.stop();
+    return 0;
+}

--- a/utils/gnss-sdr-tui/proto/gnss_synchro.proto
+++ b/utils/gnss-sdr-tui/proto/gnss_synchro.proto
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// SPDX-FileCopyrightText: 2018-2020 Carles Fernandez-Prades <carles.fernandez@cttc.es>
+syntax = "proto3";
+
+package gnss_sdr;
+
+/* GnssSynchro represents the processing measurements at a given time taken by a given processing channel */
+message GnssSynchro {
+  string system = 1;  // GNSS constellation: "G" for GPS, "R" for Glonass, "S" for SBAS, "E" for Galileo and "C" for Beidou.
+  string signal = 2;  // GNSS signal: "1C" for GPS L1 C/A, "1B" for Galileo E1b/c, "1G" for Glonass L1 C/A, "2S" for GPS L2 L2C(M), "2G" for Glonass L2 C/A, "L5" for GPS L5 and "5X" for Galileo E5a
+
+  uint32 prn = 3;        // PRN number
+  int32 channel_id = 4;  // Channel number
+
+  double acq_delay_samples = 5;        // Coarse code delay estimation, in samples
+  double acq_doppler_hz = 6;           // Coarse Doppler estimation in each channel, in Hz
+  uint64 acq_samplestamp_samples = 7;  // Number of samples at signal SampleStamp
+  uint32 acq_doppler_step = 8;         // Step of the frequency bin in the search grid, in Hz
+  bool flag_valid_acquisition = 9;     // Acquisition status
+
+  int64 fs = 10;                        // Sampling frequency, in samples per second
+  double prompt_i = 11;                 // In-phase (real) component of the prompt correlator output
+  double prompt_q = 12;                 // Quadrature (imaginary) component of the prompt correlator output
+  double cn0_db_hz = 13;                // Carrier-to-Noise density ratio, in dB-Hz
+  double carrier_doppler_hz = 14;       // Doppler estimation, in [Hz].
+  double carrier_phase_rads = 15;       // Carrier phase estimation, in rad
+  double code_phase_samples = 16;       // Code phase in samples
+  uint64 tracking_sample_counter = 17;  // Sample counter indicating the number of processed samples
+  bool flag_valid_symbol_output = 18;   // Indicates the validity of signal tracking
+  int32 correlation_length_ms = 19;     // Time duration of coherent correlation integration, in ms
+
+  bool flag_valid_word = 20;             // Indicates the validity of the decoded navigation message word
+  uint32 tow_at_current_symbol_ms = 21;  // Time of week of the current symbol, in ms
+
+  double pseudorange_m = 22;                // Pseudorange computation, in m
+  double rx_time = 23;                      // Receiving time after the start of the week, in s
+  bool flag_valid_pseudorange = 24;         // Pseudorange computation status
+  double interp_tow_ms = 25;                // Interpolated time of week, in ms
+  bool flag_PLL_180_deg_phase_locked = 26;  // PLL lock at 180º
+  bool flag_cycle_slip = 27;                // Carrier cycle slip detection flag
+}
+
+/* Observables represents a collection of GnssSynchro annotations */
+message Observables {
+  repeated GnssSynchro observable = 1;
+}

--- a/utils/gnss-sdr-tui/proto/monitor_pvt.proto
+++ b/utils/gnss-sdr-tui/proto/monitor_pvt.proto
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// SPDX-FileCopyrightText: 2018-2020 Carles Fernandez-Prades <carles.fernandez@cttc.es>
+syntax = "proto3";
+
+package gnss_sdr;
+
+/* MonitorPvt represents a search query, with pagination options to
+ * indicate which results to include in the response. */
+message MonitorPvt {
+  uint32 tow_at_current_symbol_ms = 1;  // Time of week of the current symbol, in ms
+  uint32 week = 2;                      // PVT GPS week
+  double rx_time = 3;                   // PVT GPS time
+  double user_clk_offset = 4;           // User clock offset, in s
+
+  double pos_x = 5;   // Position X component in ECEF, expressed in m
+  double pos_y = 6;   // Position Y component in ECEF, expressed in m
+  double pos_z = 7;   // Position Z component in ECEF, expressed in m
+  double vel_x = 8;   // Velocity X component in ECEF, in m/s
+  double vel_y = 9;   // Velocity Y component in ECEF, in m/s
+  double vel_z = 10;  // Velocity Z component in ECEF, in m/s
+
+  double cov_xx = 11;  // Position variance in the Y component, in m2
+  double cov_yy = 12;  // Position variance in the Y component, in m2
+  double cov_zz = 13;  // Position variance in the Z component, in m2
+  double cov_xy = 14;  // Position XY covariance, in m2
+  double cov_yz = 15;  // Position YZ covariance, in m2
+  double cov_zx = 16;  // Position ZX covariance, in m2
+
+  double latitude = 17;   // Latitude, in deg. Positive: North
+  double longitude = 18;  // Longitude, in deg. Positive: East
+  double height = 19;     // Height, in m
+
+  uint32 valid_sats = 20;         // Number of valid satellites
+  uint32 solution_status = 21;    // RTKLIB solution status
+  uint32 solution_type = 22;      // RTKLIB solution type (0: xyz-ecef, 1: enu-baseline)
+  float ar_ratio_factor = 23;     // Ambiguity resolution ratio factor for validation
+  float ar_ratio_threshold = 24;  // Ambiguity resolution ratio threshold for validation
+
+  double gdop = 25;  // Geometric Dilution of Precision
+  double pdop = 26;  // Position (3D) Dilution of Precision
+  double hdop = 27;  // Horizontal Dilution of Precision
+  double vdop = 28;  // Vertical Dilution of Precision
+
+  double user_clk_drift_ppm = 29;  // User clock drift [ppm]
+  string utc_time = 30;            // PVT UTC time (rfc 3339 datetime string)
+
+  double vel_e = 31;  // Velocity East component in the local frame, in m/s
+  double vel_n = 32;  // Velocity North component in the local frame, in m/s
+  double vel_u = 33;  // Velocity Up component in the local frame, in m/s
+
+  double cog = 34;  // Course Over Ground, in deg
+
+  uint32 galhas_status = 35;  // Galileo HAS status: 1- HAS messages decoded and applied, 0 - HAS not available
+  string geohash = 36;        // Encoded geographic location. See https://en.wikipedia.org/wiki/Geohash
+}

--- a/utils/gnss-sdr-tui/screens/event_log.cc
+++ b/utils/gnss-sdr-tui/screens/event_log.cc
@@ -1,0 +1,53 @@
+/*!
+ * \file event_log.cc
+ * \brief FTXUI event log panel for the GNSS-SDR TUI.
+ * \author Generated for GNSS-SDR contributors
+ *
+ * -----------------------------------------------------------------------------
+ *
+ * GNSS-SDR is a Global Navigation Satellite System software-defined receiver.
+ * This file is part of GNSS-SDR.
+ *
+ * SPDX-FileCopyrightText: 2025 (see AUTHORS file for a list of contributors)
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * -----------------------------------------------------------------------------
+ */
+
+#include "event_log.h"
+#include <ctime>
+#include <iomanip>
+#include <sstream>
+#include <vector>
+
+ftxui::Element render_event_log(const DataStore& store)
+{
+    using namespace ftxui;
+
+    const auto logs = store.get_logs(20);
+    if (logs.empty())
+        {
+            Elements out;
+            out.push_back(text("Events") | bold | center);
+            out.push_back(separator());
+            out.push_back(text("No events yet...") | dim | center);
+            return vbox(std::move(out)) | border | size(HEIGHT, LESS_THAN, 6);
+        }
+
+    Elements inner;
+    for (const auto& entry : logs)
+        {
+            const auto tt = std::chrono::system_clock::to_time_t(entry.timestamp);
+            std::tm tm{};
+            localtime_r(&tt, &tm);
+            std::ostringstream ts;
+            ts << std::put_time(&tm, "%H:%M:%S");
+            inner.push_back(text(ts.str() + " " + entry.message) | dim);
+        }
+
+    Elements out;
+    out.push_back(text("Events") | bold | center);
+    out.push_back(separator());
+    out.push_back(vbox(std::move(inner)));
+    return vbox(std::move(out)) | border | size(HEIGHT, LESS_THAN, 6);
+}

--- a/utils/gnss-sdr-tui/screens/event_log.h
+++ b/utils/gnss-sdr-tui/screens/event_log.h
@@ -1,0 +1,25 @@
+/*!
+ * \file event_log.h
+ * \brief FTXUI event log panel for the GNSS-SDR TUI.
+ * \author Generated for GNSS-SDR contributors
+ *
+ * -----------------------------------------------------------------------------
+ *
+ * GNSS-SDR is a Global Navigation Satellite System software-defined receiver.
+ * This file is part of GNSS-SDR.
+ *
+ * SPDX-FileCopyrightText: 2025 (see AUTHORS file for a list of contributors)
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * -----------------------------------------------------------------------------
+ */
+
+#ifndef GNSS_SDR_TUI_EVENT_LOG_H
+#define GNSS_SDR_TUI_EVENT_LOG_H
+
+#include "data_store.h"
+#include <ftxui/dom/elements.hpp>
+
+ftxui::Element render_event_log(const DataStore& store);
+
+#endif  // GNSS_SDR_TUI_EVENT_LOG_H

--- a/utils/gnss-sdr-tui/screens/help_screen.cc
+++ b/utils/gnss-sdr-tui/screens/help_screen.cc
@@ -1,0 +1,57 @@
+/*!
+ * \file help_screen.cc
+ * \brief Help overlay for the GNSS-SDR TUI.
+ * \author Generated for GNSS-SDR contributors
+ *
+ * -----------------------------------------------------------------------------
+ *
+ * GNSS-SDR is a Global Navigation Satellite System software-defined receiver.
+ * This file is part of GNSS-SDR.
+ *
+ * SPDX-FileCopyrightText: 2025 (see AUTHORS file for a list of contributors)
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * -----------------------------------------------------------------------------
+ */
+
+#include "help_screen.h"
+#include <vector>
+
+ftxui::Element render_help_screen()
+{
+    ftxui::Elements out;
+    out.push_back(ftxui::text("GNSS-SDR TUI Help") | ftxui::bold | ftxui::center);
+    out.push_back(ftxui::separator());
+
+    auto make_row = [](const std::string& key, const std::string& desc) {
+        ftxui::Elements row;
+        row.push_back(ftxui::text("  " + key));
+        row.push_back(ftxui::text(desc) | ftxui::dim);
+        return ftxui::hbox(std::move(row));
+    };
+
+    out.push_back(make_row("q          ", "Quit"));
+    out.push_back(make_row("h          ", "Toggle this help"));
+    out.push_back(make_row("+ / -      ", "Increase / decrease refresh rate"));
+    out.push_back(ftxui::separator());
+    out.push_back(ftxui::text("Color legend:"));
+    out.push_back(ftxui::hbox({ftxui::text("  G ")
+                | ftxui::bgcolor(ftxui::Color::Green),
+            ftxui::text(" GPS   "),
+            ftxui::text("  E  ")
+                | ftxui::bgcolor(ftxui::Color::Blue),
+            ftxui::text(" Galileo   "),
+            ftxui::text("  R  ")
+                | ftxui::bgcolor(ftxui::Color::RedLight),
+            ftxui::text(" GLONASS")}));
+    out.push_back(ftxui::hbox({ftxui::text("  C  ")
+                | ftxui::bgcolor(ftxui::Color::Yellow),
+            ftxui::text(" BeiDou   "),
+            ftxui::text("  S  ")
+                | ftxui::bgcolor(ftxui::Color::Cyan),
+            ftxui::text(" SBAS")}));
+    out.push_back(ftxui::separator());
+    out.push_back(ftxui::text("Press h to close") | ftxui::dim | ftxui::center);
+
+    return ftxui::vbox(std::move(out)) | ftxui::border | ftxui::center;
+}

--- a/utils/gnss-sdr-tui/screens/help_screen.h
+++ b/utils/gnss-sdr-tui/screens/help_screen.h
@@ -1,0 +1,24 @@
+/*!
+ * \file help_screen.h
+ * \brief Help overlay for the GNSS-SDR TUI.
+ * \author Generated for GNSS-SDR contributors
+ *
+ * -----------------------------------------------------------------------------
+ *
+ * GNSS-SDR is a Global Navigation Satellite System software-defined receiver.
+ * This file is part of GNSS-SDR.
+ *
+ * SPDX-FileCopyrightText: 2025 (see AUTHORS file for a list of contributors)
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * -----------------------------------------------------------------------------
+ */
+
+#ifndef GNSS_SDR_TUI_HELP_SCREEN_H
+#define GNSS_SDR_TUI_HELP_SCREEN_H
+
+#include <ftxui/dom/elements.hpp>
+
+ftxui::Element render_help_screen();
+
+#endif  // GNSS_SDR_TUI_HELP_SCREEN_H

--- a/utils/gnss-sdr-tui/screens/pvt_panel.cc
+++ b/utils/gnss-sdr-tui/screens/pvt_panel.cc
@@ -1,0 +1,68 @@
+/*!
+ * \file pvt_panel.cc
+ * \brief FTXUI PVT information panel for the GNSS-SDR TUI.
+ * \author Generated for GNSS-SDR contributors
+ *
+ * -----------------------------------------------------------------------------
+ *
+ * GNSS-SDR is a Global Navigation Satellite System software-defined receiver.
+ * This file is part of GNSS-SDR.
+ *
+ * SPDX-FileCopyrightText: 2025 (see AUTHORS file for a list of contributors)
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * -----------------------------------------------------------------------------
+ */
+
+#include "pvt_panel.h"
+#include <ftxui/dom/elements.hpp>
+#include <sstream>
+
+ftxui::Element render_pvt_panel(const DataStore& store)
+{
+    using namespace ftxui;
+
+    auto pvt = store.get_pvt();
+    if (!pvt)
+        {
+            return vbox({
+                text("PVT") | bold | center,
+                separator(),
+                text("Waiting for fix...") | dim | center,
+            }) | border;
+        }
+
+    std::ostringstream lat_str, lon_str, h_str;
+    lat_str.precision(5);
+    lat_str << std::fixed << pvt->latitude;
+    lon_str.precision(5);
+    lon_str << std::fixed << pvt->longitude;
+    h_str.precision(1);
+    h_str << std::fixed << pvt->height;
+
+    std::ostringstream hdop_str, vdop_str, pdop_str, gdop_str;
+    hdop_str.precision(1);
+    hdop_str << std::fixed << pvt->hdop;
+    vdop_str.precision(1);
+    vdop_str << std::fixed << pvt->vdop;
+    pdop_str.precision(1);
+    pdop_str << std::fixed << pvt->pdop;
+    gdop_str.precision(1);
+    gdop_str << std::fixed << pvt->gdop;
+
+    return vbox({
+        text("PVT Solution") | bold | center,
+        separator(),
+        hbox({text(" Lat: "), text(lat_str.str()) | bold}),
+        hbox({text(" Lon: "), text(lon_str.str()) | bold}),
+        hbox({text(" Hgt: "), text(h_str.str() + " m") | bold}),
+        separator(),
+        hbox({text(" HDOP: "), text(hdop_str.str())}),
+        hbox({text(" VDOP: "), text(vdop_str.str())}),
+        hbox({text(" PDOP: "), text(pdop_str.str())}),
+        hbox({text(" GDOP: "), text(gdop_str.str())}),
+        separator(),
+        hbox({text(" Sats: "), text(std::to_string(pvt->valid_sats)) | bold}),
+        hbox({text(" Time: "), text(pvt->utc_time) | dim}),
+    }) | border;
+}

--- a/utils/gnss-sdr-tui/screens/pvt_panel.h
+++ b/utils/gnss-sdr-tui/screens/pvt_panel.h
@@ -1,0 +1,25 @@
+/*!
+ * \file pvt_panel.h
+ * \brief FTXUI PVT information panel for the GNSS-SDR TUI.
+ * \author Generated for GNSS-SDR contributors
+ *
+ * -----------------------------------------------------------------------------
+ *
+ * GNSS-SDR is a Global Navigation Satellite System software-defined receiver.
+ * This file is part of GNSS-SDR.
+ *
+ * SPDX-FileCopyrightText: 2025 (see AUTHORS file for a list of contributors)
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * -----------------------------------------------------------------------------
+ */
+
+#ifndef GNSS_SDR_TUI_PVT_PANEL_H
+#define GNSS_SDR_TUI_PVT_PANEL_H
+
+#include "data_store.h"
+#include <ftxui/dom/elements.hpp>
+
+ftxui::Element render_pvt_panel(const DataStore& store);
+
+#endif  // GNSS_SDR_TUI_PVT_PANEL_H

--- a/utils/gnss-sdr-tui/screens/satellite_detail.cc
+++ b/utils/gnss-sdr-tui/screens/satellite_detail.cc
@@ -1,0 +1,103 @@
+/*!
+ * \file satellite_detail.cc
+ * \brief Detailed satellite info overlay for the GNSS-SDR TUI.
+ * \author Generated for GNSS-SDR contributors
+ *
+ * -----------------------------------------------------------------------------
+ *
+ * GNSS-SDR is a Global Navigation Satellite System software-defined receiver.
+ * This file is part of GNSS-SDR.
+ *
+ * SPDX-FileCopyrightText: 2025 (see AUTHORS file for a list of contributors)
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * -----------------------------------------------------------------------------
+ */
+
+#include "satellite_detail.h"
+#include <algorithm>
+#include <sstream>
+#include <vector>
+
+namespace
+{
+
+std::string sparkline(const std::deque<double>& vals, double max_val)
+{
+    static const char* bar[] = {" ", "\xe2\x96\x81", "\xe2\x96\x82", "\xe2\x96\x83",
+        "\xe2\x96\x84", "\xe2\x96\x85", "\xe2\x96\x86", "\xe2\x96\x87", "\xe2\x96\x88"};
+    std::string out;
+    for (auto v : vals)
+        {
+            int idx = std::min(8, std::max(0, static_cast<int>(v / max_val * 8.0)));
+            out += bar[idx];
+        }
+    return out;
+}
+
+}  // namespace
+
+ftxui::Element render_satellite_detail(const DataStore& store, int channel)
+{
+    using namespace ftxui;
+
+    const auto sat = store.get_satellite(channel);
+    if (sat.system.empty())
+        {
+            Elements out;
+            out.push_back(text("Satellite Detail") | bold | center);
+            out.push_back(separator());
+            out.push_back(text("Satellite not found on channel " + std::to_string(channel)) | dim | center);
+            out.push_back(separator());
+            out.push_back(text("Press Enter or Esc to close") | dim | center);
+            return vbox(std::move(out)) | border | center;
+        }
+
+    const auto history = store.get_cn0_history(channel);
+
+    Elements lines;
+    lines.push_back(text("Satellite Detail: " + sat.system + std::to_string(sat.prn)) | bold | center);
+    lines.push_back(separator());
+
+    auto field = [](const std::string& label, const std::string& value) {
+        return hbox({text("  " + label + ": ") | dim, text(value) | bold});
+    };
+
+    lines.push_back(field("Channel", std::to_string(sat.channel_id)));
+    lines.push_back(field("System", constellation_color(sat.system) + " (" + sat.system + ")"));
+    lines.push_back(field("Signal", sat.signal));
+    lines.push_back(field("PRN", std::to_string(sat.prn)));
+    lines.push_back(separator());
+
+    std::ostringstream cn0_s, dop_s, phase_s, pr_s;
+    cn0_s.precision(1);
+    cn0_s << std::fixed << sat.cn0_db_hz << " dB-Hz";
+    dop_s.precision(1);
+    dop_s << std::fixed << sat.carrier_doppler_hz << " Hz";
+    phase_s.precision(2);
+    phase_s << std::fixed << sat.carrier_phase_rads << " rad";
+    pr_s.precision(3);
+    pr_s << std::fixed << sat.pseudorange_m << " m";
+
+    lines.push_back(field("CN0", cn0_s.str()));
+    lines.push_back(field("Doppler", dop_s.str()));
+    lines.push_back(field("Carrier Phase", phase_s.str()));
+    lines.push_back(field("Pseudorange", pr_s.str()));
+    lines.push_back(separator());
+
+    lines.push_back(field("PLL Locked", sat.flag_pll_locked ? "YES" : "NO"));
+    lines.push_back(field("Valid Pseudorange", sat.flag_valid_pseudorange ? "YES" : "NO"));
+    lines.push_back(field("Cycle Slip", sat.flag_cycle_slip ? "YES" : "NO"));
+
+    if (!history.empty())
+        {
+            lines.push_back(separator());
+            lines.push_back(text("CN0 History (last " + std::to_string(history.size()) + " samples):") | dim);
+            lines.push_back(text(sparkline(history, 55.0)));
+        }
+
+    lines.push_back(separator());
+    lines.push_back(text("Press Enter or Esc to close") | dim | center);
+
+    return vbox(std::move(lines)) | border | center;
+}

--- a/utils/gnss-sdr-tui/screens/satellite_detail.h
+++ b/utils/gnss-sdr-tui/screens/satellite_detail.h
@@ -1,0 +1,25 @@
+/*!
+ * \file satellite_detail.h
+ * \brief Detailed satellite info overlay for the GNSS-SDR TUI.
+ * \author Generated for GNSS-SDR contributors
+ *
+ * -----------------------------------------------------------------------------
+ *
+ * GNSS-SDR is a Global Navigation Satellite System software-defined receiver.
+ * This file is part of GNSS-SDR.
+ *
+ * SPDX-FileCopyrightText: 2025 (see AUTHORS file for a list of contributors)
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * -----------------------------------------------------------------------------
+ */
+
+#ifndef GNSS_SDR_TUI_SATELLITE_DETAIL_H
+#define GNSS_SDR_TUI_SATELLITE_DETAIL_H
+
+#include "data_store.h"
+#include <ftxui/dom/elements.hpp>
+
+ftxui::Element render_satellite_detail(const DataStore& store, int channel);
+
+#endif  // GNSS_SDR_TUI_SATELLITE_DETAIL_H

--- a/utils/gnss-sdr-tui/screens/satellite_table.cc
+++ b/utils/gnss-sdr-tui/screens/satellite_table.cc
@@ -1,0 +1,99 @@
+/*!
+ * \file satellite_table.cc
+ * \brief FTXUI satellite status table for the GNSS-SDR TUI.
+ * \author Generated for GNSS-SDR contributors
+ *
+ * -----------------------------------------------------------------------------
+ *
+ * GNSS-SDR is a Global Navigation Satellite System software-defined receiver.
+ * This file is part of GNSS-SDR.
+ *
+ * SPDX-FileCopyrightText: 2025 (see AUTHORS file for a list of contributors)
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * -----------------------------------------------------------------------------
+ */
+
+#include "satellite_table.h"
+#include <ftxui/dom/table.hpp>
+#include <algorithm>
+#include <sstream>
+#include <vector>
+
+namespace
+{
+
+ftxui::Color color_for_sys(const std::string& sys)
+{
+    if (sys == "G") return ftxui::Color::GreenLight;
+    if (sys == "E") return ftxui::Color::CornflowerBlue;
+    if (sys == "R") return ftxui::Color::RedLight;
+    if (sys == "C") return ftxui::Color::YellowLight;
+    if (sys == "S") return ftxui::Color::Cyan;
+    return ftxui::Color::Default;
+}
+
+}  // namespace
+
+ftxui::Element render_satellite_table(const DataStore& store, int selected_row)
+{
+    using namespace ftxui;
+
+    const auto sorted = store.get_sorted_satellites();
+
+    using Row = std::vector<std::string>;
+    std::vector<Row> rows;
+
+    rows.push_back({"PRN", "Sys", "Sig", "CN0", "Doppler", "Lock"});
+
+    for (const auto& [ch, sat] : sorted)
+        {
+            std::ostringstream prn_str;
+            prn_str << sat.system << std::to_string(sat.prn);
+            std::ostringstream cn0_str;
+            cn0_str.precision(1);
+            cn0_str << std::fixed << sat.cn0_db_hz;
+            std::ostringstream dop_str;
+            dop_str.precision(0);
+            dop_str << std::fixed << sat.carrier_doppler_hz;
+            rows.push_back({prn_str.str(), sat.system, sat.signal,
+                cn0_str.str(), dop_str.str(),
+                sat.flag_pll_locked ? "LOCK" : "----"});
+        }
+
+    auto table = ftxui::Table(rows);
+    table.SelectAll().Border(ftxui::ROUNDED);
+
+    if (rows.size() > 1)
+        {
+            table.SelectRow(0).Decorate(ftxui::bold);
+            table.SelectRow(0).Separator(ftxui::HEAVY);
+
+            table.SelectAll().DecorateCellsAlternateRow(bgcolor(Color::Black), 2, 0);
+            table.SelectAll().DecorateCellsAlternateRow(bgcolor(Color::GrayDark), 2, 1);
+
+            for (size_t i = 1; i < rows.size(); ++i)
+                {
+                    const auto& sat = sorted[i - 1].second;
+                    const auto fc = color_for_sys(sat.system);
+                    table.SelectCell(0, static_cast<int>(i)).Decorate(color(fc) | bold);
+                    table.SelectCell(1, static_cast<int>(i)).Decorate(color(fc));
+                    if (sat.flag_pll_locked)
+                        {
+                            table.SelectCell(5, static_cast<int>(i)).Decorate(color(Color::GreenLight) | bold);
+                        }
+                    else
+                        {
+                            table.SelectCell(5, static_cast<int>(i)).Decorate(color(Color::RedLight));
+                        }
+
+                    if (static_cast<int>(i) == selected_row)
+                        {
+                            table.SelectRow(static_cast<int>(i)).Decorate(bgcolor(Color::DarkBlue));
+                        }
+                }
+        }
+
+    auto element = table.Render() | ftxui::flex;
+    return element;
+}

--- a/utils/gnss-sdr-tui/screens/satellite_table.h
+++ b/utils/gnss-sdr-tui/screens/satellite_table.h
@@ -1,0 +1,25 @@
+/*!
+ * \file satellite_table.h
+ * \brief FTXUI satellite status table for the GNSS-SDR TUI.
+ * \author Generated for GNSS-SDR contributors
+ *
+ * -----------------------------------------------------------------------------
+ *
+ * GNSS-SDR is a Global Navigation Satellite System software-defined receiver.
+ * This file is part of GNSS-SDR.
+ *
+ * SPDX-FileCopyrightText: 2025 (see AUTHORS file for a list of contributors)
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * -----------------------------------------------------------------------------
+ */
+
+#ifndef GNSS_SDR_TUI_SATELLITE_TABLE_H
+#define GNSS_SDR_TUI_SATELLITE_TABLE_H
+
+#include "data_store.h"
+#include <ftxui/dom/elements.hpp>
+
+ftxui::Element render_satellite_table(const DataStore& store, int selected_row = -1);
+
+#endif  // GNSS_SDR_TUI_SATELLITE_TABLE_H

--- a/utils/gnss-sdr-tui/screens/signal_overview.cc
+++ b/utils/gnss-sdr-tui/screens/signal_overview.cc
@@ -1,0 +1,128 @@
+/*!
+ * \file signal_overview.cc
+ * \brief Signal overview panel for the GNSS-SDR TUI.
+ * \author Generated for GNSS-SDR contributors
+ *
+ * -----------------------------------------------------------------------------
+ *
+ * GNSS-SDR is a Global Navigation Satellite System software-defined receiver.
+ * This file is part of GNSS-SDR.
+ *
+ * SPDX-FileCopyrightText: 2025 (see AUTHORS file for a list of contributors)
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * -----------------------------------------------------------------------------
+ */
+
+#include "signal_overview.h"
+#include <algorithm>
+#include <deque>
+#include <map>
+#include <sstream>
+#include <vector>
+
+namespace
+{
+
+std::string sparkline(const std::deque<double>& vals, double max_val)
+{
+    static const char* bar[] = {" ", "\xe2\x96\x81", "\xe2\x96\x82", "\xe2\x96\x83",
+        "\xe2\x96\x84", "\xe2\x96\x85", "\xe2\x96\x86", "\xe2\x96\x87", "\xe2\x96\x88"};
+    std::string out;
+    for (auto v : vals)
+        {
+            int idx = std::min(8, std::max(0, static_cast<int>(v / max_val * 8.0)));
+            out += bar[idx];
+        }
+    return out;
+}
+
+ftxui::Color color_for_sys(const std::string& sys)
+{
+    if (sys == "G") return ftxui::Color::GreenLight;
+    if (sys == "E") return ftxui::Color::CornflowerBlue;
+    if (sys == "R") return ftxui::Color::RedLight;
+    if (sys == "C") return ftxui::Color::YellowLight;
+    if (sys == "S") return ftxui::Color::Cyan;
+    return ftxui::Color::Default;
+}
+
+}  // namespace
+
+ftxui::Element render_signal_overview(const DataStore& store)
+{
+    using namespace ftxui;
+
+    const auto sorted = store.get_sorted_satellites();
+    const auto pvt = store.get_pvt();
+
+    Elements left_lines;
+
+    left_lines.push_back(text("Satellites: ") | bold);
+    left_lines.push_back(text(std::to_string(sorted.size()) + " tracked") | dim);
+
+    std::map<std::string, int> const_counts;
+    for (const auto& [ch, sat] : sorted)
+        {
+            const_counts[constellation_color(sat.system)]++;
+        }
+
+    for (const auto& [name, count] : const_counts)
+        {
+            Color c = Color::Default;
+            if (name == "GPS") c = Color::GreenLight;
+            else if (name == "Galileo") c = Color::CornflowerBlue;
+            else if (name == "GLONASS") c = Color::RedLight;
+            else if (name == "BeiDou") c = Color::YellowLight;
+            else if (name == "SBAS") c = Color::Cyan;
+            left_lines.push_back(
+                hbox({text(name) | color(c) | bold, text(": "), text(std::to_string(count))}));
+        }
+
+    if (!sorted.empty())
+        {
+            left_lines.push_back(separator());
+            left_lines.push_back(text("Top signals:") | bold);
+
+            std::vector<std::pair<int, SatelliteData>> top(sorted.begin(), sorted.end());
+            std::sort(top.begin(), top.end(),
+                [](const auto& a, const auto& b) {
+                    return a.second.cn0_db_hz > b.second.cn0_db_hz;
+                });
+
+            for (size_t i = 0; i < std::min(top.size(), size_t(3)); ++i)
+                {
+                    const auto& sat = top[i].second;
+                    std::ostringstream ss;
+                    ss.precision(1);
+                    ss << std::fixed << sat.cn0_db_hz;
+                    int bars = static_cast<int>(sat.cn0_db_hz / 5.0);
+                    std::string bar_str(bars, '#');
+                    left_lines.push_back(
+                        hbox({text(sat.system + std::to_string(sat.prn)) | color(color_for_sys(sat.system)),
+                            text(" " + ss.str()) | bold,
+                            text(" " + bar_str) | color(Color::GreenLight)}));
+                }
+
+            const auto& best = top[0].second;
+            const auto hist = store.get_cn0_history(best.channel_id);
+            if (!hist.empty())
+                {
+                    left_lines.push_back(separator());
+                    left_lines.push_back(
+                        text(best.system + std::to_string(best.prn) + " CN0 trend:") | dim);
+                    left_lines.push_back(text(sparkline(hist, 55.0)));
+                }
+        }
+
+    if (pvt)
+        {
+            left_lines.push_back(separator());
+            left_lines.push_back(text("Position: ") | bold);
+            left_lines.push_back(text("Lat: " + std::to_string(pvt->latitude).substr(0, 8)));
+            left_lines.push_back(text("Lon: " + std::to_string(pvt->longitude).substr(0, 8)));
+            left_lines.push_back(text("HDOP: " + std::to_string(pvt->hdop).substr(0, 4)));
+        }
+
+    return vbox(std::move(left_lines)) | border | size(WIDTH, GREATER_THAN, 24);
+}

--- a/utils/gnss-sdr-tui/screens/signal_overview.h
+++ b/utils/gnss-sdr-tui/screens/signal_overview.h
@@ -1,0 +1,25 @@
+/*!
+ * \file signal_overview.h
+ * \brief FTXUI Canvas-based signal overview for the GNSS-SDR TUI.
+ * \author Generated for GNSS-SDR contributors
+ *
+ * -----------------------------------------------------------------------------
+ *
+ * GNSS-SDR is a Global Navigation Satellite System software-defined receiver.
+ * This file is part of GNSS-SDR.
+ *
+ * SPDX-FileCopyrightText: 2025 (see AUTHORS file for a list of contributors)
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * -----------------------------------------------------------------------------
+ */
+
+#ifndef GNSS_SDR_TUI_SIGNAL_OVERVIEW_H
+#define GNSS_SDR_TUI_SIGNAL_OVERVIEW_H
+
+#include "data_store.h"
+#include <ftxui/dom/elements.hpp>
+
+ftxui::Element render_signal_overview(const DataStore& store);
+
+#endif  // GNSS_SDR_TUI_SIGNAL_OVERVIEW_H

--- a/utils/gnss-sdr-tui/udp_listener.cc
+++ b/utils/gnss-sdr-tui/udp_listener.cc
@@ -1,0 +1,170 @@
+/*!
+ * \file udp_listener.cc
+ * \brief Asynchronous UDP listener for GNSS-SDR monitor streams.
+ * \author Generated for GNSS-SDR contributors
+ *
+ * -----------------------------------------------------------------------------
+ *
+ * GNSS-SDR is a Global Navigation Satellite System software-defined receiver.
+ * This file is part of GNSS-SDR.
+ *
+ * SPDX-FileCopyrightText: 2025 (see AUTHORS file for a list of contributors)
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * -----------------------------------------------------------------------------
+ */
+
+#include "udp_listener.h"
+#include "gnss_synchro.pb.h"
+#include "monitor_pvt.pb.h"
+#include <arpa/inet.h>
+#include <cstring>
+#include <iostream>
+#include <sys/socket.h>
+#include <unistd.h>
+
+UdpListener::UdpListener(DataStore& store,
+    const std::string& address,
+    unsigned short gnss_port,
+    unsigned short pvt_port)
+    : store_(store),
+      address_(address),
+      gnss_port_(gnss_port),
+      pvt_port_(pvt_port) {}
+
+UdpListener::~UdpListener()
+{
+    stop();
+}
+
+int UdpListener::create_socket(const std::string& address, unsigned short port)
+{
+    const int fd = socket(AF_INET, SOCK_DGRAM, 0);
+    if (fd < 0)
+        {
+            return -1;
+        }
+
+    struct sockaddr_in addr;
+    std::memset(&addr, 0, sizeof(addr));
+    addr.sin_family = AF_INET;
+    addr.sin_port = htons(port);
+    addr.sin_addr.s_addr = inet_addr(address.c_str());
+
+    if (bind(fd, reinterpret_cast<struct sockaddr*>(&addr), sizeof(addr)) < 0)
+        {
+            close(fd);
+            return -1;
+        }
+
+    return fd;
+}
+
+void UdpListener::start()
+{
+    running_ = true;
+    gnss_thread_ = std::make_unique<std::thread>(&UdpListener::listen_gnss, this);
+    pvt_thread_ = std::make_unique<std::thread>(&UdpListener::listen_pvt, this);
+}
+
+void UdpListener::stop()
+{
+    running_ = false;
+    if (gnss_thread_ && gnss_thread_->joinable())
+        {
+            gnss_thread_->join();
+        }
+    if (pvt_thread_ && pvt_thread_->joinable())
+        {
+            pvt_thread_->join();
+        }
+}
+
+void UdpListener::listen_gnss()
+{
+    const int fd = create_socket(address_, gnss_port_);
+    if (fd < 0)
+        {
+            std::cerr << "Failed to create GnssSynchro socket on "
+                      << address_ << ":" << gnss_port_ << '\n';
+            return;
+        }
+
+    char buffer[65536];
+    while (running_)
+        {
+            struct sockaddr_in sender;
+            socklen_t sender_len = sizeof(sender);
+            const ssize_t len = recvfrom(fd, buffer, sizeof(buffer), 0,
+                reinterpret_cast<struct sockaddr*>(&sender), &sender_len);
+            if (len <= 0)
+                {
+                    continue;
+                }
+
+            gnss_sdr::Observables observables;
+            if (observables.ParseFromArray(buffer, static_cast<int>(len)))
+                {
+                    for (const auto& obs : observables.observable())
+                        {
+                            SatelliteData s;
+                            s.system = obs.system();
+                            s.signal = obs.signal();
+                            s.prn = obs.prn();
+                            s.channel_id = obs.channel_id();
+                            s.cn0_db_hz = obs.cn0_db_hz();
+                            s.carrier_doppler_hz = obs.carrier_doppler_hz();
+                            s.carrier_phase_rads = obs.carrier_phase_rads();
+                            s.pseudorange_m = obs.pseudorange_m();
+                            s.flag_valid_pseudorange = obs.flag_valid_pseudorange();
+                            s.flag_pll_locked = obs.flag_pll_180_deg_phase_locked();
+                            s.flag_cycle_slip = obs.flag_cycle_slip();
+                            store_.update_satellite(s.channel_id, s);
+                        }
+                }
+        }
+
+    close(fd);
+}
+
+void UdpListener::listen_pvt()
+{
+    const int fd = create_socket(address_, pvt_port_);
+    if (fd < 0)
+        {
+            std::cerr << "Failed to create PVT socket on "
+                      << address_ << ":" << pvt_port_ << '\n';
+            return;
+        }
+
+    char buffer[65536];
+    while (running_)
+        {
+            struct sockaddr_in sender;
+            socklen_t sender_len = sizeof(sender);
+            const ssize_t len = recvfrom(fd, buffer, sizeof(buffer), 0,
+                reinterpret_cast<struct sockaddr*>(&sender), &sender_len);
+            if (len <= 0)
+                {
+                    continue;
+                }
+
+            gnss_sdr::MonitorPvt pvt_msg;
+            if (pvt_msg.ParseFromArray(buffer, static_cast<int>(len)))
+                {
+                    PvtData p;
+                    p.latitude = pvt_msg.latitude();
+                    p.longitude = pvt_msg.longitude();
+                    p.height = pvt_msg.height();
+                    p.hdop = pvt_msg.hdop();
+                    p.vdop = pvt_msg.vdop();
+                    p.pdop = pvt_msg.pdop();
+                    p.gdop = pvt_msg.gdop();
+                    p.valid_sats = pvt_msg.valid_sats();
+                    p.utc_time = pvt_msg.utc_time();
+                    store_.update_pvt(p);
+                }
+        }
+
+    close(fd);
+}

--- a/utils/gnss-sdr-tui/udp_listener.h
+++ b/utils/gnss-sdr-tui/udp_listener.h
@@ -1,0 +1,57 @@
+/*!
+ * \file udp_listener.h
+ * \brief Asynchronous UDP listener for GNSS-SDR monitor streams.
+ * \author Generated for GNSS-SDR contributors
+ *
+ * -----------------------------------------------------------------------------
+ *
+ * GNSS-SDR is a Global Navigation Satellite System software-defined receiver.
+ * This file is part of GNSS-SDR.
+ *
+ * SPDX-FileCopyrightText: 2025 (see AUTHORS file for a list of contributors)
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * -----------------------------------------------------------------------------
+ */
+
+#ifndef GNSS_SDR_TUI_UDP_LISTENER_H
+#define GNSS_SDR_TUI_UDP_LISTENER_H
+
+#include "data_store.h"
+#include <atomic>
+#include <memory>
+#include <string>
+#include <thread>
+
+class UdpListener
+{
+public:
+    UdpListener(DataStore& store,
+        const std::string& address,
+        unsigned short gnss_port,
+        unsigned short pvt_port);
+    ~UdpListener();
+
+    UdpListener(const UdpListener&) = delete;
+    UdpListener& operator=(const UdpListener&) = delete;
+    UdpListener(UdpListener&&) = delete;
+    UdpListener& operator=(UdpListener&&) = delete;
+
+    void start();
+    void stop();
+
+private:
+    int create_socket(const std::string& address, unsigned short port);
+    void listen_gnss();
+    void listen_pvt();
+
+    DataStore& store_;
+    std::string address_;
+    unsigned short gnss_port_;
+    unsigned short pvt_port_;
+    std::atomic<bool> running_{false};
+    std::unique_ptr<std::thread> gnss_thread_;
+    std::unique_ptr<std::thread> pvt_thread_;
+};
+
+#endif  // GNSS_SDR_TUI_UDP_LISTENER_H


### PR DESCRIPTION
### Summary
Adds a new optional utility `gnss-sdr-tui` — a full-screen terminal user interface for monitoring GNSS-SDR in real time.

### Features
- Real-time UDP protobuf listener — receives both GnssSynchro (observables) and MonitorPvt streams concurrently
- Signal overview panel — constellation counts, top-3 signals by CN0 with bar charts, CN0 sparkline for strongest satellite
- Satellite table — sortable, color-coded by constellation, row selection with arrow keys
- PVT panel — latitude, longitude, height, all DOP values, UTC time
- Event log — scrolling log of satellite acquisition, PLL lock/unlock transitions, cycle slip events
- Satellite detail view — full telemetry for a selected satellite
- Help overlay — toggle with h key
- Color coding — GPS (green), Galileo (blue), GLONASS (red), BeiDou (yellow), SBAS (cyan)
- Keyboard controls — arrows/jk to select, Enter/Esc for detail, h for help, q to quit, +/- for refresh

### Build
cmake -DENABLE_GNSS_SDR_TUI=ON .. && make gnss_sdr_tui