### PR TITLE
Fix Course Over Ground never being estimated

### DIFF
--- a/src/algorithms/PVT/libs/rtklib_solver.cc
+++ b/src/algorithms/PVT/libs/rtklib_solver.cc
@@ -1435,12 +1435,12 @@ bool Rtklib_Solver::get_PVT(const std::map<int, Gnss_Synchro> &gnss_observables_
                     this->set_rx_pos({rx_position_and_time[0], rx_position_and_time[1], rx_position_and_time[2]});  // save ECEF position for the next iteration
 
                     // compute Ground speed and COG
-                    double ground_speed_ms = 0.0;
                     std::array<double, 3> pos{};
                     std::array<double, 3> enuv{};
                     ecef2pos(pvt_sol.rr, pos.data());
                     ecef2enu(pos.data(), &pvt_sol.rr[3], enuv.data());
-                    this->set_speed_over_ground(norm_rtk(enuv.data(), 2));
+                    const double ground_speed_ms = norm_rtk(enuv.data(), 2);
+                    this->set_speed_over_ground(ground_speed_ms);
                     double new_cog = -9999.0;  // COG not estimated due to insufficient velocity
                     if (ground_speed_ms >= 1.0)
                         {


### PR DESCRIPTION
## Summary
- `ground_speed_ms` in `Rtklib_Solver::get_PVT()` was declared and left at its `0.0` initializer instead of being assigned the computed ENU ground speed (`norm_rtk(enuv.data(), 2)`), which only ever reached `set_speed_over_ground()`.
- The `ground_speed_ms >= 1.0` gate that decides whether to compute Course Over Ground was therefore always false, so `cog` stayed permanently at its `-9999.0` "not estimated" sentinel regardless of actual receiver speed.
- Fix: assign the computed speed to `ground_speed_ms` before the threshold check, and reuse it for `set_speed_over_ground()`.

## Test plan
- [x] Rebuilt `pvt_libs` and the `gnss-sdr` executable cleanly with this change.
- [x] Verified `clang-format-19` (CI's pinned version) makes no changes to the touched file.