### PR TITLE
Gnss_Ephemeris: Fix BeiDou GEO position/velocity calculation

### DIFF
--- a/src/core/system_parameters/gnss_ephemeris.cc
+++ b/src/core/system_parameters/gnss_ephemeris.cc
@@ -255,9 +255,18 @@ void Gnss_Ephemeris::satellitePosVelComputation(double transmitTime, std::array<
     // Compute the angle between the ascending node and the Greenwich meridian
     double Omega;
     double Omega_dot;
+    bool is_BeiDou_GEO = false;
     if (this->System == 'C')
         {
-            Omega_dot = this->OMEGAdot - BEIDOU_OMEGA_EARTH_DOT;
+            if (this->PRN <= 5 || this->PRN > 58)
+                {
+                    Omega_dot = this->OMEGAdot;
+                    is_BeiDou_GEO = true;
+                }
+            else
+                {
+                    Omega_dot = this->OMEGAdot - BEIDOU_OMEGA_EARTH_DOT;
+                }
             Omega = this->OMEGA_0 + Omega_dot * tk - BEIDOU_OMEGA_EARTH_DOT * static_cast<double>(this->toe);
         }
     else
@@ -273,18 +282,48 @@ void Gnss_Ephemeris::satellitePosVelComputation(double transmitTime, std::array<
     const double xprime = r * cuk;
     const double yprime = r * suk;
 
-    pos_vel_dtr[0] = xprime * cok - yprime * cik * sok;
-    pos_vel_dtr[1] = xprime * sok + yprime * cik * cok;  // ********NOTE: in GALILEO ICD this expression is not correct because it has minus (- sin(u) * r * cos(i) * cos(Omega)) instead of plus
-    pos_vel_dtr[2] = yprime * sik;
+    if (is_BeiDou_GEO)
+        {
+            constexpr double SIN_5 = -0.0871557427476582; /* sin(-5.0 deg) */
+            constexpr double COS_5 = 0.9961946980917456;  /* cos(-5.0 deg) */
 
-    // Satellite's velocity. Can be useful for Vector Tracking loops
-    const double xpkdot = rkdot * cuk - yprime * ukdot;
-    const double ypkdot = rkdot * suk + xprime * ukdot;
-    const double tmp = ypkdot * cik - pos_vel_dtr[2] * ikdot;
+            const double xg = xprime * cok - yprime * cik * sok;
+            const double yg = xprime * sok + yprime * cik * cok;
+            const double zg = yprime * sik;
+            const double sino = sin(BEIDOU_OMEGA_EARTH_DOT * tk);
+            const double coso = cos(BEIDOU_OMEGA_EARTH_DOT * tk);
 
-    pos_vel_dtr[3] = -Omega_dot * pos_vel_dtr[1] + xpkdot * cok - tmp * sok;
-    pos_vel_dtr[4] = Omega_dot * pos_vel_dtr[0] + xpkdot * sok + tmp * cok;
-    pos_vel_dtr[5] = yprime * cik * ikdot + ypkdot * sik;
+            pos_vel_dtr[0] = xg * coso + yg * sino * COS_5 + zg * sino * SIN_5;
+            pos_vel_dtr[1] = -xg * sino + yg * coso * COS_5 + zg * coso * SIN_5;
+            pos_vel_dtr[2] = -yg * SIN_5 + zg * COS_5;
+            // Satellite's velocity. Can be useful for Vector Tracking loops
+            const double xpkdot = rkdot * cuk - yprime * ukdot;
+            const double ypkdot = rkdot * suk + xprime * ukdot;
+            const double tmp = ypkdot * cik - zg * ikdot;
+
+            const double vx = -Omega_dot * yg + xpkdot * cok - tmp * sok;
+            const double vy = Omega_dot * xg + xpkdot * sok + tmp * cok;
+            const double vz = yprime * cik * ikdot + ypkdot * sik;
+
+            pos_vel_dtr[3] = vx * coso + vy * sino * COS_5 + vz * sino * SIN_5 + sin(BEIDOU_OMEGA_EARTH_DOT) * pos_vel_dtr[1];
+            pos_vel_dtr[4] = -vx * sino + vy * coso * COS_5 + vz * coso * SIN_5 - sin(BEIDOU_OMEGA_EARTH_DOT) * pos_vel_dtr[0];
+            pos_vel_dtr[5] = -vy * SIN_5 + vz * COS_5;
+        }
+    else
+        {
+            pos_vel_dtr[0] = xprime * cok - yprime * cik * sok;
+            pos_vel_dtr[1] = xprime * sok + yprime * cik * cok;  // ********NOTE: in GALILEO ICD this expression is not correct because it has minus (- sin(u) * r * cos(i) * cos(Omega)) instead of plus
+            pos_vel_dtr[2] = yprime * sik;
+            // Satellite's velocity. Can be useful for Vector Tracking loops
+            const double xpkdot = rkdot * cuk - yprime * ukdot;
+            const double ypkdot = rkdot * suk + xprime * ukdot;
+            const double tmp = ypkdot * cik - pos_vel_dtr[2] * ikdot;
+
+            pos_vel_dtr[3] = -Omega_dot * pos_vel_dtr[1] + xpkdot * cok - tmp * sok;
+            pos_vel_dtr[4] = Omega_dot * pos_vel_dtr[0] + xpkdot * sok + tmp * cok;
+            pos_vel_dtr[5] = yprime * cik * ikdot + ypkdot * sik;
+        }
+
 
     // Time from ephemeris reference clock
     tk = check_t(transmitTime - this->toc);

--- a/tests/unit-tests/system-parameters/gnss_ephemeris_posvel_test.cc
+++ b/tests/unit-tests/system-parameters/gnss_ephemeris_posvel_test.cc
@@ -246,7 +246,7 @@ TEST(GnssEphemerisPosVelTest, Galileo)
 }
 
 
-TEST(GnssEphemerisPosVelTest, DNAV)
+TEST(GnssEphemerisPosVelTest, DNAV_MEO)
 {
     Beidou_Dnav_Ephemeris e{};
     e.PRN = 41;
@@ -308,6 +308,148 @@ TEST(GnssEphemerisPosVelTest, DNAV)
     double satpos_Y = e.satpos_Y;
     double satpos_Z = e.satpos_Z;
     e.satellitePosition(590328.005);
+    double d_X = (e.satpos_X - satpos_X) * 100.;
+    double d_Y = (e.satpos_Y - satpos_Y) * 100.;
+    double d_Z = (e.satpos_Z - satpos_Z) * 100.;
+    EXPECT_NEAR(d_X, satvel_X, 1e-4);
+    EXPECT_NEAR(d_Y, satvel_Y, 1e-4);
+    EXPECT_NEAR(d_Z, satvel_Z, 1e-4);
+}
+
+
+TEST(GnssEphemerisPosVelTest, DNAV_GEO)
+{
+    Beidou_Dnav_Ephemeris e{};
+    e.PRN = 2;
+    e.M_0 = -2.61675466105504029e+00;
+    e.delta_n = -7.00743474492716572e-10;
+    e.ecc = 2.27454933337867233e-04;
+    e.sqrtA = 6.49340903472900391e+03;
+    e.OMEGA_0 = 2.11101911340236281e+00;
+    e.i_0 = 1.37762755606023468e-01;
+    e.omega = 9.72540339237386253e-01;
+    e.OMEGAdot = 1.84186243524920458e-09;
+    e.idot = 6.45384025692323640e-10;
+    e.Cuc = -1.65463425219058990e-05;
+    e.Cus = 5.06918877363204956e-06;
+    e.Crc = -1.57140625000000000e+02;
+    e.Crs = -5.02812500000000000e+02;
+    e.Cic = -1.56462192535400391e-07;
+    e.Cis = -8.52160155773162842e-08;
+    e.toe = 590400;
+    e.toc = 590400;
+    e.af0 = 6.37955963611602651e-08;
+    e.af1 = -1.06581410364015028e-13;
+    e.af2 = 0.00000000000000000e+00;
+    e.WN = 1072;
+    e.tow = 591357;
+    e.satClkDrift = 0.00000000000000000e+00;
+    e.dtr = 0.00000000000000000e+00;
+    e.AODE = 1.00000000000000000e+00;
+    e.SV_accuracy = 0;
+    e.SV_health = 0;
+    e.AODC = 1.00000000000000000e+00;
+    e.TGD1 = 4.73000000000000000e-08;
+    e.TGD2 = 4.73000000000000000e-08;
+    e.sig_type = 1;
+    e.nav_type = 2;
+    e.AODO = 0;
+    e.fit_interval_flag = 0;
+    e.spare1 = 0.00000000000000000e+00;
+    e.spare2 = 0.00000000000000000e+00;
+    e.integrity_status_flag = 0;
+    e.alert_flag = 0;
+    e.antispoofing_flag = 0;
+    auto dopplerL1 = e.predicted_doppler(591000., 0., 0., 0., 0., 0., 0., 1);
+    auto dopplerL3 = e.predicted_doppler(591000., 0., 0., 0., 0., 0., 0., 3);
+    e.satellitePosition(591000.);
+    EXPECT_NEAR(-0.468139, dopplerL1, 1e-4);
+    EXPECT_NEAR(-0.380402, dopplerL3, 1e-4);
+    EXPECT_NEAR(7282284.6601, e.satpos_X, 1e-4);
+    EXPECT_NEAR(41483008.42595, e.satpos_Y, 1e-4);
+    EXPECT_NEAR(-2157310.914266, e.satpos_Z, 1e-4);
+    EXPECT_NEAR(-2.581621, e.satvel_X, 1e-4);
+    EXPECT_NEAR(1.305572, e.satvel_Y, 1e-4);
+    EXPECT_NEAR(22.291453, e.satvel_Z, 1e-4);
+    double satvel_X = e.satvel_X;
+    double satvel_Y = e.satvel_Y;
+    double satvel_Z = e.satvel_Z;
+    e.satellitePosition(590999.995);
+    double satpos_X = e.satpos_X;
+    double satpos_Y = e.satpos_Y;
+    double satpos_Z = e.satpos_Z;
+    e.satellitePosition(591000.005);
+    double d_X = (e.satpos_X - satpos_X) * 100.;
+    double d_Y = (e.satpos_Y - satpos_Y) * 100.;
+    double d_Z = (e.satpos_Z - satpos_Z) * 100.;
+    EXPECT_NEAR(d_X, satvel_X, 1e-4);
+    EXPECT_NEAR(d_Y, satvel_Y, 1e-4);
+    EXPECT_NEAR(d_Z, satvel_Z, 1e-4);
+}
+
+
+TEST(GnssEphemerisPosVelTest, DNAV_IGSO)
+{
+    Beidou_Dnav_Ephemeris e{};
+    e.PRN = 8;
+    e.M_0 = -1.96010426198161447e+00;
+    e.delta_n = 6.03239413057185651e-10;
+    e.ecc = 4.62797412183135661e-03;
+    e.sqrtA = 6.49328671455383301e+03;
+    e.OMEGA_0 = -2.84366631754490673e-01;
+    e.i_0 = 9.55790891292791489e-01;
+    e.omega = -2.88036029820220163e+00;
+    e.OMEGAdot = -1.47756154636919916e-09;
+    e.idot = -3.91802034413104032e-10;
+    e.Cuc = 1.69612467288970947e-05;
+    e.Cus = 1.32843852043151855e-05;
+    e.Crc = -1.54000000000000000e+02;
+    e.Crs = 5.17625000000000000e+02;
+    e.Cic = -1.99768692255020142e-07;
+    e.Cis = -7.77654349803924561e-08;
+    e.toe = 590400;
+    e.toc = 590400;
+    e.af0 = -2.52385274507105296e-04;
+    e.af1 = -3.34754446384977200e-12;
+    e.af2 = 0.00000000000000000e+00;
+    e.WN = 1072;
+    e.tow = 591342;
+    e.satClkDrift = 0.00000000000000000e+00;
+    e.dtr = 0.00000000000000000e+00;
+    e.AODE = 1.00000000000000000e+00;
+    e.SV_accuracy = 0;
+    e.SV_health = 0;
+    e.AODC = 1.00000000000000000e+00;
+    e.TGD1 = 8.99999999999999994e-10;
+    e.TGD2 = 8.99999999999999994e-10;
+    e.sig_type = 1;
+    e.nav_type = 1;
+    e.AODO = 0;
+    e.fit_interval_flag = 0;
+    e.spare1 = 0.00000000000000000e+00;
+    e.spare2 = 0.00000000000000000e+00;
+    e.integrity_status_flag = 0;
+    e.alert_flag = 0;
+    e.antispoofing_flag = 0;
+    auto dopplerL1 = e.predicted_doppler(591000., 0., 100., 0., 0., 0., 0., 1);
+    auto dopplerL3 = e.predicted_doppler(591000., 0., 100., 0., 0., 0., 0., 3);
+    e.satellitePosition(591000.);
+    EXPECT_NEAR(-478.907311, dopplerL1, 1e-4);
+    EXPECT_NEAR(-389.151419, dopplerL3, 1e-4);
+    EXPECT_NEAR(-10494445.564195, e.satpos_X, 1e-4);
+    EXPECT_NEAR(22221395.784030, e.satpos_Y, 1e-4);
+    EXPECT_NEAR(34342997.780007, e.satpos_Z, 1e-4);
+    EXPECT_NEAR(-989.313135, e.satvel_X, 1e-4);
+    EXPECT_NEAR(-835.796243, e.satvel_Y, 1e-4);
+    EXPECT_NEAR(221.987047, e.satvel_Z, 1e-4);
+    double satvel_X = e.satvel_X;
+    double satvel_Y = e.satvel_Y;
+    double satvel_Z = e.satvel_Z;
+    e.satellitePosition(590999.995);
+    double satpos_X = e.satpos_X;
+    double satpos_Y = e.satpos_Y;
+    double satpos_Z = e.satpos_Z;
+    e.satellitePosition(591000.005);
     double d_X = (e.satpos_X - satpos_X) * 100.;
     double d_Y = (e.satpos_Y - satpos_Y) * 100.;
     double d_Z = (e.satpos_Z - satpos_Z) * 100.;


### PR DESCRIPTION
I've found, that satellite positions/velocities/doppler shifts reported by `Gnss_Ephemeris::satellitePosition`/`Gnss_Ephemeris::predicted_doppler` differ too much from positions/velocities/doppler shifts reported by `Gnss_Almanac::satellitePosVelComputation`/`Gnss_Almanac::predicted_doppler` for GEO satellites even after fixing almanac parameter scaling (removal of multiplication by PI).
This PR implements BeiDou GEO satellite position/velocity computation as suggested by the BeiDou ICD V3.0/2019
I'm not absolutely sure if velocity computation is mathematically correct, but analytical velocity versus finite differences tests are showing typical error less, than 0.1mm/s and worst case error less, than 0.5mm/s, that should be acceptable if predicted doppler will be used to improve assisted acquisition performance.
GEO/IGSO position/velocity/predicted doppler regression tests are included.