### PR TITLE
Improved plot_acq_grid.py. Fixed python tracking dump reader.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@
 .settings
 .vs/
 .vscode/
+*.pyc

--- a/utils/python/gps_l1_ca_kf_plot_sample.py
+++ b/utils/python/gps_l1_ca_kf_plot_sample.py
@@ -1,17 +1,21 @@
 """
  gps_l1_ca_kf_plot_sample.py
 
- Reads GNSS-SDR Tracking dump binary file using the provided
- function and plots some internal variables
+ Reads a GPS L1 C/A Kalman-filter tracking dump binary file
+ (GPS_L1_CA_KF_Tracking) and plots some internal tracking and Kalman-filter
+ variables.
 
  Irene Pérez Riega, 2023. iperrie@inta.es
+ Minhaj Uddin Ahmad, 2026. mahmad12@crimson.ua.edu
 
  Modifiable in the file:
-   sampling_freq     - Sampling frequency [Hz]
-   channels          - Number of channels to check if they exist
+   samplingFreq      - Sampling frequency [Hz]
+   channels          - Number of channels
    first_channel     - Number of the first channel
-   path              - Path to folder which contains raw file
-   'trk_dump_ch'     - Fixed part in tracking dump files names
+   code_period       - Code period [s]
+   path              - Path to folder which contains the tracking dump files
+   fig_path          - Path where the plots will be saved
+   file_prefix       - Fixed part of the tracking dump file names
 
  -----------------------------------------------------------------------------
 
@@ -35,52 +39,55 @@ trackResults = []
 kalmanResults = []
 
 # ---------- CHANGE HERE:
-# Signal parameters:
-samplingFreq = 6625000
+samplingFreq = 4000000  # must match SignalSource.sampling_frequency in the .conf
 channels = 5
 first_channel = 0
 code_period = 0.001
-
-path = '/home/labnav/Desktop/TEST_IRENE/tracking'
+path = '../../../out/'
+fig_path = '../../../PLOTS/KF_Tracking'
+file_prefix = 'track_ch'
 
 for N in range(1, channels + 1):
     tracking_log_path = os.path.join(path,
-                                     f'trk_dump_ch{N-1+first_channel}.dat')
+                                     f'{file_prefix}{N-1+first_channel}.dat')
     GNSS_tracking.append(gps_l1_ca_kf_read_tracking_dump(tracking_log_path))
 
-# todo lee lo mismo que dll_pll_velm_plot_sample y guarda diferente v13 y v14
-# GNSS-SDR format conversion to Python GPS receiver
 for N in range(1, channels + 1):
-    trackResult= {
+    trackResult = {
         'status': 'T',  # fake track
-        'codeFreq': np.copy(GNSS_tracking[N - 1]["code_freq_hz"]),
-        'carrFreq': np.copy(GNSS_tracking[N - 1]["carrier_doppler_hz"]),
+        'codeFreq': np.copy(GNSS_tracking[N-1]["code_freq_hz"]),
+        'carrFreq': np.copy(GNSS_tracking[N-1]["carrier_doppler_hz"]),
         'carrFreqRate':
-            np.copy(GNSS_tracking[N - 1]["carrier_doppler_rate_hz2"]),#todo no se usa en dll, carrier_doppler_rate_hz_s segun dll
-        'dllDiscr': np.copy(GNSS_tracking[N - 1]["code_error"]),
-        'dllDiscrFilt': np.copy(GNSS_tracking[N - 1]["code_nco"]),
-        'pllDiscr': np.copy(GNSS_tracking[N - 1]["carr_error"]),#todo code_freq_rate_hz_s segun dll
-        'pllDiscrFilt': np.copy(GNSS_tracking[N - 1]["carr_nco"]),
+            np.copy(GNSS_tracking[N-1]["carrier_doppler_rate_hz2"]),
+        'dllDiscr': np.copy(GNSS_tracking[N-1]["code_error"]),
+        'dllDiscrFilt': np.copy(GNSS_tracking[N-1]["code_nco"]),
+        'pllDiscr': np.copy(GNSS_tracking[N-1]["carr_error"]),
+        'pllDiscrFilt': np.copy(GNSS_tracking[N-1]["carr_nco"]),
 
-        'I_P': np.copy(GNSS_tracking[N - 1]["prompt_I"]),#todo distinto de dll
-        'Q_P': np.copy(GNSS_tracking[N - 1]["prompt_Q"]),#todo distinto de dll
+        'I_P': np.copy(GNSS_tracking[N-1]["prompt_I"]),
+        'Q_P': np.copy(GNSS_tracking[N-1]["prompt_Q"]),
 
-        'I_E': np.copy(GNSS_tracking[N - 1]["E"]),
-        'I_L': np.copy(GNSS_tracking[N - 1]["L"]),
-        'Q_E': np.zeros(len(GNSS_tracking[N - 1]["E"])),
-        'Q_L': np.zeros(len(GNSS_tracking[N - 1]["L"])),
-        'PRN': np.copy(GNSS_tracking[N - 1]["PRN"]),
-        'CNo': np.copy(GNSS_tracking[N - 1]["CN0_SNV_dB_Hz"])
+        'I_E': np.copy(GNSS_tracking[N-1]["E"]),
+        'I_L': np.copy(GNSS_tracking[N-1]["L"]),
+        'Q_E': np.zeros(len(GNSS_tracking[N-1]["E"])),
+        'Q_L': np.zeros(len(GNSS_tracking[N-1]["L"])),
+        'PRN': np.copy(GNSS_tracking[N-1]["PRN"]),
+        'CNo': np.copy(GNSS_tracking[N-1]["CN0_SNV_dB_Hz"]),
+        'prn_start_time_s':
+            np.copy(GNSS_tracking[N-1]["PRN_start_sample"]) / samplingFreq
     }
 
-    kalmanResult= {
-        'PRN': np.copy(GNSS_tracking[N - 1]["PRN"]),
-        'innovation': np.copy(GNSS_tracking[N - 1]["carr_error"]),#todo code_freq_rate_hz_s segun dll
-        'state1': np.copy(GNSS_tracking[N - 1]["carr_nco"]),
-        'state2': np.copy(GNSS_tracking[N - 1]["carrier_doppler_hz"]),
-        'state3': GNSS_tracking[N - 1]["carrier_doppler_rate_hz2"],#todo segun el dll es carrier_doppler_rate_hz_s
-        'r_noise_cov': np.copy(GNSS_tracking[N - 1]["carr_noise_sigma2"]),#todo carr_error segun dll
-        'CNo': np.copy(GNSS_tracking[N - 1]["CN0_SNV_dB_Hz"])
+    # Kalman-filter internals. The KF dump stores the carrier discriminator
+    # (carr_error -> innovation) and the filter states, but no measurement
+    # noise covariance, so 'r_noise_cov' is intentionally left out (plotKalman
+    # skips that panel when it is absent).
+    kalmanResult = {
+        'PRN': np.copy(GNSS_tracking[N-1]["PRN"]),
+        'innovation': np.copy(GNSS_tracking[N-1]["carr_error"]),
+        'state1': np.copy(GNSS_tracking[N-1]["carr_nco"]),
+        'state2': np.copy(GNSS_tracking[N-1]["carrier_doppler_hz"]),
+        'state3': np.copy(GNSS_tracking[N-1]["carrier_doppler_rate_hz2"]),
+        'CNo': np.copy(GNSS_tracking[N-1]["CN0_SNV_dB_Hz"])
     }
 
     trackResults.append(trackResult)
@@ -90,7 +97,9 @@ for N in range(1, channels + 1):
         'numberOfChannels': channels,
         'msToProcess': len(GNSS_tracking[N-1]['E']),
         'codePeriod': code_period,
-        'timeStartInSeconds': 20
+        'timeStartInSeconds': 0,
+        'fig_path': fig_path,
+        'show': False  # set True to display the figures interactively
     }
 
     # Create and save graphics as PNG

--- a/utils/python/lib/dll_pll_veml_read_tracking_dump.py
+++ b/utils/python/lib/dll_pll_veml_read_tracking_dump.py
@@ -6,6 +6,7 @@
  Opens GNSS-SDR tracking binary log file .dat and returns the contents
 
  Irene Pérez Riega, 2023. iperrie@inta.es
+ Minhaj Uddin Ahmad, 2026. mahmad12@crimson.ua.edu
 
       Args:
         filename: path to file .dat with the raw data
@@ -25,198 +26,61 @@
 """
 
 import struct
