### PR TITLE
Add optional median-based outlier pseudorange rejection.

### DIFF
--- a/src/algorithms/observables/adapters/hybrid_observables.cc
+++ b/src/algorithms/observables/adapters/hybrid_observables.cc
@@ -51,6 +51,7 @@ HybridObservables::HybridObservables(const ConfigurationInterface* configuration
     conf.always_output_gs = configuration->property("PVT.an_output_enabled", conf.always_output_gs) || configuration->property(role + ".always_output_gs", conf.always_output_gs);
     conf.enable_E6 = configuration->property(role + ".enable_E6", conf.enable_E6);
     conf.enable_monitor = configuration->property("Monitor.enable_monitor", conf.enable_monitor);
+    conf.reject_outlier_pseudoranges = configuration->property(role + ".reject_outlier_pseudoranges", conf.reject_outlier_pseudoranges);
 
 #if USE_GLOG_AND_GFLAGS
     if (FLAGS_carrier_smoothing_factor == DEFAULT_CARRIER_SMOOTHING_FACTOR)

--- a/src/algorithms/observables/gnuradio_blocks/hybrid_observables_gs.cc
+++ b/src/algorithms/observables/gnuradio_blocks/hybrid_observables_gs.cc
@@ -593,11 +593,16 @@ void hybrid_observables_gs::update_TOW(const std::vector<Gnss_Synchro> &data)
 
 void hybrid_observables_gs::compute_pranges(std::vector<Gnss_Synchro> &data) const
 {
-    // std::cout.precision(17);
-    // std::cout << " d_T_rx_TOW_ms: " << static_cast<double>(d_T_rx_TOW_ms) << '\n';
+    constexpr double PR_OUTLIER_RELATIVE_THRESHOLD_M = 1.0e8;
+
     std::vector<Gnss_Synchro>::iterator it;
     const auto current_T_rx_TOW_ms = static_cast<double>(d_T_rx_TOW_ms);
     const double current_T_rx_TOW_s = current_T_rx_TOW_ms / 1000.0;
+    std::vector<double> valid_pseudoranges;
+    if (d_conf.reject_outlier_pseudoranges)
+        {
+            valid_pseudoranges.reserve(data.size());
+        }
     for (it = data.begin(); it != data.end(); it++)
         {
             if (it->Flag_valid_word)
@@ -610,13 +615,31 @@ void hybrid_observables_gs::compute_pranges(std::vector<Gnss_Synchro> &data) con
                     it->RX_time = current_T_rx_TOW_s;
                     it->Pseudorange_m = traveltime_ms * SPEED_OF_LIGHT_M_MS;
                     it->Flag_valid_pseudorange = true;
-                    // debug code
-                    // std::cout << "[" << it->Channel_ID << "] interp_TOW_ms: " << it->interp_TOW_ms << '\n';
-                    // std::cout << "[" << it->Channel_ID << "] Diff d_T_rx_TOW_ms - interp_TOW_ms: " << static_cast<double>(d_T_rx_TOW_ms) - it->interp_TOW_ms << '\n';
+                    if (d_conf.reject_outlier_pseudoranges)
+                        {
+                            valid_pseudoranges.push_back(it->Pseudorange_m);
+                        }
                 }
             else
                 {
                     it->RX_time = current_T_rx_TOW_s;
+                }
+        }
+    if (d_conf.reject_outlier_pseudoranges && !valid_pseudoranges.empty())
+        {
+            const auto mid = static_cast<std::ptrdiff_t>(valid_pseudoranges.size() / 2);
+            std::nth_element(valid_pseudoranges.begin(), valid_pseudoranges.begin() + mid, valid_pseudoranges.end());
+            const double reference_pseudorange = valid_pseudoranges[static_cast<size_t>(mid)];
+            for (it = data.begin(); it != data.end(); it++)
+                {
+                    if (it->Flag_valid_pseudorange &&
+                        (std::abs(it->Pseudorange_m - reference_pseudorange) > PR_OUTLIER_RELATIVE_THRESHOLD_M))
+                        {
+                            DLOG(INFO) << "Reject outlier pseudorange " << it->Pseudorange_m
+                                       << " m (ref median " << reference_pseudorange << " m) on ch "
+                                       << it->Channel_ID << " PRN " << it->PRN << " Signal " << it->Signal;
+                            it->Flag_valid_pseudorange = false;
+                        }
                 }
         }
 }

--- a/src/algorithms/observables/libs/obs_conf.h
+++ b/src/algorithms/observables/libs/obs_conf.h
@@ -43,6 +43,7 @@ public:
     bool dump_mat{false};
     bool enable_E6{true};
     bool enable_monitor{false};
+    bool reject_outlier_pseudoranges{false};
 };
 
 /** \} */


### PR DESCRIPTION
Gate the check behind Observables.reject_outlier_pseudoranges (default false) so existing configs keep previous behavior. When enabled, mark pseudoranges far from the epoch median as invalid.

However, this function is currently worthy of discussion and verification.