### PR TITLE
acquisition: fix stale include in OpenCL acquisition test

### DIFF
--- a/tests/unit-tests/signal-processing-blocks/acquisition/gps_l1_ca_pcps_opencl_acquisition_gsoc2013_test.cc
+++ b/tests/unit-tests/signal-processing-blocks/acquisition/gps_l1_ca_pcps_opencl_acquisition_gsoc2013_test.cc
@@ -26,8 +26,8 @@
 #include "gnss_block_interface.h"
 #include "gnss_sdr_valve.h"
 #include "gnss_synchro.h"
-#include "gps_l1_ca_pcps_opencl_acquisition.h"
 #include "in_memory_configuration.h"
+#include "pcps_opencl_acquisition_cc.h"
 #include "signal_generator.h"
 #include "signal_generator_c.h"
 #include <gnuradio/analog/sig_source_waveform.h>
@@ -498,7 +498,8 @@ TEST_F(GpsL1CaPcpsOpenClAcquisitionGSoC2013Test, ValidationOfResults)
         acquisition->connect(top_block);
     }) << "Failure connecting acquisition to the top_block.";
 
-    if (!acquisition->opencl_ready())
+    auto opencl_block = std::dynamic_pointer_cast<pcps_opencl_acquisition_cc>(acquisition->get_right_block());
+    if (!opencl_block || !opencl_block->opencl_ready())
         {
             std::cout << "OpenCL Platform is not ready.\n";
         }
@@ -572,7 +573,8 @@ TEST_F(GpsL1CaPcpsOpenClAcquisitionGSoC2013Test, ValidationOfResultsProbabilitie
         acquisition->connect(top_block);
     }) << "Failure connecting acquisition to the top_block.";
 
-    if (!acquisition->opencl_ready())
+    auto opencl_block = std::dynamic_pointer_cast<pcps_opencl_acquisition_cc>(acquisition->get_right_block());
+    if (!opencl_block || !opencl_block->opencl_ready())
         {
             std::cout << "OpenCL Platform is not ready.\n";
         }


### PR DESCRIPTION
## Summary

`gps_l1_ca_pcps_opencl_acquisition_gsoc2013_test.cc` still included `gps_l1_ca_pcps_opencl_acquisition.h`, which was deleted when the old per-variant custom acquisition adapters (OpenCL, QuickSync, Tong, CCCWSR, 8ms) were consolidated into the generic `PcpsAcquisitionAdapterCustom`. This broke any build combining `-DENABLE_UNIT_TESTING=ON` with `-DENABLE_OPENCL=ON`, even though the rest of the file already used the generic `AcquisitionInterface` / `block_factory::GetAcqBlock()` pattern, matching its already-working QuickSync/Tong siblings.

Drops the dead include. The test also called `acquisition->opencl_ready()`, a method that only ever existed on the concrete GNU Radio block (`pcps_opencl_acquisition_cc`), never on the generic `AcquisitionInterface` returned by the factory; reaches it instead via a `dynamic_pointer_cast` on `get_right_block()`, the same pattern already used elsewhere in this codebase to recover a concrete type from a generic block interface.

Fixes: 8f29c4f88edaefdc9fd9e3456e59432d8454f3b7 ("Cleanup custom acquisition adapters")

## Test plan

- Rebuilt with `-DENABLE_UNIT_TESTING=ON -DENABLE_OPENCL=ON`: compiles cleanly (previously a fatal `#include` error).
- `run_tests --gtest_filter='*OpenCl*'` runs (see the companion fix in #1068 for the runtime crash this then exposed).