-import sys
+
+# Binary layout of one tracking dump record, matching the writer in
+# src/algorithms/tracking/gnuradio_blocks/dll_pll_veml_tracking.cc
+#
+# Fields are written back-to-back.
+# '<' selects little-endian / standard sizes / no alignment padding.
+_RECORD_FORMAT = '<' + (
+    'f'    # VE  -> Magnitude of the Very Early correlator.
+    'f'    # E   -> Magnitude of the Early correlator.
+    'f'    # P   -> Magnitude of the Prompt correlator.
+    'f'    # L   -> Magnitude of the Late correlator.
+    'f'    # VL  -> Magnitude of the Very Late correlator.
+    'f'    # prompt_I -> Prompt correlator, In-phase component.
+    'f'    # prompt_Q -> Prompt correlator, Quadrature component.
+    'Q'    # PRN_start_sample -> Sample counter from tracking start.
+    'f'    # acc_carrier_phase_rad -> Accumulated carrier phase, in rad.
+    'f'    # carrier_doppler_hz -> Doppler shift, in Hz.
+    'f'    # carrier_doppler_rate_hz_s -> Doppler rate, in Hz/s.
+    'f'    # code_freq_hz -> Code frequency, in chips/s.
+    'f'    # code_freq_rate_hz_s -> Code frequency rate, in chips/s^2.
+    'f'    # carr_error -> Raw carrier error at the PLL output, in Hz.
+    'f'    # carr_nco -> Carrier error at the output of the PLL filter, in Hz.
+    'f'    # code_error -> Raw code error at the DLL output, in chips.
+    'f'    # code_nco -> Code error at the output of the DLL filter, in chips.
+    'f'    # CN0_SNV_dB_Hz -> C/N0 estimation, in dB-Hz.
+    'f'    # carrier_lock_test -> Output of the carrier lock test.
+    'f'    # var1 -> aux variable.
+    'd'    # var2 -> aux variable.
+    'I'    # PRN -> Satellite ID.
+    'Q'    # TOW_ms -> Time of week, in ms.
+    'I'    # WN -> Week number.
+)
+
+_FIELD_NAMES = [
+    'VE', 'E', 'P', 'L', 'VL', 'prompt_I', 'prompt_Q', 'PRN_start_sample',
+    'acc_carrier_phase_rad', 'carrier_doppler_hz', 'carrier_doppler_rate_hz_s',
+    'code_freq_hz', 'code_freq_rate_hz_s', 'carr_error', 'carr_nco',
+    'code_error', 'code_nco', 'CN0_SNV_dB_Hz', 'carrier_lock_test',
+    'var1', 'var2', 'PRN', 'TOW_ms', 'WN',
+]
 
 
 def dll_pll_veml_read_tracking_dump (filename):
 
-    v1 = []
-    v2 = []
-    v3 = []
-    v4 = []
-    v5 = []
-    v6 = []
-    v7 = []
-    v8 = []
-    v9 = []
-    v10= []
-    v11 = []
-    v12 = []
-    v13 = []
-    v14 = []
-    v15 = []
-    v16 = []
-    v17 = []
-    v18 = []
-    v19 = []
-    v20 = []
-    v21 = []
-    v22 = []
-    GNSS_tracking = {}
+    record_size = struct.calcsize(_RECORD_FORMAT)
+    columns = [[] for _ in _FIELD_NAMES]
 
