### PR TITLE
Fix tracking-dump I/Q swap and Python plot channel/signal mislabeling

### DIFF
--- a/src/algorithms/tracking/gnuradio_blocks/dll_pll_veml_tracking.cc
+++ b/src/algorithms/tracking/gnuradio_blocks/dll_pll_veml_tracking.cc
@@ -1809,8 +1809,11 @@ void dll_pll_veml_tracking::log_data()
             uint64_t tmp_long_int;
             if (d_trk_parameters.track_pilot)
                 {
-                    prompt_I = d_Prompt_Data.data()->real();
-                    prompt_Q = d_Prompt_Data.data()->imag();
+                    // Same I/Q interchange as assign_correlators_to_synchro(): for signals whose
+                    // data and pilot components are true RF quadrature (e.g. Galileo E5a/E5b,
+                    // GPS L5), d_interchange_iq is true and the data bits are on the imaginary
+                    // axis of d_Prompt_Data, not the real one.
+                    map_correlator_to_iq(*d_Prompt_Data.data(), prompt_I, prompt_Q);
                 }
             else
                 {

--- a/utils/python/dll_pll_veml_plot_sample.py
+++ b/utils/python/dll_pll_veml_plot_sample.py
@@ -184,13 +184,28 @@ def apply_conf_defaults(args):
     if args.file_prefix is None:
         args.file_prefix = DEFAULT_FILE_PREFIX
 
-    manual_signal = args.signal_type or (
+    manual_signal_fallback = args.signal_type or (
         signals[0].signal if signals else DEFAULT_SIGNAL_TYPE
     )
+
+    def signal_for_channel(channel):
+        # An explicit --first-channel/--channels range overrides the conf's
+        # auto-derived range, but the channel-to-signal mapping should still
+        # come from the conf when possible: signals[0] (first enabled signal
+        # in SIGNAL_ORDER) is not necessarily the signal actually occupying
+        # this channel index once the range has been overridden manually.
+        if args.signal_type is not None:
+            return args.signal_type
+        if conf is not None:
+            for signal in conf.signals:
+                if channel in signal.channels:
+                    return signal.signal
+        return manual_signal_fallback
+
     args.channel_plan = [
         ChannelDump(
             channel=channel,
-            signal=manual_signal,
+            signal=signal_for_channel(channel),
             file_prefix=args.file_prefix,
         )
         for channel in range(args.first_channel, args.first_channel + args.channels)

--- a/utils/python/lib/gnss_sdr_conf.py
+++ b/utils/python/lib/gnss_sdr_conf.py
@@ -20,9 +20,10 @@ from pathlib import Path
 from typing import Optional
 
 
-# Keep this order in sync with src/core/receiver/gnss_block_factory.cc. GNSS-SDR
-# assigns absolute channel IDs by walking the configured signal counts in this
-# order.
+# Keep this order in sync with signal_mapping in
+# src/core/receiver/gnss_block_factory.cc. GNSS-SDR assigns absolute channel
+# IDs by walking the configured signal counts in this order (it does not use
+# the per-channel Channel<N>.signal lines in the conf file for this).
 SIGNAL_ORDER = (
     "1C",
     "2S",
@@ -33,10 +34,12 @@ SIGNAL_ORDER = (
     "1G",
     "2G",
     "B1",
+    "1D",
     "B3",
     "7X",
     "J1",
     "J5",
+    "S1",
 )
 
 @dataclass(frozen=True)
@@ -66,9 +69,11 @@ SIGNAL_TYPES = {
     "1G": SignalType("R", 511, "GLONASS L1 C/A"),
     "2G": SignalType("R", 511, "GLONASS L2 C/A"),
     "B1": SignalType("C", 2046, "BeiDou B1I"),
+    "1D": SignalType("C", 10230, "BeiDou B1C"),
     "B3": SignalType("C", 10230, "BeiDou B3I"),
     "J1": SignalType("J", 1023, "QZSS L1 C/A"),
     "J5": SignalType("J", 10230, "QZSS L5"),
+    "S1": SignalType("S", 1023, "SBAS L1"),
 }
 
 N_CHIPS = {


### PR DESCRIPTION
## Summary
Three small, independent fixes found while validating a dual-band (Galileo E1+E5a) tracking-dump plotting workflow:

- **C++**: `dll_pll_veml_tracking::log_data()` read the data-arm Prompt correlator's real/imaginary components directly instead of going through `map_correlator_to_iq()`, unlike `assign_correlators_to_synchro()` which already does this correctly. For pilot-tracked signals whose data and pilot components are true RF quadrature (Galileo E5a/E5b, GPS L5), `d_interchange_iq` is `true` and the data bits are on the imaginary axis of `d_Prompt_Data`, not the real one. This only affects the `.dat`/`.mat` tracking dump used by the plotting utilities — receiver operation (telemetry decoding, PVT) is unaffected since it uses the already-correct `assign_correlators_to_synchro()` path.
- **Python**: `utils/python/lib/gnss_sdr_conf.py`'s `SIGNAL_ORDER` (meant to mirror `signal_mapping` in `gnss_block_factory.cc`, used to infer channel-ID ranges per signal type) was missing `"1D"` (BeiDou B1C) and `"S1"` (SBAS L1).
- **Python**: `utils/python/dll_pll_veml_plot_sample.py`'s `apply_conf_defaults()` mislabeled every plot with the conf's first enabled signal type whenever `--first-channel`/`--channels` was passed explicitly to override the conf-derived range, regardless of which channels were actually requested (even though the correct `.dat` files were read, since `--file-prefix` is normally also given explicitly in that case).

## Test plan
- [x] `dll_pll_veml_tracking.cc` change builds cleanly against `next` (both GCC and Clang 20 toolchains)
- [x] `clang-format` (v22.1.8, matching CI) reports no changes needed
- [x] `clang-tidy-20` reports zero warnings for the touched lines (line-filtered to the diff)
- [x] Both Python files pass `ast.parse` / import cleanly; `SIGNAL_ORDER`/`SIGNAL_TYPES` consistency re-verified (15/15 entries)
- [x] Verified the channel-range label fix against multiple confs/ranges, including a range straddling two signal types, confirming per-channel (not per-run) resolution

🤖 Generated with [Claude Code](https://claude.com/claude-code)