### PR TITLE
Glonass_Gnav_Navigation_Message: fix crash in almanac decoder

### DIFF
--- a/src/core/system_parameters/glonass_gnav_navigation_message.cc
+++ b/src/core/system_parameters/glonass_gnav_navigation_message.cc
@@ -503,7 +503,7 @@ int32_t Glonass_Gnav_Navigation_Message::string_decoder(const std::string& frame
             i_alm_satellite_slot_number = static_cast<uint32_t>(read_navigation_unsigned(string_bits, N_A));
             d_frame_ID = get_frame_number(i_alm_satellite_slot_number);
             // Make sure a valid frame_ID or satellite slot number is returned
-            if (d_frame_ID == 0)
+            if (d_frame_ID == 0 || i_alm_satellite_slot_number == 0 || i_alm_satellite_slot_number > GLONASS_CA_NBR_SATS)
                 {
                     return 0;
                 }
@@ -522,7 +522,7 @@ int32_t Glonass_Gnav_Navigation_Message::string_decoder(const std::string& frame
 
         case 7:
             // --- It is string 7 ----------------------------------------------
-            if (flag_almanac_str_6 == true)
+            if (flag_almanac_str_6 == true && i_alm_satellite_slot_number > 0 && i_alm_satellite_slot_number <= GLONASS_CA_NBR_SATS)
                 {
                     gnav_almanac[i_alm_satellite_slot_number - 1].d_omega_n_A = static_cast<double>(read_navigation_signed(string_bits, OMEGA_N_A)) * TWO_N15 * GNSS_PI;
                     gnav_almanac[i_alm_satellite_slot_number - 1].d_t_lambda_n_A = static_cast<double>(read_navigation_unsigned(string_bits, T_LAMBDA_N_A)) * TWO_N5;
@@ -548,7 +548,7 @@ int32_t Glonass_Gnav_Navigation_Message::string_decoder(const std::string& frame
             i_alm_satellite_slot_number = static_cast<uint32_t>(read_navigation_unsigned(string_bits, N_A));
             d_frame_ID = get_frame_number(i_alm_satellite_slot_number);
             // Make sure a valid frame_ID or satellite slot number is returned
-            if (d_frame_ID == 0)
+            if (d_frame_ID == 0 || i_alm_satellite_slot_number == 0 || i_alm_satellite_slot_number > GLONASS_CA_NBR_SATS)
                 {
                     return 0;
                 }
@@ -567,7 +567,7 @@ int32_t Glonass_Gnav_Navigation_Message::string_decoder(const std::string& frame
 
         case 9:
             // --- It is string 9 ----------------------------------------------
-            if (flag_almanac_str_8 == true)
+            if (flag_almanac_str_8 == true && i_alm_satellite_slot_number > 0 && i_alm_satellite_slot_number <= GLONASS_CA_NBR_SATS)
                 {
                     gnav_almanac[i_alm_satellite_slot_number - 1].d_omega_n_A = static_cast<double>(read_navigation_signed(string_bits, OMEGA_N_A)) * TWO_N15 * GNSS_PI;
                     gnav_almanac[i_alm_satellite_slot_number - 1].d_t_lambda_n_A = static_cast<double>(read_navigation_unsigned(string_bits, T_LAMBDA_N_A)) * TWO_N5;
@@ -588,7 +588,7 @@ int32_t Glonass_Gnav_Navigation_Message::string_decoder(const std::string& frame
             i_alm_satellite_slot_number = static_cast<uint32_t>(read_navigation_unsigned(string_bits, N_A));
             d_frame_ID = get_frame_number(i_alm_satellite_slot_number);
             // Make sure a valid frame_ID or satellite slot number is returned
-            if (d_frame_ID == 0)
+            if (d_frame_ID == 0 || i_alm_satellite_slot_number == 0 || i_alm_satellite_slot_number > GLONASS_CA_NBR_SATS)
                 {
                     return 0;
                 }
@@ -607,7 +607,7 @@ int32_t Glonass_Gnav_Navigation_Message::string_decoder(const std::string& frame
 
         case 11:
             // --- It is string 11 ---------------------------------------------
-            if (flag_almanac_str_10 == true)
+            if (flag_almanac_str_10 == true && i_alm_satellite_slot_number > 0 && i_alm_satellite_slot_number <= GLONASS_CA_NBR_SATS)
                 {
                     gnav_almanac[i_alm_satellite_slot_number - 1].d_omega_n_A = static_cast<double>(read_navigation_signed(string_bits, OMEGA_N_A)) * TWO_N15 * GNSS_PI;
                     gnav_almanac[i_alm_satellite_slot_number - 1].d_t_lambda_n_A = static_cast<double>(read_navigation_unsigned(string_bits, T_LAMBDA_N_A)) * TWO_N5;
@@ -628,7 +628,7 @@ int32_t Glonass_Gnav_Navigation_Message::string_decoder(const std::string& frame
             i_alm_satellite_slot_number = static_cast<uint32_t>(read_navigation_unsigned(string_bits, N_A));
             d_frame_ID = get_frame_number(i_alm_satellite_slot_number);
             // Make sure a valid frame_ID or satellite slot number is returned
-            if (d_frame_ID == 0)
+            if (d_frame_ID == 0 || i_alm_satellite_slot_number == 0 || i_alm_satellite_slot_number > GLONASS_CA_NBR_SATS)
                 {
                     return 0;
                 }
@@ -646,7 +646,7 @@ int32_t Glonass_Gnav_Navigation_Message::string_decoder(const std::string& frame
 
         case 13:
             // --- It is string 13 ---------------------------------------------
-            if (flag_almanac_str_12 == true)
+            if (flag_almanac_str_12 == true && i_alm_satellite_slot_number > 0 && i_alm_satellite_slot_number <= GLONASS_CA_NBR_SATS)
                 {
                     gnav_almanac[i_alm_satellite_slot_number - 1].d_omega_n_A = static_cast<double>(read_navigation_signed(string_bits, OMEGA_N_A)) * TWO_N15 * GNSS_PI;
                     gnav_almanac[i_alm_satellite_slot_number - 1].d_t_lambda_n_A = static_cast<double>(read_navigation_unsigned(string_bits, T_LAMBDA_N_A)) * TWO_N5;
@@ -681,7 +681,7 @@ int32_t Glonass_Gnav_Navigation_Message::string_decoder(const std::string& frame
                     i_alm_satellite_slot_number = static_cast<uint32_t>(read_navigation_unsigned(string_bits, N_A));
                     // In frames 1-4, string 14 carries the almanac of a satellite
                     // assigned to the frame being received
-                    if (get_frame_number(i_alm_satellite_slot_number) != d_frame_ID)
+                    if (get_frame_number(i_alm_satellite_slot_number) != d_frame_ID || i_alm_satellite_slot_number == 0 || i_alm_satellite_slot_number > GLONASS_CA_NBR_SATS)
                         {
                             return 0;
                         }
@@ -699,7 +699,7 @@ int32_t Glonass_Gnav_Navigation_Message::string_decoder(const std::string& frame
 
         case 15:
             // --- It is string 15 ----------------------------------------------
-            if (d_frame_ID >= 1 && d_frame_ID <= 4 && flag_almanac_str_14 == true)
+            if (d_frame_ID >= 1 && d_frame_ID <= 4 && flag_almanac_str_14 == true && i_alm_satellite_slot_number > 0 && i_alm_satellite_slot_number <= GLONASS_CA_NBR_SATS)
                 {
                     gnav_almanac[i_alm_satellite_slot_number - 1].d_omega_n_A = static_cast<double>(read_navigation_signed(string_bits, OMEGA_N_A)) * TWO_N15 * GNSS_PI;
                     gnav_almanac[i_alm_satellite_slot_number - 1].d_t_lambda_n_A = static_cast<double>(read_navigation_unsigned(string_bits, T_LAMBDA_N_A)) * TWO_N5;


### PR DESCRIPTION
Validate i_alm_satellite_slot_number before trying to access gnav_almanac elements by index in Glonass_Gnav_Navigation_Message::string_decoder.

Testing plan:
 - [ ] Realtime configuration long run: 4 hrs elapsed, no crash so far
 - [ ] Collect telemetry bits from live broadcast signal
 - [ ] glonass_gnav_telemetry_decoder_gs testing harness (Gnss_Synchro emitter, message receiver)
 - [ ] Regression test: confirm that bitstream decoding results match the expectations
 - [ ] Bitstream corruption test: craft a corrupted bitstream, that would pass the CRC check, but will contain invalid N_A field, confirm, that decoding this bitstream does not result in memory corruption