-    bytes_shift = 0
-
-    if sys.maxsize > 2 ** 36:  # 64 bits computer
-        float_size_bytes = 4
-        unsigned_long_int_size_bytes = 8
-        double_size_bytes = 8
-        unsigned_int_size_bytes = 4
-
-    else: # 32 bits
-        float_size_bytes = 4
-        unsigned_long_int_size_bytes = 4
-        double_size_bytes = 8
-        unsigned_int_size_bytes = 4
-
-    f = open(filename, 'rb')
-    if f is None:
-        return None
-    else:
+    with open(filename, 'rb') as f:
         while True:
-            f.seek(bytes_shift, 0)
-            # VE -> Magnitude of the Very Early correlator.
-            v1.append(struct.unpack('f', f.read(float_size_bytes))[0])
-            bytes_shift += float_size_bytes
-            f.seek(bytes_shift, 0)
-            # E -> Magnitude of the Early correlator.
-            v2.append(struct.unpack('f', f.read(float_size_bytes))[0])
-            bytes_shift += float_size_bytes
-            f.seek(bytes_shift, 0)
-            # P -> Magnitude of the Prompt correlator.
-            v3.append(struct.unpack('f', f.read(float_size_bytes))[0])
-            bytes_shift += float_size_bytes
-            f.seek(bytes_shift, 0)
-            # L -> Magnitude of the Late correlator.
-            v4.append(struct.unpack('f', f.read(float_size_bytes))[0])
-            bytes_shift += float_size_bytes
-            f.seek(bytes_shift, 0)
-            # VL -> Magnitude of the Very Late correlator.
-            v5.append(struct.unpack('f', f.read(float_size_bytes))[0])
-            bytes_shift += float_size_bytes
-            f.seek(bytes_shift, 0)
-            # promp_I -> Value of the Prompt correlator in the In-phase
-            # component.
-            v6.append(struct.unpack('f', f.read(float_size_bytes))[0])
-            bytes_shift += float_size_bytes
-            f.seek(bytes_shift, 0)
-            # promp_Q -> Value of the Prompt correlator in the Quadrature
-            # component.
-            v7.append(struct.unpack('f',
-                                    f.read(float_size_bytes))[0])
-            bytes_shift += float_size_bytes
-            f.seek(bytes_shift, 0)
-            # PRN_start_sample -> Sample counter from tracking start.
-            if unsigned_long_int_size_bytes == 8:
-                v8.append(struct.unpack(
-                    'Q', f.read(unsigned_long_int_size_bytes))[0])
-                bytes_shift += unsigned_long_int_size_bytes
-            else:
-                v8.append(struct.unpack('I',
-                                        f.read(unsigned_int_size_bytes))[0])
-                bytes_shift += unsigned_int_size_bytes
-            f.seek(bytes_shift, 0)
-            # acc_carrier_phase_rad - > Accumulated carrier phase, in rad.
-            v9.append(struct.unpack('f', f.read(float_size_bytes))[0])
-            bytes_shift += float_size_bytes
-            f.seek(bytes_shift, 0)
-            # carrier doppler hz -> Doppler shift, in Hz.
-            v10.append(struct.unpack('f',
-                                     f.read(float_size_bytes))[0])
-            bytes_shift += float_size_bytes
-            f.seek(bytes_shift, 0)
-            # carrier doppler rate hz s -> Doppler rate, in Hz/s.
-            v11.append(struct.unpack('f',
-                                     f.read(float_size_bytes))[0])
-            bytes_shift += float_size_bytes
-            f.seek(bytes_shift, 0)
-            # code freq hz -> Code frequency, in chips/s.
-            v12.append(struct.unpack('f',
-                                     f.read(float_size_bytes))[0])
-            bytes_shift += float_size_bytes
-            f.seek(bytes_shift, 0)
-            # code_freq_rate_hz_s -> Code frequency rate, in chips/s².
-            v13.append(struct.unpack('f',
-                                     f.read(float_size_bytes))[0])
-            bytes_shift += float_size_bytes
-            f.seek(bytes_shift, 0)
-            # carr_error -> Raw carrier error (unfiltered) at the PLL
-            # output, in Hz.
-            v14.append(struct.unpack('f',
-                                     f.read(float_size_bytes))[0])
-            bytes_shift += float_size_bytes
-            f.seek(bytes_shift, 0)
-            # carr_nco -> Carrier error at the output of the PLL
-            # filter, in Hz.
-            v15.append(struct.unpack('f',
-                                     f.read(float_size_bytes))[0])
-            bytes_shift += float_size_bytes
-            f.seek(bytes_shift, 0)
-            # code error -> Raw code error (unfiltered) at the DLL
-            # output, in chips.
-            v16.append(struct.unpack('f',
-                                     f.read(float_size_bytes))[0])
-            bytes_shift += float_size_bytes
-            f.seek(bytes_shift, 0)
-            # code nco -> Code error at the output of the DLL
-            # filter, in chips.
-            v17.append(struct.unpack('f',
-                                     f.read(float_size_bytes))[0])
-            bytes_shift += float_size_bytes
-            f.seek(bytes_shift, 0)
-            # CN0_SNV_dB_Hz -> C/N0 estimation, in dB-Hz.
-            v18.append(struct.unpack('f',
-                                     f.read(float_size_bytes))[0])
-            bytes_shift += float_size_bytes
-            f.seek(bytes_shift, 0)
-            # carrier lock test -> Output of the carrier lock test.
-            v19.append(struct.unpack('f',
-                                     f.read(float_size_bytes))[0])
-            bytes_shift += float_size_bytes
-            f.seek(bytes_shift, 0)
-            # var 1 -> not used ?
-            v20.append(struct.unpack('f',
-                                     f.read(float_size_bytes))[0])
-            bytes_shift += float_size_bytes
-            f.seek(bytes_shift, 0)
-            # var 2 -> not used ?
-            v21.append(struct.unpack('d',
-                                     f.read(double_size_bytes))[0])
-            bytes_shift += double_size_bytes
-            f.seek(bytes_shift, 0)
-            # PRN ->  Satellite ID.
-            v22.append(struct.unpack('I',
-                                     f.read(unsigned_int_size_bytes))[0])
-            bytes_shift += unsigned_int_size_bytes
-            f.seek(bytes_shift, 0)
-
-            # Check file
-            linea = f.readline()
-            if not linea:
+            record = f.read(record_size)
+            if len(record) < record_size:
+                # Clean end of file (or a trailing partial record).
                 break
