### PR TITLE
Fix NMEA missing SNR and used satellites in non-L1 configurations

### DIFF
--- a/src/algorithms/libs/rtklib/rtklib_pntpos.cc
+++ b/src/algorithms/libs/rtklib/rtklib_pntpos.cc
@@ -1162,7 +1162,10 @@ int pntpos(const obsd_t *obs, int n, const nav_t *nav,
                 {
                     ssat[obs[i].sat - 1].azel[0] = azel_[i * 2];
                     ssat[obs[i].sat - 1].azel[1] = azel_[1 + i * 2];
-                    ssat[obs[i].sat - 1].snr[0] = obs[i].SNR[0];
+                    for (int j = 0; j < NFREQ; j++)
+                        {
+                            ssat[obs[i].sat - 1].snr[j] = obs[i].SNR[j];
+                        }
                     if (!vsat[i])
                         {
                             continue;

--- a/src/algorithms/libs/rtklib/rtklib_solution.cc
+++ b/src/algorithms/libs/rtklib/rtklib_solution.cc
@@ -34,6 +34,7 @@
 #include "rtklib_solution.h"
 #include "rtklib_rtkcmn.h"
 #include "rtklib_rtksvr.h"
+#include <algorithm>
 #include <cctype>
 #include <cmath>
 #include <cstring>
@@ -1955,7 +1956,7 @@ int outnmea_gsv(unsigned char *buff, const sol_t *sol,
                                     az += 360.0;
                                 }
                             el = ssat[sats[k] - 1].azel[1] * R2D;
-                            snr = ssat[sats[k] - 1].snr[0] * 0.25;
+                            snr = *std::max_element(std::begin(ssat[sats[k] - 1].snr), std::end(ssat[sats[k] - 1].snr)) * 0.25;
                             p += std::snprintf(p, MAXSOLBUF - (s - p), ",%02d,%02.0f,%03.0f,%02.0f", prn, el, az, snr);
                         }
                     else
@@ -2001,7 +2002,7 @@ int outnmea_gsv(unsigned char *buff, const sol_t *sol,
                                     az += 360.0;
                                 }
                             el = ssat[sats[k] - 1].azel[1] * R2D;
-                            snr = ssat[sats[k] - 1].snr[0] * 0.25;
+                            snr = *std::max_element(std::begin(ssat[sats[k] - 1].snr), std::end(ssat[sats[k] - 1].snr)) * 0.25;
                             p += std::snprintf(p, MAXSOLBUF - (s - p), ",%02d,%02.0f,%03.0f,%02.0f", prn, el, az, snr);
                         }
                     else
@@ -2046,7 +2047,7 @@ int outnmea_gsv(unsigned char *buff, const sol_t *sol,
                                     az += 360.0;
                                 }
                             el = ssat[sats[k] - 1].azel[1] * R2D;
-                            snr = ssat[sats[k] - 1].snr[0] * 0.25;
+                            snr = *std::max_element(std::begin(ssat[sats[k] - 1].snr), std::end(ssat[sats[k] - 1].snr)) * 0.25;
                             p += std::snprintf(p, MAXSOLBUF - (s - p), ",%02d,%02.0f,%03.0f,%02.0f", prn, el, az, snr);
                         }
                     else
@@ -2091,7 +2092,7 @@ int outnmea_gsv(unsigned char *buff, const sol_t *sol,
                                     az += 360.0;
                                 }
                             el = ssat[sats[k] - 1].azel[1] * R2D;
-                            snr = ssat[sats[k] - 1].snr[0] * 0.25;
+                            snr = *std::max_element(std::begin(ssat[sats[k] - 1].snr), std::end(ssat[sats[k] - 1].snr)) * 0.25;
                             p += std::snprintf(p, MAXSOLBUF - (s - p), ",%02d,%02.0f,%03.0f,%02.0f", prn, el, az, snr);
                         }
                     else
@@ -2136,7 +2137,7 @@ int outnmea_gsv(unsigned char *buff, const sol_t *sol,
                                     az += 360.0;
                                 }
                             el = ssat[sats[k] - 1].azel[1] * R2D;
-                            snr = ssat[sats[k] - 1].snr[0] * 0.25;
+                            snr = *std::max_element(std::begin(ssat[sats[k] - 1].snr), std::end(ssat[sats[k] - 1].snr)) * 0.25;
                             p += std::snprintf(p, MAXSOLBUF - (s - p), ",%02d,%02.0f,%03.0f,%02.0f", prn, el, az, snr);
                         }
                     else


### PR DESCRIPTION
Use maximum SNR of all received signals instead of hardcoded band 1 signal.
May close https://github.com/gnss-sdr/gnss-sdr/issues/1043
TBD: tests