### PR TITLE
pcps_acquisition: fix crash in PcpsAcquisitionAdapterCustom::set_local_code

### DIFF
--- a/src/algorithms/acquisition/adapters/pcps_acquisition_adapter_custom.cc
+++ b/src/algorithms/acquisition/adapters/pcps_acquisition_adapter_custom.cc
@@ -489,9 +489,9 @@ void PcpsAcquisitionAdapterCustom::set_local_code()
                     const auto vector_length = acq_parameters_.vector_length;
 
                     auto& codeI_ = code_;
-                    std::vector<std::complex<float>> codeQ_(code_length);
-                    std::vector<std::complex<float>> codeI(code_length);
-                    std::vector<std::complex<float>> codeQ(code_length);
+                    std::vector<std::complex<float>> codeQ_(vector_length);
+                    std::vector<std::complex<float>> codeI(vector_length);
+                    std::vector<std::complex<float>> codeQ(vector_length);
 
                     if (gnss_synchro_->Signal[0] == '5' && gnss_synchro_->Signal[1] == 'X')
                         {


### PR DESCRIPTION
... when Acquisition_5X.coherent_integration_time_ms is greater than 1. In this case vectors codeQ_, codeI, codeQ are constructed with code_length size, but written with vector_length which results in arbitrary memory overwriting and crash.
Construct these arrays with vector_length size to make sure that there will be enough space for all primary code replicas and zero padding.