+            for column, value in zip(columns, struct.unpack(_RECORD_FORMAT,
+                                                             record)):
+                column.append(value)
 
-        f.close()
-
-        GNSS_tracking['VE'] = v1
-        GNSS_tracking['E'] = v2
-        GNSS_tracking['P'] = v3
-        GNSS_tracking['L'] = v4
-        GNSS_tracking['VL'] = v5
-        GNSS_tracking['prompt_I'] = v6
-        GNSS_tracking['prompt_Q'] = v7
-        GNSS_tracking['PRN_start_sample'] = v8
-        GNSS_tracking['acc_carrier_phase_rad'] = v9
-        GNSS_tracking['carrier_doppler_hz'] = v10
-        GNSS_tracking['carrier_doppler_rate_hz_s'] = v11
-        GNSS_tracking['code_freq_hz'] = v12
-        GNSS_tracking['code_freq_rate_hz_s'] = v13
-        GNSS_tracking['carr_error'] = v14
-        GNSS_tracking['carr_nco'] = v15
-        GNSS_tracking['code_error'] = v16
-        GNSS_tracking['code_nco'] = v17
-        GNSS_tracking['CN0_SNV_dB_Hz'] = v18
-        GNSS_tracking['carrier_lock_test'] = v19
-        GNSS_tracking['var1'] = v20
-        GNSS_tracking['var2'] = v21
-        GNSS_tracking['PRN'] = v22
-
-    return GNSS_tracking
+    return dict(zip(_FIELD_NAMES, columns))

--- a/utils/python/lib/gps_l1_ca_kf_read_tracking_dump.py
+++ b/utils/python/lib/gps_l1_ca_kf_read_tracking_dump.py
@@ -1,18 +1,18 @@
 """
  gps_l1_ca_kf_read_tracking_dump.py
+   gps_l1_ca_kf_read_tracking_dump (filename)
 
  Read GNSS-SDR Tracking dump binary file into Python.
- Opens GNSS-SDR tracking binary log file .dat and returns the contents in a dictionary
-
- gps_l1_ca_kf_read_tracking_dump(filename)
-
-   Args:
-        filename        - Path to file .dat with the raw data
-
-   Return:
-        GNSS_tracking   - A dictionary with the processed data in lists
+ Opens GNSS-SDR tracking binary log file .dat and returns the contents
 
  Irene Pérez Riega, 2023. iperrie@inta.es
+ Minhaj Uddin Ahmad, 2026. mahmad12@crimson.ua.edu
+
+      Args:
+        filename: path to file .dat with the raw data
+
+      Return:
+        GNSS_tracking: A dictionary with the processed data in lists
 
  -----------------------------------------------------------------------------
 
@@ -26,200 +26,60 @@
 """
 
 import struct
-import sys
+
+# Binary layout of one GPS_L1_CA_KF_Tracking dump record, matching the writer
+# in src/algorithms/tracking/gnuradio_blocks/kf_tracking.cc
+#
+# Fields are written back-to-back. Unlike the DLL/PLL VEML dump, the KF dump
+# ends at PRN (no TOW_ms / WN fields), so a record is 22 fields / 96 bytes.
+# '<' selects little-endian / standard sizes / no alignment padding.
+_RECORD_FORMAT = '<' + (
+    'f'    # VE  -> Magnitude of the Very Early correlator.
+    'f'    # E   -> Magnitude of the Early correlator.
+    'f'    # P   -> Magnitude of the Prompt correlator.
+    'f'    # L   -> Magnitude of the Late correlator.
+    'f'    # VL  -> Magnitude of the Very Late correlator.
+    'f'    # prompt_I -> Prompt correlator, In-phase component.
+    'f'    # prompt_Q -> Prompt correlator, Quadrature component.
+    'Q'    # PRN_start_sample -> Sample counter from tracking start.
+    'f'    # acc_carrier_phase_rad -> Accumulated carrier phase, in rad.
+    'f'    # carrier_doppler_hz -> KF carrier Doppler estimate, in Hz.
+    'f'    # carrier_doppler_rate_hz2 -> KF carrier Doppler rate, in Hz/s.
+    'f'    # code_freq_hz -> KF code frequency, in chips/s.
+    'f'    # code_freq_rate_hz_s -> Code phase rate, in chips/s^2.
+    'f'    # carr_error -> Carrier phase discriminator output, in Hz.
+    'f'    # carr_nco -> KF carrier state estimate.
+    'f'    # code_error -> Code discriminator output, in chips.
+    'f'    # code_nco -> KF code error estimate, in chips.
+    'f'    # CN0_SNV_dB_Hz -> C/N0 estimation, in dB-Hz.
+    'f'    # carrier_lock_test -> Output of the carrier lock test.
+    'f'    # var1 -> aux variable.
+    'd'    # var2 -> aux variable.
+    'I'    # PRN -> Satellite ID.
+)
+
+_FIELD_NAMES = [
+    'VE', 'E', 'P', 'L', 'VL', 'prompt_I', 'prompt_Q', 'PRN_start_sample',
+    'acc_carrier_phase_rad', 'carrier_doppler_hz', 'carrier_doppler_rate_hz2',
+    'code_freq_hz', 'code_freq_rate_hz_s', 'carr_error', 'carr_nco',
+    'code_error', 'code_nco', 'CN0_SNV_dB_Hz', 'carrier_lock_test',
+    'var1', 'var2', 'PRN',
+]
 
 
-def gps_l1_ca_kf_read_tracking_dump(filename):
+def gps_l1_ca_kf_read_tracking_dump (filename):
 
