### PR TITLE
acquisition: define OPENCL_BLOCKS on acquisition_adapters target

### DIFF
--- a/src/algorithms/acquisition/adapters/CMakeLists.txt
+++ b/src/algorithms/acquisition/adapters/CMakeLists.txt
@@ -77,6 +77,12 @@ if(ENABLE_FPGA)
     )
 endif()
 
+if(ENABLE_OPENCL)
+    target_compile_definitions(acquisition_adapters PRIVATE -DOPENCL_BLOCKS=1)
+else()
+    target_compile_definitions(acquisition_adapters PRIVATE -DOPENCL_BLOCKS=0)
+endif()
+
 target_include_directories(acquisition_adapters
     PUBLIC
         ${GNSSSDR_SOURCE_DIR}/src/core/interfaces


### PR DESCRIPTION
## Summary

`GPS_L1_CA_PCPS_OpenCl_Acquisition` segfaulted as soon as it was connected into a flowgraph. `PcpsAcquisitionAdapterCustom`'s constructor gates the code that builds the underlying `pcps_opencl_acquisition_cc` block behind `#if OPENCL_BLOCKS`, but that macro was only ever defined on the `core_receiver` target. The `acquisition_adapters` target, which actually contains `pcps_acquisition_adapter_custom.cc`, never received it, so in that translation unit `OPENCL_BLOCKS` was implicitly 0 and the branch that constructs the OpenCL block was compiled out entirely, leaving `acquisition_cc_` null for this implementation even though `implementation_` was still correctly set to `"GPS_L1_CA_PCPS_OpenCl_Acquisition"`.

`Instantiate()` never noticed, since it only holds the resulting object. `connect()` does: it passes the null `acquisition_cc_` to `gr::hier_block2::connect()` as a real block reference, which dereferences its nonexistent vtable and crashes. Confirmed with gdb (`print *this` inside `PcpsAcquisitionAdapterCustom::connect()` showed `acquisition_cc_` as an empty `shared_ptr`) after recompiling the two relevant translation units with `-g`.

Defines `OPENCL_BLOCKS` on `acquisition_adapters` too, mirroring the existing pattern already used on `core_receiver`.

Fixes: 8f29c4f88edaefdc9fd9e3456e59432d8454f3b7 ("Cleanup custom acquisition adapters")

## Test plan

- Rebuilt with `-DENABLE_OPENCL=ON`.
- `run_tests --gtest_filter='*OpenCl*'`: all 4 tests in `GpsL1CaPcpsOpenClAcquisitionGSoC2013Test` pass (previously segfaulted on `ConnectAndRun`).
- `run_tests --gtest_filter='*Acquisition*'`: all 64 tests across 17 suites pass, confirming no regression in the other acquisition implementations sharing `PcpsAcquisitionAdapterCustom`.