### PR TITLE
CMake: fix building against modern protobuf

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2294,15 +2294,9 @@ if(((CMAKE_CXX_COMPILER_ID STREQUAL "GNU") AND (CMAKE_CXX_COMPILER_VERSION VERSI
 else()
     find_package(Protobuf)
 
-    if((CMAKE_BUILD_TYPE STREQUAL "Debug") AND Protobuf_FOUND AND absl_FOUND)
-        # This Regular Expression is used to convert the version string provided by `find_package(Protobuf)` into the
-        # appropriate binary version string. So, for instance, "4.25.3" becomes "25.3.0".
-        string(REGEX REPLACE "^[0-9]+\.([0-9]+\.[0-9]+)$" "\\1.0" PROTOBUF_LIBRARY_VERSION "${Protobuf_VERSION}")
-        if(NOT (PROTOBUF_LIBRARY_VERSION VERSION_LESS "22") AND
-            PROTOBUF_LIBRARY_VERSION VERSION_LESS "26")
-            pkg_check_modules(protobuf REQUIRED IMPORTED_TARGET protobuf=${PROTOBUF_LIBRARY_VERSION})
-            target_link_libraries(protobuf::libprotobuf INTERFACE PkgConfig::protobuf)
-        endif()
+    if(Protobuf_FOUND AND absl_FOUND)
+        pkg_check_modules(protobuf REQUIRED IMPORTED_TARGET protobuf)
+        target_link_libraries(protobuf::libprotobuf INTERFACE PkgConfig::protobuf)
     endif()
 endif()
 set_package_properties(Protobuf PROPERTIES


### PR DESCRIPTION
tested with protobuf 34.2 on Gentoo
the Debug check was dropped altogether as it breaks the same on RelWithDebInfo
