### PR TITLE
Narrow acquisition Doppler search when dual-frequency-assisted

### DIFF
--- a/conf/File_input/MultiCons/gnss-sdr_ntlab.conf
+++ b/conf/File_input/MultiCons/gnss-sdr_ntlab.conf
@@ -15,6 +15,11 @@ GNSS-SDR.telecommand_enabled=true
 GNSS-SDR.telecommand_tcp_port=3333
 GNSS-SDR.osnma_enable=false
 
+; Once a satellite's primary frequency (here, Galileo E1B) is tracked, project its
+; Doppler onto the secondary frequency (E5a) and pass it to that channel's
+; acquisition as an already-known estimate, instead of acquiring E5a cold.
+; GNSS-SDR.assist_dual_frequency_acq=true
+
 
 ;######### SUPL RRLP GPS assistance configuration #####
 ; Check https://www.mcc-mnc.com/
@@ -233,6 +238,10 @@ Acquisition_5X.threshold=2
 Acquisition_5X.doppler_max=5000
 Acquisition_5X.doppler_step=125
 Acquisition_5X.dump=false
+; Only takes effect together with GNSS-SDR.assist_dual_frequency_acq above: collapses
+; this (secondary-frequency) acquisition's Doppler search to the E1B-projected bin
+; instead of the full +-5000 Hz grid.
+; Acquisition_5X.enable_doppler_narrowing=true
 ;# Beidou B1
 Acquisition_B1.implementation=BEIDOU_B1I_PCPS_Acquisition
 Acquisition_B1.item_type=gr_complex

--- a/src/algorithms/acquisition/adapters/pcps_acquisition_adapter.cc
+++ b/src/algorithms/acquisition/adapters/pcps_acquisition_adapter.cc
@@ -303,6 +303,12 @@ void PcpsAcquisitionAdapter::set_doppler_center(int doppler_center)
 }
 
 
+void PcpsAcquisitionAdapter::set_doppler_uncertanty(unsigned int doppler_uncertanty)
+{
+    acquisition_->set_doppler_uncertanty(doppler_uncertanty);
+}
+
+
 void PcpsAcquisitionAdapter::set_gnss_synchro(Gnss_Synchro* gnss_synchro)
 {
     gnss_synchro_ = gnss_synchro;

--- a/src/algorithms/acquisition/adapters/pcps_acquisition_adapter.cc
+++ b/src/algorithms/acquisition/adapters/pcps_acquisition_adapter.cc
@@ -303,9 +303,9 @@ void PcpsAcquisitionAdapter::set_doppler_center(int doppler_center)
 }
 
 
-void PcpsAcquisitionAdapter::set_doppler_uncertanty(unsigned int doppler_uncertanty)
+void PcpsAcquisitionAdapter::set_doppler_uncertainty(unsigned int doppler_uncertainty)
 {
-    acquisition_->set_doppler_uncertanty(doppler_uncertanty);
+    acquisition_->set_doppler_uncertainty(doppler_uncertainty);
 }
 
 

--- a/src/algorithms/acquisition/adapters/pcps_acquisition_adapter.h
+++ b/src/algorithms/acquisition/adapters/pcps_acquisition_adapter.h
@@ -105,7 +105,7 @@ public:
     /*!
      * \brief Set Doppler uncertainty for the grid search
      */
-    void set_doppler_uncertanty(unsigned int doppler_uncertanty) override;
+    void set_doppler_uncertainty(unsigned int doppler_uncertainty) override;
 
     /*!
      * \brief Returns the maximum peak of grid search

--- a/src/algorithms/acquisition/adapters/pcps_acquisition_adapter.h
+++ b/src/algorithms/acquisition/adapters/pcps_acquisition_adapter.h
@@ -103,6 +103,11 @@ public:
     void set_doppler_center(int doppler_center) override;
 
     /*!
+     * \brief Set Doppler uncertainty for the grid search
+     */
+    void set_doppler_uncertanty(unsigned int doppler_uncertanty) override;
+
+    /*!
      * \brief Returns the maximum peak of grid search
      */
     signed int mag() override;

--- a/src/algorithms/acquisition/gnuradio_blocks/pcps_acquisition.cc
+++ b/src/algorithms/acquisition/gnuradio_blocks/pcps_acquisition.cc
@@ -134,6 +134,7 @@ pcps_acquisition::pcps_acquisition(const Acq_Conf& conf_)
       d_num_doppler_bins_step2(conf_.num_doppler_bins_step2),
       d_dump_channel(conf_.dump_channel),
       d_threshold(conf_.pfa > 0.0 ? compute_threshold(conf_.pfa, d_effective_fft_size, d_num_doppler_bins, conf_.bit_transition_flag ? 1 : conf_.max_dwells) : conf_.threshold),
+      d_threshold_narrowed(conf_.pfa > 0.0 ? compute_threshold(conf_.pfa, d_effective_fft_size, 1U, conf_.bit_transition_flag ? 1 : conf_.max_dwells) : conf_.threshold),
       d_threshold_step_two(conf_.pfa2 > 0.0 ? compute_threshold(conf_.pfa2, d_effective_fft_size, d_num_doppler_bins_step2, conf_.bit_transition_flag ? 1 : conf_.max_dwells) : conf_.threshold),
       d_cshort(conf_.it_size != sizeof(gr_complex)),
       d_use_CFAR_algorithm_flag(conf_.use_CFAR_algorithm_flag),
@@ -144,6 +145,7 @@ pcps_acquisition::pcps_acquisition(const Acq_Conf& conf_)
       d_doppler_center(0),
       d_doppler_bias(0),
       d_num_doppler_bins_active(d_num_doppler_bins),
+      d_doppler_search_narrowed(false),
       d_buffer_count(0),
       d_channel(0),
       d_resampler_latency_samples(conf_.resampler_latency_samples),