-    bytes_shift = 0
+    record_size = struct.calcsize(_RECORD_FORMAT)
+    columns = [[] for _ in _FIELD_NAMES]
 
-    GNSS_tracking = {}
-
-    v1 = []
-    v2 = []
-    v3 = []
-    v4 = []
-    v5 = []
-    v6 = []
-    v7 = []
-    v8 = []
-    v9 = []
-    v10= []
-    v11 = []
-    v12 = []
-    v13 = []
-    v14 = []
-    v15 = []
-    v16 = []
-    v17 = []
-    v18 = []
-    v19 = []
-    v20 = []
-    v21 = []
-    v22 = []
-
-    if sys.maxsize > 2 ** 36:  # 64 bits computer
-        float_size_bytes = 4
-        unsigned_long_int_size_bytes = 8
-        double_size_bytes = 8
-        unsigned_int_size_bytes = 4
-
-    else: # 32 bits
-        float_size_bytes = 4
-        unsigned_long_int_size_bytes = 4
-        double_size_bytes = 8
-        unsigned_int_size_bytes = 4
-
-    f = open(filename, 'rb')
-    if f is None:
-        help(gps_l1_ca_kf_read_tracking_dump)
-        return None
-
-    else:
+    with open(filename, 'rb') as f:
         while True:
-            f.seek(bytes_shift, 0)
-            # VE -> Magnitude of the Very Early correlator.
-            v1.append(struct.unpack('f', f.read(float_size_bytes))[0])
-            bytes_shift += float_size_bytes
-            f.seek(bytes_shift, 0)
-            # E -> Magnitude of the Early correlator.
-            v2.append(struct.unpack('f', f.read(float_size_bytes))[0])
-            bytes_shift += float_size_bytes
-            f.seek(bytes_shift, 0)
-            # P -> Magnitude of the Prompt correlator.
-            v3.append(struct.unpack('f', f.read(float_size_bytes))[0])
-            bytes_shift += float_size_bytes
-            f.seek(bytes_shift, 0)
-            # L -> Magnitude of the Late correlator.
-            v4.append(struct.unpack('f', f.read(float_size_bytes))[0])
-            bytes_shift += float_size_bytes
-            f.seek(bytes_shift, 0)
-            # VL -> Magnitude of the Very Late correlator.
-            v5.append(struct.unpack('f', f.read(float_size_bytes))[0])
-            bytes_shift += float_size_bytes
-            f.seek(bytes_shift, 0)
-            # promp_I -> Value of the Prompt correlator in the
-            # In-phase component.
-            v6.append(struct.unpack('f', f.read(float_size_bytes))[0])
-            bytes_shift += float_size_bytes
-            f.seek(bytes_shift, 0)
-            # promp_Q -> Value of the Prompt correlator in the
-            # Quadrature component.
-            v7.append(struct.unpack('f', f.read(float_size_bytes))[0])
-            bytes_shift += float_size_bytes
-            f.seek(bytes_shift, 0)
-            # PRN_start_sample -> Sample counter from tracking start.
-            if unsigned_long_int_size_bytes == 8:
-                v8.append(struct.unpack(
-                    'Q', f.read(unsigned_long_int_size_bytes))[0])
-                bytes_shift += unsigned_long_int_size_bytes
-            else:
-                v8.append(struct.unpack(
-                    'I', f.read(unsigned_int_size_bytes))[0])
-                bytes_shift += unsigned_int_size_bytes
-            f.seek(bytes_shift, 0)
-            # acc_carrier_phase_rad - > Accumulated carrier phase, in rad.
-            v9.append(struct.unpack('f', f.read(float_size_bytes))[0])
-            bytes_shift += float_size_bytes
-            f.seek(bytes_shift, 0)
-            # carrier doppler hz -> Doppler shift, in Hz.
-            v10.append(struct.unpack('f',
-                                     f.read(float_size_bytes))[0])
-            bytes_shift += float_size_bytes
-            f.seek(bytes_shift, 0)
-            # carrier doppler rate hz s -> Doppler rate, in Hz/s.
-            v11.append(struct.unpack('f',
-                                     f.read(float_size_bytes))[0])
-            bytes_shift += float_size_bytes
-            f.seek(bytes_shift, 0)
-            # code freq hz -> Code frequency, in chips/s.
-            v12.append(struct.unpack('f',
-                                     f.read(float_size_bytes))[0])
-            bytes_shift += float_size_bytes
-            f.seek(bytes_shift, 0)
-            # code_freq_rate_hz_s -> Code frequency rate, in chips/s².
-            #todo carr_error in gps_l1_ca_kf_read_tracking_dump.m
-            v13.append(struct.unpack('f',
-                                     f.read(float_size_bytes))[0])
-            bytes_shift += float_size_bytes
-            f.seek(bytes_shift, 0)
-            # carr_error -> Raw carrier error (unfiltered) at the PLL
-            # output, in Hz.
-            #todo carr_noise_sigma2 in gps_l1_ca_kf_read_tracking_dump.m
-            v14.append(struct.unpack('f',
-                                     f.read(float_size_bytes))[0])
-            bytes_shift += float_size_bytes
-            f.seek(bytes_shift, 0)
-            # carr_nco -> Carrier error at the output of the PLL
-            # filter, in Hz.
-            v15.append(struct.unpack('f',
-                                     f.read(float_size_bytes))[0])
-            bytes_shift += float_size_bytes
-            f.seek(bytes_shift, 0)
-            # code error -> Raw code error (unfiltered) at the DLL
-            # output, in chips.
-            v16.append(struct.unpack('f',
-                                     f.read(float_size_bytes))[0])
-            bytes_shift += float_size_bytes
-            f.seek(bytes_shift, 0)
-            # code nco -> Code error at the output of the DLL
-            # filter, in chips.
-            v17.append(struct.unpack('f',
-                                     f.read(float_size_bytes))[0])
-            bytes_shift += float_size_bytes
-            f.seek(bytes_shift, 0)
-            # CN0_SNV_dB_Hz -> C/N0 estimation, in dB-Hz.
-            v18.append(struct.unpack('f',
-                                     f.read(float_size_bytes))[0])
-            bytes_shift += float_size_bytes
-            f.seek(bytes_shift, 0)
-            # carrier lock test -> Output of the carrier lock test.
-            v19.append(struct.unpack('f',
-                                     f.read(float_size_bytes))[0])
-            bytes_shift += float_size_bytes
-            f.seek(bytes_shift, 0)
-            # var 1 -> not used ?
-            v20.append(struct.unpack('f',
-                                     f.read(float_size_bytes))[0])
-            bytes_shift += float_size_bytes
-            f.seek(bytes_shift, 0)
-            # var 2 -> not used ?
-            v21.append(struct.unpack('d',
-                                     f.read(double_size_bytes))[0])
-            bytes_shift += double_size_bytes
-            f.seek(bytes_shift, 0)
-            # PRN ->  Satellite ID.
-            v22.append(struct.unpack('I',
-                                     f.read(unsigned_int_size_bytes))[0])
-            bytes_shift += unsigned_int_size_bytes
-            f.seek(bytes_shift, 0)
-
-            linea = f.readline()
-            if not linea:
+            record = f.read(record_size)
+            if len(record) < record_size:
+                # Clean end of file (or a trailing partial record).
                 break
