### PR TITLE
Reinitialize CNAV Viterbi decoder on channel restart (GPS L5/L2C)

### DIFF
--- a/src/algorithms/telemetry_decoder/gnuradio_blocks/gps_l2c_telemetry_decoder_gs.cc
+++ b/src/algorithms/telemetry_decoder/gnuradio_blocks/gps_l2c_telemetry_decoder_gs.cc
@@ -126,6 +126,15 @@ void gps_l2c_telemetry_decoder_gs::set_channel(int channel)
 
 void gps_l2c_telemetry_decoder_gs::reset()
 {
+    // Channels are reused (not recreated) across a stop/restart -- without
+    // this, the underlying libswiftcnav Viterbi/frame-sync decoder
+    // (d_cnav_decoder) is only ever initialized once, in the constructor,
+    // so a channel reacquiring after being stopped mid-track carries stale
+    // internal decoder state (two Viterbi decoders' path history, sync
+    // hypothesis) into the new tracking session instead of starting clean
+    // like a channel used for the first time does. Same issue as GPS L5,
+    // which shares this decoder.
+    cnav_msg_decoder_init(&d_cnav_decoder);
     d_last_valid_preamble = d_sample_counter;
     d_TOW_at_current_symbol = 0;
     d_sent_tlm_failed_msg = false;

--- a/src/algorithms/telemetry_decoder/gnuradio_blocks/gps_l5_telemetry_decoder_gs.cc
+++ b/src/algorithms/telemetry_decoder/gnuradio_blocks/gps_l5_telemetry_decoder_gs.cc
@@ -145,6 +145,14 @@ void gps_l5_telemetry_decoder_gs::set_channel(int32_t channel)
 
 void gps_l5_telemetry_decoder_gs::reset()
 {
+    // Channels are reused (not recreated) across a stop/restart -- without
+    // this, the underlying libswiftcnav Viterbi/frame-sync decoder
+    // (d_cnav_decoder) is only ever initialized once, in the constructor,
+    // so a channel reacquiring after being stopped mid-track carries stale
+    // internal decoder state (two Viterbi decoders' path history, sync
+    // hypothesis) into the new tracking session instead of starting clean
+    // like a channel used for the first time does.
+    cnav_msg_decoder_init(&d_cnav_decoder);
     d_last_valid_preamble = d_sample_counter;
     d_TOW_at_current_symbol_ms = 0;
     d_sent_tlm_failed_msg = false;


### PR DESCRIPTION
## Problem

Channels are reused objects across a stop/restart, not recreated -- but the
libswiftcnav CNAV decoder (shared by GPS L5 and GPS L2C) is only ever
initialized once, in the constructor. `reset()` never calls
`cnav_msg_decoder_init()` again. A channel that reacquires after being
stopped mid-track therefore carries stale internal decoder state (two
Viterbi decoders' path history, frame-sync hypothesis) into the new
tracking session, instead of starting clean the way a channel used for the
first time does.

Symptom: after a receiver restart that reuses already-tracking channels,
affected L5/L2C channels re-lock the carrier almost immediately and show
excellent lock quality, yet no valid CNAV frame is ever decoded for roughly
a minute -- until the telemetry decoder's own "no valid frame" watchdog
times out and forces a hard loss-of-lock. The channel then reacquires and
(now with clean decoder state) works normally, until the same restart
condition repeats it.

## How this was tested

Using a real dual-band Galileo/GPS capture (L1/E1 + L5/E5a) replayed through
the receiver:

1. Let the receiver reach steady state: all primary and secondary channels
   acquired and tracking (13 channels total: 7 primary GPS/Galileo, 6
   secondary GPS L5).
2. Triggered a stop-then-reacquire sequence on the already-tracking channels
   (the same "stop tracking, then start again on the same channel objects"
   path a receiver hot-start goes through), rather than restarting the whole
   process -- this is what actually exercises the stale-state bug, since a
   fresh process never reuses a channel.
3. **Before the fix**: all 6 L5 channels re-locked the carrier within
   seconds (`carrier_lock_test` 0.994-0.998, CN0 42-51 dB-Hz -- essentially
   perfect lock), then simultaneously lost lock again ~65-70s later via the
   telemetry decoder's watchdog (`carrier_lock_fail_counter` forced to its
   ceiling), despite the strong, stable carrier lock the whole time. That
   combination -- perfect carrier lock, yet no frame ever decoded -- is what
   pointed at the frame-sync/decoder layer rather than the tracking loop.
4. Confirmed a genuine fresh boot (channels used for the first time, never
   reused) never exhibits this: watched 6 L5 channels for over 3 minutes
   past acquisition with zero loss-of-lock events, ruling out a general
   CNAV-decoding problem and confirming it's specific to channel reuse
   across a restart.
5. **After the fix** (adding the missing `cnav_msg_decoder_init()` call to
   `reset()`): re-ran the identical stop/reacquire sequence and watched 120s
   past the point where every channel had previously failed. Zero
   loss-of-lock events, with all 6 channels successfully and repeatedly
   decoding full CNAV messages (ephemeris, iono, UTC model, Earth
   orientation parameters) throughout.

Also checked every other telemetry decoder in the tree for the same
pattern, to see how far it reaches: Galileo's Viterbi decoder is fully
stateless per call (it reinitializes its own working buffers at the start
of every `decode()`) and its `reset()` is already thorough; SBAS L1's
Viterbi decoder is block-based with a `reset()` that properly cascades
through every sub-component; BeiDou B1C/D1D2 and GLONASS GNAV have no
persistent stateful FEC decoder at all. GPS L2C shares the exact same
libswiftcnav decoder as L5 and the exact same gap, so it gets the same fix
here, though it wasn't independently reproduced live (not configured in the
capture used to diagnose L5) -- the fix there is by code inspection and
parity with the confirmed L5 root cause, not a live A/B test.

## Verification

- Built cleanly from a clean worktree against current `next`.
- `clang-format` (22) run over both changed files: no formatting drift.