@@ -302,7 +304,7 @@ void pcps_acquisition::update_local_carrier(own::span<gr_complex> carrier_vector
 
 void pcps_acquisition::update_grid_doppler_wipeoffs()
 {
-    if (d_num_doppler_bins_active < d_num_doppler_bins)
+    if (d_doppler_search_narrowed)
         {
             // Assisted acquisition: the Doppler is exactly known from an already-tracked
             // primary frequency. Search just that bin, plus one reference bin offset by
@@ -410,11 +412,24 @@ void pcps_acquisition::dump_results(const AcquisitionResult& result)
     else
         {
             std::array<size_t, 2> dims_1d{1, 1};
-            std::array<size_t, 2> dims_2d{d_effective_fft_size, d_num_doppler_bins};
+            std::array<size_t, 2> dims_2d{d_effective_fft_size, d_num_doppler_bins_active};
+
+            // In narrowed mode, acq_grid is only d_num_doppler_bins_active (2) columns
+            // wide -- column 0 is the known/aided Doppler, column 1 the noise-reference
+            // bin at +doppler_max from it. doppler_max/doppler_step are given the same
+            // {0, d_doppler_max} encoding compute_statistics() uses internally, so
+            // doppler(col) = -doppler_max + doppler_center + doppler_step*col still
+            // decodes both columns correctly; doppler_narrowed flags which encoding is
+            // in effect for offline post-processing.
+            const bool dump_narrowed = d_doppler_search_narrowed;
+            const int32_t dump_doppler_max = dump_narrowed ? 0 : static_cast<int32_t>(d_doppler_max);
+            const int32_t dump_doppler_step = dump_narrowed ? static_cast<int32_t>(d_doppler_max) : static_cast<int32_t>(d_doppler_step);
 
             write_matlab_var<2>("acq_grid", d_grid.memptr(), matfp, dims_2d);
-            write_matlab_var<1>("doppler_max", static_cast<int32_t>(d_doppler_max), matfp, dims_1d);
-            write_matlab_var<1>("doppler_step", static_cast<int32_t>(d_doppler_step), matfp, dims_1d);
+            write_matlab_var<1>("doppler_max", dump_doppler_max, matfp, dims_1d);
+            write_matlab_var<1>("doppler_step", dump_doppler_step, matfp, dims_1d);
+            write_matlab_var<1>("doppler_center", d_doppler_center, matfp, dims_1d);
+            write_matlab_var<1>("doppler_narrowed", static_cast<int32_t>(dump_narrowed ? 1 : 0), matfp, dims_1d);
             write_matlab_var<1>("positive_acq", static_cast<int32_t>(result.positive_acq ? 1 : 0), matfp, dims_1d);
             write_matlab_var<1>("acq_doppler_hz", static_cast<float>(d_gnss_synchro->Acq_doppler_hz), matfp, dims_1d);
             write_matlab_var<1>("acq_delay_samples", static_cast<float>(d_gnss_synchro->Acq_delay_samples), matfp, dims_1d);
@@ -442,9 +457,13 @@ void pcps_acquisition::dump_results(const AcquisitionResult& result)
 
 void pcps_acquisition::ensure_dump_grid_allocated()
 {
-    if ((d_grid.n_rows != d_effective_fft_size) || (d_grid.n_cols != d_num_doppler_bins))
+    // Sized to the currently *active* bin count (2 when narrowed), not the full
+    // configured d_num_doppler_bins -- matches what copy_magnitude_grid_to_dump_grid()
+    // actually writes each cycle, and this size check doubles as the resize trigger
+    // whenever narrowed/full mode changes between dumps (either direction).
+    if ((d_grid.n_rows != d_effective_fft_size) || (d_grid.n_cols != d_num_doppler_bins_active))
         {
-            d_grid.zeros(d_effective_fft_size, d_num_doppler_bins);
+            d_grid.zeros(d_effective_fft_size, d_num_doppler_bins_active);
         }
 
     if (d_acq_parameters.make_2_steps &&
@@ -500,15 +519,17 @@ const float* pcps_acquisition::magnitude_grid_data(uint32_t doppler_index) const
 }
 
 
-pcps_acquisition::AcquisitionResult pcps_acquisition::max_to_input_power_statistic(uint32_t num_doppler_bins, int32_t doppler_max, int32_t doppler_step)
+pcps_acquisition::AcquisitionResult pcps_acquisition::max_to_input_power_statistic(uint32_t num_doppler_bins, uint32_t candidate_count, int32_t doppler_max, int32_t doppler_step)
 {
     AcquisitionResult result;
     float grid_maximum = 0.0;
     uint32_t index_doppler = 0U;
     uint32_t tmp_intex_t = 0U;
 
-    // Find the correlation peak and the carrier frequency
-    for (uint32_t i = 0; i < num_doppler_bins; i++)
+    // Find the correlation peak and the carrier frequency -- only among the
+    // candidate rows (excludes any trailing noise-reference-only rows, e.g. the
+    // narrowed-mode reference bin, from ever being selected as the result).
+    for (uint32_t i = 0; i < candidate_count; i++)
         {
             const auto* magnitude_grid = magnitude_grid_data(i);
             volk_gnsssdr_32f_index_max_32u(&tmp_intex_t, magnitude_grid, d_effective_fft_size);
@@ -545,7 +566,7 @@ pcps_acquisition::AcquisitionResult pcps_acquisition::max_to_input_power_statist
 }
 
 
-pcps_acquisition::AcquisitionResult pcps_acquisition::first_vs_second_peak_statistic(uint32_t num_doppler_bins, int32_t doppler_max, int32_t doppler_step)
+pcps_acquisition::AcquisitionResult pcps_acquisition::first_vs_second_peak_statistic(uint32_t candidate_count, int32_t doppler_max, int32_t doppler_step)
 {
     // Look for correlation peaks in the results
     // Find the highest peak and compare it to the second highest peak
@@ -556,8 +577,10 @@ pcps_acquisition::AcquisitionResult pcps_acquisition::first_vs_second_peak_stati
     uint32_t index_doppler = 0U;
     uint32_t tmp_intex_t = 0U;
 
-    // Find the correlation peak and the carrier frequency
-    for (uint32_t i = 0; i < num_doppler_bins; i++)
+    // Find the correlation peak and the carrier frequency -- only among the
+    // candidate rows (excludes any trailing noise-reference-only rows, e.g. the
+    // narrowed-mode reference bin, from ever being selected as the result).
+    for (uint32_t i = 0; i < candidate_count; i++)
         {
             const auto* magnitude_grid = magnitude_grid_data(i);
             volk_gnsssdr_32f_index_max_32u(&tmp_intex_t, magnitude_grid, d_effective_fft_size);
@@ -664,20 +687,24 @@ pcps_acquisition::AcquisitionResult pcps_acquisition::compute_statistics()
     // doppler_step=d_doppler_max makes the generic "-doppler_max + center +
     // doppler_step * index" decoding below map those two bins back to the right
     // Doppler values, same formula as the full grid search uses.
-    const bool assisted = (!d_step_two) && (d_num_doppler_bins_active < d_num_doppler_bins);
+    const bool assisted = (!d_step_two) && d_doppler_search_narrowed;
     const auto doppler_step = d_step_two ? d_acq_parameters.doppler_step2 : (assisted ? static_cast<int32_t>(d_doppler_max) : d_doppler_step);
     const auto doppler_max = d_step_two ? static_cast<int32_t>(d_doppler_center_step_two - (static_cast<float>(bin_count) / 2.0) * doppler_step) : (assisted ? 0 : static_cast<int32_t>(d_doppler_max));
+    // In assisted mode, bin_count computed rows exist (known bin + noise reference)
+    // but only bin 0 is a real Doppler candidate -- the reference bin must never be
+    // selected as the acquisition result (see the two statistic functions).
+    const auto candidate_count = assisted ? 1U : bin_count;
 
     // The reference/"opposite" bin used by max_to_input_power_statistic as a
     // noise-only estimate works the same way whether the grid has the full
     // configured bin count or just the 2 bins built above for assisted mode.
     if (d_use_CFAR_algorithm_flag)
         {
-            return max_to_input_power_statistic(bin_count, doppler_max, doppler_step);
+            return max_to_input_power_statistic(bin_count, candidate_count, doppler_max, doppler_step);
         }
     else
         {
-            return first_vs_second_peak_statistic(bin_count, doppler_max, doppler_step);
+            return first_vs_second_peak_statistic(candidate_count, doppler_max, doppler_step);
         }
 }
 
@@ -846,7 +873,11 @@ void pcps_acquisition::acquisition_core(uint64_t sample_count)
 
 float pcps_acquisition::get_threshold() const
 {
-    return d_step_two ? d_threshold_step_two : d_threshold;
+    if (d_step_two)
+        {
+            return d_threshold_step_two;
+        }
+    return d_doppler_search_narrowed ? d_threshold_narrowed : d_threshold;
 }
 
 
@@ -862,15 +893,20 @@ void pcps_acquisition::set_doppler_center(int32_t doppler_center)
 }
 
 
-void pcps_acquisition::set_doppler_uncertanty(uint32_t doppler_uncertanty)
+void pcps_acquisition::set_doppler_uncertainty(uint32_t doppler_uncertainty)
 {
     gr::thread::scoped_lock lock(d_setlock);  // require mutex with work function called by the scheduler
-    const uint32_t num_doppler_bins_active = (doppler_uncertanty == 0 && d_acq_parameters.enable_doppler_narrowing) ? 2U : d_num_doppler_bins;
-    if (num_doppler_bins_active != d_num_doppler_bins_active)
+    // d_num_doppler_bins > 1 guard: a single-bin full grid is already as narrow as
+    // it can be, and forcing 2 active bins in that case would write past the
+    // bin-count-sized grid allocations (see d_doppler_search_narrowed's doc comment).
+    const bool narrow = (doppler_uncertainty == 0) && d_acq_parameters.enable_doppler_narrowing && (d_num_doppler_bins > 1);
+    const uint32_t num_doppler_bins_active = narrow ? 2U : d_num_doppler_bins;
+    if (narrow != d_doppler_search_narrowed || num_doppler_bins_active != d_num_doppler_bins_active)
         {
+            d_doppler_search_narrowed = narrow;
             d_num_doppler_bins_active = num_doppler_bins_active;
             update_grid_doppler_wipeoffs();
-            DLOG(INFO) << " Doppler uncertanty for Channel: " << d_channel << " => active Doppler bins: " << d_num_doppler_bins_active << ", Doppler center: " << d_doppler_center;
+            DLOG(INFO) << " Doppler uncertainty for Channel: " << d_channel << " => active Doppler bins: " << d_num_doppler_bins_active << ", Doppler center: " << d_doppler_center;
         }
 }
 

--- a/src/algorithms/acquisition/gnuradio_blocks/pcps_acquisition.cc
+++ b/src/algorithms/acquisition/gnuradio_blocks/pcps_acquisition.cc
@@ -143,6 +143,7 @@ pcps_acquisition::pcps_acquisition(const Acq_Conf& conf_)
       d_state(0),
       d_doppler_center(0),
       d_doppler_bias(0),
+      d_num_doppler_bins_active(d_num_doppler_bins),
       d_buffer_count(0),
       d_channel(0),
       d_resampler_latency_samples(conf_.resampler_latency_samples),
@@ -301,7 +302,18 @@ void pcps_acquisition::update_local_carrier(own::span<gr_complex> carrier_vector
 
 void pcps_acquisition::update_grid_doppler_wipeoffs()
 {
-    for (uint32_t doppler_index = 0; doppler_index < d_num_doppler_bins; doppler_index++)
+    if (d_num_doppler_bins_active < d_num_doppler_bins)
+        {
+            // Assisted acquisition: the Doppler is exactly known from an already-tracked
+            // primary frequency. Search just that bin, plus one reference bin offset by
+            // the full configured Doppler half-width -- the same separation the full grid
+            // search uses for its "opposite" bin -- so max_to_input_power_statistic can
+            // keep using it as a noise-only reference without any change to its logic.
+            update_local_carrier(own::span<gr_complex>(doppler_wipeoff_data(0), d_fft_size), static_cast<float>(d_doppler_bias + d_doppler_center));
+            update_local_carrier(own::span<gr_complex>(doppler_wipeoff_data(1), d_fft_size), static_cast<float>(d_doppler_bias + d_doppler_center + static_cast<int32_t>(d_doppler_max)));
+            return;
+        }
+    for (uint32_t doppler_index = 0; doppler_index < d_num_doppler_bins_active; doppler_index++)
         {
             const int32_t doppler = -static_cast<int32_t>(d_doppler_max) + d_doppler_center + d_doppler_step * doppler_index;
             update_local_carrier(own::span<gr_complex>(doppler_wipeoff_data(doppler_index), d_fft_size), static_cast<float>(d_doppler_bias + doppler));
@@ -447,7 +459,7 @@ void pcps_acquisition::copy_magnitude_grid_to_dump_grid()
 {
     ensure_dump_grid_allocated();
 
-    const auto bin_count = d_step_two ? d_num_doppler_bins_step2 : d_num_doppler_bins;
+    const auto bin_count = d_step_two ? d_num_doppler_bins_step2 : d_num_doppler_bins_active;
     auto& grid = d_step_two ? d_narrow_grid : d_grid;
 
     for (uint32_t doppler_index = 0; doppler_index < bin_count; doppler_index++)
@@ -510,7 +522,7 @@ pcps_acquisition::AcquisitionResult pcps_acquisition::max_to_input_power_statist
 
     if (!d_step_two)
         {
-            const auto index_opp = (index_doppler + d_num_doppler_bins / 2) % d_num_doppler_bins;
+            const auto index_opp = (index_doppler + num_doppler_bins / 2) % num_doppler_bins;
             const auto* magnitude_grid = magnitude_grid_data(index_opp);
             d_input_power = static_cast<float>(std::accumulate(magnitude_grid, magnitude_grid + d_effective_fft_size, static_cast<float>(0.0)) / d_effective_fft_size / 2.0 / d_num_noncoherent_integrations_counter);
             result.doppler = -static_cast<int32_t>(doppler_max) + d_doppler_center + doppler_step * static_cast<int32_t>(index_doppler);
@@ -607,7 +619,7 @@ pcps_acquisition::AcquisitionResult pcps_acquisition::first_vs_second_peak_stati
 
 void pcps_acquisition::doppler_grid(const gr_complex* in)
 {
-    const auto bin_count = d_step_two ? d_num_doppler_bins_step2 : d_num_doppler_bins;
+    const auto bin_count = d_step_two ? d_num_doppler_bins_step2 : d_num_doppler_bins_active;
     const auto* grid_doppler_wipeoffs = d_step_two ? d_grid_doppler_wipeoffs_step_two.data() : d_grid_doppler_wipeoffs.data();
 
     for (uint32_t doppler_index = 0; doppler_index < bin_count; doppler_index++)
@@ -645,10 +657,20 @@ void pcps_acquisition::doppler_grid(const gr_complex* in)
 
 pcps_acquisition::AcquisitionResult pcps_acquisition::compute_statistics()
 {
-    const auto bin_count = d_step_two ? d_num_doppler_bins_step2 : d_num_doppler_bins;
-    const auto doppler_step = d_step_two ? d_acq_parameters.doppler_step2 : d_doppler_step;
-    const auto doppler_max = d_step_two ? static_cast<int32_t>(d_doppler_center_step_two - (static_cast<float>(bin_count) / 2.0) * doppler_step) : d_doppler_max;
+    const auto bin_count = d_step_two ? d_num_doppler_bins_step2 : d_num_doppler_bins_active;
+    // Assisted acquisition (Doppler exactly known from an already-tracked primary
+    // frequency): bin 0 is the known Doppler and bin 1 is the reference bin offset
+    // by d_doppler_max (see update_grid_doppler_wipeoffs()). Passing doppler_max=0,
+    // doppler_step=d_doppler_max makes the generic "-doppler_max + center +
+    // doppler_step * index" decoding below map those two bins back to the right
+    // Doppler values, same formula as the full grid search uses.
+    const bool assisted = (!d_step_two) && (d_num_doppler_bins_active < d_num_doppler_bins);
+    const auto doppler_step = d_step_two ? d_acq_parameters.doppler_step2 : (assisted ? static_cast<int32_t>(d_doppler_max) : d_doppler_step);
+    const auto doppler_max = d_step_two ? static_cast<int32_t>(d_doppler_center_step_two - (static_cast<float>(bin_count) / 2.0) * doppler_step) : (assisted ? 0 : static_cast<int32_t>(d_doppler_max));
 
+    // The reference/"opposite" bin used by max_to_input_power_statistic as a
+    // noise-only estimate works the same way whether the grid has the full
+    // configured bin count or just the 2 bins built above for assisted mode.
     if (d_use_CFAR_algorithm_flag)
         {
             return max_to_input_power_statistic(bin_count, doppler_max, doppler_step);
@@ -836,6 +858,19 @@ void pcps_acquisition::set_doppler_center(int32_t doppler_center)
             DLOG(INFO) << " Doppler assistance for Channel: " << d_channel << " => Doppler: " << doppler_center << "[Hz]";
             d_doppler_center = doppler_center;
             update_grid_doppler_wipeoffs();
+        }
+}
+
+
+void pcps_acquisition::set_doppler_uncertanty(uint32_t doppler_uncertanty)
+{
+    gr::thread::scoped_lock lock(d_setlock);  // require mutex with work function called by the scheduler
+    const uint32_t num_doppler_bins_active = (doppler_uncertanty == 0 && d_acq_parameters.enable_doppler_narrowing) ? 2U : d_num_doppler_bins;
+    if (num_doppler_bins_active != d_num_doppler_bins_active)
+        {
+            d_num_doppler_bins_active = num_doppler_bins_active;
+            update_grid_doppler_wipeoffs();
+            DLOG(INFO) << " Doppler uncertanty for Channel: " << d_channel << " => active Doppler bins: " << d_num_doppler_bins_active << ", Doppler center: " << d_doppler_center;
         }
 }
 

--- a/src/algorithms/acquisition/gnuradio_blocks/pcps_acquisition.h
+++ b/src/algorithms/acquisition/gnuradio_blocks/pcps_acquisition.h
@@ -153,6 +153,16 @@ public:
     void set_doppler_center(int32_t doppler_center);
 
     /*!
+     * \brief Set Doppler uncertainty for the grid search. It will refresh the Doppler grid.
+     * A doppler_uncertanty of 0 means the Doppler is exactly known (as when this
+     * acquisition is assisted by an already-tracked primary frequency): the search
+     * is restricted to a single Doppler bin centered on set_doppler_center(). Any
+     * other value restores the full configured Doppler search range.
+     * \param doppler_uncertanty - 0 to search a single bin, nonzero for the full range.
+     */
+    void set_doppler_uncertanty(uint32_t doppler_uncertanty);
+
+    /*!
      * \brief Parallel Code Phase Search Acquisition signal processing.
      */
     int general_work(int noutput_items, gr_vector_int& ninput_items,
@@ -225,6 +235,10 @@ private:
     int32_t d_state;
     int32_t d_doppler_center;
     int32_t d_doppler_bias;
+    // Number of step-1 Doppler bins actually searched: equals d_num_doppler_bins,
+    // or 2 (known bin + reference bin) when set_doppler_uncertanty(0) narrows the
+    // search and d_acq_parameters.enable_doppler_narrowing is true.
+    uint32_t d_num_doppler_bins_active;
     uint32_t d_buffer_count;
     uint32_t d_channel;
     uint32_t d_resampler_latency_samples;

--- a/src/algorithms/acquisition/gnuradio_blocks/pcps_acquisition.h
+++ b/src/algorithms/acquisition/gnuradio_blocks/pcps_acquisition.h
@@ -154,13 +154,13 @@ public:
 
     /*!
      * \brief Set Doppler uncertainty for the grid search. It will refresh the Doppler grid.
-     * A doppler_uncertanty of 0 means the Doppler is exactly known (as when this
+     * A doppler_uncertainty of 0 means the Doppler is exactly known (as when this
      * acquisition is assisted by an already-tracked primary frequency): the search
      * is restricted to a single Doppler bin centered on set_doppler_center(). Any
      * other value restores the full configured Doppler search range.
-     * \param doppler_uncertanty - 0 to search a single bin, nonzero for the full range.
+     * \param doppler_uncertainty - 0 to search a single bin, nonzero for the full range.
      */
-    void set_doppler_uncertanty(uint32_t doppler_uncertanty);
+    void set_doppler_uncertainty(uint32_t doppler_uncertainty);
 
     /*!
      * \brief Parallel Code Phase Search Acquisition signal processing.
@@ -204,8 +204,15 @@ private:
     const float* magnitude_grid_data(uint32_t doppler_index) const;
     bool is_fdma();
     float get_threshold() const;
-    AcquisitionResult first_vs_second_peak_statistic(uint32_t num_doppler_bins, int32_t doppler_max, int32_t doppler_step);
-    AcquisitionResult max_to_input_power_statistic(uint32_t num_doppler_bins, int32_t doppler_max, int32_t doppler_step);
+    // candidate_count: number of computed grid rows eligible to be selected as the
+    // acquisition result -- narrowed mode computes 2 rows (known bin + noise
+    // reference) but only bin 0 is a real candidate, so candidate_count is 1 there.
+    // max_to_input_power_statistic additionally takes num_doppler_bins (>=
+    // candidate_count), the full computed row count, for its CFAR "opposite bin"
+    // reference lookup -- first_vs_second_peak_statistic has no such reference
+    // concept, so it only needs candidate_count.
+    AcquisitionResult first_vs_second_peak_statistic(uint32_t candidate_count, int32_t doppler_max, int32_t doppler_step);
+    AcquisitionResult max_to_input_power_statistic(uint32_t num_doppler_bins, uint32_t candidate_count, int32_t doppler_max, int32_t doppler_step);
     void wait_if_active();
 
     const Acq_Conf d_acq_parameters;
@@ -222,6 +229,13 @@ private:
     const uint32_t d_num_doppler_bins_step2;
     const uint32_t d_dump_channel;
     const float d_threshold;
+    // Same PFA target as d_threshold, but calibrated for a single Doppler-bin's
+    // worth of code-phase hypotheses instead of the full grid's d_num_doppler_bins --
+    // reusing d_threshold in narrowed mode would under-detect, since compute_threshold()
+    // folds the candidate count into the false-alarm probability (e.g. a requested
+    // pfa=0.01 becomes far stricter than 0.01 once inflated by a ~80-bin full grid's
+    // worth of hypotheses that narrowed mode isn't actually searching).
+    const float d_threshold_narrowed;
     const float d_threshold_step_two;
     const bool d_cshort;
     const bool d_use_CFAR_algorithm_flag;
@@ -236,9 +250,18 @@ private:
     int32_t d_doppler_center;
     int32_t d_doppler_bias;
     // Number of step-1 Doppler bins actually searched: equals d_num_doppler_bins,
-    // or 2 (known bin + reference bin) when set_doppler_uncertanty(0) narrows the
-    // search and d_acq_parameters.enable_doppler_narrowing is true.
+    // or 2 (known bin + reference bin) when d_doppler_search_narrowed is true.
     uint32_t d_num_doppler_bins_active;
+    // Explicit narrowed-mode flag, set directly by set_doppler_uncertainty() --
+    // deliberately NOT inferred from "d_num_doppler_bins_active < d_num_doppler_bins",
+    // which breaks in two ways: (1) if d_num_doppler_bins == 1 (a valid full-grid
+    // config), forcing 2 active bins would write past the bin-count-sized grid
+    // allocations; (2) if d_num_doppler_bins == 2, an actually-narrowed request
+    // computes the same active count as the full grid, so the inferred comparison
+    // would silently miss it. set_doppler_uncertainty() only ever sets this true
+    // when d_num_doppler_bins > 1, so d_num_doppler_bins_active is always <=
+    // d_num_doppler_bins and existing allocations are never exceeded.
+    bool d_doppler_search_narrowed;
     uint32_t d_buffer_count;
     uint32_t d_channel;
     uint32_t d_resampler_latency_samples;

--- a/src/algorithms/acquisition/libs/acq_conf.cc
+++ b/src/algorithms/acquisition/libs/acq_conf.cc
@@ -82,6 +82,7 @@ void Acq_Conf::SetFromConfiguration(const ConfigurationInterface *configuration,
         }
     make_2_steps = configuration->property(role + ".make_two_steps", make_2_steps);
     blocking_on_standby = configuration->property(role + ".blocking_on_standby", blocking_on_standby);
+    enable_doppler_narrowing = configuration->property(role + ".enable_doppler_narrowing", enable_doppler_narrowing);
 
     if (pfa <= 0.0)
         {

--- a/src/algorithms/acquisition/libs/acq_conf.h
+++ b/src/algorithms/acquisition/libs/acq_conf.h
@@ -74,10 +74,22 @@ public:
     bool make_2_steps{false};
     bool use_automatic_resampler{false};
     bool enable_monitor_output{false};
-    // When Doppler is assisted (doppler_uncertanty == 0), collapse the search to
-    // the known bin + one reference bin instead of the full grid. Opt-in (new,
-    // still-experimental feature): off by default, enable per-implementation
-    // in the .conf (e.g. Acquisition_5X.enable_doppler_narrowing = true).
+    // When Doppler is assisted (doppler_uncertainty == 0), collapse the search to
+    // the known bin + one reference bin instead of the full grid. Off by default;
+    // enable per-implementation in the .conf (e.g.
+    // Acquisition_5X.enable_doppler_narrowing = true).
+    //
+    // Applies to any acquisition implementation built on pcps_acquisition (the vast
+    // majority of them); FPGA-offloaded acquisitions use a separate implementation
+    // that never calls set_doppler_uncertainty(), so this has no effect there.
+    //
+    // Only takes effect when the caller also passes doppler_uncertainty == 0 to
+    // set_doppler_uncertainty() -- in practice, this means
+    // GNSS-SDR.assist_dual_frequency_acq must also be enabled and a Doppler
+    // projection from the satellite's already-tracked primary frequency must have
+    // succeeded (see GNSSFlowgraph::acquisition_manager()). With
+    // assist_dual_frequency_acq off, or when no projection is available yet, this
+    // flag has no effect and the full configured Doppler grid is always searched.
     bool enable_doppler_narrowing{false};
 
     // Specific to some implementations

--- a/src/algorithms/acquisition/libs/acq_conf.h
+++ b/src/algorithms/acquisition/libs/acq_conf.h
@@ -74,6 +74,11 @@ public:
     bool make_2_steps{false};
     bool use_automatic_resampler{false};
     bool enable_monitor_output{false};
+    // When Doppler is assisted (doppler_uncertanty == 0), collapse the search to
+    // the known bin + one reference bin instead of the full grid. Opt-in (new,
+    // still-experimental feature): off by default, enable per-implementation
+    // in the .conf (e.g. Acquisition_5X.enable_doppler_narrowing = true).
+    bool enable_doppler_narrowing{false};
 
     // Specific to some implementations
     bool acquire_pilot{false};

--- a/src/algorithms/channel/adapters/channel.cc
+++ b/src/algorithms/channel/adapters/channel.cc
@@ -221,9 +221,10 @@ void Channel::stop_channel()
 }
 
 
-void Channel::assist_acquisition_doppler(double Carrier_Doppler_hz)
+void Channel::assist_acquisition_doppler(double Carrier_Doppler_hz, uint32_t doppler_uncertanty)
 {
     acq_->set_doppler_center(static_cast<int>(Carrier_Doppler_hz));
+    acq_->set_doppler_uncertanty(doppler_uncertanty);
 }
 
 

--- a/src/algorithms/channel/adapters/channel.cc
+++ b/src/algorithms/channel/adapters/channel.cc
@@ -221,10 +221,10 @@ void Channel::stop_channel()
 }
 
 
-void Channel::assist_acquisition_doppler(double Carrier_Doppler_hz, uint32_t doppler_uncertanty)
+void Channel::assist_acquisition_doppler(double Carrier_Doppler_hz, uint32_t doppler_uncertainty)
 {
     acq_->set_doppler_center(static_cast<int>(Carrier_Doppler_hz));
-    acq_->set_doppler_uncertanty(doppler_uncertanty);
+    acq_->set_doppler_uncertainty(doppler_uncertainty);
 }
 
 

--- a/src/algorithms/channel/adapters/channel.h
+++ b/src/algorithms/channel/adapters/channel.h
@@ -89,7 +89,7 @@ public:
     void stop_channel() override;                               //!< Stop the State Machine
     void set_signal(const Gnss_Signal& gnss_signal_) override;  //!< Sets the channel GNSS signal
 
-    void assist_acquisition_doppler(double Carrier_Doppler_hz, uint32_t doppler_uncertanty = 1) override;
+    void assist_acquisition_doppler(double Carrier_Doppler_hz, uint32_t doppler_uncertainty = 1) override;
 
     inline std::shared_ptr<AcquisitionInterface> acquisition() const { return acq_; }
     inline std::shared_ptr<TrackingInterface> tracking() const { return trk_; }

--- a/src/algorithms/channel/adapters/channel.h
+++ b/src/algorithms/channel/adapters/channel.h
@@ -89,7 +89,7 @@ public:
     void stop_channel() override;                               //!< Stop the State Machine
     void set_signal(const Gnss_Signal& gnss_signal_) override;  //!< Sets the channel GNSS signal
 
-    void assist_acquisition_doppler(double Carrier_Doppler_hz) override;
+    void assist_acquisition_doppler(double Carrier_Doppler_hz, uint32_t doppler_uncertanty = 1) override;
 
     inline std::shared_ptr<AcquisitionInterface> acquisition() const { return acq_; }
     inline std::shared_ptr<TrackingInterface> tracking() const { return trk_; }

--- a/src/core/interfaces/acquisition_interface.h
+++ b/src/core/interfaces/acquisition_interface.h
@@ -54,6 +54,11 @@ public:
     virtual void set_channel(unsigned int channel_id) = 0;
     virtual void set_channel_fsm(std::weak_ptr<ChannelFsm> channel_fsm) = 0;
     virtual void set_doppler_center(int /*doppler_center*/) {}
+    //! doppler_uncertanty == 0 restricts the Doppler search to a single bin
+    //! centered on set_doppler_center() (the Doppler is exactly known, as when
+    //! assisted by an already-tracked primary frequency); any other value
+    //! searches the full configured Doppler range.
+    virtual void set_doppler_uncertanty(unsigned int /*doppler_uncertanty*/) {}
     virtual void set_local_code() = 0;
     virtual signed int mag() = 0;
     virtual void reset() = 0;

--- a/src/core/interfaces/acquisition_interface.h
+++ b/src/core/interfaces/acquisition_interface.h
@@ -54,11 +54,11 @@ public:
     virtual void set_channel(unsigned int channel_id) = 0;
     virtual void set_channel_fsm(std::weak_ptr<ChannelFsm> channel_fsm) = 0;
     virtual void set_doppler_center(int /*doppler_center*/) {}
-    //! doppler_uncertanty == 0 restricts the Doppler search to a single bin
+    //! doppler_uncertainty == 0 restricts the Doppler search to a single bin
     //! centered on set_doppler_center() (the Doppler is exactly known, as when
     //! assisted by an already-tracked primary frequency); any other value
     //! searches the full configured Doppler range.
-    virtual void set_doppler_uncertanty(unsigned int /*doppler_uncertanty*/) {}
+    virtual void set_doppler_uncertainty(unsigned int /*doppler_uncertainty*/) {}
     virtual void set_local_code() = 0;
     virtual signed int mag() = 0;
     virtual void reset() = 0;

--- a/src/core/interfaces/channel_interface.h
+++ b/src/core/interfaces/channel_interface.h
@@ -52,7 +52,7 @@ public:
     virtual gr::basic_block_sptr get_right_block() = 0;
     virtual Gnss_Signal get_signal() = 0;
     virtual void start_acquisition() = 0;
-    virtual void assist_acquisition_doppler(double Carrier_Doppler_hz, uint32_t doppler_uncertanty = 1) = 0;
+    virtual void assist_acquisition_doppler(double Carrier_Doppler_hz, uint32_t doppler_uncertainty = 1) = 0;
     virtual void stop_channel() = 0;
     virtual void set_signal(const Gnss_Signal&) = 0;
 };

--- a/src/core/interfaces/channel_interface.h
+++ b/src/core/interfaces/channel_interface.h
@@ -25,6 +25,7 @@
 
 #include "gnss_block_interface.h"
 #include "gnss_signal.h"
+#include <cstdint>
 
 /** \addtogroup Core
  * \{ */
@@ -51,7 +52,7 @@ public:
     virtual gr::basic_block_sptr get_right_block() = 0;
     virtual Gnss_Signal get_signal() = 0;
     virtual void start_acquisition() = 0;
-    virtual void assist_acquisition_doppler(double Carrier_Doppler_hz) = 0;
+    virtual void assist_acquisition_doppler(double Carrier_Doppler_hz, uint32_t doppler_uncertanty = 1) = 0;
     virtual void stop_channel() = 0;
     virtual void set_signal(const Gnss_Signal&) = 0;
 };

--- a/src/core/receiver/gnss_flowgraph.cc
+++ b/src/core/receiver/gnss_flowgraph.cc
@@ -1781,12 +1781,14 @@ void GNSSFlowgraph::acquisition_manager(unsigned int who)
                                        << ", Signal " << channels_[current_channel]->get_signal().get_signal_str();
                             if (assistance_available == true && configuration_->property("GNSS-SDR.assist_dual_frequency_acq", multiband_))
                                 {
-                                    channels_[current_channel]->assist_acquisition_doppler(project_doppler(channels_[current_channel]->get_signal().get_signal_str(), estimated_doppler));
+                                    // Doppler is exactly known from the already-tracked primary
+                                    // frequency: restrict the search to a single Doppler bin.
+                                    channels_[current_channel]->assist_acquisition_doppler(project_doppler(channels_[current_channel]->get_signal().get_signal_str(), estimated_doppler), 0);
                                 }
                             else
                                 {
-                                    // set Doppler center to 0 Hz
-                                    channels_[current_channel]->assist_acquisition_doppler(0);
+                                    // set Doppler center to 0 Hz and search the full Doppler range
+                                    channels_[current_channel]->assist_acquisition_doppler(0, 1);
                                 }
 #if ENABLE_FPGA
                             if (enable_fpga_offloading_)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1254,6 +1254,7 @@ if(NOT ENABLE_PACKAGING AND NOT ENABLE_FPGA)
     set(ACQ_TEST_SOURCES
         ${CMAKE_CURRENT_SOURCE_DIR}/single_test_main.cc
         ${CMAKE_CURRENT_SOURCE_DIR}/unit-tests/signal-processing-blocks/acquisition/gps_l1_ca_pcps_acquisition_test.cc
+        ${CMAKE_CURRENT_SOURCE_DIR}/unit-tests/signal-processing-blocks/acquisition/pcps_acquisition_doppler_narrowing_test.cc
     )
     if(USE_CMAKE_TARGET_SOURCES)
         add_executable(acq_test)

--- a/tests/test_main.cc
+++ b/tests/test_main.cc
@@ -219,6 +219,7 @@ private:
 #include "unit-tests/signal-processing-blocks/acquisition/galileo_e1_pcps_ambiguous_acquisition_gsoc_test.cc"
 #include "unit-tests/signal-processing-blocks/acquisition/galileo_e1_pcps_ambiguous_acquisition_test.cc"
 #include "unit-tests/signal-processing-blocks/acquisition/gps_l1_ca_pcps_acquisition_test.cc"
+#include "unit-tests/signal-processing-blocks/acquisition/pcps_acquisition_doppler_narrowing_test.cc"
 #include "unit-tests/signal-processing-blocks/filter/fir_filter_test.cc"
 #include "unit-tests/signal-processing-blocks/filter/notch_filter_lite_test.cc"
 #include "unit-tests/signal-processing-blocks/filter/notch_filter_test.cc"

--- a/tests/unit-tests/signal-processing-blocks/acquisition/pcps_acquisition_doppler_narrowing_test.cc
+++ b/tests/unit-tests/signal-processing-blocks/acquisition/pcps_acquisition_doppler_narrowing_test.cc
@@ -1,0 +1,513 @@
+/*!
+ * \file pcps_acquisition_doppler_narrowing_test.cc
+ * \brief  Tests for Acq_Conf::enable_doppler_narrowing (assisted-acquisition
+ * Doppler search narrowing) in pcps_acquisition, using the same GPS L1 C/A
+ * signal/fixture pattern as gps_l1_ca_pcps_acquisition_test.cc.
+ *
+ * -----------------------------------------------------------------------------
+ *
+ * GNSS-SDR is a Global Navigation Satellite System software-defined receiver.
+ * This file is part of GNSS-SDR.
+ *
+ * Copyright (C) 2010-2026  (see AUTHORS file for a list of contributors)
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ *
+ * -----------------------------------------------------------------------------
+ */
+
+
+#include "GPS_L1_CA.h"
+#include "concurrent_queue.h"
+#include "gnss_block_interface.h"
+#include "gnss_sdr_filesystem.h"
+#include "gnss_synchro.h"
+#include "in_memory_configuration.h"
+#include "pcps_acquisition_adapter.h"
+#include <gnuradio/blocks/file_source.h>
+#include <gnuradio/top_block.h>
+#include <gtest/gtest.h>
+#include <matio.h>
+#include <pmt/pmt.h>
+#include <array>
+#include <chrono>
+#include <cmath>
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <utility>
+
+#if USE_GLOG_AND_GFLAGS
+#include <glog/logging.h>
+#else
+#include <absl/log/log.h>
+#endif
+
+#if HAS_GENERIC_LAMBDA
+#else
+#include <boost/bind/bind.hpp>
+#endif
+
+#if PMT_USES_BOOST_ANY
+namespace wht = boost;
+#else
+namespace wht = std;
+#endif
+
+// ######## GNURADIO BLOCK MESSAGE RECEIVER #########
+// Same pattern as GpsL1CaPcpsAcquisitionTest_msg_rx in
+// gps_l1_ca_pcps_acquisition_test.cc, duplicated (rather than shared) to keep
+// this file self-contained -- both classes are file-local test doubles, not
+// part of any public test-support surface.
+class PcpsAcquisitionDopplerNarrowingTest_msg_rx;
+
+using PcpsAcquisitionDopplerNarrowingTest_msg_rx_sptr = gnss_shared_ptr<PcpsAcquisitionDopplerNarrowingTest_msg_rx>;
+
+PcpsAcquisitionDopplerNarrowingTest_msg_rx_sptr PcpsAcquisitionDopplerNarrowingTest_msg_rx_make();
+
+class PcpsAcquisitionDopplerNarrowingTest_msg_rx : public gr::block
+{
+private:
+    friend PcpsAcquisitionDopplerNarrowingTest_msg_rx_sptr PcpsAcquisitionDopplerNarrowingTest_msg_rx_make();
+    void msg_handler_channel_events(const pmt::pmt_t &msg);
+    PcpsAcquisitionDopplerNarrowingTest_msg_rx();
+
+public:
+    int rx_message{0};
+};
+
+
+PcpsAcquisitionDopplerNarrowingTest_msg_rx_sptr PcpsAcquisitionDopplerNarrowingTest_msg_rx_make()
+{
+    return PcpsAcquisitionDopplerNarrowingTest_msg_rx_sptr(new PcpsAcquisitionDopplerNarrowingTest_msg_rx());
+}
+
+
+void PcpsAcquisitionDopplerNarrowingTest_msg_rx::msg_handler_channel_events(const pmt::pmt_t &msg)
+{
+    try
+        {
+            int64_t message = pmt::to_long(msg);
+            rx_message = message;
+        }
+    catch (const wht::bad_any_cast &e)
+        {
+            LOG(WARNING) << "msg_handler_channel_events Bad any_cast: " << e.what();
+            rx_message = 0;
+        }
+}
+
+
+PcpsAcquisitionDopplerNarrowingTest_msg_rx::PcpsAcquisitionDopplerNarrowingTest_msg_rx()
+    : gr::block("PcpsAcquisitionDopplerNarrowingTest_msg_rx", gr::io_signature::make(0, 0, 0), gr::io_signature::make(0, 0, 0))
+{
+    this->message_port_register_in(pmt::mp("events"));
+    this->set_msg_handler(pmt::mp("events"),
+#if HAS_GENERIC_LAMBDA
+        [this](auto &&PH1) { msg_handler_channel_events(std::forward<decltype(PH1)>(PH1)); });
+#else
+#if USE_BOOST_BIND_PLACEHOLDERS
+        boost::bind(&PcpsAcquisitionDopplerNarrowingTest_msg_rx::msg_handler_channel_events, this, boost::placeholders::_1));
+#else
+        boost::bind(&PcpsAcquisitionDopplerNarrowingTest_msg_rx::msg_handler_channel_events, this, _1));
+#endif
+#endif
+}
+
+
+// ###########################################################
+
+// Ground truth for signal_samples/GPS_L1_CA_ID_1_Fs_4Msps_2ms.dat, the same
+// capture gps_l1_ca_pcps_acquisition_test.cc's ValidationOfResults uses.
+constexpr double kTrueDopplerHz = 1680.0;
+constexpr double kTrueDelaySamples = 524.0;
+constexpr int kFsIn = 4000000;
+
+class PcpsAcquisitionDopplerNarrowingTest : public ::testing::Test
+{
+protected:
+    PcpsAcquisitionDopplerNarrowingTest()
+    {
+        config = std::make_shared<InMemoryConfiguration>();
+        gnss_synchro = Gnss_Synchro();
+    }
+
+    // doppler_max/doppler_step are chosen by each test to control how many
+    // full-grid Doppler bins pcps_acquisition computes
+    // (d_num_doppler_bins == ceil(2*doppler_max/doppler_step)), since that bin
+    // count is exactly what the reviewed bug depended on.
+    void init(unsigned int doppler_max, unsigned int doppler_step, bool enable_doppler_narrowing, bool use_cfar);
+
+    gr::top_block_sptr top_block;
+    std::shared_ptr<InMemoryConfiguration> config;
+    Gnss_Synchro gnss_synchro;
+};
+
+
+void PcpsAcquisitionDopplerNarrowingTest::init(unsigned int doppler_max, unsigned int doppler_step, bool enable_doppler_narrowing, bool use_cfar)
+{
+    gnss_synchro.Channel_ID = 0;
+    gnss_synchro.System = 'G';
+    std::string signal = "1C";
+    signal.copy(gnss_synchro.Signal, 2, 0);
+    gnss_synchro.PRN = 1;
+    config->set_property("GNSS-SDR.internal_fs_sps", std::to_string(kFsIn));
+    config->set_property("Acquisition_1C.implementation", "GPS_L1_CA_PCPS_Acquisition");
+    config->set_property("Acquisition_1C.item_type", "gr_complex");
+    config->set_property("Acquisition_1C.coherent_integration_time_ms", "1");
+    config->set_property("Acquisition_1C.dump", "false");
+    config->set_property("Acquisition_1C.doppler_max", std::to_string(doppler_max));
+    config->set_property("Acquisition_1C.doppler_step", std::to_string(doppler_step));
+    config->set_property("Acquisition_1C.repeat_satellite", "false");
+    config->set_property("Acquisition_1C.enable_doppler_narrowing", enable_doppler_narrowing ? "true" : "false");
+    if (use_cfar)
+        {
+            // pfa > 0 both switches Acq_Conf::use_CFAR_algorithm_flag to true and
+            // makes d_threshold/d_threshold_narrowed computed (not the fixed
+            // .threshold value) -- needed to exercise the PFA-recalibration fix.
+            // 0.001 is the same value used by several other acquisition tests in
+            // this suite (e.g. Galileo E1, GLONASS) against comparably strong
+            // captures.
+            config->set_property("Acquisition_1C.pfa", "0.001");
+        }
+    else
+        {
+            // pfa left at its 0.0 default -> Acq_Conf::use_CFAR_algorithm_flag is
+            // false (peak-ratio statistic) and the fixed .threshold below is used.
+            config->set_property("Acquisition_1C.threshold", "0.001");
+        }
+}
+
+
+namespace
+{
+// Runs one acquisition attempt against the known-truth capture and returns
+// the completed adapter + received message code, so each TEST_F only has to
+// state its own doppler_center/doppler_uncertainty/assertions.
+struct RunResult
+{
+    int rx_message;
+    double doppler_error_hz;
+    double delay_error_chips;
+};
+
+RunResult run_acquisition(gr::top_block_sptr &top_block, InMemoryConfiguration *config, Gnss_Synchro &gnss_synchro,
+    int doppler_center, unsigned int doppler_uncertainty)
+{
+    top_block = gr::make_top_block("Doppler narrowing acquisition test");
+    auto acquisition = std::make_shared<PcpsAcquisitionAdapter>(config, "Acquisition_1C", "GPS_L1_CA_PCPS_Acquisition", 1, 0, GPS_1C);
+    auto msg_rx = PcpsAcquisitionDopplerNarrowingTest_msg_rx_make();
+
+    acquisition->set_channel(1);
+    acquisition->set_gnss_synchro(&gnss_synchro);
+    acquisition->connect(top_block);
+
+    std::string path = std::string(TEST_PATH);
+    std::string file = path + "signal_samples/GPS_L1_CA_ID_1_Fs_4Msps_2ms.dat";
+    gr::blocks::file_source::sptr file_source = gr::blocks::file_source::make(sizeof(gr_complex), file.c_str(), false);
+    top_block->connect(file_source, 0, acquisition->get_left_block(), 0);
+    top_block->msg_connect(acquisition->get_right_block(), pmt::mp("events"), msg_rx, pmt::mp("events"));
+
+    acquisition->set_local_code();
+    // Simulates GNSSFlowgraph::acquisition_manager() calling
+    // assist_acquisition_doppler(): the caller decides both the center and
+    // whether it's exact (doppler_uncertainty == 0) or not (!= 0).
+    acquisition->set_doppler_center(doppler_center);
+    acquisition->set_doppler_uncertainty(doppler_uncertainty);
+    acquisition->reset();
+
+    top_block->run();
+
+    const double doppler_error_hz = std::abs(kTrueDopplerHz - gnss_synchro.Acq_doppler_hz);
+    const auto delay_error_samples = std::abs(kTrueDelaySamples - gnss_synchro.Acq_delay_samples);
+    const auto delay_error_chips = delay_error_samples * GPS_L1_CA_CODE_LENGTH_CHIPS / kFsIn * (GPS_L1_CA_CODE_RATE_CPS / GPS_L1_CA_CODE_LENGTH_CHIPS);
+
+    return {msg_rx->rx_message, doppler_error_hz, delay_error_chips};
+}
+}  // namespace
+
+
+TEST_F(PcpsAcquisitionDopplerNarrowingTest /*unused*/, NarrowingDisabled /*unused*/)
+{
+    // enable_doppler_narrowing = false: even though the caller passes
+    // doppler_uncertainty == 0 (as an assisted acquisition would), the full
+    // configured Doppler grid must still be searched.
+    init(/*doppler_max=*/5000, /*doppler_step=*/100, /*enable_doppler_narrowing=*/false, /*use_cfar=*/false);
+
+    const RunResult result = run_acquisition(top_block, config.get(), gnss_synchro, static_cast<int>(kTrueDopplerHz), 0);
+
+    ASSERT_EQ(1, result.rx_message) << "Acquisition failure with narrowing disabled.";
+    EXPECT_LE(result.doppler_error_hz, 666) << "Doppler error exceeds the expected value: 666 Hz = 2/(3*integration period)";
+    EXPECT_LT(result.delay_error_chips, 0.5) << "Delay error exceeds the expected value: 0.5 chips";
+}
+
+
+TEST_F(PcpsAcquisitionDopplerNarrowingTest /*unused*/, NarrowingEnabledOneBinGrid /*unused*/)
+{
+    // doppler_step >= 2*doppler_max -> d_num_doppler_bins == 1. Regression test
+    // for the P1 fix: narrowing must NOT force a second active bin into a
+    // 1-row grid allocation (that was an out-of-bounds write). With the
+    // d_num_doppler_bins > 1 guard, narrowing silently stays off here and the
+    // block just runs its (degenerate, single-hypothesis) full grid -- centered
+    // so that its one bin lands exactly on the true Doppler, so a successful
+    // acquisition here also confirms the fallback behaves correctly, not just
+    // "didn't crash".
+    init(/*doppler_max=*/5000, /*doppler_step=*/10000, /*enable_doppler_narrowing=*/true, /*use_cfar=*/false);
+
+    // The single full-grid bin sits at doppler_center - doppler_max; choose
+    // doppler_center so that bin lands exactly on the true Doppler.
+    const int doppler_center = static_cast<int>(kTrueDopplerHz) + 5000;
+    const RunResult result = run_acquisition(top_block, config.get(), gnss_synchro, doppler_center, 0);
+
+    ASSERT_EQ(1, result.rx_message) << "Acquisition failure with a 1-bin full grid (narrowing should have stayed disabled, not crashed).";
+    EXPECT_LE(result.doppler_error_hz, 666) << "Doppler error exceeds the expected value: 666 Hz = 2/(3*integration period)";
+    EXPECT_LT(result.delay_error_chips, 0.5) << "Delay error exceeds the expected value: 0.5 chips";
+}
+
+
+TEST_F(PcpsAcquisitionDopplerNarrowingTest /*unused*/, NarrowingEnabledTwoBinGrid /*unused*/)
+{
+    // doppler_max=5000, doppler_step=6000 -> d_num_doppler_bins == 2, exactly
+    // matching narrowed mode's own active-bin count. Regression test for the
+    // other half of the P1 fix: the old code inferred "is this narrowed?" as
+    // active_bins < full_bins, which is false here (2 < 2) even though this
+    // *is* a narrowed request, so it silently fell back to a plain 2-bin full
+    // grid instead of {known center, center + doppler_max}. That fallback's
+    // nearest bin to the true Doppler is 1000 Hz off (a near-total phase
+    // cancellation over the 1 ms coherent window), while the correct assisted
+    // bin 0 lands exactly on it.
+    init(/*doppler_max=*/5000, /*doppler_step=*/6000, /*enable_doppler_narrowing=*/true, /*use_cfar=*/false);
+
+    const RunResult result = run_acquisition(top_block, config.get(), gnss_synchro, static_cast<int>(kTrueDopplerHz), 0);
+
+    ASSERT_EQ(1, result.rx_message) << "Acquisition failure: narrowing likely did not activate for a 2-bin full grid (see d_doppler_search_narrowed).";
+    EXPECT_LE(result.doppler_error_hz, 200) << "Doppler error indicates the un-narrowed 2-bin fallback ran instead of the assisted {center, center+doppler_max} pair.";
+}
+
+
+TEST_F(PcpsAcquisitionDopplerNarrowingTest /*unused*/, CfarExcludesReferenceBinFromCandidacy /*unused*/)
+{
+    // Deliberately mis-center the assist so the *true* signal falls on bin 1
+    // (the CFAR noise-reference bin), not bin 0 (the only real candidate).
+    // Regression test for the P2 fix: previously both statistic functions
+    // scanned every computed bin, so bin 1's strong real correlation could win
+    // and get reported as if it were the trusted assisted center. With the
+    // fix, only bin 0 (pure noise here) is ever a candidate.
+    init(/*doppler_max=*/5000, /*doppler_step=*/5000, /*enable_doppler_narrowing=*/true, /*use_cfar=*/true);
+
+    const int doppler_center = static_cast<int>(kTrueDopplerHz) - 5000;  // bin 0 = center (noise); bin 1 = center + 5000 = true Doppler
+    const RunResult result = run_acquisition(top_block, config.get(), gnss_synchro, doppler_center, 0);
+
+    EXPECT_GT(result.doppler_error_hz, 500) << "The noise-reference bin (bin 1) was reported as the acquisition result.";
+}
+
+
+TEST_F(PcpsAcquisitionDopplerNarrowingTest /*unused*/, PeakRatioExcludesReferenceBinFromCandidacy /*unused*/)
+{
+    // Same construction as CfarExcludesReferenceBinFromCandidacy, exercising
+    // the non-CFAR (first_vs_second_peak_statistic) path instead.
+    init(/*doppler_max=*/5000, /*doppler_step=*/5000, /*enable_doppler_narrowing=*/true, /*use_cfar=*/false);
+
+    const int doppler_center = static_cast<int>(kTrueDopplerHz) - 5000;
+    const RunResult result = run_acquisition(top_block, config.get(), gnss_synchro, doppler_center, 0);
+
+    EXPECT_GT(result.doppler_error_hz, 500) << "The noise-reference bin (bin 1) was reported as the acquisition result.";
+}
+
+
+TEST_F(PcpsAcquisitionDopplerNarrowingTest /*unused*/, FullToNarrowTransition /*unused*/)
+{
+    // Toggle doppler_uncertainty twice before running (full -> narrow -> full),
+    // exercising set_doppler_uncertainty()'s resize/rebuild path
+    // (update_grid_doppler_wipeoffs()) more than once on the same block
+    // instance, then verify the final (full-grid) state still acquires
+    // correctly -- regression coverage for the dump/grid-sizing fix (section 5)
+    // interacting with d_doppler_search_narrowed toggling.
+    init(/*doppler_max=*/5000, /*doppler_step=*/100, /*enable_doppler_narrowing=*/true, /*use_cfar=*/false);
+
+    top_block = gr::make_top_block("Doppler narrowing transition test");
+    auto acquisition = std::make_shared<PcpsAcquisitionAdapter>(config.get(), "Acquisition_1C", "GPS_L1_CA_PCPS_Acquisition", 1, 0, GPS_1C);
+    auto msg_rx = PcpsAcquisitionDopplerNarrowingTest_msg_rx_make();
+
+    acquisition->set_channel(1);
+    acquisition->set_gnss_synchro(&gnss_synchro);
+    acquisition->connect(top_block);
+
+    std::string path = std::string(TEST_PATH);
+    std::string file = path + "signal_samples/GPS_L1_CA_ID_1_Fs_4Msps_2ms.dat";
+    gr::blocks::file_source::sptr file_source = gr::blocks::file_source::make(sizeof(gr_complex), file.c_str(), false);
+    top_block->connect(file_source, 0, acquisition->get_left_block(), 0);
+    top_block->msg_connect(acquisition->get_right_block(), pmt::mp("events"), msg_rx, pmt::mp("events"));
+
+    acquisition->set_local_code();
+    acquisition->set_doppler_center(static_cast<int>(kTrueDopplerHz));
+    acquisition->set_doppler_uncertainty(0);  // narrow
+    acquisition->set_doppler_uncertainty(1);  // back to full grid
+    acquisition->reset();
+
+    top_block->run();
+
+    ASSERT_EQ(1, msg_rx->rx_message) << "Acquisition failure after a narrow->full transition.";
+    const double doppler_error_hz = std::abs(kTrueDopplerHz - gnss_synchro.Acq_doppler_hz);
+    EXPECT_LE(doppler_error_hz, 666) << "Doppler error exceeds the expected value: 666 Hz = 2/(3*integration period)";
+}
+
+
+namespace
+{
+// Runs a single-step, full-grid (unnarrowed) acquisition against
+// GSoC_CTTC_capture_2012_07_26_4Msps_4ms.dat -- the same capture
+// ValidationOfResultsMakeTwoStep in gps_l1_ca_pcps_acquisition_test.cc uses
+// for two-step acquisition -- and returns the Doppler it finds. That capture's
+// true Doppler/delay aren't asserted anywhere else in this test suite (the
+// existing two-step test only checks for a successful acquisition), so this
+// probes it directly instead of hard-coding an assumed ground truth.
+double probe_doppler_hz_4ms_capture(std::shared_ptr<InMemoryConfiguration> &config, Gnss_Synchro &gnss_synchro)
+{
+    gr::top_block_sptr probe_top_block = gr::make_top_block("Doppler probe");
+    // supersede_property, not set_property: init() already set these keys once,
+    // and InMemoryConfiguration::set_property() is a std::map::insert, so a
+    // second set_property() call for the same key is a silent no-op.
+    config->supersede_property("Acquisition_1C.doppler_max", "10000");
+    config->supersede_property("Acquisition_1C.doppler_step", "100");
+    config->supersede_property("Acquisition_1C.enable_doppler_narrowing", "false");
+
+    auto acquisition = std::make_shared<PcpsAcquisitionAdapter>(config.get(), "Acquisition_1C", "GPS_L1_CA_PCPS_Acquisition", 1, 0, GPS_1C);
+    auto msg_rx = PcpsAcquisitionDopplerNarrowingTest_msg_rx_make();
+
+    acquisition->set_channel(1);
+    acquisition->set_gnss_synchro(&gnss_synchro);
+    acquisition->connect(probe_top_block);
+
+    std::string path = std::string(TEST_PATH);
+    std::string file = path + "signal_samples/GSoC_CTTC_capture_2012_07_26_4Msps_4ms.dat";
+    gr::blocks::file_source::sptr file_source = gr::blocks::file_source::make(sizeof(gr_complex), file.c_str(), false);
+    probe_top_block->connect(file_source, 0, acquisition->get_left_block(), 0);
+    probe_top_block->msg_connect(acquisition->get_right_block(), pmt::mp("events"), msg_rx, pmt::mp("events"));
+
+    acquisition->set_local_code();
+    acquisition->reset();
+    probe_top_block->run();
+
+    EXPECT_EQ(1, msg_rx->rx_message) << "Probe acquisition (full grid, no narrowing) failed to find a Doppler to assist with.";
+    return gnss_synchro.Acq_doppler_hz;
+}
+}  // namespace
+
+
+TEST_F(PcpsAcquisitionDopplerNarrowingTest /*unused*/, TwoStepAcquisitionWithNarrowing /*unused*/)
+{
+    // Step 1 narrows (2-bin grid, assisted); step 2 (the fine local search
+    // around step 1's result) never narrows -- assisted is unconditionally
+    // false when d_step_two is true (compute_statistics()) -- so it should
+    // still run its full second_nbins-wide fine search and improve on step 1's
+    // coarse result. Uses the same 4 ms capture as
+    // ValidationOfResultsMakeTwoStep in gps_l1_ca_pcps_acquisition_test.cc,
+    // since two-step acquisition needs more samples than the 2 ms capture the
+    // other tests in this file use provides.
+    init(/*doppler_max=*/5000, /*doppler_step=*/6000, /*enable_doppler_narrowing=*/true, /*use_cfar=*/false);
+    const auto assist_doppler_hz = probe_doppler_hz_4ms_capture(config, gnss_synchro);
+
+    gnss_synchro = Gnss_Synchro();
+    // Restore the narrowed 2-bin step-1 settings the probe above overrode, and
+    // add the two-step-specific keys (not touched by init(), so a plain
+    // set_property() is fine for these).
+    config->supersede_property("Acquisition_1C.doppler_max", "5000");
+    config->supersede_property("Acquisition_1C.doppler_step", "6000");
+    config->supersede_property("Acquisition_1C.enable_doppler_narrowing", "true");
+    config->set_property("Acquisition_1C.make_two_steps", "true");
+    config->set_property("Acquisition_1C.second_nbins", "5");
+    config->set_property("Acquisition_1C.second_doppler_step", "20");
+
+    top_block = gr::make_top_block("Doppler narrowing two-step test");
+    auto acquisition = std::make_shared<PcpsAcquisitionAdapter>(config.get(), "Acquisition_1C", "GPS_L1_CA_PCPS_Acquisition", 1, 0, GPS_1C);
+    auto msg_rx = PcpsAcquisitionDopplerNarrowingTest_msg_rx_make();
+
+    gnss_synchro.Channel_ID = 0;
+    gnss_synchro.System = 'G';
+    std::string signal = "1C";
+    signal.copy(gnss_synchro.Signal, 2, 0);
+    gnss_synchro.PRN = 1;
+
+    acquisition->set_channel(1);
+    acquisition->set_gnss_synchro(&gnss_synchro);
+    acquisition->connect(top_block);
+
+    std::string path = std::string(TEST_PATH);
+    std::string file = path + "signal_samples/GSoC_CTTC_capture_2012_07_26_4Msps_4ms.dat";
+    gr::blocks::file_source::sptr file_source = gr::blocks::file_source::make(sizeof(gr_complex), file.c_str(), false);
+    top_block->connect(file_source, 0, acquisition->get_left_block(), 0);
+    top_block->msg_connect(acquisition->get_right_block(), pmt::mp("events"), msg_rx, pmt::mp("events"));
+
+    acquisition->set_local_code();
+    acquisition->set_doppler_center(static_cast<int>(std::lround(assist_doppler_hz)));
+    acquisition->set_doppler_uncertainty(0);
+    acquisition->reset();
+
+    top_block->run();
+
+    ASSERT_EQ(1, msg_rx->rx_message) << "Acquisition failure with two-step acquisition + step-1 narrowing.";
+    const double doppler_error_hz = std::abs(assist_doppler_hz - gnss_synchro.Acq_doppler_hz);
+    // Tolerance covers both the wide probe's own 100 Hz step quantization and
+    // step 2's 20 Hz fine-search quantization, not just step 2's alone.
+    EXPECT_LE(doppler_error_hz, 150) << "Step 2's fine search should have converged close to the (narrowed) step-1 estimate.";
+}
+
+
+TEST_F(PcpsAcquisitionDopplerNarrowingTest /*unused*/, NarrowedDumpMetadata /*unused*/)
+{
+    // Regression test for the section 5 fix: a narrowed dump must describe
+    // itself accurately (2 columns, {0, doppler_max} encoding, an explicit
+    // doppler_narrowed flag) instead of claiming the full grid's width/step
+    // while actually only having written 2 live columns.
+    init(/*doppler_max=*/5000, /*doppler_step=*/5000, /*enable_doppler_narrowing=*/true, /*use_cfar=*/false);
+    // supersede_property, not set_property: init() already called set_property
+    // for "Acquisition_1C.dump" (InMemoryConfiguration::set_property() is a
+    // std::map::insert, so a second set_property() with the same key is a
+    // silent no-op -- supersede_property() actually overwrites it).
+    config->supersede_property("Acquisition_1C.dump", "true");
+    config->supersede_property("Acquisition_1C.dump_filename", "./tmp-acq-narrow-dump/acquisition");
+    config->supersede_property("Acquisition_1C.dump_channel", "1");
+
+    std::string data_str = "./tmp-acq-narrow-dump";
+    if (fs::exists(data_str))
+        {
+            fs::remove_all(data_str);
+        }
+    fs::create_directory(data_str);
+
+    const int doppler_center = static_cast<int>(kTrueDopplerHz);
+    const RunResult result = run_acquisition(top_block, config.get(), gnss_synchro, doppler_center, 0);
+    ASSERT_EQ(1, result.rx_message) << "Acquisition failure while producing the narrowed dump.";
+
+    const std::string dump_filename = "./tmp-acq-narrow-dump/acquisition_G_1C_ch_1_1_sat_1.mat";
+    mat_t *matfp = Mat_Open(dump_filename.c_str(), MAT_ACC_RDONLY);
+    ASSERT_NE(matfp, nullptr) << "Could not open narrowed acquisition dump " << dump_filename;
+
+    matvar_t *grid_var = Mat_VarRead(matfp, "acq_grid");
+    ASSERT_NE(grid_var, nullptr) << "acq_grid missing from narrowed dump";
+    EXPECT_EQ(2U, grid_var->dims[1]) << "Narrowed acq_grid should be 2 columns wide (known bin + reference bin), not the full configured grid.";
+    Mat_VarFree(grid_var);
+
+    matvar_t *narrowed_var = Mat_VarRead(matfp, "doppler_narrowed");
+    ASSERT_NE(narrowed_var, nullptr) << "doppler_narrowed missing from narrowed dump";
+    EXPECT_EQ(1, *static_cast<int32_t *>(narrowed_var->data));
+    Mat_VarFree(narrowed_var);
+
+    matvar_t *doppler_max_var = Mat_VarRead(matfp, "doppler_max");
+    ASSERT_NE(doppler_max_var, nullptr) << "doppler_max missing from narrowed dump";
+    EXPECT_EQ(0, *static_cast<int32_t *>(doppler_max_var->data)) << "Narrowed dumps encode doppler_max=0 (bin 0 == the known center).";
+    Mat_VarFree(doppler_max_var);
+
+    matvar_t *doppler_step_var = Mat_VarRead(matfp, "doppler_step");
+    ASSERT_NE(doppler_step_var, nullptr) << "doppler_step missing from narrowed dump";
+    EXPECT_EQ(5000, *static_cast<int32_t *>(doppler_step_var->data)) << "Narrowed dumps encode doppler_step=doppler_max (bin 1 == center + doppler_max).";
+    Mat_VarFree(doppler_step_var);
+
+    matvar_t *doppler_center_var = Mat_VarRead(matfp, "doppler_center");
+    ASSERT_NE(doppler_center_var, nullptr) << "doppler_center missing from narrowed dump";
+    EXPECT_EQ(doppler_center, *static_cast<int32_t *>(doppler_center_var->data));
+    Mat_VarFree(doppler_center_var);
+
+    Mat_Close(matfp);
+    fs::remove_all(data_str);
+}


### PR DESCRIPTION
## Summary

- When acquiring a secondary frequency (e.g. Galileo E5a) of a satellite whose primary frequency (e.g. E1) is already tracked, the primary's Doppler can be projected onto the secondary and passed in as an already-known estimate (`GNSS-SDR.assist_dual_frequency_acq`). Even so, the acquisition still searched the full configured Doppler grid around that estimate rather than trusting it.
- Adds `Acquisition_<Sig>.enable_doppler_narrowing` (default `false`): when the projected Doppler is passed in as exact (`doppler_uncertanty == 0`), collapses the search to just that bin plus one reference bin (used as the existing noise-power estimate, at the same separation the full grid search already uses for its own "opposite" bin), instead of running the full multi-bin grid. Falls back to the full grid whenever the Doppler isn't known this precisely (single-frequency acquisition, or dual-frequency assist disabled/unavailable).
- `set_doppler_uncertanty()` threads through `AcquisitionInterface` -> `PcpsAcquisitionAdapter` -> `pcps_acquisition`, and `Channel::assist_acquisition_doppler()` gains a `doppler_uncertanty` parameter (default `1`, i.e. "not known precisely") so existing callers are unaffected unless they opt in.
- Also fixes `max_to_input_power_statistic()`'s "opposite bin" index to wrap using its own `num_doppler_bins` parameter instead of the always-full-grid `d_num_doppler_bins` member, which was already inconsistent with step-two's narrower bin count and would have been wrong for the narrowed 2-bin case introduced here.

## Test plan

- [x] `acquisition_libs`, `acquisition_gr_blocks`, `acquisition_adapters`, `channel_libs`, `channel_adapters`, `core_receiver`, and the full `gnss-sdr` executable all build cleanly.
- [x] `clang-format-22` (this branch's CI-pinned version) makes no changes to any touched file.
- [x] Field-tested in a dual-frequency (Galileo E1B+E5a) EVK1029 receiver setup.