-    f.close()
+            for column, value in zip(columns, struct.unpack(_RECORD_FORMAT,
+                                                             record)):
+                column.append(value)
 
-    GNSS_tracking['VE'] = v1
-    GNSS_tracking['E'] = v2
-    GNSS_tracking['P'] = v3
-    GNSS_tracking['L'] = v4
-    GNSS_tracking['VL'] = v5
-    GNSS_tracking['prompt_I'] = v6
-    GNSS_tracking['prompt_Q'] = v7
-    GNSS_tracking['PRN_start_sample'] = v8
-    GNSS_tracking['acc_carrier_phase_rad'] = v9
-    GNSS_tracking['carrier_doppler_hz'] = v10
-    GNSS_tracking['carrier_doppler_rate_hz2'] = v11 #todo segun el dll es carrier_doppler_rate_hz_s
-    GNSS_tracking['code_freq_hz'] = v12
-    GNSS_tracking['carr_error'] = v13 #todo code_freq_rate_hz_s segun dll
-    GNSS_tracking['carr_noise_sigma2'] = v14 #todo carr_error segun dll
-    GNSS_tracking['carr_nco'] = v15
-    GNSS_tracking['code_error'] = v16
-    GNSS_tracking['code_nco'] = v17
-    GNSS_tracking['CN0_SNV_dB_Hz'] = v18
-    GNSS_tracking['carrier_lock_test'] = v19
-    GNSS_tracking['var1'] = v20
-    GNSS_tracking['var2'] = v21
-    GNSS_tracking['PRN'] = v22
-
-    return GNSS_tracking
+    return dict(zip(_FIELD_NAMES, columns))

--- a/utils/python/lib/plotKalman.py
+++ b/utils/python/lib/plotKalman.py
@@ -32,8 +32,9 @@ import os
 
 def plotKalman(channelNr, trackResults, settings):
 
-    # ---------- CHANGE HERE:
-    fig_path = '/home/labnav/Desktop/TEST_IRENE/PLOTS/PlotKalman'
+    # ---------- CHANGE HERE (or pass 'fig_path' in settings):
+    fig_path = settings.get('fig_path',
+                            '../../../PLOTS/PlotKalman')
 
     if not os.path.exists(fig_path):
         os.makedirs(fig_path)
@@ -49,7 +50,7 @@ def plotKalman(channelNr, trackResults, settings):
         # Plot all figures
         plt.figure(figsize=(1920 / 100, 1080 / 100))
         plt.clf()
