### PR TITLE
Warm start: keep in-memory almanac instead of reloading from XML

### DIFF
--- a/src/algorithms/PVT/adapters/rtklib_pvt.cc
+++ b/src/algorithms/PVT/adapters/rtklib_pvt.cc
@@ -890,6 +890,12 @@ void Rtklib_Pvt::clear_ephemeris()
 }
 
 
+void Rtklib_Pvt::clear_ephemeris_keep_almanac()
+{
+    pvt_->clear_ephemeris_keep_almanac();
+}
+
+
 std::map<int, Gps_Ephemeris> Rtklib_Pvt::get_gps_ephemeris() const
 {
     return pvt_->get_gps_ephemeris_map();

--- a/src/algorithms/PVT/adapters/rtklib_pvt.h
+++ b/src/algorithms/PVT/adapters/rtklib_pvt.h
@@ -223,6 +223,7 @@ public:
     }
 
     void clear_ephemeris() override;
+    void clear_ephemeris_keep_almanac() override;
     std::map<int, Gps_Ephemeris> get_gps_ephemeris() const override;
     std::map<int, Galileo_Ephemeris> get_galileo_ephemeris() const override;
     std::map<int, Beidou_Dnav_Ephemeris> get_beidou_dnav_ephemeris() const override;

--- a/src/algorithms/PVT/gnuradio_blocks/rtklib_pvt_gs.cc
+++ b/src/algorithms/PVT/gnuradio_blocks/rtklib_pvt_gs.cc
@@ -2127,6 +2127,24 @@ void rtklib_pvt_gs::clear_ephemeris()
 }
 
 
