### PR TITLE
pcps_acquisition: batch idle-state general_work() calls to cut scheduler overhead

### DIFF
--- a/src/algorithms/acquisition/gnuradio_blocks/pcps_acquisition.cc
+++ b/src/algorithms/acquisition/gnuradio_blocks/pcps_acquisition.cc
@@ -192,6 +192,20 @@ pcps_acquisition::pcps_acquisition(const Acq_Conf& conf_)
     std::fill(d_magnitude_grid.begin(), d_magnitude_grid.end(), 0.0F);
 
     update_grid_doppler_wipeoffs();
+
+    // While idle (not actively searching), general_work() only drains its input to avoid
+    // stalling the upstream block, producing no output. Without a batching hint the TPB
+    // scheduler wakes this block's thread for every small burst of new input (observed:
+    // tens of thousands of calls/s, a few hundred/thousand samples each), which is pure
+    // scheduling overhead. Requiring a larger noutput_items granularity forces the
+    // scheduler to accumulate more input per wakeup, cutting call frequency without
+    // changing behavior (production while idle is still always 0 either way).
+    // One PRN code period (1 ms) at this signal's own decimated rate is the natural
+    // lower bound: the algorithm never does anything meaningful below that granularity,
+    // so batching to it (instead of a fixed sample count) self-scales with fs_in/decimation
+    // across signals/configs instead of being tuned for one particular sample rate.
+    const auto output_multiple_samples = std::max<uint32_t>(1U, static_cast<uint32_t>(std::lround(conf_.samples_per_ms)));
+    this->set_output_multiple(output_multiple_samples);
 }
 
 


### PR DESCRIPTION
## Summary

While a channel is idle (acquisition not actively searching for that
channel), `pcps_acquisition::general_work()` only drains its input via
`consume_each()` to avoid stalling the upstream block -- it produces no
output either way. Without any batching hint, GNU Radio's thread-per-block
scheduler was waking this block's thread for every small burst of new
input: observed live at **5,000-22,000 calls/s per idle channel**,
handling only ~850-3,400 samples each. Total throughput matched the
configured sample rate exactly (no excess data movement), confirming this
was pure per-call scheduling overhead (mutex lock, function call, thread
wake), not real work -- measured as a steady **17-23% CPU per idle
acquisition thread** that should have been doing nothing.

## Fix

`set_output_multiple()` in the constructor, forcing the scheduler to
accumulate more input per wakeup before calling `general_work()` again.
The batch size is derived from the signal's own `Acq_Conf::samples_per_ms`
(one PRN code period's worth of samples at that signal's own decimated
rate) rather than a fixed constant: the algorithm never does anything
meaningful below that granularity, and deriving it self-scales correctly
across signals/configs running at different sample rates instead of being
silently wrong outside whatever one setup it might otherwise have been
tuned for.

## Test plan

- [x] Clean build from this branch in isolation, zero errors/warnings.
- [x] Live-verified against a real capture: idle-channel `pcps_acquisition`
      call rate dropped ~10x (from 5,000-22,000/s to ~1,400-1,800/s, some
      channels lower still), and idle-thread CPU dropped from a steady
      17-23% to mostly 3-12%.
- [x] Also tested `output_multiple` values well beyond `samples_per_ms`
      (up to 8x): no further CPU reduction observed, confirming the
      `samples_per_ms`-derived value is the practical floor for this fix
      rather than an arbitrarily chosen number.
- [x] No functional/behavioral regression: acquisition and tracking still
      succeed normally with the fix in place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)