-        plt.gcf().canvas.set_window_title(
+        plt.gcf().canvas.manager.set_window_title(
             f'Channel {channelNr} (PRN '
             f'{str(trackResults[channelNr-1]["PRN"][-2])}) results')
         plt.subplots_adjust(left=0.1, right=0.9, top=0.9, bottom=0.1,
@@ -122,19 +123,23 @@ def plotKalman(channelNr, trackResults, settings):
 
         # Row 4
         # ----- PLL discriminator covariance ---------------------------------
-        plt.subplot(4, 2, (7,8))
-        plt.plot(time_axis_in_seconds,
-                 trackResults[channelNr-1]['r_noise_cov'], 'r')
-        plt.grid()
-        plt.axis('auto')
-        plt.xlim(time_start, time_axis_in_seconds[-1])
-        plt.xlabel('Time (s)')
-        plt.ylabel('Variance')
-        plt.title('Estimated Noise Variance', fontweight='bold')
+        # Only plotted if the dump provides a noise covariance. The GPS L1 C/A
+        # KF tracking dump does not store one, so this panel is skipped there.
+        if 'r_noise_cov' in trackResults[channelNr-1]:
+            plt.subplot(4, 2, (7,8))
+            plt.plot(time_axis_in_seconds,
+                     trackResults[channelNr-1]['r_noise_cov'], 'r')
+            plt.grid()
+            plt.axis('auto')
+            plt.xlim(time_start, time_axis_in_seconds[-1])
+            plt.xlabel('Time (s)')
+            plt.ylabel('Variance')
+            plt.title('Estimated Noise Variance', fontweight='bold')
 
         plt.tight_layout()
         plt.savefig(os.path.join(fig_path,
                                  f'kalman_ch{channelNr}_PRN_'
                                  f'{trackResults[channelNr - 1]["PRN"][-1]}'
                                  f'.png'))
-        plt.show()
+        if settings.get('show', True):
+            plt.show()

--- a/utils/python/lib/plotTracking.py
+++ b/utils/python/lib/plotTracking.py
@@ -32,8 +32,9 @@ import matplotlib.pyplot as plt
 
 def plotTracking(channelNr, trackResults, settings):
 
-    # ---------- CHANGE HERE:
-    fig_path = '/home/labnav/Desktop/TEST_IRENE/PLOTS/PlotTracking'
+    # ---------- CHANGE HERE (or pass 'fig_path' in settings):
+    fig_path = settings.get('fig_path',
+                            '../../../PLOTS/PlotTracking')
 
     if not os.path.exists(fig_path):
         os.makedirs(fig_path)
@@ -43,7 +44,7 @@ def plotTracking(channelNr, trackResults, settings):
 
         plt.figure(figsize=(1920 / 120, 1080 / 120))
         plt.clf()
-        plt.gcf().canvas.set_window_title(
+        plt.gcf().canvas.manager.set_window_title(
             f'Channel {channelNr} (PRN '
             f'{trackResults[channelNr-1]["PRN"][0]}) results')
         plt.subplots_adjust(left=0.1, right=0.9, top=0.9, bottom=0.1,
@@ -187,4 +188,5 @@ def plotTracking(channelNr, trackResults, settings):
                                  f'trk_dump_ch{channelNr}_PRN_'
                                  f'{trackResults[channelNr - 1]["PRN"][-1]}'
                                  f'.png'))
-        plt.show()
+        if settings.get('show', True):
+            plt.show()

--- a/utils/python/plot_acq_grid.py
+++ b/utils/python/plot_acq_grid.py
@@ -35,7 +35,6 @@
 """
 
 import os
-import sys
 from pathlib import Path
 import numpy as np
 import matplotlib.pyplot as plt

--- a/utils/python/plot_acq_grid.py
+++ b/utils/python/plot_acq_grid.py
@@ -5,15 +5,15 @@
  plots acquisition grid of acquisition statistic of PRN sat
 
  Irene Pérez Riega, 2023. iperrie@inta.es
+ Minhaj Uddin Ahmad, 2026. mahmad12@crimson.ua.edu
 
  Modifiable in the file:
-   sampling_freq        - Sampling frequency [Hz]
-   channels             - Number of channels to check if they exist
    path                 - Path to folder which contains raw file
    fig_path             - Path where plots will be save
    plot_all_files       - Plot all the files in a folder (True/False)
+   plot_positive_acqs   - Only plot the positive acquisition cases
    ----
-   file                 - Fixed part in files names. In our case: acq_dump
+   file_prefix          - Fixed part in files names. In our case: acquisition
    sat                  - Satellite. In our case: 1
    channel              - Channel. In our case: 1
    execution            - In our case: 0
@@ -36,23 +36,39 @@
 
 import os
 import sys
+from pathlib import Path
 import numpy as np
 import matplotlib.pyplot as plt
 from scipy.interpolate import CubicSpline
 import h5py
 
 # ---------- CHANGE HERE:
-path = '/home/labnav/Desktop/TEST_IRENE/acquisition/'
-fig_path = '/home/labnav/Desktop/TEST_IRENE/PLOTS/Acquisition/'
-plot_all_files = False
+path = '../../../out/' # path to acquisition .mat dumps
+fig_path = '../../../PLOTS/Acquisition/' # path to store figures
+plot_all_files = True
+plot_positive_acqs = True
+file_prefix = "acquisition"
+
+signal_types = {
+    1: ('G', '1C', 1023), # GPS L1
+    2: ('G', '2S', 10230), # GPS L2M
+    3: ('G', 'L5', 10230), # GPS L5
+    4: ('E', '1B', 4092), # Galileo E1B
+    5: ('E', '5X', 10230), # Galileo E5
+    6: ('R', '1G', 511), # Glonass 1G
+    7: ('R', '2G', 511), # Glonass 2G
+    8: ('C', 'B1', 2048), # Beidou B1
+    9: ('C', 'B3', 10230), # Beidou B3
+    10: ('C', '5C', 10230) # Beidou B2a
+}
+# (system, signal) -> n_chips, derived from the table above
+N_CHIPS = {(sys_, sig): nc for sys_, sig, nc in signal_types.values()}
 
 if not os.path.exists(fig_path):
     os.makedirs(fig_path)
 
 if not plot_all_files:
-
     # ---------- CHANGE HERE:
-    file = 'acq_dump'
     sat = 1
     channel = 0
     execution = 1
@@ -64,24 +80,12 @@ if not plot_all_files:
     n_samples_per_chip = 3
     d_samples_per_code = 25000
 
-    signal_types = {
-        1: ('G', '1C', 1023), # GPS L1
-        2: ('G', '2S', 10230), # GPS L2M
-        3: ('G', 'L5', 10230), # GPS L5
-        4: ('E', '1B', 4092), # Galileo E1B
-        5: ('E', '5X', 10230), # Galileo E5
-        6: ('R', '1G', 511), # Glonass 1G
-        7: ('R', '2G', 511), # Glonass 2G
-        8: ('C', 'B1', 2048), # Beidou B1
-        9: ('C', 'B3', 10230), # Beidou B3
-        10: ('C', '5C', 10230) # Beidou B2a
-    }
     system, signal, n_chips = signal_types.get(signal_type)
 
     # Load data
-    filename = (f'{path}{file}_ch_{system}_{signal}_ch_{channel}_{execution}'
+    filename = (f'{path}{file_prefix}_ch_{system}_{signal}_ch_{channel}_{execution}'
                 f'_sat_{sat}.mat')
-    img_name_root = (f'{fig_path}{file}_ch_{system}_{signal}_ch_{channel}_'
+    img_name_root = (f'{fig_path}{file_prefix}_ch_{system}_{signal}_ch_{channel}_'
                    f'{execution}_sat_{sat}')
 
     with h5py.File(filename, 'r') as data:
@@ -153,51 +157,30 @@ else:
     n_samples_per_chip = 3
     d_samples_per_code = 25000
 
-    filenames = os.listdir(path)
-    for filename in filenames:
-        sat = 1
-        channel = 0
-        execution = 1
+    file_paths = Path(path).glob(f'{file_prefix}*.mat')
+    for file_path in file_paths:
+        #     {prefix}_{system}_{signal}_ch_{channel}_{execution}_sat_{PRN}
+        #                -7       -6     -5   -4         -3       -2   -1
+        parts = file_path.stem.split('_')
 
-        system = filename[12]
-        signal = filename[14:16]
-        if system == "G":
-            if signal == "1C":
-                n_chips = 1023
-            elif signal == "2S" or "L5":
-                n_chips = 10230
-            else:
-                print("Incorrect files format. Change the code or the "
-                      "filenames.")
-                sys.exit()
-        elif system == "E":
-            if signal == "1B":
-                n_chips = 4092
-            elif signal == "5X":
-                n_chips = 10230
-            else:
-                print("Incorrect files format. Change the code or the "
-                      "filenames.")
-                sys.exit()
-        elif system == "R":
-            if signal == "1G" or "2G":
-                n_chips = 511
-            else:
-                print("Incorrect files format. Change the code or the "
-                      "filenames.")
-                sys.exit()
-        elif system == "C":
-            if signal == "B1":
-                n_chips = 2048
-            elif signal == "B3" or "5C":
-                n_chips = 10230
-            else:
-                print("Incorrect files format. Change the code or the "
-                      "filenames.")
-                sys.exit()
+        system = parts[-7]
+        signal = parts[-6]
+        channel = int(parts[-4])
+        execution = int(parts[-3])
+        sat = int(parts[-1])
 
-        complete_path = path + filename
-        with h5py.File(complete_path, 'r') as data:
+        filename = file_path.name
+
+        n_chips = N_CHIPS.get((system, signal))
+        if n_chips is None:
+            print(f"Unknown system/signal {system}/{signal}, skipping: "
+                f"{filename}")
+            continue
+
+        with h5py.File(file_path, 'r') as data:
+            if plot_positive_acqs and data.get('positive_acq')[0] != 1:
+                continue
+
             acq_grid = data['acq_grid'][:]
             n_fft, n_dop_bins = acq_grid.shape
             d_max, f_max = np.unravel_index(np.argmax(acq_grid),

--- a/utils/python/plot_tracking_quality_indicators.py
+++ b/utils/python/plot_tracking_quality_indicators.py
@@ -1,16 +1,15 @@
 """
  plot_tracking_quality_indicators.py
 
-
-
  Irene Pérez Riega, 2023. iperrie@inta.es
+ Minhaj Uddin Ahmad, 2026. mahmad12@crimson.ua.edu
 
  Modifiable in the file:
    channels             - Number of channels
-   firs_channel         - Number of the first channel
+   first_channel         - Number of the first channel
    path                 - Path to folder which contains raw files
    fig_path             - Path where doppler plots will be save
-   'trk_dump_ch'        - Fixed part of the tracking dump files names
+   file_prefix          - Fixed part of the tracking dump files names
 
  -----------------------------------------------------------------------------
 
@@ -35,12 +34,13 @@ plot_names = []
 # ---------- CHANGE HERE:
 channels = 5
 first_channel = 0
-path = '/home/labnav/Desktop/TEST_IRENE/tracking'
-fig_path = '/home/labnav/Desktop/TEST_IRENE/PLOTS/TrackingQualityIndicator'
+path = '../../../out/'
+fig_path = '../../../PLOTS/TrackingQualityIndicator'
+file_prefix = "track_ch"
 
 for N in range(1, channels + 1):
     tracking_log_path = os.path.join(path,
-                                     f'trk_dump_ch{N-1+first_channel}.dat')
+                                     f'{file_prefix}{N-1+first_channel}.dat')
     GNSS_tracking.append(dll_pll_veml_read_tracking_dump(tracking_log_path))
 
 if not os.path.exists(fig_path):
@@ -59,7 +59,7 @@ plt.legend(plot_names)
 plt.savefig(os.path.join(fig_path,
                          f'carrier_lock_test '
                          f'{str(round(np.mean(GNSS_tracking[n]["PRN"])))}'))
-plt.show()
+# plt.show()
 
 # Second plot
 plt.figure()
@@ -73,4 +73,4 @@ for n in range(len(GNSS_tracking)):
 plt.legend(plot_names)
 plt.savefig(os.path.join(
     fig_path, f'SV {str(round(np.mean(GNSS_tracking[n]["PRN"])))}'))
-plt.show()
+# plt.show()


### PR DESCRIPTION
- Added a plot_positive_acq filter option, to enable plotting only the positive acquisitions.
- Improved the file path processing. Previous version used hardcoded character offset that will not work if someone sets custom dump prefix. Now we use python's built-in pathlib and split-parse using the "_" separator.
- The scripts used to use two different ways of encoding system,channel,chips, one with python dict another with massive if-else nest. This has been uniformed.
- The script used to assume all files in the dump folder would be acquisition dump but now we filter for acq dumps using pathlib's glob()