+void rtklib_pvt_gs::clear_ephemeris_keep_almanac()
+{
+    d_internal_pvt_solver->clear_gps_ephemerides();
+    d_internal_pvt_solver->galileo_ephemeris_map.clear();
+    d_internal_pvt_solver->galileo_ephemeris_store.clear();
+    d_internal_pvt_solver->galileo_reduced_ced_map.clear();
+    d_internal_pvt_solver->beidou_dnav_ephemeris_map.clear();
+    if (d_enable_rx_clock_correction == true)
+        {
+            d_user_pvt_solver->clear_gps_ephemerides();
+            d_user_pvt_solver->galileo_ephemeris_map.clear();
+            d_user_pvt_solver->galileo_ephemeris_store.clear();
+            d_user_pvt_solver->galileo_reduced_ced_map.clear();
+            d_user_pvt_solver->beidou_dnav_ephemeris_map.clear();
+        }
+}
+
+
 bool rtklib_pvt_gs::send_ttff_msg(double ttff) const
 {
     if (d_mq)

--- a/src/algorithms/PVT/gnuradio_blocks/rtklib_pvt_gs.h
+++ b/src/algorithms/PVT/gnuradio_blocks/rtklib_pvt_gs.h
@@ -125,6 +125,11 @@ public:
     void clear_ephemeris();
 
     /*!
+     * \brief Clear ephemeris information only, leaving GPS/Galileo/BeiDou almanacs untouched
+     */
+    void clear_ephemeris_keep_almanac();
+
+    /*!
      * \brief Interpolates one observable between two epochs, in the carrier
      * polarity frame of the later epoch.
      *

--- a/src/core/interfaces/pvt_interface.h
+++ b/src/core/interfaces/pvt_interface.h
@@ -52,6 +52,18 @@ class PvtInterface : public GNSSBlockInterface
 public:
     virtual void reset() = 0;
     virtual void clear_ephemeris() = 0;
+    // Ephemeris-only clear, leaving the almanac maps untouched -- used by a
+    // WARMSTART telecommand to drop trust in ephemeris while keeping whatever
+    // almanac the receiver currently has in memory, matching the classic
+    // cold/warm/hot start table (warm start: almanac current, ephemeris
+    // unknown/stale) instead of clear_ephemeris()'s wipe-everything behavior.
+    // Deliberately does NOT reload almanac from an XML file first -- the
+    // receiver's own in-memory almanac (from live demodulation, or from
+    // whatever assistance data it started with) is already at least as
+    // current as any file on disk could be, and reloading from a file risks
+    // regressing past it (discarding satellites/pages the receiver has
+    // accumulated live since its last start in favor of a stale snapshot).
+    virtual void clear_ephemeris_keep_almanac() = 0;
     virtual std::map<int, Gps_Ephemeris> get_gps_ephemeris() const = 0;
     virtual std::map<int, Galileo_Ephemeris> get_galileo_ephemeris() const = 0;
     virtual std::map<int, Beidou_Dnav_Ephemeris> get_beidou_dnav_ephemeris() const = 0;

--- a/src/core/receiver/control_thread.cc
+++ b/src/core/receiver/control_thread.cc
@@ -1025,14 +1025,23 @@ void ControlThread::apply_action(unsigned int what)
             break;
         case 13:
             LOG(INFO) << "Receiver action WARMSTART";
-            // delete all ephemeris and almanac information from maps (also the PVT map queue)
+            // Ephemeris isn't trusted yet (per the classic cold/warm/hot start table:
+            // almanac current, ephemeris unknown/stale) -- keep whatever almanac the
+            // receiver currently has in memory (it's already as fresh as it can be;
+            // no XML file on disk can be more current than live-demodulated data)
+            // and only drop ephemeris, so satellites still get elevation-classified/
+            // prioritized purely from almanac + assisted position/time and have to
+            // redemodulate their own ephemeris during acquisition/tracking. No XML
+            // reload here -- deliberately: reloading assistance data from a file
+            // risks *regressing* past whatever the receiver has already accumulated
+            // live since its last start (a fresher live almanac would otherwise get
+            // discarded in favor of a stale on-disk snapshot) -- see
+            // clear_ephemeris_keep_almanac()'s doc comment.
             pvt_ptr = flowgraph_->get_pvt();
-            pvt_ptr->clear_ephemeris();
-            // load the ephemeris and the almanac from XML files (receiver assistance)
-            read_assistance_from_XML();
+            pvt_ptr->clear_ephemeris_keep_almanac();
             // call here the function that computes the set of visible satellites and its elevation
             // for the date and time specified by the warm start command and the assisted position
-            get_visible_sats(cmd_interface_.get_utc_time(), cmd_interface_.get_LLH());
+            visible_satellites = get_visible_sats(cmd_interface_.get_utc_time(), cmd_interface_.get_LLH());
             // reorder the satellite queue to acquire first those visible satellites
             flowgraph_->priorize_satellites(visible_satellites);
             // start again the satellite acquisitions


### PR DESCRIPTION
## Summary

`WARMSTART` used to clear both ephemeris and almanac and then reload
both from local XML assistance files. That reload can silently
regress the receiver's live-accumulated almanac (new satellites/pages
demodulated since the last start) back to whatever stale snapshot
happens to be on disk -- nothing gets written back to disk first, so
it's a one-way loss with no merge against what the receiver already
has.

This adds `PvtInterface::clear_ephemeris_keep_almanac()`, which clears
only the ephemeris maps and leaves almanac untouched, and uses it in
`WARMSTART` instead of `clear_ephemeris()` + `read_assistance_from_XML()`.
That matches the classic cold/warm/hot start table (warm: almanac
current, ephemeris unknown/stale) using whatever almanac the receiver
already has in memory -- which can't be any staler than a file on disk
-- rather than reloading from one.

Along the way this also fixes a real bug in the same handler:
`get_visible_sats()`'s return value was never assigned to
`visible_satellites`, so `priorize_satellites()` was always reordering
the search queue with an empty list -- warm start's visibility-based
prioritization was silently a no-op.

## Test plan

- [x] Builds clean against `next`
- [x] Full unit test suite: 665 passed, 1 skipped (`RtklibTlsTest.AcceptsTrustedAnyEkuLeaf`, unrelated TLS/certificate test, not touched by this change)
- [x] Live-tested on hardware: cold/warm/hot start telecommands all verified behaving correctly (warm start now correctly falls back to almanac-based classification instead of using stale/leftover ephemeris)