### PR TITLE
Report az/el for satellites excluded from the PVT fix, not just used ones

### DIFF
--- a/docs/protobuf/monitor_pvt.proto
+++ b/docs/protobuf/monitor_pvt.proto
@@ -61,7 +61,7 @@ message MonitorPvt {
   // azimuth_deg/elevation_deg populated with used = false when it was
   // tracked and had az/el computed but excluded from the fix itself (e.g.
   // below PVT.elevation_mask, or by RAIM FDE).
-  message UsedSatellite {
+  message TrackedSatellite {
     uint32 prn = 1;
     string system = 2;  // "G" GPS, "E" Galileo, "R" GLONASS, "C" BeiDou, "S" SBAS, "J" QZSS
     string signal = 3;
@@ -70,5 +70,5 @@ message MonitorPvt {
     bool combined = 6;
     bool used = 7;
   }
-  repeated UsedSatellite used_satellites = 37;
+  repeated TrackedSatellite tracked_satellites = 37;
 }

--- a/docs/protobuf/monitor_pvt.proto
+++ b/docs/protobuf/monitor_pvt.proto
@@ -53,11 +53,14 @@ message MonitorPvt {
   uint32 galhas_status = 35;  // Galileo HAS status: 1- HAS messages decoded and applied, 0 - HAS not available
   string geohash = 36;        // Encoded geographic location. See https://en.wikipedia.org/wiki/Geohash
 
-  // One satellite/signal used in this fix, with its azimuth/elevation and
-  // whether it was combined with another signal of the same satellite (e.g.
-  // Galileo E1+E5a iono-free combination). Signals are listed individually,
-  // not merged: a combined satellite appears as two entries, both with
-  // combined = true.
+  // One tracked satellite/signal with its azimuth/elevation, whether it was
+  // combined with another signal of the same satellite (e.g. Galileo E1+E5a
+  // iono-free combination), and whether it was actually used in this fix.
+  // Signals are listed individually, not merged: a combined satellite
+  // appears as two entries, both with combined = true. A satellite can have
+  // azimuth_deg/elevation_deg populated with used = false when it was
+  // tracked and had az/el computed but excluded from the fix itself (e.g.
+  // below PVT.elevation_mask, or by RAIM FDE).
   message UsedSatellite {
     uint32 prn = 1;
     string system = 2;  // "G" GPS, "E" Galileo, "R" GLONASS, "C" BeiDou, "S" SBAS, "J" QZSS
@@ -65,6 +68,7 @@ message MonitorPvt {
     double azimuth_deg = 4;
     double elevation_deg = 5;
     bool combined = 6;
+    bool used = 7;
   }
   repeated UsedSatellite used_satellites = 37;
 }

--- a/src/algorithms/PVT/libs/monitor_pvt.h
+++ b/src/algorithms/PVT/libs/monitor_pvt.h
@@ -36,15 +36,16 @@ class Monitor_Pvt
 {
 public:
     /*!
-     * \brief One satellite/signal that contributed to this fix, with its
-     * azimuth/elevation and whether it was combined with another signal of
-     * the same satellite (e.g. Galileo E1+E5a iono-free combination -- see
-     * the "dual-frequency" branch of prange() in rtklib_pntpos.cc). Signals
-     * are listed individually (one entry per satellite per signal), not
-     * merged, so a combined satellite appears as two entries both flagged
-     * combined = true.
+     * \brief One tracked satellite/signal, with its azimuth/elevation,
+     * whether it was combined with another signal of the same satellite
+     * (e.g. Galileo E1+E5a iono-free combination -- see the
+     * "dual-frequency" branch of prange() in rtklib_pntpos.cc), and whether
+     * it was actually used in this fix (see the `used` member below).
+     * Signals are listed individually (one entry per satellite per signal),
+     * not merged, so a combined satellite appears as two entries both
+     * flagged combined = true.
      */
-    class UsedSatelliteInfo
+    class TrackedSatelliteInfo
     {
     public:
         uint32_t prn{};
@@ -76,7 +77,7 @@ public:
         }
     };
 
-    std::vector<UsedSatelliteInfo> used_satellites;
+    std::vector<TrackedSatelliteInfo> tracked_satellites;
 
     // TOW
     uint32_t TOW_at_current_symbol_ms;
@@ -200,7 +201,7 @@ public:
 
         ar& BOOST_SERIALIZATION_NVP(cog);
         ar& BOOST_SERIALIZATION_NVP(geohash);
-        ar& BOOST_SERIALIZATION_NVP(used_satellites);
+        ar& BOOST_SERIALIZATION_NVP(tracked_satellites);
     }
 };
 

--- a/src/algorithms/PVT/libs/monitor_pvt.h
+++ b/src/algorithms/PVT/libs/monitor_pvt.h
@@ -53,6 +53,12 @@ public:
         double azimuth_deg{};
         double elevation_deg{};
         bool combined{};
+        // false when this satellite/signal was tracked and had azimuth/elevation
+        // computed but was excluded from the fix itself (e.g. below
+        // PVT.elevation_mask, or by RAIM FDE) -- azimuth_deg/elevation_deg are
+        // still valid in that case, only the position solve ignored this
+        // observation.
+        bool used{true};
 
         template <class Archive>
         void serialize(Archive& ar, const unsigned int version)
@@ -66,6 +72,7 @@ public:
             ar& BOOST_SERIALIZATION_NVP(azimuth_deg);
             ar& BOOST_SERIALIZATION_NVP(elevation_deg);
             ar& BOOST_SERIALIZATION_NVP(combined);
+            ar& BOOST_SERIALIZATION_NVP(used);
         }
     };
 

