### PR TITLE
Reject corrupted BeiDou D1 ephemeris assemblies.

### DIFF
--- a/src/core/system_parameters/Beidou_DNAV.h
+++ b/src/core/system_parameters/Beidou_DNAV.h
@@ -55,6 +55,13 @@ constexpr double D1_CRC_LSB = TWO_N6;
 constexpr double D1_CRS_LSB = TWO_N6;
 constexpr double D1_SQRT_A_LSB = TWO_N19;
 constexpr double D1_TOE_LSB = TWO_P3;
+/* ICD B1I §5.2.4.12 Table 5-10: toe scale 2^3, valid range 0..604792 s */
+constexpr double D1_TOE_MAX_S = 604792.0;
+/* ICD B1I Table 5-10: sqrt(A) scale 2^-19, valid range 0..8192 m^1/2.
+ * Practical MEO/IGSO/GEO broadcast values are ~4200..7000; reject clearly
+ * corrupted assemblies (e.g. mismatched SF2/SF3) below this floor. */
+constexpr double D1_SQRT_A_MAX = 8192.0;
+constexpr double D1_SQRT_A_MIN_SANE = 4000.0;
 constexpr double D1_I0_LSB = PI_TWO_N31;
 constexpr double D1_CIC_LSB = TWO_N31;
 constexpr double D1_OMEGA_DOT_LSB = PI_TWO_N43;

--- a/src/core/system_parameters/beidou_dnav_navigation_message.cc
+++ b/src/core/system_parameters/beidou_dnav_navigation_message.cc
@@ -255,6 +255,10 @@ int32_t Beidou_Dnav_Navigation_Message::d1_subframe_decoder(std::string const& s
 
             d_AODE = static_cast<double>(read_navigation_unsigned(subframe_bits, D1_AODE));
 
+            // New SF1: drop buffered SF2/SF3 (ICD B1I §5.2.4.12).
+            flag_d1_sf2 = false;
+            flag_d1_sf3 = false;
+
             // Set system flags for message reception
             flag_d1_sf1 = true;
             flag_iono_valid = true;
@@ -907,6 +911,17 @@ bool Beidou_Dnav_Navigation_Message::have_new_ephemeris()  // Check if we have a
                     // if all ephemeris pages have the same IOD, then they belong to the same block
                     if (d_previous_aode != d_AODE)
                         {
+                            const double toe_s = (d_Toe_sf2 + d_Toe_sf3) * D1_TOE_LSB;
+                            // ICD B1I Table 5-10 range checks.
+                            if (toe_s < 0.0 || toe_s > D1_TOE_MAX_S ||
+                                d_sqrt_A < D1_SQRT_A_MIN_SANE || d_sqrt_A > D1_SQRT_A_MAX)
+                                {
+                                    flag_d1_sf1 = false;
+                                    flag_d1_sf2 = false;
+                                    flag_d1_sf3 = false;
+                                    return false;
+                                }
+
                             // Clear flags for all received subframes
                             flag_d1_sf1 = false;
                             flag_d1_sf2 = false;

--- a/tests/unit-tests/system-parameters/beidou_dnav_navigation_message_test.cc
+++ b/tests/unit-tests/system-parameters/beidou_dnav_navigation_message_test.cc
@@ -128,3 +128,15 @@ TEST(BeidouDnavNavigationMessageTest, D2Subframe1PagesAcceptSowWeekRollover)
     EXPECT_EQ(1, dnav_msg.d2_subframe_decoder(make_d2_subframe1_page(3, 3)));
     EXPECT_TRUE(dnav_msg.get_flag_CRC_test());
 }
+
+
+TEST(BeidouDnavNavigationMessageTest, D1ToeAndSqrtAIcdLimits)
+{
+    // ICD B1I Table 5-10: toe max 604792 s, sqrt(A) max 8192 m^1/2.
+    // The corrupt PRN7 DNAV case (toe=988032, sqrtA≈1698) must be rejected.
+    EXPECT_GT(988032.0, D1_TOE_MAX_S);
+    EXPECT_LT(1698.0, D1_SQRT_A_MIN_SANE);
+    EXPECT_LE(201600.0, D1_TOE_MAX_S);
+    EXPECT_GE(5282.0, D1_SQRT_A_MIN_SANE);
+    EXPECT_LE(6493.0, D1_SQRT_A_MAX);
+}


### PR DESCRIPTION
Clear buffered SF2/SF3 when a new SF1 arrives, and drop candidate ephemerides whose toe or sqrt(A) fall outside ICD Table 5-10 bounds (with a practical sqrt(A) floor against clearly mismatched SF2/SF3).