### PR TITLE
Fix broken GPS_L1_CA_PCPS_Acquisition_Fine_Doppler

### DIFF
--- a/src/algorithms/acquisition/adapters/pcps_acquisition_adapter_custom.cc
+++ b/src/algorithms/acquisition/adapters/pcps_acquisition_adapter_custom.cc
@@ -223,11 +223,6 @@ Acq_Conf get_acq_conf(
     acq_parameters.dump_filename = default_dump_filename;  // Set as default value
     acq_parameters.SetFromConfiguration(configuration, role, chip_rate, opt_freq);
 
-    if (implementation == "GPS_L1_CA_PCPS_Acquisition_Fine_Doppler")
-        {
-            acq_parameters.samples_per_ms = static_cast<float>(acq_parameters.vector_length);
-        }
-
 #if USE_GLOG_AND_GFLAGS
     if (FLAGS_doppler_max != 0)
         {
@@ -259,6 +254,11 @@ Acq_Conf get_acq_conf(
     acq_parameters.code_length = static_cast<unsigned int>(round(acq_parameters.fs_in / (chip_rate / code_length_chips)));
     acq_parameters.vector_length = acq_parameters.code_length * acq_parameters.num_codes;
     acq_parameters.threshold = threshold_compute->calculate_threshold(acq_parameters);
+
+    if (implementation == "GPS_L1_CA_PCPS_Acquisition_Fine_Doppler")
+        {
+            acq_parameters.samples_per_ms = static_cast<float>(acq_parameters.vector_length);
+        }
 
     return acq_parameters;
 }

--- a/src/algorithms/acquisition/gnuradio_blocks/pcps_acquisition_fine_doppler_cc.cc
+++ b/src/algorithms/acquisition/gnuradio_blocks/pcps_acquisition_fine_doppler_cc.cc
@@ -177,7 +177,7 @@ void pcps_acquisition_fine_doppler_cc::update_carrier_wipeoff()
     d_grid_doppler_wipeoffs = volk_gnsssdr::vector<volk_gnsssdr::vector<std::complex<float>>>(d_num_doppler_points, volk_gnsssdr::vector<std::complex<float>>(d_fft_size));
     for (int doppler_index = 0; doppler_index < d_num_doppler_points; doppler_index++)
         {
-            doppler_hz = d_acq_params.doppler_step * doppler_index - d_acq_params.doppler_step;
+            doppler_hz = d_acq_params.doppler_step * doppler_index - d_acq_params.doppler_max;
             // doppler search steps
             // compute the carrier doppler wipe-off signal and store it
             phase_step_rad = static_cast<float>(TWO_PI) * static_cast<float>(doppler_hz) / static_cast<float>(d_acq_params.fs_in);


### PR DESCRIPTION
Move `acq_parameters.samples_per_ms` assignment after `acq_parameters.vector_length` calculation to avoid crash during flowgraph construction.
Fix typo in `pcps_acquisition_fine_doppler_cc::update_carrier_wipeoff`: s/doppler_step/doppler_max/
This may fix https://github.com/gnss-sdr/gnss-sdr/issues/1062