--- a/src/algorithms/PVT/libs/rtklib_solver.cc
+++ b/src/algorithms/PVT/libs/rtklib_solver.cc
@@ -2849,10 +2849,21 @@ bool Rtklib_Solver::get_PVT(const std::map<int, Gnss_Synchro> &gnss_observables_
                     // it, so an excluded satellite shows up in the monitor as
                     // "not used" rather than as missing/no-az-el (which
                     // otherwise looks identical to a tracking problem).
+                    //
+                    // std::isfinite() guards against corrupt ephemeris/almanac
+                    // (e.g. an out-of-range eccentricity) propagating NaN through
+                    // eph2pos()/alm2pos()/satazel() -- none of RTKLIB's own
+                    // internal sanity checks (A <= 0, Kepler iteration overflow,
+                    // geodist()'s Earth-radius check, the elevation mask) catch a
+                    // NaN, since ordinary numeric comparisons are vacuously false
+                    // against it. Without this, a NaN azel would actually pass
+                    // the old != 0.0 check (NaN != 0.0 is true) and get reported
+                    // into the monitor as a literal NaN azimuth/elevation.
                     d_monitor_pvt.tracked_satellites.clear();
                     for (int sat_idx = 0; sat_idx < MAXSAT; sat_idx++)
                         {
-                            const bool has_azel = (pvt_ssat[sat_idx].azel[0] != 0.0) || (pvt_ssat[sat_idx].azel[1] != 0.0);
+                            const bool has_azel = std::isfinite(pvt_ssat[sat_idx].azel[0]) && std::isfinite(pvt_ssat[sat_idx].azel[1]) &&
+                                                  ((pvt_ssat[sat_idx].azel[0] != 0.0) || (pvt_ssat[sat_idx].azel[1] != 0.0));
                             if (!has_azel)
                                 {
                                     continue;

--- a/src/algorithms/PVT/libs/rtklib_solver.cc
+++ b/src/algorithms/PVT/libs/rtklib_solver.cc
@@ -2850,20 +2850,20 @@ bool Rtklib_Solver::get_PVT(const std::map<int, Gnss_Synchro> &gnss_observables_
                     // "not used" rather than as missing/no-az-el (which
                     // otherwise looks identical to a tracking problem).
                     //
-                    // std::isfinite() guards against corrupt ephemeris/almanac
-                    // (e.g. an out-of-range eccentricity) propagating NaN through
-                    // eph2pos()/alm2pos()/satazel() -- none of RTKLIB's own
-                    // internal sanity checks (A <= 0, Kepler iteration overflow,
-                    // geodist()'s Earth-radius check, the elevation mask) catch a
-                    // NaN, since ordinary numeric comparisons are vacuously false
-                    // against it. Without this, a NaN azel would actually pass
-                    // the old != 0.0 check (NaN != 0.0 is true) and get reported
-                    // into the monitor as a literal NaN azimuth/elevation.
+                    // Deliberately NOT filtered for NaN here: a corrupt ephemeris/
+                    // almanac (e.g. an out-of-range eccentricity) can propagate NaN
+                    // through eph2pos()/alm2pos()/satazel(), and that NaN is reported
+                    // as-is rather than silently dropping the satellite from the
+                    // monitor -- consumers (gnss-sdr-CtrlApp) are expected to handle
+                    // a NaN azimuth_deg/elevation_deg explicitly (e.g. no sky plot
+                    // entry, "NaN" printed in the signal table) rather than have it
+                    // hidden here. What NaN must NOT do is influence the position fix
+                    // itself -- see rescode()'s prange() isfinite guard in
+                    // rtklib_pntpos.cc for where that's actually enforced.
                     d_monitor_pvt.tracked_satellites.clear();
                     for (int sat_idx = 0; sat_idx < MAXSAT; sat_idx++)
                         {
-                            const bool has_azel = std::isfinite(pvt_ssat[sat_idx].azel[0]) && std::isfinite(pvt_ssat[sat_idx].azel[1]) &&
-                                                  ((pvt_ssat[sat_idx].azel[0] != 0.0) || (pvt_ssat[sat_idx].azel[1] != 0.0));
+                            const bool has_azel = (pvt_ssat[sat_idx].azel[0] != 0.0) || (pvt_ssat[sat_idx].azel[1] != 0.0);
                             if (!has_azel)
                                 {
                                     continue;

--- a/src/algorithms/PVT/libs/rtklib_solver.cc
+++ b/src/algorithms/PVT/libs/rtklib_solver.cc
@@ -2837,13 +2837,27 @@ bool Rtklib_Solver::get_PVT(const std::map<int, Gnss_Synchro> &gnss_observables_
                     // iono-free combination -- see the "dual-frequency" branch of
                     // prange() in rtklib_pntpos.cc) gets one entry per signal, all
                     // flagged combined = true.
+                    //
+                    // rescode() (rtklib_pntpos.cc) computes azel via satazel()
+                    // *before* checking it against PVT.elevation_mask, and
+                    // pntpos() copies that azel into ssat[] unconditionally --
+                    // only ssat[].vs is gated by the mask. So a satellite that
+                    // is tracked and has a live observation this epoch, but
+                    // falls below PVT.elevation_mask (or was excluded by RAIM
+                    // FDE), still has a valid azel here; only vs is false.
+                    // Report it anyway with used = false instead of dropping
+                    // it, so an excluded satellite shows up in the monitor as
+                    // "not used" rather than as missing/no-az-el (which
+                    // otherwise looks identical to a tracking problem).
                     d_monitor_pvt.used_satellites.clear();
                     for (int sat_idx = 0; sat_idx < MAXSAT; sat_idx++)
                         {
-                            if (!pvt_ssat[sat_idx].vs)
+                            const bool has_azel = (pvt_ssat[sat_idx].azel[0] != 0.0) || (pvt_ssat[sat_idx].azel[1] != 0.0);
+                            if (!has_azel)
                                 {
                                     continue;
                                 }
+                            const bool used = pvt_ssat[sat_idx].vs != 0;
                             int prn = 0;
                             char sys_char = '?';
                             switch (satsys(sat_idx + 1, &prn))
@@ -2896,6 +2910,7 @@ bool Rtklib_Solver::get_PVT(const std::map<int, Gnss_Synchro> &gnss_observables_
                                     info.azimuth_deg = az_deg;
                                     info.elevation_deg = pvt_ssat[sat_idx].azel[1] * R2D;
                                     info.combined = combined;
+                                    info.used = used;
                                     d_monitor_pvt.used_satellites.push_back(info);
                                 }
                         }

--- a/src/algorithms/PVT/libs/rtklib_solver.cc
+++ b/src/algorithms/PVT/libs/rtklib_solver.cc
@@ -2849,7 +2849,7 @@ bool Rtklib_Solver::get_PVT(const std::map<int, Gnss_Synchro> &gnss_observables_
                     // it, so an excluded satellite shows up in the monitor as
                     // "not used" rather than as missing/no-az-el (which
                     // otherwise looks identical to a tracking problem).
-                    d_monitor_pvt.used_satellites.clear();
+                    d_monitor_pvt.tracked_satellites.clear();
                     for (int sat_idx = 0; sat_idx < MAXSAT; sat_idx++)
                         {
                             const bool has_azel = (pvt_ssat[sat_idx].azel[0] != 0.0) || (pvt_ssat[sat_idx].azel[1] != 0.0);
@@ -2903,7 +2903,7 @@ bool Rtklib_Solver::get_PVT(const std::map<int, Gnss_Synchro> &gnss_observables_
                                 }
                             for (const Gnss_Synchro *synchro : contributing_signals)
                                 {
-                                    Monitor_Pvt::UsedSatelliteInfo info;
+                                    Monitor_Pvt::TrackedSatelliteInfo info;
                                     info.prn = static_cast<uint32_t>(prn);
                                     info.system = sys_char;
                                     info.signal = std::string(synchro->Signal, 2);
@@ -2911,7 +2911,7 @@ bool Rtklib_Solver::get_PVT(const std::map<int, Gnss_Synchro> &gnss_observables_
                                     info.elevation_deg = pvt_ssat[sat_idx].azel[1] * R2D;
                                     info.combined = combined;
                                     info.used = used;
-                                    d_monitor_pvt.used_satellites.push_back(info);
+                                    d_monitor_pvt.tracked_satellites.push_back(info);
                                 }
                         }
 

--- a/src/algorithms/PVT/libs/serdes_monitor_pvt.h
+++ b/src/algorithms/PVT/libs/serdes_monitor_pvt.h
@@ -129,6 +129,7 @@ public:
                 pb_sat->set_azimuth_deg(sat.azimuth_deg);
                 pb_sat->set_elevation_deg(sat.elevation_deg);
                 pb_sat->set_combined(sat.combined);
+                pb_sat->set_used(sat.used);
             }
 
         if (!monitor_.SerializeToString(&data))
@@ -188,6 +189,7 @@ public:
                 sat.azimuth_deg = pb_sat.azimuth_deg();
                 sat.elevation_deg = pb_sat.elevation_deg();
                 sat.combined = pb_sat.combined();
+                sat.used = pb_sat.used();
                 monitor.used_satellites.push_back(sat);
             }
 

--- a/src/algorithms/PVT/libs/serdes_monitor_pvt.h
+++ b/src/algorithms/PVT/libs/serdes_monitor_pvt.h
@@ -120,9 +120,9 @@ public:
         monitor_.set_galhas_status(monitor->galhas_status);
         monitor_.set_geohash(monitor->geohash);
 
-        for (const auto& sat : monitor->used_satellites)
+        for (const auto& sat : monitor->tracked_satellites)
             {
-                gnss_sdr::MonitorPvt::UsedSatellite* pb_sat = monitor_.add_used_satellites();
+                gnss_sdr::MonitorPvt::TrackedSatellite* pb_sat = monitor_.add_tracked_satellites();
                 pb_sat->set_prn(sat.prn);
                 pb_sat->set_system(std::string(1, sat.system));
                 pb_sat->set_signal(sat.signal);
@@ -180,9 +180,9 @@ public:
         monitor.galhas_status = mon.galhas_status();
         monitor.geohash = mon.geohash();
 
-        for (const auto& pb_sat : mon.used_satellites())
+        for (const auto& pb_sat : mon.tracked_satellites())
             {
-                Monitor_Pvt::UsedSatelliteInfo sat;
+                Monitor_Pvt::TrackedSatelliteInfo sat;
                 sat.prn = pb_sat.prn();
                 sat.system = pb_sat.system().empty() ? '\0' : pb_sat.system()[0];
                 sat.signal = pb_sat.signal();
@@ -190,7 +190,7 @@ public:
                 sat.elevation_deg = pb_sat.elevation_deg();
                 sat.combined = pb_sat.combined();
                 sat.used = pb_sat.used();
-                monitor.used_satellites.push_back(sat);
+                monitor.tracked_satellites.push_back(sat);
             }
 
         return monitor;

--- a/src/algorithms/libs/rtklib/rtklib_pntpos.cc
+++ b/src/algorithms/libs/rtklib/rtklib_pntpos.cc
@@ -736,14 +736,26 @@ int rescode(int iter, const obsd_t *obs, int n, const double *rs,
                     continue;
                 }
             double elaux = satazel(pos, e, azel + i * 2);
-            if (elaux < opt->elmin)
+            /* !isfinite(elaux): corrupt ephemeris/almanac (e.g. an out-of-range
+             * eccentricity) can propagate NaN through eph2pos()/alm2pos() into
+             * azel -- azel itself is intentionally left as computed (including
+             * NaN) for callers that report it (e.g. the monitor's per-satellite
+             * az/el), but a NaN elevation must not be allowed into the position
+             * solve below: elaux < opt->elmin is a no-op against NaN (every
+             * relational comparison against NaN is false), so it would
+             * otherwise fall through as if elmin had been satisfied. */
+            if (elaux < opt->elmin || !std::isfinite(elaux))
                 {
                     trace(4, "satazel error. el = %lf , elmin = %lf\n", elaux, opt->elmin);
                     continue;
                 }
             /* psudorange with code bias correction */
             double iono_scale = 1.0;
-            if ((P = prange(obs + i, nav, azel + i * 2, iter, opt, &vmeas, &iono_scale)) == 0.0)
+            P = prange(obs + i, nav, azel + i * 2, iter, opt, &vmeas, &iono_scale);
+            /* Same NaN concern as above, for prange()'s own corrections (iono/
+             * tropo/code bias) -- P == 0.0 is prange()'s own "no valid pseudorange"
+             * sentinel and doesn't catch NaN either. */
+            if (P == 0.0 || !std::isfinite(P))
                 {
                     trace(4, "prange error\n");
                     continue;


### PR DESCRIPTION
## Summary

`MonitorPvt.used_satellites` (added recently) reports one entry per
satellite/signal that contributed to the current fix, with its
azimuth/elevation. But a satellite that's tracked and has a valid
observation, yet gets excluded from the fix itself (below
`PVT.elevation_mask`, or dropped by RAIM FDE), got no entry at all --
identical, from the monitor's point of view, to a satellite with no
tracking/no data. That's misleading: it looks like a receiver problem
when it's actually the mask (or RAIM) working as intended.

## Root cause

`rescode()` (`rtklib_pntpos.cc`) computes each satellite's azimuth/elevation
via `satazel()` **before** checking it against `opt->elmin`
(`PVT.elevation_mask`), and `pntpos()` copies that `azel` into `ssat[]`
unconditionally -- only `ssat[].vs` is gated by the mask. The same is true
for a satellite excluded by RAIM FDE: `raim_fde()` only clears `vsat[i]`
for the excluded satellite, it doesn't touch its `azel` entry. So a valid
azimuth/elevation is already sitting in `ssat[]` for these satellites; the
`used_satellites` loop in `rtklib_solver.cc` was just discarding it by
gating the entire per-satellite entry on `vs`.

## Fix

- The `used_satellites` loop now keys on whether `azel` was actually
  computed this epoch (non-zero -- the same "no data" sentinel `pntpos()`
  itself resets `ssat[]` to at the top of every call), instead of `vs`.
- Added a `used` bool (default `true`) to `Monitor_Pvt::UsedSatelliteInfo`,
  the `UsedSatellite` protobuf message (field 7), and
  `serdes_monitor_pvt.h`'s read/write, reflecting `vs`.

A satellite that's tracked but excluded from the fix now still reports its
real azimuth/elevation, with `used = false`, instead of disappearing from
the list entirely.

## Test plan

- [x] Clean build against `upstream/next` (this worktree).
- [x] Full unit test suite (`run_tests`, `-DENABLE_UNIT_TESTING=ON`): 661
      passed, 1 skipped (unrelated `RtklibTlsTest`), 0 failed.
- [x] Verified live: added a temporary debug log of the raw `vs`/`azel`
      values RTKLIB computes for a satellite sitting a few degrees below
      `PVT.elevation_mask` -- confirmed `vs=0`, `used=0`, and a real,
      continuously-updating elevation value, matching the intended
      behavior; removed before this PR.
