### PR TITLE
Add full_grid_search option to acquisition

### DIFF
--- a/src/algorithms/acquisition/gnuradio_blocks/pcps_acquisition.cc
+++ b/src/algorithms/acquisition/gnuradio_blocks/pcps_acquisition.cc
@@ -842,19 +842,47 @@ void pcps_acquisition::acquisition_core(uint64_t sample_count)
 
     if (!d_acq_parameters.bit_transition_flag)
         {
-            if (result.test_statistics > get_threshold())
+            if (d_acq_parameters.full_grid_search)
                 {
-                    handle_threshold_reached(result);
+                    // Search the entire acquisition grid (accumulate through the full max_dwells)
+                    // before deciding accept/reject, instead of exiting as soon as any single dwell's
+                    // (possibly still noisy, partially non-coherently accumulated) grid crosses
+                    // threshold -- a later dwell's fuller integration can reveal a different, genuinely
+                    // stronger peak elsewhere in the same grid that an early exit never gets the chance
+                    // to compare against.
+                    if (d_num_noncoherent_integrations_counter == d_acq_parameters.max_dwells)
+                        {
+                            if (result.test_statistics > get_threshold())
+                                {
+                                    handle_threshold_reached(result);
+                                }
+                            else
+                                {
+                                    handle_integration_done(result);
+                                }
+                        }
+                    else
+                        {
+                            d_buffer_count = 0;
+                            d_state = 1;
+                        }
                 }
             else
                 {
-                    d_buffer_count = 0;
-                    d_state = 1;
-                }
+                    if (result.test_statistics > get_threshold())
+                        {
+                            handle_threshold_reached(result);
+                        }
+                    else
+                        {
+                            d_buffer_count = 0;
+                            d_state = 1;
+                        }
 
-            if (d_num_noncoherent_integrations_counter == d_acq_parameters.max_dwells)
-                {
-                    handle_integration_done(result);
+                    if (d_num_noncoherent_integrations_counter == d_acq_parameters.max_dwells)
+                        {
+                            handle_integration_done(result);
+                        }
                 }
         }
     else

--- a/src/algorithms/acquisition/libs/acq_conf.cc
+++ b/src/algorithms/acquisition/libs/acq_conf.cc
@@ -83,6 +83,7 @@ void Acq_Conf::SetFromConfiguration(const ConfigurationInterface *configuration,
     make_2_steps = configuration->property(role + ".make_two_steps", make_2_steps);
     blocking_on_standby = configuration->property(role + ".blocking_on_standby", blocking_on_standby);
     enable_doppler_narrowing = configuration->property(role + ".enable_doppler_narrowing", enable_doppler_narrowing);
+    full_grid_search = configuration->property(role + ".full_grid_search", full_grid_search);
 
     if (pfa <= 0.0)
         {

--- a/src/algorithms/acquisition/libs/acq_conf.h
+++ b/src/algorithms/acquisition/libs/acq_conf.h
@@ -92,6 +92,14 @@ public:
     // flag has no effect and the full configured Doppler grid is always searched.
     bool enable_doppler_narrowing{false};
 
+    // Accumulate through the full max_dwells before deciding accept/reject, instead
+    // of exiting as soon as any single dwell's (possibly still noisy, partially
+    // accumulated) grid crosses threshold -- a later dwell's fuller integration can
+    // reveal a different, genuinely stronger peak elsewhere in the grid that an early
+    // exit never gets the chance to compare against. Opt-in: off by default, enable
+    // per-implementation in the .conf (e.g. Acquisition_1B.full_grid_search = true).
+    bool full_grid_search{false};
+
     // Specific to some implementations
     bool acquire_pilot{false};
     bool acquire_iq{false};


### PR DESCRIPTION
## Summary

Extracted from #1071, which originally bundled this together with the
frequency-error-reduction tracking work -- splitting it out so each
can be reviewed independently.

Previously, the (possibly still noisy, partially non-coherently
accumulated) grid was checked against threshold after every single
dwell, and the first bin anywhere to cross it won immediately -- even
if a later dwell's fuller integration would have revealed a different,
genuinely stronger peak elsewhere in the same grid that never got the
chance to be compared.

This is not just a weak-signal problem. For strong signals, secondary
lobes of the Doppler search grid's correlation response can be high
enough in amplitude to consistently cross the detection threshold on
an early, not-yet-fully-accumulated dwell -- before the true peak bin
has had the chance to separate from them. When that happens, the
early-exit logic can lock onto one of these secondary lobes instead of
the true Doppler bin, handing tracking an out-of-frequency acquisition
that almost certainly ends up as a loss of lock once tracking takes
over.

## Configuration

| Parameter | Default | Meaning |
|---|---|---|
| `Acquisition_<Sig>.full_grid_search` | `false` | When `true`, defers the accept/reject decision until the final dwell, from the fully `max_dwells`-accumulated grid, instead of exiting on the first dwell whose still-partial accumulation happens to cross threshold. `false` preserves the existing early-exit behavior exactly. |

Example, from an EVK1029 dual-band Galileo+GPS configuration:

```ini
Acquisition_1B.implementation                 = Galileo_E1_PCPS_Ambiguous_Acquisition
Acquisition_1B.full_grid_search               = true
Acquisition_1B.enable_assisted_doppler_narrowing = true
Acquisition_1B.acquire_pilot                  = true
Acquisition_1B.item_type                      = gr_complex
Acquisition_1B.coherent_integration_time_ms   = 4
Acquisition_1B.doppler_max                    = 5000
Acquisition_1B.doppler_step                   = 125; * 1/2*T (3.8 dB max loss)
Acquisition_1B.max_dwells                     = 5; 20 ms incoherent accumulation
Acquisition_1B.pfa                            = 1e-7
```

## Test plan

- [x] Builds clean against `next`
- [x] Full unit test suite: 672 passed, 1 skipped (`RtklibTlsTest.AcceptsTrustedAnyEkuLeaf`, unrelated TLS/certificate test)
- [x] `clang-format-22` (this branch's CI-pinned version) makes no changes to any touched file
