### PR TITLE
Fix Gnss_Synchro move-assignment to copy Flag_cycle_slip.

### DIFF
--- a/src/core/system_parameters/gnss_synchro.h
+++ b/src/core/system_parameters/gnss_synchro.h
@@ -159,6 +159,7 @@ public:
                 this->Flag_valid_word = other.Flag_valid_word;
                 this->Flag_valid_pseudorange = other.Flag_valid_pseudorange;
                 this->Flag_PLL_180_deg_phase_locked = other.Flag_PLL_180_deg_phase_locked;
+                this->Flag_cycle_slip = other.Flag_cycle_slip;
 
                 // Leave the source object in a valid but unspecified state
                 other.Signal[0] = '\0';


### PR DESCRIPTION
Fix Gnss_Synchro move-assignment to copy Flag_cycle_slip. The field was already handled in copy-assignment and move-from cleanup, but move-assignment omitted it and could drop a cycle-slip flag.