### PR TITLE
Fix tracking.enable_doppler_correction option parsing

### DIFF
--- a/src/algorithms/tracking/libs/dll_pll_conf.cc
+++ b/src/algorithms/tracking/libs/dll_pll_conf.cc
@@ -58,6 +58,7 @@ void Dll_Pll_Conf::SetFromConfiguration(const ConfigurationInterface *configurat
     double fs_in_deprecated = configuration->property("GNSS-SDR.internal_fs_hz", fs_in);
     fs_in = configuration->property("GNSS-SDR.internal_fs_sps", fs_in_deprecated);
     high_dyn = configuration->property(role + ".high_dyn", high_dyn);
+    enable_doppler_correction = configuration->property(role + ".enable_doppler_correction", enable_doppler_correction);
     dump = configuration->property(role + ".dump", dump);
     dump_filename = configuration->property(role + ".dump_filename", dump_filename);
     dump_mat = configuration->property(role + ".dump_mat", dump_mat);


### PR DESCRIPTION
`dll_pll_veml_tracking` `enable_doppler_correction` flag was not parsed from a config file.
I've tested this flag and found that it somehow works and improves tracking stability (not always though).
Feel free to reject this PR if 'enable_doppler_correction' experiment is opted for removal.