### PR TITLE
Fix broken test IbyteToComplexValidationOfResults

### DIFF
--- a/tests/unit-tests/signal-processing-blocks/adapter/adapter_test.cc
+++ b/tests/unit-tests/signal-processing-blocks/adapter/adapter_test.cc
@@ -288,7 +288,7 @@ TEST_F(DataTypeAdapter, IbyteToCbyteValidationOfResults)
 
 TEST_F(DataTypeAdapter, IbyteToComplexValidationOfResults)
 {
-    run_ibyte_to_cbyte_block();
+    run_ibyte_to_complex_block();
     std::ifstream ifs(file_name_output.data(), std::ifstream::binary | std::ifstream::in);
     gr_complex iSample;
     int i = 0;


### PR DESCRIPTION
Call run_ibyte_to_complex_block instead of run_ibyte_to_cbyte_block before valudating the result.
